### PR TITLE
git: implement initial SHA-256 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,7 +258,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -268,6 +268,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -717,6 +726,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "csscolorparser"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -886,9 +904,19 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -1656,6 +1684,7 @@ dependencies = [
  "faster-hex",
  "gix-features",
  "sha1-checked",
+ "sha2 0.11.0",
  "thiserror 2.0.18",
 ]
 
@@ -2229,6 +2258,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2608,7 +2646,7 @@ dependencies = [
  "chrono",
  "clru",
  "criterion",
- "digest",
+ "digest 0.10.7",
  "dunce",
  "either",
  "etcetera",
@@ -4172,7 +4210,7 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -4181,7 +4219,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89f599ac0c323ebb1c6082821a54962b839832b03984598375bff3975b804423"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "sha1",
 ]
 
@@ -4193,7 +4231,18 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -4472,7 +4521,7 @@ dependencies = [
  "pest",
  "pest_derive",
  "phf",
- "sha2",
+ "sha2 0.10.9",
  "signal-hook",
  "siphasher",
  "terminfo",
@@ -5149,7 +5198,7 @@ checksum = "692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7"
 dependencies = [
  "getrandom 0.3.4",
  "mac_address",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
  "uuid",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ gix = { version = "0.85.0", default-features = false, features = [
     "index",
     "max-performance-safe",
     "sha1",
+    "sha256",
     "zlib-rs",
 ] }
 gix-ignore = { version = "0.21.0" }

--- a/cli/examples/custom-backend/main.rs
+++ b/cli/examples/custom-backend/main.rs
@@ -104,7 +104,7 @@ struct JitBackend {
 
 impl JitBackend {
     fn init(settings: &UserSettings, store_path: &Path) -> Result<Self, BackendInitError> {
-        let inner = GitBackend::init_internal(settings, store_path)?;
+        let inner = GitBackend::init_internal(settings, store_path, gix::hash::Kind::default())?;
         Ok(Self { inner })
     }
 

--- a/cli/examples/custom-working-copy/main.rs
+++ b/cli/examples/custom-working-copy/main.rs
@@ -66,8 +66,11 @@ async fn run_custom_command(
             let wc_path = command_helper.cwd();
             let settings = command_helper.settings_for_new_workspace(ui, wc_path)?.0;
             let backend_initializer = |settings: &UserSettings, store_path: &Path| {
-                let backend: Box<dyn Backend> =
-                    Box::new(GitBackend::init_internal(settings, store_path)?);
+                let backend: Box<dyn Backend> = Box::new(GitBackend::init_internal(
+                    settings,
+                    store_path,
+                    gix::hash::Kind::default(),
+                )?);
                 Ok(backend)
             };
             Workspace::init_with_factories(

--- a/cli/src/commands/git/clone.rs
+++ b/cli/src/commands/git/clone.rs
@@ -34,6 +34,7 @@ use jj_lib::repo::Repo as _;
 use jj_lib::str_util::StringExpression;
 use jj_lib::workspace::Workspace;
 
+use super::ObjectHash;
 use super::RepoPresets;
 use super::write_repo_presets;
 use crate::cli_util::CommandHelper;
@@ -139,6 +140,23 @@ pub struct GitCloneArgs {
     ///     https://docs.jj-vcs.dev/latest/revsets/#string-patterns
     #[arg(long = "tag", short, value_name = "TAG")]
     tags: Option<Vec<String>>,
+
+    /// Object hash algorithm for the local Git repository.
+    ///
+    /// *Must* match the remote's hash algorithm, otherwise the operation will
+    /// fail. Most existing repositories today still use the classic SHA-1
+    /// format, which is also the default if not configured otherwise by the
+    /// [git.object-hash config].
+    ///
+    /// See also Git's [hash-function-transition] document for an in-depth
+    /// explanation of the migration towards stronger hash functions.
+    ///
+    /// [git.object-hash config]:
+    ///     https://docs.jj-vcs.dev/latest/config/#default-object-hash-format
+    /// [hash-function-transition]:
+    ///     https://git-scm.com/docs/hash-function-transition
+    #[arg(long, value_enum)]
+    object_hash: Option<ObjectHash>,
 }
 
 fn clone_destination_for_source(source: &str) -> Option<&str> {
@@ -191,6 +209,10 @@ pub async fn cmd_git_clone(
         Some(texts) => Some(parse_union_name_patterns(ui, texts)?),
         None => is_specific.then(StringExpression::none),
     };
+    let object_hash = args.object_hash.map_or_else(
+        || command.settings().get::<ObjectHash>("git.object-hash"),
+        Result::Ok,
+    )?;
 
     // Canonicalize because fs::remove_dir_all() doesn't seem to like e.g.
     // `/some/path/.`
@@ -198,8 +220,14 @@ pub async fn cmd_git_clone(
         .map_err(|err| user_error_with_message(format!("Failed to create {wc_path_str}"), err))?;
 
     let clone_result: Result<_, CommandError> = async {
-        let (workspace_command, config_env) =
-            init_workspace(ui, command, &canonical_wc_path, colocate).await?;
+        let (workspace_command, config_env) = init_workspace(
+            ui,
+            command,
+            &canonical_wc_path,
+            colocate,
+            object_hash.into(),
+        )
+        .await?;
         let remote_settings = workspace_command.settings().remote_settings()?;
         let bookmark = if let Some(expr) = &specific_bookmark_expr {
             expr.clone()
@@ -299,14 +327,13 @@ async fn init_workspace(
     command: &CommandHelper,
     wc_path: &Path,
     colocate: bool,
+    object_hash: gix::hash::Kind,
 ) -> Result<(WorkspaceCommandHelper, ConfigEnv), CommandError> {
     let (settings, config_env) = command.settings_for_new_workspace(ui, wc_path)?;
-    // TODO: cloning needs to obtain the object hash from remote, figure out a
-    // solution (git does it in a funny way)
     let (workspace, repo) = if colocate {
-        Workspace::init_colocated_git(&settings, wc_path, Default::default()).await?
+        Workspace::init_colocated_git(&settings, wc_path, object_hash).await?
     } else {
-        Workspace::init_internal_git(&settings, wc_path, Default::default()).await?
+        Workspace::init_internal_git(&settings, wc_path, object_hash).await?
     };
     let workspace_command = command.for_workable_repo(ui, workspace, repo)?;
     maybe_add_gitignore(&workspace_command)?;

--- a/cli/src/commands/git/clone.rs
+++ b/cli/src/commands/git/clone.rs
@@ -301,10 +301,12 @@ async fn init_workspace(
     colocate: bool,
 ) -> Result<(WorkspaceCommandHelper, ConfigEnv), CommandError> {
     let (settings, config_env) = command.settings_for_new_workspace(ui, wc_path)?;
+    // TODO: cloning needs to obtain the object hash from remote, figure out a
+    // solution (git does it in a funny way)
     let (workspace, repo) = if colocate {
-        Workspace::init_colocated_git(&settings, wc_path).await?
+        Workspace::init_colocated_git(&settings, wc_path, Default::default()).await?
     } else {
-        Workspace::init_internal_git(&settings, wc_path).await?
+        Workspace::init_internal_git(&settings, wc_path, Default::default()).await?
     };
     let workspace_command = command.for_workable_repo(ui, workspace, repo)?;
     maybe_add_gitignore(&workspace_command)?;

--- a/cli/src/commands/git/init.rs
+++ b/cli/src/commands/git/init.rs
@@ -30,6 +30,7 @@ use jj_lib::repo::Repo as _;
 use jj_lib::view::View;
 use jj_lib::workspace::Workspace;
 
+use super::ObjectHash;
 use super::RepoPresets;
 use super::write_repo_presets;
 use crate::cli_util::CommandHelper;
@@ -125,24 +126,6 @@ pub struct GitInitArgs {
         value_hint = clap::ValueHint::DirPath,
     )]
     git_repo: Option<String>,
-}
-
-#[derive(Debug, Default, Clone, Copy, serde::Deserialize, clap::ValueEnum)]
-#[serde(rename_all = "lowercase")]
-#[value(rename_all = "lower")]
-enum ObjectHash {
-    #[default]
-    Sha1,
-    Sha256,
-}
-
-impl From<ObjectHash> for gix::hash::Kind {
-    fn from(value: ObjectHash) -> Self {
-        match value {
-            ObjectHash::Sha1 => Self::Sha1,
-            ObjectHash::Sha256 => Self::Sha256,
-        }
-    }
 }
 
 pub async fn cmd_git_init(

--- a/cli/src/commands/git/init.rs
+++ b/cli/src/commands/git/init.rs
@@ -92,6 +92,23 @@ pub struct GitInitArgs {
     #[arg(long, conflicts_with = "colocate")]
     no_colocate: bool,
 
+    /// Object hash algorithm for the newly created Git repository.
+    ///
+    /// Corresponds to `git init`'s `--object-format` option. If not given, the
+    /// [git.object-hash config] determines the default value.
+    ///
+    /// Note that the object hash cannot currently be changed for an existing
+    /// repo, and not all code forges support SHA-256 repositories yet. See also
+    /// Git's [hash-function-transition] document for an in-depth explanation of
+    /// the migration towards stronger hash functions.
+    ///
+    /// [git.object-hash config]:
+    ///     https://docs.jj-vcs.dev/latest/config/#default-object-hash-format
+    /// [hash-function-transition]:
+    ///     https://git-scm.com/docs/hash-function-transition
+    #[arg(long, value_enum, conflicts_with = "git_repo")]
+    object_hash: Option<ObjectHash>,
+
     /// Specifies a path to an **existing** git repository to be
     /// used as the backing git repo for the newly created `jj` repo.
     ///
@@ -102,8 +119,30 @@ pub struct GitInitArgs {
     ///
     /// This option is mutually exclusive with `--colocate`, and so if passed,
     /// turns colocation off.
-    #[arg(long, conflicts_with = "colocate", value_hint = clap::ValueHint::DirPath)]
+    #[arg(
+        long,
+        conflicts_with_all = ["colocate", "object_hash"],
+        value_hint = clap::ValueHint::DirPath,
+    )]
     git_repo: Option<String>,
+}
+
+#[derive(Debug, Default, Clone, Copy, serde::Deserialize, clap::ValueEnum)]
+#[serde(rename_all = "lowercase")]
+#[value(rename_all = "lower")]
+enum ObjectHash {
+    #[default]
+    Sha1,
+    Sha256,
+}
+
+impl From<ObjectHash> for gix::hash::Kind {
+    fn from(value: ObjectHash) -> Self {
+        match value {
+            ObjectHash::Sha1 => Self::Sha1,
+            ObjectHash::Sha256 => Self::Sha256,
+        }
+    }
 }
 
 pub async fn cmd_git_init(
@@ -132,7 +171,19 @@ pub async fn cmd_git_init(
         args.colocate
     };
 
-    do_init(ui, command, &wc_path, colocate, args.git_repo.as_deref()).await?;
+    let object_hash = args.object_hash.map_or_else(
+        || command.settings().get::<ObjectHash>("git.object-hash"),
+        Result::Ok,
+    )?;
+    do_init(
+        ui,
+        command,
+        &wc_path,
+        colocate,
+        object_hash.into(),
+        args.git_repo.as_deref(),
+    )
+    .await?;
 
     let relative_wc_path = file_util::relative_path(cwd, &wc_path);
     writeln!(
@@ -149,6 +200,7 @@ async fn do_init(
     command: &CommandHelper,
     workspace_root: &Path,
     colocate: bool,
+    object_hash: gix::hash::Kind,
     git_repo: Option<&str>,
 ) -> Result<(), CommandError> {
     #[derive(Clone, Debug)]
@@ -201,7 +253,7 @@ async fn do_init(
     match &init_mode {
         GitInitMode::Colocate => {
             let (workspace, repo) =
-                Workspace::init_colocated_git(&settings, workspace_root).await?;
+                Workspace::init_colocated_git(&settings, workspace_root, object_hash).await?;
             let workspace_command = command.for_workable_repo(ui, workspace, repo)?;
             maybe_add_gitignore(&workspace_command)?;
         }
@@ -235,7 +287,7 @@ async fn do_init(
             print_trackable_remote_bookmarks(ui, workspace_command.repo().view())?;
         }
         GitInitMode::Internal => {
-            Workspace::init_internal_git(&settings, workspace_root).await?;
+            Workspace::init_internal_git(&settings, workspace_root, object_hash).await?;
         }
     }
     Ok(())

--- a/cli/src/commands/git/mod.rs
+++ b/cli/src/commands/git/mod.rs
@@ -279,3 +279,20 @@ fn join_string_expressions(exprs: &[String]) -> String {
         _ => exprs.join(" | "), // no parentheses since | is the weakest operator
     }
 }
+
+#[derive(Debug, Clone, Copy, serde::Deserialize, clap::ValueEnum)]
+#[serde(rename_all = "lowercase")]
+#[value(rename_all = "lower")]
+enum ObjectHash {
+    Sha1,
+    Sha256,
+}
+
+impl From<ObjectHash> for gix::hash::Kind {
+    fn from(value: ObjectHash) -> Self {
+        match value {
+            ObjectHash::Sha1 => Self::Sha1,
+            ObjectHash::Sha256 => Self::Sha256,
+        }
+    }
+}

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -543,6 +543,11 @@
                     "type": "boolean",
                     "description": "Whether to colocate the working copy with the git repository",
                     "default": true
+                },
+                "object-hash": {
+                    "enum": ["sha1", "sha256"],
+                    "description": "Object hash algorithm used when initializing a new Git repository",
+                    "default": "sha1"
                 }
             }
         },

--- a/cli/src/config/misc.toml
+++ b/cli/src/config/misc.toml
@@ -26,6 +26,7 @@ disabled-branches = []
 
 [git]
 colocate = true
+object-hash = "sha1"
 private-commits = "none()"
 sign-on-push = false
 track-default-bookmark-on-clone = true

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -1757,6 +1757,16 @@ Create a new Git backed repo
    See [colocation docs] for some minor advantages of non-colocated workspaces.
 
    [colocation docs]: https://docs.jj-vcs.dev/latest/git-compatibility/#colocated-jujutsugit-repos
+* `--object-hash <OBJECT_HASH>` — Object hash algorithm for the newly created Git repository.
+
+   Corresponds to `git init`'s `--object-format` option. If not given, the [git.object-hash config] determines the default value.
+
+   Note that the object hash cannot currently be changed for an existing repo, and not all code forges support SHA-256 repositories yet. See also Git's [hash-function-transition] document for an in-depth explanation of the migration towards stronger hash functions.
+
+   [git.object-hash config]: https://docs.jj-vcs.dev/latest/config/#default-object-hash-format [hash-function-transition]: https://git-scm.com/docs/hash-function-transition
+
+  Possible values: `sha1`, `sha256`
+
 * `--git-repo <GIT_REPO>` — Specifies a path to an **existing** git repository to be used as the backing git repo for the newly created `jj` repo.
 
    If the specified `--git-repo` path happens to be the same as the `jj` repo path (both .jj and .git directories are in the same working directory), then both `jj` and `git` commands will work on the same repo. This is called a colocated workspace.

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -1614,6 +1614,16 @@ Create a new repo backed by a clone of a Git repo
    By default, the specified pattern matches tag names with glob syntax, but only `*` is expanded. Other wildcard characters such as `?` are *not* supported. Patterns can be repeated or combined with [logical operators] to specify multiple tags, but only union and negative intersection are supported.
 
    [logical operators]: https://docs.jj-vcs.dev/latest/revsets/#string-patterns
+* `--object-hash <OBJECT_HASH>` — Object hash algorithm for the local Git repository.
+
+   *Must* match the remote's hash algorithm, otherwise the operation will fail. Most existing repositories today still use the classic SHA-1 format, which is also the default if not configured otherwise by the [git.object-hash config].
+
+   See also Git's [hash-function-transition] document for an in-depth explanation of the migration towards stronger hash functions.
+
+   [git.object-hash config]: https://docs.jj-vcs.dev/latest/config/#default-object-hash-format [hash-function-transition]: https://git-scm.com/docs/hash-function-transition
+
+  Possible values: `sha1`, `sha256`
+
 
 
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -1778,6 +1778,23 @@ default. Set `git.colocate` to `false` to disable it.
 See [Colocated Jujutsu/Git workspaces](git-compatibility.md#colocated-jujutsugit-repos)
 for more information.
 
+### Default object hash format
+
+Traditionally, Git used the SHA-1 hash function to compute the identifiers for
+[objects]. Because SHA-1 is not considered cryptographically secure anymore, Git
+is in the [process of transitioning][transition] to a stronger hash function,
+namely SHA-256.
+
+Currently, the object hash function can only be set when initializing a new Git
+repository. The setting `git.object-hash` controls the default choice for that
+purpose. It can take the values `sha1` (default) and `sha256`.
+
+Note that at the moment there is no interopability between the formats, and not
+all code forges support SHA-256 repositories yet.
+
+[objects]: https://git-scm.com/book/en/v2/Git-Internals-Git-Objects
+[transition]: https://git-scm.com/docs/hash-function-transition
+
 ### Default remotes for `jj git fetch` and `jj git push`
 
 By default, if a single remote exists it is used for `jj git fetch` and `jj git

--- a/lib/src/git_backend.rs
+++ b/lib/src/git_backend.rs
@@ -214,12 +214,16 @@ impl GitBackend {
     pub fn init_internal(
         settings: &UserSettings,
         store_path: &Path,
+        object_hash: gix::hash::Kind,
     ) -> Result<Self, Box<GitBackendInitError>> {
         let git_repo_path = Path::new("git");
         let git_repo = gix::ThreadSafeRepository::init_opts(
             store_path.join(git_repo_path),
             gix::create::Kind::Bare,
-            gix::create::Options::default(),
+            gix::create::Options {
+                object_hash: Some(object_hash),
+                ..Default::default()
+            },
             gix_open_opts_from_settings(settings),
         )
         .map_err(GitBackendInitError::InitRepository)?;
@@ -234,6 +238,7 @@ impl GitBackend {
         settings: &UserSettings,
         store_path: &Path,
         workspace_root: &Path,
+        object_hash: gix::hash::Kind,
     ) -> Result<Self, Box<GitBackendInitError>> {
         let canonical_workspace_root = {
             let path = store_path.join(workspace_root);
@@ -244,7 +249,10 @@ impl GitBackend {
         let git_repo = gix::ThreadSafeRepository::init_opts(
             canonical_workspace_root,
             gix::create::Kind::WithWorktree,
-            gix::create::Options::default(),
+            gix::create::Options {
+                object_hash: Some(object_hash),
+                ..Default::default()
+            },
             gix_open_opts_from_settings(settings),
         )
         .map_err(GitBackendInitError::InitRepository)?;
@@ -2247,7 +2255,7 @@ mod tests {
     fn commit_has_ref() -> TestResult {
         let settings = user_settings();
         let temp_dir = new_temp_dir();
-        let backend = GitBackend::init_internal(&settings, temp_dir.path())?;
+        let backend = GitBackend::init_internal(&settings, temp_dir.path(), gix::hash::Kind::Sha1)?;
         let git_repo = backend.git_repo();
         let signature = Signature {
             name: "Someone".to_string(),
@@ -2295,7 +2303,7 @@ mod tests {
     fn import_head_commits_duplicates() -> TestResult {
         let settings = user_settings();
         let temp_dir = new_temp_dir();
-        let backend = GitBackend::init_internal(&settings, temp_dir.path())?;
+        let backend = GitBackend::init_internal(&settings, temp_dir.path(), gix::hash::Kind::Sha1)?;
         let git_repo = backend.git_repo();
 
         let signature = gix::actor::Signature {
@@ -2331,7 +2339,7 @@ mod tests {
     fn overlapping_git_commit_id() -> TestResult {
         let settings = user_settings();
         let temp_dir = new_temp_dir();
-        let backend = GitBackend::init_internal(&settings, temp_dir.path())?;
+        let backend = GitBackend::init_internal(&settings, temp_dir.path(), gix::hash::Kind::Sha1)?;
         let commit1 = Commit {
             parents: vec![backend.root_commit_id().clone()],
             predecessors: vec![],
@@ -2371,7 +2379,7 @@ mod tests {
     fn write_signed_commit() -> TestResult {
         let settings = user_settings();
         let temp_dir = new_temp_dir();
-        let backend = GitBackend::init_internal(&settings, temp_dir.path())?;
+        let backend = GitBackend::init_internal(&settings, temp_dir.path(), gix::hash::Kind::Sha1)?;
 
         let commit = Commit {
             parents: vec![backend.root_commit_id().clone()],

--- a/lib/src/git_backend.rs
+++ b/lib/src/git_backend.rs
@@ -1614,6 +1614,7 @@ mod tests {
     use gix::objs::CommitRef;
     use indoc::indoc;
     use pollster::FutureExt as _;
+    use test_case::test_case;
 
     use super::*;
     use crate::config::StackedConfig;
@@ -1639,24 +1640,28 @@ mod tests {
             .strict_config(true)
     }
 
-    fn git_init(directory: impl AsRef<Path>) -> gix::Repository {
+    fn git_init(directory: impl AsRef<Path>, object_hash: gix::hash::Kind) -> gix::Repository {
         gix::ThreadSafeRepository::init_opts(
             directory,
             gix::create::Kind::WithWorktree,
-            gix::create::Options::default(),
+            gix::create::Options {
+                object_hash: Some(object_hash),
+                ..Default::default()
+            },
             open_options(),
         )
         .unwrap()
         .to_thread_local()
     }
 
-    #[test]
-    fn read_plain_git_commit() -> TestResult {
+    #[test_case(gix::hash::Kind::Sha1 ; "sha1")]
+    #[test_case(gix::hash::Kind::Sha256; "sha256")]
+    fn read_plain_git_commit(object_hash: gix::hash::Kind) -> TestResult {
         let settings = user_settings();
         let temp_dir = new_temp_dir();
         let store_path = temp_dir.path();
         let git_repo_path = temp_dir.path().join("git");
-        let git_repo = git_init(git_repo_path);
+        let git_repo = git_init(git_repo_path, object_hash);
 
         // Add a commit with some files in
         let blob1 = git_repo.write_blob(b"content1")?.detach();
@@ -1689,9 +1694,20 @@ mod tests {
             )?
             .detach();
         git_repo.find_reference("refs/heads/dummy")?.delete()?;
-        let commit_id = CommitId::from_hex("efdcea5ca4b3658149f899ca7feee6876d077263");
         // The change id is the leading reverse bits of the commit id
-        let change_id = ChangeId::from_hex("c64ee0b6e16777fe53991f9281a6cd25");
+        let (commit_id, change_id) = match object_hash {
+            gix::hash::Kind::Sha1 => (
+                CommitId::from_hex("efdcea5ca4b3658149f899ca7feee6876d077263"),
+                ChangeId::from_hex("c64ee0b6e16777fe53991f9281a6cd25"),
+            ),
+            gix::hash::Kind::Sha256 => (
+                CommitId::from_hex(
+                    "64366022e4938d697015b775945be93aea6d3fc221feeaf7c516420262e3fa54",
+                ),
+                ChangeId::from_hex("2a5fc746404268a3ef577f8443fcb657"),
+            ),
+            _ => unreachable!(),
+        };
         // Check that the git commit above got the hash we expect
         assert_eq!(
             git_commit_id.as_bytes(),
@@ -1728,7 +1744,10 @@ mod tests {
 
         let commit = backend.read_commit(&commit_id).block_on()?;
         assert_eq!(&commit.change_id, &change_id);
-        assert_eq!(commit.parents, vec![CommitId::from_bytes(&[0; 20])]);
+        assert_eq!(
+            commit.parents,
+            vec![CommitId::from_bytes(object_hash.null_ref().as_bytes())]
+        );
         assert_eq!(commit.predecessors, vec![]);
         assert_eq!(
             commit.root_tree,
@@ -1800,13 +1819,14 @@ mod tests {
         Ok(())
     }
 
-    #[test]
-    fn read_git_commit_without_importing() -> TestResult {
+    #[test_case(gix::hash::Kind::Sha1 ; "sha1")]
+    #[test_case(gix::hash::Kind::Sha256; "sha256")]
+    fn read_git_commit_without_importing(object_hash: gix::hash::Kind) -> TestResult {
         let settings = user_settings();
         let temp_dir = new_temp_dir();
         let store_path = temp_dir.path();
         let git_repo_path = temp_dir.path().join("git");
-        let git_repo = git_init(&git_repo_path);
+        let git_repo = git_init(&git_repo_path, object_hash);
 
         let signature = gix::actor::Signature {
             name: GIT_USER.into(),
@@ -1843,13 +1863,14 @@ mod tests {
         Ok(())
     }
 
-    #[test]
-    fn read_signed_git_commit() -> TestResult {
+    #[test_case(gix::hash::Kind::Sha1 ; "sha1")]
+    #[test_case(gix::hash::Kind::Sha256; "sha256")]
+    fn read_signed_git_commit(object_hash: gix::hash::Kind) -> TestResult {
         let settings = user_settings();
         let temp_dir = new_temp_dir();
         let store_path = temp_dir.path();
         let git_repo_path = temp_dir.path().join("git");
-        let git_repo = git_init(git_repo_path);
+        let git_repo = git_init(git_repo_path, object_hash);
 
         let signature = gix::actor::Signature {
             name: GIT_USER.into(),
@@ -1877,6 +1898,7 @@ mod tests {
 
         commit
             .extra_headers
+            // TODO: should this conditionally become gpgsig-sha256 once gix supports it?
             .push(("gpgsig".into(), secure_sig.into()));
 
         let git_commit_id = git_repo.write_object(&commit)?;
@@ -1967,8 +1989,9 @@ mod tests {
         );
     }
 
-    #[test]
-    fn round_trip_change_id_via_git_header() -> TestResult {
+    #[test_case(gix::hash::Kind::Sha1 ; "sha1")]
+    #[test_case(gix::hash::Kind::Sha256; "sha256")]
+    fn round_trip_change_id_via_git_header(object_hash: gix::hash::Kind) -> TestResult {
         let settings = user_settings();
         let temp_dir = new_temp_dir();
 
@@ -1977,7 +2000,7 @@ mod tests {
         let empty_store_path = temp_dir.path().join("empty_store");
         fs::create_dir(&empty_store_path)?;
         let git_repo_path = temp_dir.path().join("git");
-        let git_repo = git_init(git_repo_path);
+        let git_repo = git_init(git_repo_path, object_hash);
 
         let backend = GitBackend::init_external(&settings, &store_path, git_repo.path())?;
         let original_change_id = ChangeId::from_hex("1111eeee1111eeee1111eeee1111eeee");
@@ -2063,13 +2086,14 @@ mod tests {
     }
 
     /// Test that parents get written correctly
-    #[test]
-    fn git_commit_parents() -> TestResult {
+    #[test_case(gix::hash::Kind::Sha1 ; "sha1")]
+    #[test_case(gix::hash::Kind::Sha256; "sha256")]
+    fn git_commit_parents(object_hash: gix::hash::Kind) -> TestResult {
         let settings = user_settings();
         let temp_dir = new_temp_dir();
         let store_path = temp_dir.path();
         let git_repo_path = temp_dir.path().join("git");
-        let git_repo = git_init(&git_repo_path);
+        let git_repo = git_init(&git_repo_path, object_hash);
 
         let backend = GitBackend::init_external(&settings, store_path, git_repo.path())?;
         let mut commit = Commit {
@@ -2134,13 +2158,14 @@ mod tests {
         Ok(())
     }
 
-    #[test]
-    fn write_tree_conflicts() -> TestResult {
+    #[test_case(gix::hash::Kind::Sha1 ; "sha1")]
+    #[test_case(gix::hash::Kind::Sha256; "sha256")]
+    fn write_tree_conflicts(object_hash: gix::hash::Kind) -> TestResult {
         let settings = user_settings();
         let temp_dir = new_temp_dir();
         let store_path = temp_dir.path();
         let git_repo_path = temp_dir.path().join("git");
-        let git_repo = git_init(&git_repo_path);
+        let git_repo = git_init(&git_repo_path, object_hash);
 
         let backend = GitBackend::init_external(&settings, store_path, git_repo.path())?;
         let create_tree = |i| {
@@ -2251,11 +2276,12 @@ mod tests {
         Ok(())
     }
 
-    #[test]
-    fn commit_has_ref() -> TestResult {
+    #[test_case(gix::hash::Kind::Sha1 ; "sha1")]
+    #[test_case(gix::hash::Kind::Sha256; "sha256")]
+    fn commit_has_ref(object_hash: gix::hash::Kind) -> TestResult {
         let settings = user_settings();
         let temp_dir = new_temp_dir();
-        let backend = GitBackend::init_internal(&settings, temp_dir.path(), gix::hash::Kind::Sha1)?;
+        let backend = GitBackend::init_internal(&settings, temp_dir.path(), object_hash)?;
         let git_repo = backend.git_repo();
         let signature = Signature {
             name: "Someone".to_string(),
@@ -2299,11 +2325,12 @@ mod tests {
         Ok(())
     }
 
-    #[test]
-    fn import_head_commits_duplicates() -> TestResult {
+    #[test_case(gix::hash::Kind::Sha1 ; "sha1")]
+    #[test_case(gix::hash::Kind::Sha256; "sha256")]
+    fn import_head_commits_duplicates(object_hash: gix::hash::Kind) -> TestResult {
         let settings = user_settings();
         let temp_dir = new_temp_dir();
-        let backend = GitBackend::init_internal(&settings, temp_dir.path(), gix::hash::Kind::Sha1)?;
+        let backend = GitBackend::init_internal(&settings, temp_dir.path(), object_hash)?;
         let git_repo = backend.git_repo();
 
         let signature = gix::actor::Signature {
@@ -2335,11 +2362,12 @@ mod tests {
         Ok(())
     }
 
-    #[test]
-    fn overlapping_git_commit_id() -> TestResult {
+    #[test_case(gix::hash::Kind::Sha1 ; "sha1")]
+    #[test_case(gix::hash::Kind::Sha256; "sha256")]
+    fn overlapping_git_commit_id(object_hash: gix::hash::Kind) -> TestResult {
         let settings = user_settings();
         let temp_dir = new_temp_dir();
-        let backend = GitBackend::init_internal(&settings, temp_dir.path(), gix::hash::Kind::Sha1)?;
+        let backend = GitBackend::init_internal(&settings, temp_dir.path(), object_hash)?;
         let commit1 = Commit {
             parents: vec![backend.root_commit_id().clone()],
             predecessors: vec![],
@@ -2376,10 +2404,65 @@ mod tests {
     }
 
     #[test]
-    fn write_signed_commit() -> TestResult {
+    fn write_signed_commit_sha1() -> TestResult {
+        let (obj, sig) = write_signed_commit(gix::hash::Kind::Sha1)?;
+        insta::assert_snapshot!(&obj, @"
+        tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904
+        author Someone <someone@example.com> 0 +0000
+        committer Someone <someone@example.com> 0 +0000
+        change-id xpxpxpxpxpxpxpxpxpxpxpxpxpxpxpxp
+        gpgsig test sig
+         hash=03feb0caccbacce2e7b7bca67f4c82292dd487e669ed8a813120c9f82d3fd0801420a1f5d05e1393abfe4e9fc662399ec4a9a1898c5f1e547e0044a52bd4bd29
+
+        initial
+        ");
+        insta::assert_snapshot!(str::from_utf8(&sig.sig)?, @"
+        test sig
+        hash=03feb0caccbacce2e7b7bca67f4c82292dd487e669ed8a813120c9f82d3fd0801420a1f5d05e1393abfe4e9fc662399ec4a9a1898c5f1e547e0044a52bd4bd29
+        ");
+        insta::assert_snapshot!(str::from_utf8(&sig.data)?, @"
+        tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904
+        author Someone <someone@example.com> 0 +0000
+        committer Someone <someone@example.com> 0 +0000
+        change-id xpxpxpxpxpxpxpxpxpxpxpxpxpxpxpxp
+
+        initial
+        ");
+        Ok(())
+    }
+
+    #[test]
+    fn write_signed_commit_sha256() -> TestResult {
+        let (obj, sig) = write_signed_commit(gix::hash::Kind::Sha256)?;
+        insta::assert_snapshot!(&obj, @"
+        tree 6ef19b41225c5369f1c104d45d8d85efa9b057b53b14b4b9b939dd74decc5321
+        author Someone <someone@example.com> 0 +0000
+        committer Someone <someone@example.com> 0 +0000
+        change-id xpxpxpxpxpxpxpxpxpxpxpxpxpxpxpxp
+        gpgsig test sig
+         hash=d6219e8e5169d409d115848dea4556b3accc76f3cd8dc9b128cc3fe9f71adae275f0e6ce9f98c581a89b960863b61c61b6479cdc20806009d63aecaaa82f4590
+
+        initial
+        ");
+        insta::assert_snapshot!(str::from_utf8(&sig.sig)?, @"
+        test sig
+        hash=d6219e8e5169d409d115848dea4556b3accc76f3cd8dc9b128cc3fe9f71adae275f0e6ce9f98c581a89b960863b61c61b6479cdc20806009d63aecaaa82f4590
+        ");
+        insta::assert_snapshot!(str::from_utf8(&sig.data)?, @"
+        tree 6ef19b41225c5369f1c104d45d8d85efa9b057b53b14b4b9b939dd74decc5321
+        author Someone <someone@example.com> 0 +0000
+        committer Someone <someone@example.com> 0 +0000
+        change-id xpxpxpxpxpxpxpxpxpxpxpxpxpxpxpxp
+
+        initial
+        ");
+        Ok(())
+    }
+
+    fn write_signed_commit(object_hash: gix::hash::Kind) -> TestResult<(String, SecureSig)> {
         let settings = user_settings();
         let temp_dir = new_temp_dir();
-        let backend = GitBackend::init_internal(&settings, temp_dir.path(), gix::hash::Kind::Sha1)?;
+        let backend = GitBackend::init_internal(&settings, temp_dir.path(), object_hash)?;
 
         let commit = Commit {
             parents: vec![backend.root_commit_id().clone()],
@@ -2401,40 +2484,15 @@ mod tests {
         let (id, commit) = backend
             .write_commit(commit, Some(&mut signer as &mut SigningFn))
             .block_on()?;
-
-        let git_repo = backend.git_repo();
-        let obj = git_repo.find_object(gix::ObjectId::from_bytes_or_panic(id.as_bytes()))?;
-        insta::assert_snapshot!(str::from_utf8(&obj.data)?, @"
-        tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904
-        author Someone <someone@example.com> 0 +0000
-        committer Someone <someone@example.com> 0 +0000
-        change-id xpxpxpxpxpxpxpxpxpxpxpxpxpxpxpxp
-        gpgsig test sig
-         hash=03feb0caccbacce2e7b7bca67f4c82292dd487e669ed8a813120c9f82d3fd0801420a1f5d05e1393abfe4e9fc662399ec4a9a1898c5f1e547e0044a52bd4bd29
-
-        initial
-        ");
-
         let returned_sig = commit.secure_sig.expect("failed to return the signature");
 
         let commit = backend.read_commit(&id).block_on()?;
-
         let sig = commit.secure_sig.expect("failed to read the signature");
         assert_eq!(&sig, &returned_sig);
 
-        insta::assert_snapshot!(str::from_utf8(&sig.sig)?, @"
-        test sig
-        hash=03feb0caccbacce2e7b7bca67f4c82292dd487e669ed8a813120c9f82d3fd0801420a1f5d05e1393abfe4e9fc662399ec4a9a1898c5f1e547e0044a52bd4bd29
-        ");
-        insta::assert_snapshot!(str::from_utf8(&sig.data)?, @"
-        tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904
-        author Someone <someone@example.com> 0 +0000
-        committer Someone <someone@example.com> 0 +0000
-        change-id xpxpxpxpxpxpxpxpxpxpxpxpxpxpxpxp
-
-        initial
-        ");
-        Ok(())
+        let git_repo = backend.git_repo();
+        let obj = git_repo.find_object(gix::ObjectId::from_bytes_or_panic(id.as_bytes()))?;
+        Ok((String::from_utf8(obj.data.clone())?, sig))
     }
 
     fn git_id(commit_id: &CommitId) -> gix::ObjectId {

--- a/lib/src/git_backend.rs
+++ b/lib/src/git_backend.rs
@@ -94,7 +94,6 @@ use crate::stacked_table::TableSegment as _;
 use crate::stacked_table::TableStore;
 use crate::stacked_table::TableStoreError;
 
-const HASH_LENGTH: usize = 20;
 const CHANGE_ID_LENGTH: usize = 16;
 /// Ref namespace used only for preventing GC.
 const NO_GC_REF_NAMESPACE: &str = "refs/jj/keep/";
@@ -193,13 +192,14 @@ impl GitBackend {
         extra_metadata_store: TableStore,
         git_settings: GitSettings,
     ) -> Self {
-        let repo = Mutex::new(base_repo.to_thread_local());
-        let root_commit_id = CommitId::from_bytes(&[0; HASH_LENGTH]);
+        let repo = base_repo.to_thread_local();
+        let root_commit_id = CommitId::from_bytes(repo.object_hash().null_ref().as_bytes());
         let root_change_id = ChangeId::from_bytes(&[0; CHANGE_ID_LENGTH]);
-        let empty_tree_id = TreeId::from_hex("4b825dc642cb6eb9a060e54bf8d69288fbee4904");
+        let empty_tree_id =
+            TreeId::from_bytes(gix::ObjectId::empty_tree(repo.object_hash()).as_bytes());
         Self {
             base_repo,
-            repo,
+            repo: Mutex::new(repo),
             root_commit_id,
             root_change_id,
             empty_tree_id,
@@ -303,7 +303,10 @@ impl GitBackend {
         fs::write(&target_path, git_repo_path_bytes)
             .context(&target_path)
             .map_err(GitBackendInitError::Path)?;
-        let extra_metadata_store = TableStore::init(extra_path, HASH_LENGTH);
+        let extra_metadata_store = TableStore::init(
+            extra_path,
+            repo.to_thread_local().object_hash().len_in_bytes(),
+        );
         Ok(Self::new(repo, extra_metadata_store, git_settings))
     }
 
@@ -328,7 +331,10 @@ impl GitBackend {
             gix_open_opts_from_settings(settings),
         )
         .map_err(GitBackendLoadError::OpenRepository)?;
-        let extra_metadata_store = TableStore::load(store_path.join("extra"), HASH_LENGTH);
+        let extra_metadata_store = TableStore::load(
+            store_path.join("extra"),
+            repo.to_thread_local().object_hash().len_in_bytes(),
+        );
         let git_settings =
             GitSettings::from_settings(settings).map_err(GitBackendLoadError::Config)?;
         Ok(Self::new(repo, extra_metadata_store, git_settings))
@@ -453,8 +459,8 @@ impl GitBackend {
     }
 
     fn read_file_sync(&self, id: &FileId) -> BackendResult<Vec<u8>> {
-        let git_blob_id = validate_git_object_id(id)?;
         let locked_repo = self.lock_git_repo();
+        let git_blob_id = validate_git_object_id(&locked_repo, id)?;
         let mut blob = locked_repo
             .find_object(git_blob_id)
             .map_err(|err| map_not_found_err(err, id))?
@@ -498,7 +504,7 @@ impl GitBackend {
         let tree = self.read_commit(id).block_on()?.root_tree;
         // TODO(kfm): probably want to do something here if it is a merge
         let tree_id = tree.first().clone();
-        let gix_id = validate_git_object_id(&tree_id)?;
+        let gix_id = validate_git_object_id(repo, &tree_id)?;
         repo.find_object(gix_id)
             .map_err(|err| map_not_found_err(err, &tree_id))?
             .try_into_tree()
@@ -596,10 +602,11 @@ fn extract_root_tree_from_commit(commit: &gix::objs::CommitRef) -> Result<Merge<
         return Ok(Merge::resolved(tree_id));
     };
 
+    let hash_len = commit.tree().kind().len_in_bytes();
     let mut tree_ids = SmallVec::new();
     for hex in value.split(|b| *b == b' ') {
         let tree_id = TreeId::try_from_hex(hex).ok_or(())?;
-        if tree_id.as_bytes().len() != HASH_LENGTH {
+        if tree_id.as_bytes().len() != hash_len {
             return Err(());
         }
         tree_ids.push(tree_id);
@@ -666,7 +673,7 @@ fn commit_from_git_without_root_parent(
         .iter()
         // gix does not recognize gpgsig-sha256, but prevent future footguns by checking for it too
         .any(|(k, _)| *k == "gpgsig" || *k == "gpgsig-sha256")
-        .then(|| CommitRefIter::signature(&git_object.data, gix::hash::Kind::Sha1))
+        .then(|| CommitRefIter::signature(&git_object.data, git_object.id.kind()))
         .transpose()
         .map_err(decode_err)?
         .flatten()
@@ -709,7 +716,7 @@ pub fn synthetic_change_id_from_git_commit_id(id: &CommitId) -> ChangeId {
     // have been enough to pick the last 16 bytes instead of the leading 16
     // bytes to address that. We also reverse the bits to make it less likely
     // that users depend on any relationship between the two ids.
-    let bytes = id.as_bytes()[4..HASH_LENGTH]
+    let bytes = id.as_bytes()[id.as_bytes().len() - CHANGE_ID_LENGTH..]
         .iter()
         .rev()
         .map(|b| b.reverse_bits())
@@ -924,16 +931,20 @@ fn run_git_gc(program: &OsStr, git_dir: &Path, keep_newer: SystemTime) -> Result
     Ok(())
 }
 
-fn validate_git_object_id(id: &impl ObjectId) -> BackendResult<gix::ObjectId> {
-    if id.as_bytes().len() != HASH_LENGTH {
-        return Err(BackendError::InvalidHashLength {
-            expected: HASH_LENGTH,
+fn validate_git_object_id(
+    repo: &gix::Repository,
+    id: &impl ObjectId,
+) -> BackendResult<gix::ObjectId> {
+    let expected_kind = repo.object_hash();
+    match gix::ObjectId::try_from(id.as_bytes()) {
+        Ok(id) if id.kind() == expected_kind => Ok(id),
+        _ => Err(BackendError::InvalidHashLength {
+            expected: expected_kind.len_in_bytes(),
             actual: id.as_bytes().len(),
             object_type: id.object_type(),
             hash: id.hex(),
-        });
+        }),
     }
-    Ok(gix::ObjectId::from_bytes_or_panic(id.as_bytes()))
 }
 
 fn map_not_found_err(err: gix::object::find::existing::Error, id: &impl ObjectId) -> BackendError {
@@ -981,7 +992,7 @@ fn import_extra_metadata_entries_from_heads(
         .collect_vec();
     while let Some(id) = work_ids.pop() {
         let git_object = git_repo
-            .find_object(validate_git_object_id(&id)?)
+            .find_object(validate_git_object_id(git_repo, &id)?)
             .map_err(|err| map_not_found_err(err, &id))?;
         let is_shallow = shallow_roots.contains(&id);
         // TODO(#1624): Should we read the root tree here and check if it has a
@@ -1014,7 +1025,7 @@ impl Backend for GitBackend {
     }
 
     fn commit_id_length(&self) -> usize {
-        HASH_LENGTH
+        self.base_repo.objects.object_hash().len_in_bytes()
     }
 
     fn change_id_length(&self) -> usize {
@@ -1059,8 +1070,8 @@ impl Backend for GitBackend {
     }
 
     async fn read_symlink(&self, _path: &RepoPath, id: &SymlinkId) -> BackendResult<String> {
-        let git_blob_id = validate_git_object_id(id)?;
         let locked_repo = self.lock_git_repo();
+        let git_blob_id = validate_git_object_id(&locked_repo, id)?;
         let mut blob = locked_repo
             .find_object(git_blob_id)
             .map_err(|err| map_not_found_err(err, id))?
@@ -1098,9 +1109,9 @@ impl Backend for GitBackend {
         if id == &self.empty_tree_id {
             return Ok(Tree::default());
         }
-        let git_tree_id = validate_git_object_id(id)?;
 
         let locked_repo = self.lock_git_repo();
+        let git_tree_id = validate_git_object_id(&locked_repo, id)?;
         let git_tree = locked_repo
             .find_object(git_tree_id)
             .map_err(|err| map_not_found_err(err, id))?
@@ -1218,10 +1229,10 @@ impl Backend for GitBackend {
                 self.empty_tree_id.clone(),
             ));
         }
-        let git_commit_id = validate_git_object_id(id)?;
 
         let mut commit = {
             let locked_repo = self.lock_git_repo();
+            let git_commit_id = validate_git_object_id(&locked_repo, id)?;
             let git_object = locked_repo
                 .find_object(git_commit_id)
                 .map_err(|err| map_not_found_err(err, id))?;
@@ -1259,7 +1270,7 @@ impl Backend for GitBackend {
         let locked_repo = self.lock_git_repo();
         let tree_ids = &contents.root_tree;
         let git_tree_id = match tree_ids.as_resolved() {
-            Some(tree_id) => validate_git_object_id(tree_id)?,
+            Some(tree_id) => validate_git_object_id(&locked_repo, tree_id)?,
             None => write_tree_conflict(&locked_repo, tree_ids)?,
         };
         let author = signature_to_git(&contents.author);
@@ -1285,7 +1296,7 @@ impl Backend for GitBackend {
                     ));
                 }
             } else {
-                parents.push(validate_git_object_id(parent_id)?);
+                parents.push(validate_git_object_id(&locked_repo, parent_id)?);
             }
         }
         let mut extra_headers: Vec<(BString, BString)> = vec![];
@@ -1794,7 +1805,7 @@ mod tests {
             email: GIT_EMAIL.into(),
             time: gix::date::Time::now_utc(),
         };
-        let empty_tree_id = gix::ObjectId::from_hex(b"4b825dc642cb6eb9a060e54bf8d69288fbee4904")?;
+        let empty_tree_id = gix::ObjectId::empty_tree(git_repo.object_hash());
         let git_commit_id = git_repo.commit_as(
             signature.to_ref(&mut TimeBuf::default()),
             signature.to_ref(&mut TimeBuf::default()),
@@ -1837,7 +1848,7 @@ mod tests {
             email: GIT_EMAIL.into(),
             time: gix::date::Time::now_utc(),
         };
-        let empty_tree_id = gix::ObjectId::from_hex(b"4b825dc642cb6eb9a060e54bf8d69288fbee4904")?;
+        let empty_tree_id = gix::ObjectId::empty_tree(git_repo.object_hash());
 
         let secure_sig =
             "here are some ASCII bytes to be used as a test signature\n\ndefinitely not PGP\n";
@@ -2292,7 +2303,7 @@ mod tests {
             email: GIT_EMAIL.into(),
             time: gix::date::Time::now_utc(),
         };
-        let empty_tree_id = gix::ObjectId::from_hex(b"4b825dc642cb6eb9a060e54bf8d69288fbee4904")?;
+        let empty_tree_id = gix::ObjectId::empty_tree(git_repo.object_hash());
         let git_commit_id = git_repo
             .commit_as(
                 signature.to_ref(&mut TimeBuf::default()),

--- a/lib/src/workspace.rs
+++ b/lib/src/workspace.rs
@@ -207,10 +207,13 @@ impl Workspace {
     pub async fn init_internal_git(
         user_settings: &UserSettings,
         workspace_root: &Path,
+        object_hash: gix::hash::Kind,
     ) -> Result<(Self, Arc<ReadonlyRepo>), WorkspaceInitError> {
         let backend_initializer: &BackendInitializer = &|settings, store_path| {
             Ok(Box::new(crate::git_backend::GitBackend::init_internal(
-                settings, store_path,
+                settings,
+                store_path,
+                object_hash,
             )?))
         };
         let signer = Signer::from_settings(user_settings)?;
@@ -223,6 +226,7 @@ impl Workspace {
     pub async fn init_colocated_git(
         user_settings: &UserSettings,
         workspace_root: &Path,
+        object_hash: gix::hash::Kind,
     ) -> Result<(Self, Arc<ReadonlyRepo>), WorkspaceInitError> {
         let backend_initializer = |settings: &UserSettings,
                                    store_path: &Path|
@@ -240,6 +244,7 @@ impl Workspace {
                 settings,
                 store_path,
                 &store_relative_workspace_root,
+                object_hash,
             )?;
             Ok(Box::new(backend))
         };

--- a/lib/tests/test_init.rs
+++ b/lib/tests/test_init.rs
@@ -52,13 +52,14 @@ fn test_init_local() -> TestResult {
     Ok(())
 }
 
-#[test]
-fn test_init_internal_git() -> TestResult {
+#[test_case(gix::hash::Kind::Sha1 ; "sha1")]
+#[test_case(gix::hash::Kind::Sha256; "sha256")]
+fn test_init_internal_git(object_hash: gix::hash::Kind) -> TestResult {
     let settings = testutils::user_settings();
     let temp_dir = testutils::new_temp_dir();
     let (canonical, uncanonical) = canonicalize(temp_dir.path());
     let (workspace, repo) =
-        Workspace::init_internal_git(&settings, &uncanonical, gix::hash::Kind::Sha1).block_on()?;
+        Workspace::init_internal_git(&settings, &uncanonical, object_hash).block_on()?;
     let git_backend: &GitBackend = repo.store().backend_impl().unwrap();
     let repo_path = canonical.join(".jj").join("repo");
     assert_eq!(workspace.workspace_root(), &canonical);
@@ -78,13 +79,14 @@ fn test_init_internal_git() -> TestResult {
     Ok(())
 }
 
-#[test]
-fn test_init_colocated_git() -> TestResult {
+#[test_case(gix::hash::Kind::Sha1 ; "sha1")]
+#[test_case(gix::hash::Kind::Sha256; "sha256")]
+fn test_init_colocated_git(object_hash: gix::hash::Kind) -> TestResult {
     let settings = testutils::user_settings();
     let temp_dir = testutils::new_temp_dir();
     let (canonical, uncanonical) = canonicalize(temp_dir.path());
     let (workspace, repo) =
-        Workspace::init_colocated_git(&settings, &uncanonical, gix::hash::Kind::Sha1).block_on()?;
+        Workspace::init_colocated_git(&settings, &uncanonical, object_hash).block_on()?;
     let git_backend: &GitBackend = repo.store().backend_impl().unwrap();
     let repo_path = canonical.join(".jj").join("repo");
     assert_eq!(workspace.workspace_root(), &canonical);

--- a/lib/tests/test_init.rs
+++ b/lib/tests/test_init.rs
@@ -57,7 +57,8 @@ fn test_init_internal_git() -> TestResult {
     let settings = testutils::user_settings();
     let temp_dir = testutils::new_temp_dir();
     let (canonical, uncanonical) = canonicalize(temp_dir.path());
-    let (workspace, repo) = Workspace::init_internal_git(&settings, &uncanonical).block_on()?;
+    let (workspace, repo) =
+        Workspace::init_internal_git(&settings, &uncanonical, gix::hash::Kind::Sha1).block_on()?;
     let git_backend: &GitBackend = repo.store().backend_impl().unwrap();
     let repo_path = canonical.join(".jj").join("repo");
     assert_eq!(workspace.workspace_root(), &canonical);
@@ -82,7 +83,8 @@ fn test_init_colocated_git() -> TestResult {
     let settings = testutils::user_settings();
     let temp_dir = testutils::new_temp_dir();
     let (canonical, uncanonical) = canonicalize(temp_dir.path());
-    let (workspace, repo) = Workspace::init_colocated_git(&settings, &uncanonical).block_on()?;
+    let (workspace, repo) =
+        Workspace::init_colocated_git(&settings, &uncanonical, gix::hash::Kind::Sha1).block_on()?;
     let git_backend: &GitBackend = repo.store().backend_impl().unwrap();
     let repo_path = canonical.join(".jj").join("repo");
     assert_eq!(workspace.workspace_root(), &canonical);

--- a/lib/testutils/src/lib.rs
+++ b/lib/testutils/src/lib.rs
@@ -247,7 +247,11 @@ impl TestRepoBackend {
         store_path: &Path,
     ) -> Result<Box<dyn Backend>, BackendInitError> {
         match self {
-            Self::Git => Ok(Box::new(GitBackend::init_internal(settings, store_path)?)),
+            Self::Git => Ok(Box::new(GitBackend::init_internal(
+                settings,
+                store_path,
+                gix::hash::Kind::default(),
+            )?)),
             Self::Simple => Ok(Box::new(SimpleBackend::init(store_path))),
             Self::Test => Ok(Box::new(env.test_backend_factory.init(store_path))),
         }


### PR DESCRIPTION
This is mostly a quick first attempt at making sha256 work, I haven't done any serious testing, but the very basics (init with existing sha256 repo, create commit, etc) seem to work so far.
I thought I'd submit it now to maybe get some feedback and input on what still needs to be done.

From what I understand, Gitoxide's sha256 support also isn't feature complete yet, but I honestly have no idea what exactly is relevant and still missing for the JJ use case.

See #3813 

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [x] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), ~~including any code drafted by an LLM.~~
- [ ] ~~For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.~~ 
