### PR TITLE
revset: Add exact count to `exactly()` error message

### DIFF
--- a/lib/src/default_index/revset_engine.rs
+++ b/lib/src/default_index/revset_engine.rs
@@ -1007,20 +1007,20 @@ impl EvaluationContext<'_> {
                     .take(count.saturating_add(1))
                     .try_collect()?;
                 if positions.len() != *count {
-                    // https://github.com/jj-vcs/jj/pull/7252#pullrequestreview-3236259998
-                    // in the default engine we have to evaluate the entire
-                    // revset (which may be very large) to get an exact count;
-                    // we would need to remove .take() above. instead just give
-                    // a vaguely approximate error message
-                    let determiner = if positions.len() > *count {
-                        "more"
+                    let message = if positions.len() > *count {
+                        // https://github.com/jj-vcs/jj/pull/7252#pullrequestreview-3236259998
+                        // In the default engine we have to evaluate the entire
+                        // revset (which may be very large) to get an exact
+                        // count; we would need to remove .take() above. Instead
+                        // just give a vague error message.
+                        format!("The revset has more than the expected {count} revisions")
                     } else {
-                        "fewer"
+                        format!(
+                            "The revset has fewer than the expected {count} revisions (got {})",
+                            positions.len()
+                        )
                     };
-                    return Err(RevsetEvaluationError::Other(
-                        format!("The revset has {determiner} than the expected {count} revisions")
-                            .into(),
-                    ));
+                    return Err(RevsetEvaluationError::Other(message.into()));
                 }
                 Ok(Box::new(EagerRevset { positions }))
             }

--- a/lib/tests/test_revset.rs
+++ b/lib/tests/test_revset.rs
@@ -3426,7 +3426,14 @@ fn test_evaluate_expression_exactly() {
     let commit2 = write_random_commit_with_parents(mut_repo, &[&commit1]);
 
     assert!(try_evaluate_expression(mut_repo, "exactly(none(), 0)").is_ok());
-    assert!(try_evaluate_expression(mut_repo, "exactly(none(), 1)").is_err());
+    assert_matches!(
+        try_evaluate_expression(mut_repo, "exactly(none(), 1)"),
+        Err(RevsetEvaluationError::Other(msg)) if msg.to_string() == "The revset has fewer than the expected 1 revisions (got 0)"
+    );
+    assert_matches!(
+        try_evaluate_expression(mut_repo, "exactly(all(), 0)"),
+        Err(RevsetEvaluationError::Other(msg)) if msg.to_string() == "The revset has more than the expected 0 revisions"
+    );
     assert!(try_evaluate_expression(mut_repo, &format!("exactly({}, 1)", commit1.id())).is_ok());
     assert!(
         try_evaluate_expression(


### PR DESCRIPTION
The tests I added are obviously very long lines, but `rustfmt` and `cargo fmt` did not change it 🤷

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
