### PR TITLE
diff: add new :auto default format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -469,6 +469,10 @@ Thanks to the people who made this release happen!
 * `jj show` now accepts multiple revisions, showing all of them one after the
   other, behaving closer to `git show`.
 
+* The default `ui.diff-formatter` is now `:auto`, which selects `:color-words`
+  when outputting to a terminal and `:git` otherwise. This makes `jj diff`
+  output parseable by scripts and AI agents without requiring `--git`.
+
 * `jj git fetch` now generates evolution history based on change IDs. If change
   IDs are preserved by the remote, local descendant revisions will be rebased
   onto the rewritten parents.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -256,6 +256,10 @@ Thanks to the people who made this release happen!
 * `jj show` now accepts multiple revisions, showing all of them one after the
   other, behaving closer to `git show`.
 
+* The default `ui.diff-formatter` is now `:auto`, which selects `:color-words`
+  when outputting to a terminal and `:git` otherwise. This makes `jj diff`
+  output parseable by scripts and AI agents without requiring `--git`.
+
 * `jj git fetch` now generates evolution history based on change IDs. If change
   IDs are preserved by the remote, local descendant revisions will be rebased
   onto the rewritten parents.

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -210,7 +210,7 @@
                 },
                 "diff-formatter": {
                     "description": "Tool for displaying or generating diffs",
-                    "default": ":color-words",
+                    "default": ":auto",
                     "oneOf": [
                         {
                             "$ref": "#/properties/ui/definitions/command"

--- a/cli/src/config/misc.toml
+++ b/cli/src/config/misc.toml
@@ -33,7 +33,7 @@ track-default-bookmark-on-clone = true
 
 [ui]
 color = "auto"
-diff-formatter = ":color-words"
+diff-formatter = ":auto"
 diff-instructions = true
 graph.style = "curved"
 pager = { command = ["less", "-FRX"], env = { LESSCHARSET = "utf-8" } }

--- a/cli/src/config/misc.toml
+++ b/cli/src/config/misc.toml
@@ -33,7 +33,7 @@ track-default-bookmark-on-clone = true
 
 [ui]
 color = "auto"
-diff-formatter = ":color-words"
+diff-formatter = ":auto"
 diff-instructions = true
 graph.style = "curved"
 pager = { command = ["less", "-FRXK"], env = { LESSCHARSET = "utf-8" } }

--- a/cli/src/diff_util.rs
+++ b/cli/src/diff_util.rs
@@ -16,7 +16,8 @@ use std::borrow::Cow;
 use std::cmp::max;
 use std::cmp::min;
 use std::future;
-use std::io;
+use std::io::IsTerminal as _;
+use std::io::{self};
 use std::iter;
 use std::ops::Range;
 use std::path::Path;
@@ -180,6 +181,7 @@ enum BuiltinFormatKind {
     NameOnly,
     Git,
     ColorWords,
+    Auto,
 }
 
 impl BuiltinFormatKind {
@@ -193,6 +195,7 @@ impl BuiltinFormatKind {
         Self::NameOnly,
         Self::Git,
         Self::ColorWords,
+        Self::Auto,
     ];
 
     fn from_name(name: &str) -> Result<Self, String> {
@@ -203,6 +206,7 @@ impl BuiltinFormatKind {
             "name-only" => Ok(Self::NameOnly),
             "git" => Ok(Self::Git),
             "color-words" => Ok(Self::ColorWords),
+            "auto" => Ok(Self::Auto),
             _ => Err(format!("Invalid builtin diff format: {name}")),
         }
     }
@@ -234,7 +238,7 @@ impl BuiltinFormatKind {
     fn is_short(self) -> bool {
         match self {
             Self::Summary | Self::Stat | Self::Types | Self::NameOnly => true,
-            Self::Git | Self::ColorWords => false,
+            Self::Git | Self::ColorWords | Self::Auto => false,
         }
     }
 
@@ -246,6 +250,7 @@ impl BuiltinFormatKind {
             Self::NameOnly => "name-only",
             Self::Git => "git",
             Self::ColorWords => "color-words",
+            Self::Auto => "auto",
         }
     }
 
@@ -272,6 +277,14 @@ impl BuiltinFormatKind {
                 let mut options = ColorWordsDiffOptions::from_settings(settings)?;
                 options.merge_args(args);
                 Ok(DiffFormat::ColorWords(Box::new(options)))
+            }
+            Self::Auto => {
+                let kind = if std::io::stdout().is_terminal() {
+                    Self::ColorWords
+                } else {
+                    Self::Git
+                };
+                kind.to_format(settings, args)
             }
         }
     }

--- a/cli/src/diff_util.rs
+++ b/cli/src/diff_util.rs
@@ -16,7 +16,8 @@ use std::borrow::Cow;
 use std::cmp::max;
 use std::cmp::min;
 use std::future;
-use std::io;
+use std::io::IsTerminal as _;
+use std::io::{self};
 use std::iter;
 use std::ops::Range;
 use std::path::Path;
@@ -181,6 +182,7 @@ enum BuiltinFormatKind {
     NameOnly,
     Git,
     ColorWords,
+    Auto,
 }
 
 impl BuiltinFormatKind {
@@ -194,6 +196,7 @@ impl BuiltinFormatKind {
         Self::NameOnly,
         Self::Git,
         Self::ColorWords,
+        Self::Auto,
     ];
 
     fn from_name(name: &str) -> Result<Self, String> {
@@ -204,6 +207,7 @@ impl BuiltinFormatKind {
             "name-only" => Ok(Self::NameOnly),
             "git" => Ok(Self::Git),
             "color-words" => Ok(Self::ColorWords),
+            "auto" => Ok(Self::Auto),
             _ => Err(format!("Invalid builtin diff format: {name}")),
         }
     }
@@ -235,7 +239,7 @@ impl BuiltinFormatKind {
     fn is_short(self) -> bool {
         match self {
             Self::Summary | Self::Stat | Self::Types | Self::NameOnly => true,
-            Self::Git | Self::ColorWords => false,
+            Self::Git | Self::ColorWords | Self::Auto => false,
         }
     }
 
@@ -247,6 +251,7 @@ impl BuiltinFormatKind {
             Self::NameOnly => "name-only",
             Self::Git => "git",
             Self::ColorWords => "color-words",
+            Self::Auto => "auto",
         }
     }
 
@@ -273,6 +278,14 @@ impl BuiltinFormatKind {
                 let mut options = ColorWordsDiffOptions::from_settings(settings)?;
                 options.merge_args(args);
                 Ok(DiffFormat::ColorWords(Box::new(options)))
+            }
+            Self::Auto => {
+                let kind = if std::io::stdout().is_terminal() {
+                    Self::ColorWords
+                } else {
+                    Self::Git
+                };
+                kind.to_format(settings, args)
             }
         }
     }

--- a/cli/tests/common/test_environment.rs
+++ b/cli/tests/common/test_environment.rs
@@ -81,6 +81,11 @@ impl Default for TestEnvironment {
 
 [git]
 colocate = false
+
+[ui]
+# Pin to color-words in tests so snapshots are stable regardless of tty.
+# The default :auto would select :git in non-tty test runners.
+diff-formatter = ":color-words"
         "#,
         );
 

--- a/cli/tests/test_completion.rs
+++ b/cli/tests/test_completion.rs
@@ -1473,9 +1473,10 @@ fn test_config_unset() {
     // Only config options set in TestEnvironment are suggested initially + other
     // viable flags
     let output = test_env.complete_fish(["config", "unset", ""]);
-    insta::assert_snapshot!(output.take_stdout_n_lines(5), @r#"
+    insta::assert_snapshot!(output.take_stdout_n_lines(6), @r#"
     template-aliases."format_time_range(time_range)"	user: 'time_range.start() ++ " - " ++ time_range.end()'
     git.colocate	user: false
+    ui.diff-formatter	user: ":color-words"
     --user	Target the user-level config
     --repo	Target the repo-level config
     --workspace	Target the workspace-level config
@@ -1549,6 +1550,7 @@ fn test_config_unset() {
     // If a config source has already been specified, only its options as completed
     let output = repo_dir.complete_fish(["config", "unset", "--user", "ui"]);
     insta::assert_snapshot!(output, @r#"
+    ui.diff-formatter	user: ":color-words"
     ui.editor	user: "nvim"
     ui.default-command	user: ["log", "--stat"]
     [EOF]
@@ -1647,6 +1649,7 @@ fn test_merge_tools() {
     :name-only
     :git
     :color-words
+    :auto
     diffedit3
     diffedit3-ssh
     difft

--- a/cli/tests/test_config_command.rs
+++ b/cli/tests/test_config_command.rs
@@ -675,6 +675,11 @@ fn test_config_set_for_user_directory() -> TestResult {
 
     [git]
     colocate = false
+
+    [ui]
+    # Pin to color-words in tests so snapshots are stable regardless of tty.
+    # The default :auto would select :git in non-tty test runners.
+    diff-formatter = ":color-words"
     "#);
 
     // Add one more config file to the directory
@@ -701,6 +706,11 @@ fn test_config_set_for_user_directory() -> TestResult {
 
     [git]
     colocate = false
+
+    [ui]
+    # Pin to color-words in tests so snapshots are stable regardless of tty.
+    # The default :auto would select :git in non-tty test runners.
+    diff-formatter = ":color-words"
     "#);
 
     insta::assert_snapshot!(

--- a/cli/tests/test_config_command.rs
+++ b/cli/tests/test_config_command.rs
@@ -675,6 +675,11 @@ fn test_config_set_for_user_directory() -> TestResult {
 
     [git]
     colocate = false
+
+    [ui]
+    # Pin to color-words in tests so snapshots are stable regardless of tty.
+    # The default :auto would select :git in non-tty test runners.
+    diff-formatter = ":color-words"
     "#);
 
     // Add one more config file to the directory
@@ -695,6 +700,11 @@ fn test_config_set_for_user_directory() -> TestResult {
 
     [git]
     colocate = false
+
+    [ui]
+    # Pin to color-words in tests so snapshots are stable regardless of tty.
+    # The default :auto would select :git in non-tty test runners.
+    diff-formatter = ":color-words"
     "#);
 
     insta::assert_snapshot!(

--- a/docs/config.md
+++ b/docs/config.md
@@ -427,11 +427,15 @@ Colors and styles can be configured differently for each diff format:
 
 ```toml
 [ui]
-# Builtin formats: ":color-words" (default), ":git",
-#                  ":summary", ":stat", ":types", ":name-only"
+# Builtin formats: ":auto" (default, chooses color-words or git based on tty),
+#                  ":color-words", ":git", ":summary", ":stat", ":types", ":name-only"
 # or external command name and arguments (see below)
 diff-formatter = ":git"
 ```
+
+The special value `":auto"` (the default) selects `":color-words"` when the output is
+a terminal (for human readers), and `":git"` otherwise (for scripts and agents, as
+the output is plain-text parsable with `+`/`-` markers).
 
 #### Color-words diff options
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -428,11 +428,15 @@ Colors and styles can be configured differently for each diff format:
 
 ```toml
 [ui]
-# Builtin formats: ":color-words" (default), ":git",
-#                  ":summary", ":stat", ":types", ":name-only"
+# Builtin formats: ":auto" (default, chooses color-words or git based on tty),
+#                  ":color-words", ":git", ":summary", ":stat", ":types", ":name-only"
 # or external command name and arguments (see below)
 diff-formatter = ":git"
 ```
+
+The special value `":auto"` (the default) selects `":color-words"` when the output is
+a terminal (for human readers), and `":git"` otherwise (for scripts and agents, as
+the output is plain-text parsable with `+`/`-` markers).
 
 #### Color-words diff options
 


### PR DESCRIPTION
Hello!

I keep experiencing issues where AI agents get confused on the default `jj diff` output---e.g., they think I added something that was actually removed---and I have to repeatedly tell them to use the `--git` flag to see the actual diff. Pretty sure that this is because some information is lost when the colors can't render, but it could also just be because agents are less familiar with the non-git format

In any case, this PR adds a new `:auto` formatter that will output `:color-words` if it detects a tty and falls back to the `:git` if not


 
Thanks!

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [x] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
