### PR TITLE
Fix workspace name quoting in shell autocompletion

### DIFF
--- a/cli/src/complete.rs
+++ b/cli/src/complete.rs
@@ -541,7 +541,7 @@ pub fn operations() -> Vec<CompletionCandidate> {
 
 pub fn workspaces() -> Vec<CompletionCandidate> {
     let template = indoc! {r#"
-        name ++ "\t" ++ if(
+        name.substr(0) ++ "\t" ++ if(
             target.description(),
             target.description().first_line(),
             "(no description set)"


### PR DESCRIPTION
**Before**:

Autocomplete for `jj workspace forget` wraps workspace names in extra quoted quotes, when we run the autocompleted command, jj fails to find the workspace as the quotes change the meaning, which means the command does not work as expected.

Example: `jj workspace forget \"workspace:name\"`

**After**:

Autocomplete no longer wraps workspace name in quotes, so autocompleted command works as expected and it is removed.

Example: `jj workspace forget workspace:name`

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
