### PR TITLE
revsets: extract default log revset to `builtin_log()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * `jj run` gained a `--ignore-errors` flag to continue running against the
   remaining revisions even if the command exits with a nonzero exit code.
 
+* Added `builtin_log()` revset alias for the built-in default `jj log` revset.
+  `revsets.log` now defaults to `builtin_log()`, so custom log revsets can
+  reuse the built-in default instead of copying its full expression.
+
 ### Fixed bugs
 
 * Recursive alias definitions are detected more precisely. jj can now expand

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -714,7 +714,7 @@
                 "log": {
                     "type": "string",
                     "description": "Default set of revisions to show when no explicit revset is given for jj log and similar commands",
-                    "default": "present(@) | ancestors(immutable_heads().., 2) | trunk()"
+                    "default": "builtin_log()"
                 },
                 "short-prefixes": {
                     "type": "string",

--- a/cli/src/config/revsets.toml
+++ b/cli/src/config/revsets.toml
@@ -9,7 +9,7 @@ simplify-parents = "reachable(@, mutable())"
 # log revset is also used as the default short-prefixes. If it failed to
 # evaluate, lengthy warning messages would be printed. Use present(expr) if
 # symbols in expr might not always exist.
-log = "present(@) | ancestors(immutable_heads().., 2) | trunk()"
+log = "builtin_log()"
 # Emit the working-copy branch first, which is usually most interesting.
 # This also helps stabilize output order.
 log-graph-prioritize = "present(@)"
@@ -31,6 +31,10 @@ latest(
   root()
 )
 '''
+
+# The default set of revisions shown by `jj log` if no revisions or paths are
+# specified.
+'builtin_log()' = 'present(@) | ancestors(immutable_heads().., 2) | trunk()'
 
 # If immutable_heads() failed to evaluate, many jj commands wouldn't work. Use
 # present(expr) if symbols in expr might not always exist.

--- a/cli/tests/test_log_command.rs
+++ b/cli/tests/test_log_command.rs
@@ -1166,6 +1166,15 @@ fn test_default_revset() {
     work_dir.write_file("file1", "foo\n");
     work_dir.run_jj(["describe", "-m", "add a file"]).success();
 
+    // The built-in default log revset can be composed with other revsets.
+    insta::assert_snapshot!(
+        work_dir.run_jj(["log", "-r", "builtin_log() & @", "-T", "description"]), @"
+    @  add a file
+    │
+    ~
+    [EOF]
+    ");
+
     // Set configuration to only show the root commit.
     test_env.add_config(r#"revsets.log = "root()""#);
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -639,8 +639,9 @@ You can configure the revisions `jj log` would show when neither `-r` nor any pa
 log = "main@origin.."
 ```
 
-The default value for `revsets.log` is
-`'present(@) | ancestors(immutable_heads().., 2) | trunk()'`.
+The default value for `revsets.log` is `builtin_log()`, which is defined as
+`'present(@) | ancestors(immutable_heads().., 2) | trunk()'`. You can use
+`builtin_log()` as a starting point for your own custom log revset.
 
 !!! warning
 

--- a/docs/revsets.md
+++ b/docs/revsets.md
@@ -632,6 +632,11 @@ for a comprehensive list.
   'trunk()' = 'your-bookmark@your-remote'
   ```
 
+* `builtin_log()`: Resolves to `present(@) |
+  ancestors(immutable_heads().., 2) | trunk()`. It is used as the default value
+  for `revsets.log`, which is the set of revisions shown by `jj log` if no
+  revisions or paths are specified.
+
 * `builtin_immutable_heads()`: Resolves to `trunk() | tags() |
   untracked_remote_bookmarks()`. It is used as the default definition for
   `immutable_heads()` below. It is not recommended to redefine this


### PR DESCRIPTION
This is a narrower alternative to #4554. Instead of adding a revset function that expands to the currently configured `revsets.log`, this exposes the built-in default log revset as a reusable revset alias.

`revsets.log` now defaults to `builtin_log()`.

`builtin_log()` is defined as the previous built-in default `present(@) | ancestors(immutable_heads().., 2) | trunk()`.

This preserves the existing default behavior while letting users compose with the built-in log revset without copying the full expression, for example:

```sh
jj log -r 'builtin_log() & mine()'
jj log -r 'builtin_log() ~ empty()'
```

This mirrors the existing pattern used by built-in log templates such as `builtin_log_compact`, and by `builtin_immutable_heads()` for extending `immutable_heads()`.

Updates #4554.


<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [X] I have updated `CHANGELOG.md`
- [X] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [X] I have updated the config schema (`cli/src/config-schema.json`)
- [X] I have added/updated tests to cover my changes
- [X] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [X] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
