### PR TITLE
fix(git): reject invalid remote names with whitespace or empty strings (#9099)

### DIFF
--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -150,6 +150,8 @@ pub enum GitRemoteNameError {
     ReservedForLocalGitRepo,
     #[error("Git remotes with slashes are incompatible with jj: {}", .0.as_symbol())]
     WithSlash(RemoteNameBuf),
+    #[error("Git remote name '{}' is invalid: {reason}", name.as_symbol())]
+    InvalidName { name: RemoteNameBuf, reason: String },
 }
 
 fn validate_remote_name(name: &RemoteName) -> Result<(), GitRemoteNameError> {
@@ -157,6 +159,20 @@ fn validate_remote_name(name: &RemoteName) -> Result<(), GitRemoteNameError> {
         Err(GitRemoteNameError::ReservedForLocalGitRepo)
     } else if name.as_str().contains('/') {
         Err(GitRemoteNameError::WithSlash(name.to_owned()))
+    } else if name.as_str().is_empty() {
+        Err(GitRemoteNameError::InvalidName {
+            name: name.to_owned(),
+            reason: String::from("remote name cannot be empty"),
+        })
+    } else if let Some(invalid) = name
+        .as_str()
+        .chars()
+        .find(|c| c.is_ascii_control() || c.is_whitespace())
+    {
+        Err(GitRemoteNameError::InvalidName {
+            name: name.to_owned(),
+            reason: format!("remote name contains invalid character: {invalid:?}"),
+        })
     } else {
         Ok(())
     }

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -55,6 +55,8 @@ use jj_lib::git::GitPushRefTargets;
 use jj_lib::git::GitPushStats;
 use jj_lib::git::GitRefKind;
 use jj_lib::git::GitRefUpdate;
+use jj_lib::git::GitRemoteManagementError;
+use jj_lib::git::GitRemoteNameError;
 use jj_lib::git::GitResetHeadError;
 use jj_lib::git::GitSettings;
 use jj_lib::git::GitSidebandLineTerminator;
@@ -6845,6 +6847,74 @@ fn test_set_remote_urls() -> TestResult {
         remote_name,
         Some("https://example.com/repo/path3"),
         Some("git@example.com:repo/path3"),
+    );
+    Ok(())
+}
+
+#[test]
+fn test_git_add_remote_invalid_name() -> TestResult {
+    let test_repo = TestRepo::init_with_backend(TestRepoBackend::Git);
+    let mut tx = test_repo.repo.start_transaction();
+    let repo_mut = tx.repo_mut();
+
+    // Empty name
+    let result = git::add_remote(
+        repo_mut,
+        "".as_ref(),
+        "https://example.com/repo.git",
+        None,
+        gix::remote::fetch::Tags::None,
+    );
+    assert_matches!(
+        result,
+        Err(GitRemoteManagementError::RemoteName(
+            GitRemoteNameError::InvalidName { .. }
+        ))
+    );
+
+    // Name with space
+    let result = git::add_remote(
+        repo_mut,
+        "foo bar".as_ref(),
+        "https://example.com/repo.git",
+        None,
+        gix::remote::fetch::Tags::None,
+    );
+    assert_matches!(
+        result,
+        Err(GitRemoteManagementError::RemoteName(
+            GitRemoteNameError::InvalidName { .. }
+        ))
+    );
+
+    // Name with tab
+    let result = git::add_remote(
+        repo_mut,
+        "foo\tbar".as_ref(),
+        "https://example.com/repo.git",
+        None,
+        gix::remote::fetch::Tags::None,
+    );
+    assert_matches!(
+        result,
+        Err(GitRemoteManagementError::RemoteName(
+            GitRemoteNameError::InvalidName { .. }
+        ))
+    );
+
+    // Name with newline
+    let result = git::add_remote(
+        repo_mut,
+        "foo\nbar".as_ref(),
+        "https://example.com/repo.git",
+        None,
+        gix::remote::fetch::Tags::None,
+    );
+    assert_matches!(
+        result,
+        Err(GitRemoteManagementError::RemoteName(
+            GitRemoteNameError::InvalidName { .. }
+        ))
     );
     Ok(())
 }


### PR DESCRIPTION
## Description

Adds validation in <code>validate_remote_name()</code> to reject empty remote names and names containing whitespace or ASCII control characters. This prevents panics when <code>jj git remote add</code> is called with invalid names such as <code>''</code>, <code>'  '</code>, or <code>'foo bar'</code>.

### Root Cause

The <code>add_remote()</code> function builds a default fetch refspec of the form <code>+refs/heads/*:refs/remotes/<remote>/*</code> and passes it to <code>gix</code>. When <remote> contains spaces or other invalid bytes, the refspec is malformed, and the subsequent <code>.expect("default refspec to be valid")</code> panics.

### Fix

A new <code>InvalidName</code> variant was added to <code>GitRemoteNameError</code>. <code>validate_remote_name()</code> now checks:
1. The name is not empty
2. The name does not contain ASCII control characters or whitespace characters

This catches all cases reported in the issue: empty string, spaces, tabs, and newlines.

### Tests

Added <code>test_git_add_remote_invalid_name</code> in <code>lib/tests/test_git.rs</code> covering empty names, spaces, tabs, and newlines.

Fixes #9099

## Checklist

- [ ] I have updated CHANGELOG.md
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does, how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with an eye towards deleting anything that is irrelevant, clarifying anything that is confusing, and adding details that are relevant.

## LLM Disclosure

This fix was created with assistance from an LLM (Kimi-k2.6). The LLM analyzed the issue, located the relevant code, proposed the fix, wrote unit tests, and verified the logic. The human operator reviewed all changes before submission.