### PR TITLE
arrange: scroll viewport to keep selection visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   remaining revisions even if the command exits with a nonzero exit code.
 
 ### Fixed bugs
+* `jj arrange` now scrolls the viewport to keep the selected commit visible
+  when the commit stack is taller than the terminal.
+  [#9033](https://github.com/jj-vcs/jj/issues/9033).
 
 * Recursive alias definitions are detected more precisely. jj can now expand
   aliases that are simply repeated. For example, with the alias `jj = []`, the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed bugs
 
+* `jj arrange` now scrolls the viewport to keep the selected commit visible
+  when the commit stack is taller than the terminal.
+  [#9033](https://github.com/jj-vcs/jj/issues/9033).
+
 * The default pager flags now include `-K` (`--quit-on-intr`), so pressing
   Ctrl+C in `less` exits cleanly instead of leaving the terminal in a
   corrupted state (raw mode, visible escape sequences, broken input).

--- a/cli/src/commands/arrange.rs
+++ b/cli/src/commands/arrange.rs
@@ -198,6 +198,10 @@ struct State {
     current_selection: usize,
     external_children: IndexSet<CommitId>,
     external_parents: IndexSet<CommitId>,
+    /// The number of rows to skip from the top of the commit list so the
+    /// selected commit stays visible when the stack is taller than the
+    /// terminal.
+    scroll_top: usize,
 }
 
 impl State {
@@ -257,6 +261,7 @@ impl State {
             current_selection: 0,
             external_children: external_children_ids,
             external_parents,
+            scroll_top: 0,
         };
         state.update_commit_order();
         Ok(state)
@@ -364,6 +369,23 @@ impl State {
         }
         let parent = parent.clone();
         self.swap_commits(&current_id, &parent);
+    }
+
+    /// Adjust scroll position so the current selection remains visible.
+    fn clamp_scroll(&mut self, viewport_rows: u16) {
+        let max_visible = (viewport_rows / 2).max(1) as usize;
+        let total_commits =
+            self.external_children.len() + self.current_order.len() + self.external_parents.len();
+        let selection_pos = self.external_children.len() + self.current_selection;
+
+        if selection_pos < self.scroll_top {
+            self.scroll_top = selection_pos;
+        } else if selection_pos >= self.scroll_top.saturating_add(max_visible) {
+            self.scroll_top = selection_pos.saturating_sub(max_visible - 1);
+        }
+
+        let max_scroll = total_commits.saturating_sub(max_visible);
+        self.scroll_top = self.scroll_top.min(max_scroll);
     }
 
     /// Swap the selected commit with one of its children. Does nothing if there
@@ -493,6 +515,7 @@ fn run_tui<B: ratatui::backend::Backend>(
                     .split(frame.area());
                 let main_area = layout[0];
                 let help_area = layout[1];
+                state.clamp_scroll(main_area.height);
                 render(&state, render_commit, frame.buffer_mut(), main_area);
                 frame.render_widget(&help_line, help_area);
             })
@@ -570,7 +593,8 @@ fn render(
         .external_children
         .iter()
         .chain(state.current_order.iter())
-        .chain(state.external_parents.iter());
+        .chain(state.external_parents.iter())
+        .skip(state.scroll_top);
     for id in commits_to_render {
         // TODO: Make the graph column width depend on what's needed to render the
         // graph.
@@ -642,6 +666,7 @@ fn render(
 
 #[cfg(test)]
 mod tests {
+    use indoc::indoc;
     use maplit::hashset;
     use pollster::FutureExt as _;
     use testutils::CommitBuilderExt as _;
@@ -1292,8 +1317,10 @@ mod tests {
 
     fn render_to_string(state: &State, width: u16, height: u16) -> String {
         let mut buf = Buffer::empty(Rect::new(0, 0, width, height));
+        let mut state = state.clone();
+        state.clamp_scroll(height);
         render(
-            state,
+            &state,
             render_commit,
             &mut buf,
             Rect::new(0, 0, width, height),
@@ -1372,11 +1399,13 @@ mod tests {
         };
         let commit_a = create_commit(
             vec![store.root_commit_id().clone()],
-            "commit A line 1
-commit A line 2
-commit A line 3
-commit A line 4
-commit A line 5",
+            indoc! {"
+                commit A line 1
+                commit A line 2
+                commit A line 3
+                commit A line 4
+                commit A line 5
+            "},
         );
 
         let state = State::new(vec![commit_a.clone()], vec![]).block_on()?;
@@ -1475,20 +1504,126 @@ commit A line 5",
         )
         .block_on()?;
         state.current_selection = 5;
-        // TODO: Show at least the part that includes the selection
+        state.clamp_scroll(10);
         insta::assert_snapshot!(render_to_string(&state, 80, 10), @"
-        ○         keep      commit G
-        │
-        ○         keep      commit F
-        │
-        ○         keep      commit E
-        │
-        ○         keep      commit D
-        │
-        ○         keep      commit C
-        │
+          ○         keep      commit F
+          │
+          ○         keep      commit E
+          │
+          ○         keep      commit D
+          │
+          ○         keep      commit C
+          │
+        ▶ ○         keep      commit B
+          │
         ");
 
+        Ok(())
+    }
+
+    #[test]
+    fn test_render_scrolls_viewport_to_keep_selection_visible() -> TestResult {
+        let test_repo = TestRepo::init();
+        let store = test_repo.repo.store();
+        let empty_tree = store.empty_merged_tree();
+
+        let mut tx = test_repo.repo.start_transaction();
+        let mut create_commit = |parents, description: &str| {
+            tx.repo_mut()
+                .new_commit(parents, empty_tree.clone())
+                .set_description(description)
+                .write_unwrap()
+        };
+        let commit_a = create_commit(vec![store.root_commit_id().clone()], "commit A");
+        let commit_b = create_commit(vec![commit_a.id().clone()], "commit B");
+        let commit_c = create_commit(vec![commit_b.id().clone()], "commit C");
+        let commit_d = create_commit(vec![commit_c.id().clone()], "commit D");
+        let commit_e = create_commit(vec![commit_d.id().clone()], "commit E");
+        let commit_f = create_commit(vec![commit_e.id().clone()], "commit F");
+        let commit_g = create_commit(vec![commit_f.id().clone()], "commit G");
+
+        let mut state = State::new(
+            vec![
+                commit_a.clone(),
+                commit_b.clone(),
+                commit_c.clone(),
+                commit_d.clone(),
+                commit_e.clone(),
+                commit_f.clone(),
+                commit_g.clone(),
+            ],
+            vec![],
+        )
+        .block_on()?;
+
+        // Viewport can only show 5 commits; selection starts at top.
+        state.current_selection = 0;
+        state.clamp_scroll(10);
+        insta::assert_snapshot!(render_to_string(&state, 80, 10), @"
+        ▶ ○         keep      commit G
+          │
+          ○         keep      commit F
+          │
+          ○         keep      commit E
+          │
+          ○         keep      commit D
+          │
+          ○         keep      commit C
+          │
+        ");
+
+        // Move selection to a commit that would fall below the viewport.
+        state.current_selection = 6;
+        state.clamp_scroll(10);
+        insta::assert_snapshot!(render_to_string(&state, 80, 10), @"
+          ○         keep      commit E
+          │
+          ○         keep      commit D
+          │
+          ○         keep      commit C
+          │
+          ○         keep      commit B
+          │
+        ▶ ○         keep      commit A
+          │
+        ");
+
+        Ok(())
+    }
+
+    /// Regression test for terminal resize. The original scrolling
+    /// implementation only reclamped after state-changing input, which left the
+    /// selected commit outside a smaller viewport.
+    #[test]
+    fn test_scroll_keeps_selection_visible_after_viewport_shrinks() -> TestResult {
+        let test_repo = TestRepo::init();
+        let store = test_repo.repo.store();
+        let empty_tree = store.empty_merged_tree();
+
+        let mut tx = test_repo.repo.start_transaction();
+        let mut create_commit = |parents, description: &str| {
+            tx.repo_mut()
+                .new_commit(parents, empty_tree.clone())
+                .set_description(description)
+                .write_unwrap()
+        };
+        let commit_a = create_commit(vec![store.root_commit_id().clone()], "commit A");
+        let commit_b = create_commit(vec![commit_a.id().clone()], "commit B");
+        let commit_c = create_commit(vec![commit_b.id().clone()], "commit C");
+
+        // Model a resize between input events: the scroll position was computed
+        // when all three commits fit, but the next draw has only four rows. No
+        // navigation event occurs to clamp it again.
+        let mut state = State::new(vec![commit_a, commit_b, commit_c], vec![]).block_on()?;
+        state.current_selection = 2;
+        state.clamp_scroll(6);
+
+        insta::assert_snapshot!(render_to_string(&state, 80, 4), @"
+          ○         keep      commit B
+          │
+        ▶ ○         keep      commit A
+          │
+        ");
         Ok(())
     }
 

--- a/cli/src/commands/arrange.rs
+++ b/cli/src/commands/arrange.rs
@@ -198,6 +198,9 @@ struct State {
     current_selection: usize,
     external_children: IndexSet<CommitId>,
     external_parents: IndexSet<CommitId>,
+    /// The number of commits to skip from the top of the rendered list to keep
+    /// the selection within the estimated viewport.
+    scroll_top: usize,
 }
 
 impl State {
@@ -257,6 +260,7 @@ impl State {
             current_selection: 0,
             external_children: external_children_ids,
             external_parents,
+            scroll_top: 0,
         };
         state.update_commit_order();
         Ok(state)
@@ -364,6 +368,28 @@ impl State {
         }
         let parent = parent.clone();
         self.swap_commits(&current_id, &parent);
+    }
+
+    /// Adjust the scroll position to keep the selection within the estimated
+    /// viewport.
+    fn clamp_scroll(&mut self, viewport_rows: u16) {
+        // `render()` configures the graph renderer with a minimum row height of
+        // two, so this estimates how many commits fit in the common case. Custom
+        // templates and graph topology can make a commit taller, so this is not
+        // a strict bound.
+        let max_visible = (viewport_rows / 2).max(1) as usize;
+        let total_commits =
+            self.external_children.len() + self.current_order.len() + self.external_parents.len();
+        let selection_pos = self.external_children.len() + self.current_selection;
+
+        if selection_pos < self.scroll_top {
+            self.scroll_top = selection_pos;
+        } else if selection_pos >= self.scroll_top.saturating_add(max_visible) {
+            self.scroll_top = selection_pos.saturating_sub(max_visible - 1);
+        }
+
+        let max_scroll = total_commits.saturating_sub(max_visible);
+        self.scroll_top = self.scroll_top.min(max_scroll);
     }
 
     /// Swap the selected commit with one of its children. Does nothing if there
@@ -493,6 +519,7 @@ fn run_tui<B: ratatui::backend::Backend>(
                     .split(frame.area());
                 let main_area = layout[0];
                 let help_area = layout[1];
+                state.clamp_scroll(main_area.height);
                 render(&state, render_commit, frame.buffer_mut(), main_area);
                 frame.render_widget(&help_line, help_area);
             })
@@ -570,7 +597,8 @@ fn render(
         .external_children
         .iter()
         .chain(state.current_order.iter())
-        .chain(state.external_parents.iter());
+        .chain(state.external_parents.iter())
+        .skip(state.scroll_top);
     for id in commits_to_render {
         // TODO: Make the graph column width depend on what's needed to render the
         // graph.
@@ -642,6 +670,7 @@ fn render(
 
 #[cfg(test)]
 mod tests {
+    use indoc::indoc;
     use maplit::hashset;
     use pollster::FutureExt as _;
     use testutils::CommitBuilderExt as _;
@@ -1292,8 +1321,10 @@ mod tests {
 
     fn render_to_string(state: &State, width: u16, height: u16) -> String {
         let mut buf = Buffer::empty(Rect::new(0, 0, width, height));
+        let mut state = state.clone();
+        state.clamp_scroll(height);
         render(
-            state,
+            &state,
             render_commit,
             &mut buf,
             Rect::new(0, 0, width, height),
@@ -1372,11 +1403,13 @@ mod tests {
         };
         let commit_a = create_commit(
             vec![store.root_commit_id().clone()],
-            "commit A line 1
-commit A line 2
-commit A line 3
-commit A line 4
-commit A line 5",
+            indoc! {"
+                commit A line 1
+                commit A line 2
+                commit A line 3
+                commit A line 4
+                commit A line 5
+            "},
         );
 
         let state = State::new(vec![commit_a.clone()], vec![]).block_on()?;
@@ -1475,20 +1508,126 @@ commit A line 5",
         )
         .block_on()?;
         state.current_selection = 5;
-        // TODO: Show at least the part that includes the selection
+        state.clamp_scroll(10);
         insta::assert_snapshot!(render_to_string(&state, 80, 10), @"
-        ○         keep      commit G
-        │
-        ○         keep      commit F
-        │
-        ○         keep      commit E
-        │
-        ○         keep      commit D
-        │
-        ○         keep      commit C
-        │
+          ○         keep      commit F
+          │
+          ○         keep      commit E
+          │
+          ○         keep      commit D
+          │
+          ○         keep      commit C
+          │
+        ▶ ○         keep      commit B
+          │
         ");
 
+        Ok(())
+    }
+
+    #[test]
+    fn test_render_scrolls_viewport_to_keep_selection_visible() -> TestResult {
+        let test_repo = TestRepo::init();
+        let store = test_repo.repo.store();
+        let empty_tree = store.empty_merged_tree();
+
+        let mut tx = test_repo.repo.start_transaction();
+        let mut create_commit = |parents, description: &str| {
+            tx.repo_mut()
+                .new_commit(parents, empty_tree.clone())
+                .set_description(description)
+                .write_unwrap()
+        };
+        let commit_a = create_commit(vec![store.root_commit_id().clone()], "commit A");
+        let commit_b = create_commit(vec![commit_a.id().clone()], "commit B");
+        let commit_c = create_commit(vec![commit_b.id().clone()], "commit C");
+        let commit_d = create_commit(vec![commit_c.id().clone()], "commit D");
+        let commit_e = create_commit(vec![commit_d.id().clone()], "commit E");
+        let commit_f = create_commit(vec![commit_e.id().clone()], "commit F");
+        let commit_g = create_commit(vec![commit_f.id().clone()], "commit G");
+
+        let mut state = State::new(
+            vec![
+                commit_a.clone(),
+                commit_b.clone(),
+                commit_c.clone(),
+                commit_d.clone(),
+                commit_e.clone(),
+                commit_f.clone(),
+                commit_g.clone(),
+            ],
+            vec![],
+        )
+        .block_on()?;
+
+        // Viewport can only show 5 commits; selection starts at top.
+        state.current_selection = 0;
+        state.clamp_scroll(10);
+        insta::assert_snapshot!(render_to_string(&state, 80, 10), @"
+        ▶ ○         keep      commit G
+          │
+          ○         keep      commit F
+          │
+          ○         keep      commit E
+          │
+          ○         keep      commit D
+          │
+          ○         keep      commit C
+          │
+        ");
+
+        // Move selection to a commit that would fall below the viewport.
+        state.current_selection = 6;
+        state.clamp_scroll(10);
+        insta::assert_snapshot!(render_to_string(&state, 80, 10), @"
+          ○         keep      commit E
+          │
+          ○         keep      commit D
+          │
+          ○         keep      commit C
+          │
+          ○         keep      commit B
+          │
+        ▶ ○         keep      commit A
+          │
+        ");
+
+        Ok(())
+    }
+
+    /// Regression test for terminal resize. The original scrolling
+    /// implementation only reclamped after state-changing input, which left the
+    /// selected commit outside a smaller viewport.
+    #[test]
+    fn test_scroll_keeps_selection_visible_after_viewport_shrinks() -> TestResult {
+        let test_repo = TestRepo::init();
+        let store = test_repo.repo.store();
+        let empty_tree = store.empty_merged_tree();
+
+        let mut tx = test_repo.repo.start_transaction();
+        let mut create_commit = |parents, description: &str| {
+            tx.repo_mut()
+                .new_commit(parents, empty_tree.clone())
+                .set_description(description)
+                .write_unwrap()
+        };
+        let commit_a = create_commit(vec![store.root_commit_id().clone()], "commit A");
+        let commit_b = create_commit(vec![commit_a.id().clone()], "commit B");
+        let commit_c = create_commit(vec![commit_b.id().clone()], "commit C");
+
+        // Model a resize between input events: the scroll position was computed
+        // when all three commits fit, but the next draw has only four rows. No
+        // navigation event occurs to clamp it again.
+        let mut state = State::new(vec![commit_a, commit_b, commit_c], vec![]).block_on()?;
+        state.current_selection = 2;
+        state.clamp_scroll(6);
+
+        insta::assert_snapshot!(render_to_string(&state, 80, 4), @"
+          ○         keep      commit B
+          │
+        ▶ ○         keep      commit A
+          │
+        ");
         Ok(())
     }
 


### PR DESCRIPTION
## Description

`jj arrange` now scrolls its viewport to keep the selected commit visible when the commit stack exceeds the terminal height.

### Changes

- Tracks the top of the rendered commit list and scrolls it as the selection changes.
- Reclamps scrolling from the current main area before every draw, so terminal resize events take effect without requiring another key press.
- Adds snapshot coverage for selection scrolling and viewport shrink behavior.

### Limitation

The viewport uses a conservative two-rows-per-commit estimate. Multiline commit templates and graph topology can require more rows, so fully height-aware scrolling remains follow-up work.

## Checklist

- [x] I have updated CHANGELOG.md
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does, how it works, how it is organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with an eye towards deleting anything that is irrelevant, clarifying anything that is confusing, and adding details that are relevant.

## LLM Disclosure

This fix was created with assistance from LLMs. The implementation and final changes were reviewed and verified by the author.