### PR TITLE
lib: make RepoLoader.merge_operations non-recursive (fixes stack-overflows)

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -730,34 +730,21 @@ impl CommandHelper {
                         ui.status(),
                         "Concurrent modification detected, resolving automatically.",
                     )?;
-                    let base_repo = repo_loader.load_at(&op_heads[0]).block_on()?;
+                    // TODO: It may be helpful to print each operation we're merging here
+                    let transaction_description = "reconcile divergent operations";
                     let transaction_attributes = [(
                         "args".to_string(),
                         command_args_to_transaction_attribute(&self.data.string_args),
                     )];
-                    let mut tx = start_repo_transaction(
-                        &base_repo,
+                    merge_operations(
+                        Some(ui),
+                        repo_loader,
+                        op_heads,
                         Some(workspace_name),
+                        Some(transaction_description),
                         transaction_attributes,
-                    );
-                    // TODO: It may be helpful to print each operation we're merging here
-                    for other_op_head in op_heads.into_iter().skip(1) {
-                        tx.merge_operation(other_op_head).await?;
-                        let num_rebased = tx.repo_mut().rebase_descendants().await?;
-                        if num_rebased > 0 {
-                            writeln!(
-                                ui.status(),
-                                "Rebased {num_rebased} descendant commits onto commits rewritten \
-                                 by other operation."
-                            )?;
-                        }
-                    }
-                    Ok(tx
-                        .write("reconcile divergent operations")
-                        .await?
-                        .leave_unpublished()
-                        .operation()
-                        .clone())
+                    )
+                    .await
                 },
             )
             .block_on()
@@ -778,6 +765,36 @@ impl CommandHelper {
         let loaded_at_head = true;
         WorkspaceCommandHelper::new(ui, workspace, repo, env, loaded_at_head)
     }
+}
+
+/// If `operations` is empty returns the root operation, if it contains a single
+/// entry returns that entry, otherwise merges the operations into a single
+/// operation. If `ui` is set, reports the number of rebased descendants.
+pub async fn merge_operations(
+    ui: Option<&Ui>,
+    repo_loader: &RepoLoader,
+    operations: Vec<Operation>,
+    workspace_name: Option<&WorkspaceName>,
+    transaction_description: Option<&str>,
+    transaction_attributes: impl IntoIterator<Item = (String, String)>,
+) -> Result<Operation, CommandError> {
+    let (merged_repo, num_rebased) = repo_loader
+        .merge_operations(
+            operations,
+            workspace_name,
+            transaction_description,
+            transaction_attributes,
+        )
+        .await?;
+    if let Some(ui) = ui
+        && num_rebased > 0
+    {
+        writeln!(
+            ui.status(),
+            "Rebased {num_rebased} descendant commits onto commits rewritten by other operation.",
+        )?;
+    }
+    Ok(merged_repo.operation().clone())
 }
 
 /// A ReadonlyRepo along with user-config-dependent derived data. The derived

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -130,7 +130,6 @@ use jj_lib::str_util::StringExpression;
 use jj_lib::str_util::StringMatcher;
 use jj_lib::transaction::Transaction;
 use jj_lib::transaction::TransactionCommitError;
-use jj_lib::transaction::start_repo_transaction;
 use jj_lib::working_copy;
 use jj_lib::working_copy::CheckoutStats;
 use jj_lib::working_copy::LockedWorkingCopy;
@@ -732,17 +731,13 @@ impl CommandHelper {
                     )?;
                     // TODO: It may be helpful to print each operation we're merging here
                     let transaction_description = "reconcile divergent operations";
-                    let transaction_attributes = [(
-                        "args".to_string(),
-                        command_args_to_transaction_attribute(&self.data.string_args),
-                    )];
                     merge_operations(
                         Some(ui),
                         repo_loader,
                         op_heads,
                         Some(workspace_name),
                         Some(transaction_description),
-                        transaction_attributes,
+                        &self.data.string_args,
                     )
                     .await
                 },
@@ -776,8 +771,9 @@ pub async fn merge_operations(
     operations: Vec<Operation>,
     workspace_name: Option<&WorkspaceName>,
     transaction_description: Option<&str>,
-    transaction_attributes: impl IntoIterator<Item = (String, String)>,
+    command_args: &[String],
 ) -> Result<Operation, CommandError> {
+    let transaction_attributes = command_args_to_transaction_attribute(command_args);
     let (merged_repo, num_rebased) = repo_loader
         .merge_operations(
             operations,
@@ -2061,14 +2057,10 @@ to the current parents may contain changes from multiple commits.
                 .map_err(snapshot_command_error)?
         };
         if new_tree.tree_ids_and_labels() != wc_commit.tree().tree_ids_and_labels() {
-            let transaction_attributes = [(
-                "args".to_string(),
-                command_args_to_transaction_attribute(self.env.command.string_args()),
-            )];
             let mut tx = start_repo_transaction(
                 &self.user_repo.repo,
-                Some(&workspace_name),
-                transaction_attributes,
+                &workspace_name,
+                self.env.command.string_args(),
             );
             tx.set_is_snapshot(true);
             let immutable_expr = self
@@ -2242,14 +2234,10 @@ to the current parents may contain changes from multiple commits.
     }
 
     pub fn start_transaction(&mut self) -> WorkspaceCommandTransaction<'_> {
-        let transaction_attributes = [(
-            "args".to_string(),
-            command_args_to_transaction_attribute(self.env.command.string_args()),
-        )];
         let tx = start_repo_transaction(
             self.repo(),
-            Some(self.workspace_name()),
-            transaction_attributes,
+            self.workspace_name(),
+            self.env.command.string_args(),
         );
         let id_prefix_context = mem::take(&mut self.user_repo.id_prefix_context);
         WorkspaceCommandTransaction {
@@ -2802,7 +2790,23 @@ jj git init",
     }
 }
 
-pub fn command_args_to_transaction_attribute(command_args: &[String]) -> String {
+pub fn start_repo_transaction(
+    repo: &Arc<ReadonlyRepo>,
+    workspace_name: &WorkspaceName,
+    string_args: &[String],
+) -> Transaction {
+    let mut tx = repo.start_transaction();
+    tx.set_workspace_name(workspace_name);
+    for (key, value) in command_args_to_transaction_attribute(string_args) {
+        tx.set_attribute(key, value);
+    }
+    tx
+}
+
+fn command_args_to_transaction_attribute(command_args: &[String]) -> Vec<(String, String)> {
+    if command_args.is_empty() {
+        return vec![];
+    }
     // TODO: Either do better shell-escaping here or store the values in some list
     // type (which we currently don't have).
     let shell_escape = |arg: &String| {
@@ -2827,7 +2831,7 @@ pub fn command_args_to_transaction_attribute(command_args: &[String]) -> String 
     };
     let mut quoted_strings = vec!["jj".to_string()];
     quoted_strings.extend(command_args.iter().skip(1).map(shell_escape));
-    quoted_strings.join(" ")
+    vec![("args".to_string(), quoted_strings.join(" "))]
 }
 
 async fn rebase_mutable_descendants(

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -130,6 +130,7 @@ use jj_lib::str_util::StringExpression;
 use jj_lib::str_util::StringMatcher;
 use jj_lib::transaction::Transaction;
 use jj_lib::transaction::TransactionCommitError;
+use jj_lib::transaction::start_repo_transaction;
 use jj_lib::working_copy;
 use jj_lib::working_copy::CheckoutStats;
 use jj_lib::working_copy::LockedWorkingCopy;
@@ -730,9 +731,16 @@ impl CommandHelper {
                         "Concurrent modification detected, resolving automatically.",
                     )?;
                     let base_repo = repo_loader.load_at(&op_heads[0]).block_on()?;
+                    let transaction_attributes = [(
+                        "args".to_string(),
+                        command_args_to_transaction_attribute(&self.data.string_args),
+                    )];
+                    let mut tx = start_repo_transaction(
+                        &base_repo,
+                        Some(workspace_name),
+                        transaction_attributes,
+                    );
                     // TODO: It may be helpful to print each operation we're merging here
-                    let mut tx =
-                        start_repo_transaction(&base_repo, workspace_name, &self.data.string_args);
                     for other_op_head in op_heads.into_iter().skip(1) {
                         tx.merge_operation(other_op_head).await?;
                         let num_rebased = tx.repo_mut().rebase_descendants().await?;
@@ -2036,10 +2044,14 @@ to the current parents may contain changes from multiple commits.
                 .map_err(snapshot_command_error)?
         };
         if new_tree.tree_ids_and_labels() != wc_commit.tree().tree_ids_and_labels() {
+            let transaction_attributes = [(
+                "args".to_string(),
+                command_args_to_transaction_attribute(self.env.command.string_args()),
+            )];
             let mut tx = start_repo_transaction(
                 &self.user_repo.repo,
-                &workspace_name,
-                self.env.command.string_args(),
+                Some(&workspace_name),
+                transaction_attributes,
             );
             tx.set_is_snapshot(true);
             let immutable_expr = self
@@ -2213,10 +2225,14 @@ to the current parents may contain changes from multiple commits.
     }
 
     pub fn start_transaction(&mut self) -> WorkspaceCommandTransaction<'_> {
+        let transaction_attributes = [(
+            "args".to_string(),
+            command_args_to_transaction_attribute(self.env.command.string_args()),
+        )];
         let tx = start_repo_transaction(
             self.repo(),
-            self.workspace_name(),
-            self.env.command.string_args(),
+            Some(self.workspace_name()),
+            transaction_attributes,
         );
         let id_prefix_context = mem::take(&mut self.user_repo.id_prefix_context);
         WorkspaceCommandTransaction {
@@ -2769,13 +2785,7 @@ jj git init",
     }
 }
 
-pub fn start_repo_transaction(
-    repo: &Arc<ReadonlyRepo>,
-    workspace_name: &WorkspaceName,
-    string_args: &[String],
-) -> Transaction {
-    let mut tx = repo.start_transaction();
-    tx.set_workspace_name(workspace_name);
+pub fn command_args_to_transaction_attribute(command_args: &[String]) -> String {
     // TODO: Either do better shell-escaping here or store the values in some list
     // type (which we currently don't have).
     let shell_escape = |arg: &String| {
@@ -2799,9 +2809,8 @@ pub fn start_repo_transaction(
         }
     };
     let mut quoted_strings = vec!["jj".to_string()];
-    quoted_strings.extend(string_args.iter().skip(1).map(shell_escape));
-    tx.set_attribute("args".to_string(), quoted_strings.join(" "));
-    tx
+    quoted_strings.extend(command_args.iter().skip(1).map(shell_escape));
+    quoted_strings.join(" ")
 }
 
 async fn rebase_mutable_descendants(

--- a/cli/src/commands/git/init.rs
+++ b/cli/src/commands/git/init.rs
@@ -27,14 +27,15 @@ use jj_lib::git::GitSettings;
 use jj_lib::git::parse_git_ref;
 use jj_lib::repo::ReadonlyRepo;
 use jj_lib::repo::Repo as _;
+use jj_lib::transaction::start_repo_transaction;
 use jj_lib::view::View;
 use jj_lib::workspace::Workspace;
 
 use super::RepoPresets;
 use super::write_repo_presets;
 use crate::cli_util::CommandHelper;
+use crate::cli_util::command_args_to_transaction_attribute;
 use crate::cli_util::shell_quote;
-use crate::cli_util::start_repo_transaction;
 use crate::command_error::CommandError;
 use crate::command_error::cli_error;
 use crate::command_error::internal_error;
@@ -263,7 +264,15 @@ async fn init_git_refs(
         record_synthetic_predecessors: false,
         ..load_git_import_options(ui, &git_settings, &remote_settings)?
     };
-    let mut tx = start_repo_transaction(&repo, workspace.workspace_name(), string_args);
+    let transaction_attributes = [(
+        "args".to_string(),
+        command_args_to_transaction_attribute(string_args),
+    )];
+    let mut tx = start_repo_transaction(
+        &repo,
+        Some(workspace.workspace_name()),
+        transaction_attributes,
+    );
     let stats = git::import_refs(tx.repo_mut(), &import_options).await?;
     print_git_import_stats_summary(ui, &stats)?;
     if !tx.repo().has_changes() {

--- a/cli/src/commands/git/init.rs
+++ b/cli/src/commands/git/init.rs
@@ -27,15 +27,14 @@ use jj_lib::git::GitSettings;
 use jj_lib::git::parse_git_ref;
 use jj_lib::repo::ReadonlyRepo;
 use jj_lib::repo::Repo as _;
-use jj_lib::transaction::start_repo_transaction;
 use jj_lib::view::View;
 use jj_lib::workspace::Workspace;
 
 use super::RepoPresets;
 use super::write_repo_presets;
 use crate::cli_util::CommandHelper;
-use crate::cli_util::command_args_to_transaction_attribute;
 use crate::cli_util::shell_quote;
+use crate::cli_util::start_repo_transaction;
 use crate::command_error::CommandError;
 use crate::command_error::cli_error;
 use crate::command_error::internal_error;
@@ -264,15 +263,7 @@ async fn init_git_refs(
         record_synthetic_predecessors: false,
         ..load_git_import_options(ui, &git_settings, &remote_settings)?
     };
-    let transaction_attributes = [(
-        "args".to_string(),
-        command_args_to_transaction_attribute(string_args),
-    )];
-    let mut tx = start_repo_transaction(
-        &repo,
-        Some(workspace.workspace_name()),
-        transaction_attributes,
-    );
+    let mut tx = start_repo_transaction(&repo, workspace.workspace_name(), string_args);
     let stats = git::import_refs(tx.repo_mut(), &import_options).await?;
     print_git_import_stats_summary(ui, &stats)?;
     if !tx.repo().has_changes() {

--- a/cli/src/commands/operation/diff.rs
+++ b/cli/src/commands/operation/diff.rs
@@ -129,14 +129,14 @@ pub async fn cmd_op_diff(
 
     let workspace_name = None;
     let transaction_description = None;
-    let transaction_attributes = [];
+    let command_args = [];
     let merged_from_op = merge_operations(
         None,
         repo_loader,
         from_ops.clone(),
         workspace_name,
         transaction_description,
-        transaction_attributes,
+        &command_args,
     )
     .await?;
     let from_repo = repo_loader.load_at(&merged_from_op).await?;

--- a/cli/src/commands/operation/diff.rs
+++ b/cli/src/commands/operation/diff.rs
@@ -49,6 +49,7 @@ use crate::cli_util::CommandHelper;
 use crate::cli_util::LogContentFormat;
 use crate::cli_util::WorkspaceCommandEnvironment;
 use crate::cli_util::default_ignored_remote_name;
+use crate::cli_util::merge_operations;
 use crate::command_error::CommandError;
 use crate::command_error::config_error_with_message;
 use crate::command_error::print_parse_diagnostics;
@@ -126,7 +127,18 @@ pub async fn cmd_op_diff(
     let graph_style = GraphStyle::from_settings(settings)?;
     let with_content_format = LogContentFormat::new(ui, settings)?;
 
-    let merged_from_op = repo_loader.merge_operations(from_ops.clone(), None).await?;
+    let workspace_name = None;
+    let transaction_description = None;
+    let transaction_attributes = [];
+    let merged_from_op = merge_operations(
+        None,
+        repo_loader,
+        from_ops.clone(),
+        workspace_name,
+        transaction_description,
+        transaction_attributes,
+    )
+    .await?;
     let from_repo = repo_loader.load_at(&merged_from_op).await?;
     let to_repo = repo_loader.load_at(&to_op).await?;
 

--- a/cli/src/commands/operation/integrate.rs
+++ b/cli/src/commands/operation/integrate.rs
@@ -14,9 +14,10 @@
 
 use jj_lib::op_heads_store;
 use jj_lib::operation::Operation;
+use jj_lib::transaction::start_repo_transaction;
 
 use crate::cli_util::CommandHelper;
-use crate::cli_util::start_repo_transaction;
+use crate::cli_util::command_args_to_transaction_attribute;
 use crate::command_error::CommandError;
 use crate::ui::Ui;
 
@@ -53,12 +54,16 @@ pub async fn cmd_op_integrate(
         repo_loader.op_store(),
         async |op_heads| -> Result<Operation, CommandError> {
             let base_repo = repo_loader.load_at(&op_heads[0]).await?;
-            // TODO: It may be helpful to print each operation we're merging here
+            let transaction_attributes = [(
+                "args".to_string(),
+                command_args_to_transaction_attribute(command.string_args()),
+            )];
             let mut tx = start_repo_transaction(
                 &base_repo,
-                workspace_command.workspace_name(),
-                command.string_args(),
+                Some(workspace_command.workspace_name()),
+                transaction_attributes,
             );
+            // TODO: It may be helpful to print each operation we're merging here
             for other_op_head in op_heads.into_iter().skip(1) {
                 tx.merge_operation(other_op_head).await?;
                 let num_rebased = tx.repo_mut().rebase_descendants().await?;

--- a/cli/src/commands/operation/integrate.rs
+++ b/cli/src/commands/operation/integrate.rs
@@ -16,7 +16,6 @@ use jj_lib::op_heads_store;
 use jj_lib::operation::Operation;
 
 use crate::cli_util::CommandHelper;
-use crate::cli_util::command_args_to_transaction_attribute;
 use crate::cli_util::merge_operations;
 use crate::command_error::CommandError;
 use crate::ui::Ui;
@@ -55,17 +54,13 @@ pub async fn cmd_op_integrate(
         async |op_heads| -> Result<Operation, CommandError> {
             // TODO: It may be helpful to print each operation we're merging here
             let transaction_description = "reconcile divergent operations";
-            let transaction_attributes = [(
-                "args".to_string(),
-                command_args_to_transaction_attribute(command.string_args()),
-            )];
             let merged_operation = merge_operations(
                 Some(ui),
                 repo_loader,
                 op_heads,
                 Some(workspace_command.workspace_name()),
                 Some(transaction_description),
-                transaction_attributes,
+                command.string_args(),
             )
             .await?;
             writeln!(

--- a/cli/src/commands/operation/integrate.rs
+++ b/cli/src/commands/operation/integrate.rs
@@ -14,10 +14,10 @@
 
 use jj_lib::op_heads_store;
 use jj_lib::operation::Operation;
-use jj_lib::transaction::start_repo_transaction;
 
 use crate::cli_util::CommandHelper;
 use crate::cli_util::command_args_to_transaction_attribute;
+use crate::cli_util::merge_operations;
 use crate::command_error::CommandError;
 use crate::ui::Ui;
 
@@ -53,38 +53,26 @@ pub async fn cmd_op_integrate(
         repo_loader.op_heads_store().as_ref(),
         repo_loader.op_store(),
         async |op_heads| -> Result<Operation, CommandError> {
-            let base_repo = repo_loader.load_at(&op_heads[0]).await?;
+            // TODO: It may be helpful to print each operation we're merging here
+            let transaction_description = "reconcile divergent operations";
             let transaction_attributes = [(
                 "args".to_string(),
                 command_args_to_transaction_attribute(command.string_args()),
             )];
-            let mut tx = start_repo_transaction(
-                &base_repo,
+            let merged_operation = merge_operations(
+                Some(ui),
+                repo_loader,
+                op_heads,
                 Some(workspace_command.workspace_name()),
+                Some(transaction_description),
                 transaction_attributes,
-            );
-            // TODO: It may be helpful to print each operation we're merging here
-            for other_op_head in op_heads.into_iter().skip(1) {
-                tx.merge_operation(other_op_head).await?;
-                let num_rebased = tx.repo_mut().rebase_descendants().await?;
-                if num_rebased > 0 {
-                    writeln!(
-                        ui.status(),
-                        "Rebased {num_rebased} descendant commits onto commits rewritten by other \
-                         operation."
-                    )?;
-                }
-            }
+            )
+            .await?;
             writeln!(
                 ui.status(),
                 "The specified operation has been integrated with other existing operations."
             )?;
-            Ok(tx
-                .write("reconcile divergent operations")
-                .await?
-                .leave_unpublished()
-                .operation()
-                .clone())
+            Ok(merged_operation)
         },
     )
     .await?;

--- a/cli/src/commands/operation/log.rs
+++ b/cli/src/commands/operation/log.rs
@@ -175,14 +175,14 @@ async fn do_op_log(
             let parent_ops = op.parents().await?;
             let workspace_name = None;
             let transaction_description = None;
-            let transaction_attributes = [];
+            let command_args = [];
             let merged_parent_op = merge_operations(
                 None,
                 repo_loader,
                 parent_ops.clone(),
                 workspace_name,
                 transaction_description,
-                transaction_attributes,
+                &command_args,
             )
             .await?;
             let parent_repo = repo_loader.load_at(&merged_parent_op).await?;

--- a/cli/src/commands/operation/log.rs
+++ b/cli/src/commands/operation/log.rs
@@ -31,6 +31,7 @@ use crate::cli_util::CommandHelper;
 use crate::cli_util::LogContentFormat;
 use crate::cli_util::WorkspaceCommandEnvironment;
 use crate::cli_util::format_template;
+use crate::cli_util::merge_operations;
 use crate::command_error::CommandError;
 use crate::complete;
 use crate::diff_util::DiffFormatArgs;
@@ -172,9 +173,18 @@ async fn do_op_log(
                                op: &Operation,
                                with_content_format: &LogContentFormat| {
             let parent_ops = op.parents().await?;
-            let merged_parent_op = repo_loader
-                .merge_operations(parent_ops.clone(), None)
-                .await?;
+            let workspace_name = None;
+            let transaction_description = None;
+            let transaction_attributes = [];
+            let merged_parent_op = merge_operations(
+                None,
+                repo_loader,
+                parent_ops.clone(),
+                workspace_name,
+                transaction_description,
+                transaction_attributes,
+            )
+            .await?;
             let parent_repo = repo_loader.load_at(&merged_parent_op).await?;
             let repo = repo_loader.load_at(op).await?;
 

--- a/cli/src/commands/operation/show.rs
+++ b/cli/src/commands/operation/show.rs
@@ -92,14 +92,14 @@ pub async fn cmd_op_show(
     let parent_ops = op.parents().await?;
     let workspace_name = None;
     let transaction_description = None;
-    let transaction_attributes = [];
+    let command_args = [];
     let merged_parent_op = merge_operations(
         None,
         repo_loader,
         parent_ops.clone(),
         workspace_name,
         transaction_description,
-        transaction_attributes,
+        &command_args,
     )
     .await?;
     let parent_repo = repo_loader.load_at(&merged_parent_op).await?;

--- a/cli/src/commands/operation/show.rs
+++ b/cli/src/commands/operation/show.rs
@@ -19,6 +19,7 @@ use super::diff::parse_op_diff_changes_in;
 use super::diff::show_op_diff;
 use crate::cli_util::CommandHelper;
 use crate::cli_util::LogContentFormat;
+use crate::cli_util::merge_operations;
 use crate::command_error::CommandError;
 use crate::complete;
 use crate::diff_util::DiffFormatArgs;
@@ -89,9 +90,18 @@ pub async fn cmd_op_show(
     let settings = workspace_command.settings();
     let op = workspace_command.resolve_single_op(&args.operation)?;
     let parent_ops = op.parents().await?;
-    let merged_parent_op = repo_loader
-        .merge_operations(parent_ops.clone(), None)
-        .await?;
+    let workspace_name = None;
+    let transaction_description = None;
+    let transaction_attributes = [];
+    let merged_parent_op = merge_operations(
+        None,
+        repo_loader,
+        parent_ops.clone(),
+        workspace_name,
+        transaction_description,
+        transaction_attributes,
+    )
+    .await?;
     let parent_repo = repo_loader.load_at(&merged_parent_op).await?;
     let repo = repo_loader.load_at(&op).await?;
 

--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -838,6 +838,11 @@ impl RepoLoader {
         transaction_description: Option<&str>,
         transaction_attributes: impl IntoIterator<Item = (String, String)>,
     ) -> Result<(Arc<ReadonlyRepo>, usize), RepoLoaderError> {
+        // IMPLEMENTATION NOTE: This used to be implemented as a much simple
+        // recursive method, but unfortunately due to the async nature of the
+        // method itself and its dependencies, that leads to stack-overflow in
+        // some cases. See https://github.com/jj-vcs/jj/pull/9586 for more
+        // details.
         match &operations[..] {
             [] => {
                 let root_operation = self.root_operation().await;
@@ -852,41 +857,94 @@ impl RepoLoader {
         }
 
         let mut num_rebased = 0;
-        let num_operations = operations.len();
+        let to_operation_ids =
+            |ops: &[Operation]| ops.iter().map(|op| op.id().clone()).collect_vec();
+        let operation_ids = to_operation_ids(&operations);
+
+        // Caches the result of merging some operations.
+        let mut merged_operations: HashMap<Vec<OperationId>, Operation> = HashMap::new();
+        // Caches the result of op_walk::closest_common_ancestors invocations. Keyed by
+        // the arguments to that method.
+        let mut closest_common_ancestors: HashMap<_, Vec<Operation>> = HashMap::new();
+
         let transaction_attributes = transaction_attributes.into_iter().collect_vec();
-        let mut tx = start_repo_transaction(
+        let tx = start_repo_transaction(
             &self.load_at(&operations[0]).await?,
             workspace_name,
             transaction_attributes.clone(),
         );
-        for other_op in operations.iter().skip(1) {
-            let ancestor_ops = op_walk::closest_common_ancestors(
-                tx.parent_ops().iter().cloned(),
-                [other_op.clone()],
-            )
-            .await?;
-            let base_op = match &ancestor_ops[..] {
-                [op] => op.clone(),
-                _ => {
-                    let (base_repo, num_rebased_inner) = Box::pin(self.merge_operations(
-                        ancestor_ops,
-                        workspace_name,
-                        transaction_description,
-                        transaction_attributes.clone(),
-                    ))
+        let mut stack = vec![(1, operations, tx)];
+
+        while let Some((index, operations, mut tx)) = stack.pop() {
+            assert!(operations.len() > 1);
+            assert!(index <= operations.len());
+            if index == operations.len() {
+                // We are done processing the operations, but there is more work on the stack.
+                // Commit the transaction and cache the result.
+                let tx_description = transaction_description.map_or_else(
+                    || format!("merge {} operations", operations.len()),
+                    |tx_description| tx_description.to_string(),
+                );
+                let merged_repo = tx.write(tx_description).await?.leave_unpublished();
+                merged_operations.insert(
+                    to_operation_ids(&operations),
+                    merged_repo.operation().clone(),
+                );
+                continue;
+            }
+
+            let other_op = &operations[index];
+
+            // Get the ancestor operations between the operations we have merged so far
+            // (represented by `tx.parent_ops()`) and the next operation to merge
+            // (`other_op`).
+            let ancestor_ops = match closest_common_ancestors
+                .entry((to_operation_ids(tx.parent_ops()), other_op.id().clone()))
+            {
+                Entry::Occupied(occupied_entry) => occupied_entry.into_mut(),
+                Entry::Vacant(vacant_entry) => {
+                    let ancestor_ops = op_walk::closest_common_ancestors(
+                        tx.parent_ops().to_vec(),
+                        [other_op.clone()],
+                    )
                     .await?;
-                    num_rebased += num_rebased_inner;
-                    base_repo.operation().clone()
+                    vacant_entry.insert(ancestor_ops.clone())
                 }
             };
-            num_rebased += tx.merge_operation(&base_op, other_op).await?;
+            assert!(!ancestor_ops.is_empty());
+
+            let ancestor_op = if let [ancestor_op] = ancestor_ops.as_slice() {
+                // There is a single common ancestor.
+                Some(ancestor_op)
+            } else {
+                // There are multiple common ancestors, check to see if we have cached their
+                // merge result.
+                let ancestor_op_ids = ancestor_ops.iter().map(|op| op.id().clone()).collect_vec();
+                merged_operations.get(&ancestor_op_ids)
+            };
+
+            if let Some(merged_ancestor_op) = ancestor_op {
+                // We have the merge of the ancestor operations. We can proceed to merge with
+                // other_op.
+                num_rebased += tx.merge_operation(merged_ancestor_op, other_op).await?;
+                // Push state on the stack to continue merging the rest of the operations.
+                stack.push((index + 1, operations, tx));
+                continue;
+            }
+
+            // We have to merge the ancestor ops.
+            // We first push the current state to the stack so that after we merge the
+            // ancestor ops, we can continue merging the rest of the operations.
+            stack.push((index, operations, tx));
+            // Then we push the ancestor ops to the stack so that we can merge them first.
+            // We need to start a separate transaction for this.
+            let new_tx = self.load_at(&ancestor_ops[0]).await?.start_transaction();
+            stack.push((1, ancestor_ops.clone(), new_tx));
         }
-        let tx_description = transaction_description.map_or_else(
-            || format!("merge {num_operations} operations"),
-            |tx_description| tx_description.to_string(),
-        );
-        let merged_repo = tx.write(tx_description).await?.leave_unpublished();
-        Ok((self.load_at(merged_repo.operation()).await?, num_rebased))
+
+        // We are all done! The result should be in the cache.
+        let merged_operation = merged_operations.get(&operation_ids).cloned().unwrap();
+        Ok((self.load_at(&merged_operation).await?, num_rebased))
     }
 
     async fn finish_load(

--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -80,6 +80,7 @@ use crate::op_store::RefTarget;
 use crate::op_store::RemoteRef;
 use crate::op_store::RemoteRefState;
 use crate::op_store::RootOperationData;
+use crate::op_walk;
 use crate::operation::Operation;
 use crate::ref_name::GitRefName;
 use crate::ref_name::RefName;
@@ -113,6 +114,7 @@ use crate::store::Store;
 use crate::submodule_store::SubmoduleStore;
 use crate::transaction::Transaction;
 use crate::transaction::TransactionCommitError;
+use crate::transaction::start_repo_transaction;
 use crate::tree_merge::MergeOptions;
 use crate::view::RenameWorkspaceError;
 use crate::view::View;
@@ -766,10 +768,20 @@ impl RepoLoader {
         let op = op_heads_store::resolve_op_heads(
             self.op_heads_store.as_ref(),
             &self.op_store,
-            async |op_heads| {
-                assert!(!op_heads.is_empty());
-                self.merge_operations(op_heads, Some("reconcile divergent operations"))
-                    .await
+            async |op_heads| -> Result<Operation, RepoLoaderError> {
+                assert!(op_heads.len() > 1);
+                let workspace_name = None;
+                let transaction_description = Some("reconcile divergent operations");
+                let transaction_attributes = [];
+                let (merged_repo, _num_rebased) = self
+                    .merge_operations(
+                        op_heads,
+                        workspace_name,
+                        transaction_description,
+                        transaction_attributes,
+                    )
+                    .await?;
+                Ok(merged_repo.operation().clone())
             },
         )
         .await?;
@@ -815,36 +827,66 @@ impl RepoLoader {
         Ok(Operation::new(self.op_store.clone(), id.clone(), data))
     }
 
-    /// Merges the given `operations` into a single operation. Returns the root
-    /// operation if the `operations` is empty.
+    /// Merges the given `operations`. Returns the merged repo and the number of
+    /// rebased commits. If `operations` is empty returns the root repo. If
+    /// `operations` has a single entry, returns that entry's repo. Otherwise
+    /// an actual merge happens. The new operation is not published.
     pub async fn merge_operations(
         &self,
         operations: Vec<Operation>,
-        tx_description: Option<&str>,
-    ) -> Result<Operation, RepoLoaderError> {
-        let num_operations = operations.len();
-        let mut operations = operations.into_iter();
-        let Some(base_op) = operations.next() else {
-            return Ok(self.root_operation().await);
-        };
-        let final_op = if num_operations > 1 {
-            let base_repo = self.load_at(&base_op).await?;
-            let mut tx = base_repo.start_transaction();
-            for other_op in operations {
-                tx.merge_operation(other_op).await?;
-                tx.repo_mut().rebase_descendants().await?;
+        workspace_name: Option<&WorkspaceName>,
+        transaction_description: Option<&str>,
+        transaction_attributes: impl IntoIterator<Item = (String, String)>,
+    ) -> Result<(Arc<ReadonlyRepo>, usize), RepoLoaderError> {
+        match &operations[..] {
+            [] => {
+                let root_operation = self.root_operation().await;
+                let root_repo = self.load_at(&root_operation).await?;
+                return Ok((root_repo, 0));
             }
-            let tx_description = tx_description.map_or_else(
-                || format!("merge {num_operations} operations"),
-                |tx_description| tx_description.to_string(),
-            );
-            let merged_repo = tx.write(tx_description).await?.leave_unpublished();
-            merged_repo.operation().clone()
-        } else {
-            base_op
-        };
+            [op] => {
+                let repo = self.load_at(op).await?;
+                return Ok((repo, 0));
+            }
+            _ => {}
+        }
 
-        Ok(final_op)
+        let mut num_rebased = 0;
+        let num_operations = operations.len();
+        let transaction_attributes = transaction_attributes.into_iter().collect_vec();
+        let mut tx = start_repo_transaction(
+            &self.load_at(&operations[0]).await?,
+            workspace_name,
+            transaction_attributes.clone(),
+        );
+        for other_op in operations.iter().skip(1) {
+            let ancestor_ops = op_walk::closest_common_ancestors(
+                tx.parent_ops().iter().cloned(),
+                [other_op.clone()],
+            )
+            .await?;
+            let base_op = match &ancestor_ops[..] {
+                [op] => op.clone(),
+                _ => {
+                    let (base_repo, num_rebased_inner) = Box::pin(self.merge_operations(
+                        ancestor_ops,
+                        workspace_name,
+                        transaction_description,
+                        transaction_attributes.clone(),
+                    ))
+                    .await?;
+                    num_rebased += num_rebased_inner;
+                    base_repo.operation().clone()
+                }
+            };
+            num_rebased += tx.merge_operation(&base_op, other_op).await?;
+        }
+        let tx_description = transaction_description.map_or_else(
+            || format!("merge {num_operations} operations"),
+            |tx_description| tx_description.to_string(),
+        );
+        let merged_repo = tx.write(tx_description).await?.leave_unpublished();
+        Ok((self.load_at(merged_repo.operation()).await?, num_rebased))
     }
 
     async fn finish_load(

--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -114,7 +114,6 @@ use crate::store::Store;
 use crate::submodule_store::SubmoduleStore;
 use crate::transaction::Transaction;
 use crate::transaction::TransactionCommitError;
-use crate::transaction::start_repo_transaction;
 use crate::tree_merge::MergeOptions;
 use crate::view::RenameWorkspaceError;
 use crate::view::View;
@@ -867,12 +866,13 @@ impl RepoLoader {
         // the arguments to that method.
         let mut closest_common_ancestors: HashMap<_, Vec<Operation>> = HashMap::new();
 
-        let transaction_attributes = transaction_attributes.into_iter().collect_vec();
-        let tx = start_repo_transaction(
-            &self.load_at(&operations[0]).await?,
-            workspace_name,
-            transaction_attributes.clone(),
-        );
+        let mut tx = self.load_at(&operations[0]).await?.start_transaction();
+        if let Some(workspace_name) = workspace_name {
+            tx.set_workspace_name(workspace_name);
+        }
+        for (key, value) in transaction_attributes {
+            tx.set_attribute(key, value);
+        }
         let mut stack = vec![(1, operations, tx)];
 
         while let Some((index, operations, mut tx)) = stack.pop() {

--- a/lib/src/transaction.rs
+++ b/lib/src/transaction.rs
@@ -164,6 +164,21 @@ impl Transaction {
     }
 }
 
+pub fn start_repo_transaction(
+    repo: &Arc<ReadonlyRepo>,
+    workspace_name: Option<&WorkspaceName>,
+    transaction_attributes: impl IntoIterator<Item = (String, String)>,
+) -> Transaction {
+    let mut tx = repo.start_transaction();
+    if let Some(workspace_name) = workspace_name {
+        tx.set_workspace_name(workspace_name);
+    }
+    for (key, value) in transaction_attributes {
+        tx.set_attribute(key, value);
+    }
+    tx
+}
+
 pub fn create_op_metadata(
     user_settings: &UserSettings,
     description: String,

--- a/lib/src/transaction.rs
+++ b/lib/src/transaction.rs
@@ -169,21 +169,6 @@ impl Transaction {
     }
 }
 
-pub fn start_repo_transaction(
-    repo: &Arc<ReadonlyRepo>,
-    workspace_name: Option<&WorkspaceName>,
-    transaction_attributes: impl IntoIterator<Item = (String, String)>,
-) -> Transaction {
-    let mut tx = repo.start_transaction();
-    if let Some(workspace_name) = workspace_name {
-        tx.set_workspace_name(workspace_name);
-    }
-    for (key, value) in transaction_attributes {
-        tx.set_attribute(key, value);
-    }
-    tx
-}
-
 pub fn create_op_metadata(
     user_settings: &UserSettings,
     description: String,

--- a/lib/src/transaction.rs
+++ b/lib/src/transaction.rs
@@ -27,7 +27,6 @@ use crate::op_store;
 use crate::op_store::OpStoreError;
 use crate::op_store::OperationMetadata;
 use crate::op_store::TimestampRange;
-use crate::op_walk;
 use crate::operation::Operation;
 use crate::ref_name::WorkspaceName;
 use crate::repo::MutableRepo;
@@ -82,6 +81,10 @@ impl Transaction {
         self.mut_repo.base_repo()
     }
 
+    pub fn parent_ops(&self) -> &[Operation] {
+        &self.parent_ops
+    }
+
     pub fn set_attribute(&mut self, key: String, value: String) {
         self.op_metadata.attributes.insert(key, value);
     }
@@ -94,18 +97,20 @@ impl Transaction {
         &mut self.mut_repo
     }
 
-    pub async fn merge_operation(&mut self, other_op: Operation) -> Result<(), RepoLoaderError> {
-        let ancestor_ops =
-            op_walk::closest_common_ancestors(self.parent_ops.iter().cloned(), [other_op.clone()])
-                .await?;
+    /// Merges other_op into this transaction, using base_op as the merge base.
+    /// Returns the number of rebased descendants.
+    pub async fn merge_operation(
+        &mut self,
+        base_op: &Operation,
+        other_op: &Operation,
+    ) -> Result<usize, RepoLoaderError> {
         let repo_loader = self.base_repo().loader();
-        let ancestor_op = Box::pin(repo_loader.merge_operations(ancestor_ops, None)).await?;
-        let base_repo = repo_loader.load_at(&ancestor_op).await?;
-        let other_repo = repo_loader.load_at(&other_op).await?;
-        self.parent_ops.push(other_op);
-        let merged_repo = self.repo_mut();
-        merged_repo.merge(&base_repo, &other_repo).await?;
-        Ok(())
+        let base_op_repo = repo_loader.load_at(base_op).await?;
+        let other_repo = repo_loader.load_at(other_op).await?;
+        self.parent_ops.push(other_op.clone());
+        self.repo_mut().merge(&base_op_repo, &other_repo).await?;
+        let num_rebased = self.repo_mut().rebase_descendants().await?;
+        Ok(num_rebased)
     }
 
     pub fn set_is_snapshot(&mut self, is_snapshot: bool) {

--- a/lib/tests/runner.rs
+++ b/lib/tests/runner.rs
@@ -27,6 +27,7 @@ mod test_local_working_copy;
 mod test_local_working_copy_concurrent;
 mod test_local_working_copy_executable_bit;
 mod test_local_working_copy_sparse;
+mod test_merge_operations;
 mod test_merge_trees;
 mod test_merged_tree;
 mod test_mut_repo;

--- a/lib/tests/test_merge_operations.rs
+++ b/lib/tests/test_merge_operations.rs
@@ -17,7 +17,6 @@ use std::process::Command;
 use jj_lib::op_store;
 use jj_lib::operation::Operation;
 use jj_lib::ref_name::WorkspaceName;
-use jj_lib::transaction::Transaction;
 use pollster::FutureExt as _;
 use testutils::CommitBuilderExt as _;
 use testutils::TestRepo;
@@ -52,17 +51,13 @@ fn test_merge_operations_deep_criss_cross() -> TestResult {
         .env(CHILD_ENV, "1")
         .env("RUST_MIN_STACK", CHILD_STACK_SIZE.to_string())
         .output()?;
-    // TODO: This test should pass!!! Fix the stack overflow and remove the if false
-    // guard.
-    if false {
-        assert!(
-            output.status.success(),
-            "deep criss-cross merge failed with {num_levels} levels and {CHILD_STACK_SIZE} byte \
-             child stack\nstdout:\n{}\nstderr:\n{}",
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr),
-        );
-    }
+    assert!(
+        output.status.success(),
+        "deep criss-cross merge failed with {num_levels} levels and {CHILD_STACK_SIZE} byte child \
+         stack\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
     Ok(())
 }
 
@@ -121,14 +116,14 @@ fn run_merge_operations_deep_criss_cross(num_levels: usize) -> TestResult {
 
     let workspace_name = None;
     let transaction_attributes = [];
-    let (merged_repo, _num_rebased) = Transaction::merge_operations(
-        repo_loader,
-        vec![left_op.clone(), right_op.clone()],
-        workspace_name,
-        Some("merge deep criss-cross"),
-        transaction_attributes,
-    )
-    .block_on()?;
+    let (merged_repo, _num_rebased) = repo_loader
+        .merge_operations(
+            vec![left_op.clone(), right_op.clone()],
+            workspace_name,
+            Some("merge deep criss-cross"),
+            transaction_attributes,
+        )
+        .block_on()?;
     assert!(!merged_repo.view().heads().is_empty());
     Ok(())
 }

--- a/lib/tests/test_merge_operations.rs
+++ b/lib/tests/test_merge_operations.rs
@@ -1,0 +1,134 @@
+// Copyright 2026 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::process::Command;
+
+use jj_lib::op_store;
+use jj_lib::operation::Operation;
+use jj_lib::ref_name::WorkspaceName;
+use jj_lib::transaction::Transaction;
+use pollster::FutureExt as _;
+use testutils::CommitBuilderExt as _;
+use testutils::TestRepo;
+use testutils::TestResult;
+use testutils::create_random_commit;
+use testutils::write_random_commit;
+
+// This test is about checking that we don't run out of stack space.
+#[test]
+fn test_merge_operations_deep_criss_cross() -> TestResult {
+    const CHILD_ENV: &str = "JJ_LIB_TEST_MERGE_OPS_DEEP_CRISS_CROSS_CHILD";
+    const LEVELS_ENV: &str = "JJ_LIB_TEST_MERGE_OPS_DEEP_CRISS_CROSS_LEVELS";
+    const CHILD_STACK_SIZE: usize = 512 * 1024;
+    const DEFAULT_NUM_LEVELS: usize = 14;
+
+    if std::env::var_os(CHILD_ENV).is_some() {
+        let num_levels = std::env::var(LEVELS_ENV)
+            .ok()
+            .and_then(|value| value.parse().ok())
+            .unwrap_or(DEFAULT_NUM_LEVELS);
+        return run_merge_operations_deep_criss_cross(num_levels);
+    }
+
+    let num_levels = std::env::var(LEVELS_ENV)
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(DEFAULT_NUM_LEVELS);
+    let output = Command::new(std::env::current_exe()?)
+        .arg("--exact")
+        .arg("test_merge_operations::test_merge_operations_deep_criss_cross")
+        .arg("--nocapture")
+        .env(CHILD_ENV, "1")
+        .env("RUST_MIN_STACK", CHILD_STACK_SIZE.to_string())
+        .output()?;
+    // TODO: This test should pass!!! Fix the stack overflow and remove the if false
+    // guard.
+    if false {
+        assert!(
+            output.status.success(),
+            "deep criss-cross merge failed with {num_levels} levels and {CHILD_STACK_SIZE} byte \
+             child stack\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+    }
+    Ok(())
+}
+
+fn run_merge_operations_deep_criss_cross(num_levels: usize) -> TestResult {
+    let test_repo = TestRepo::init();
+    let repo_loader = test_repo.repo.loader();
+
+    let mut tx_a = test_repo.repo.start_transaction();
+    let commit_k = write_random_commit(tx_a.repo_mut());
+    tx_a.repo_mut()
+        .set_wc_commit(WorkspaceName::DEFAULT.to_owned(), commit_k.id().clone())?;
+    let repo_a = tx_a.commit("K").block_on()?;
+
+    let mut tx_b = repo_a.start_transaction();
+    let _commit_k2 = tx_b
+        .repo_mut()
+        .rewrite_commit(&commit_k)
+        .set_description("K2")
+        .write_unwrap();
+    tx_b.repo_mut().rebase_descendants().block_on()?;
+
+    let mut tx_c = repo_a.start_transaction();
+    let commit_l = create_random_commit(tx_c.repo_mut())
+        .set_description("L")
+        .set_parents(vec![commit_k.id().clone()])
+        .write_unwrap();
+    tx_c.repo_mut()
+        .set_wc_commit(WorkspaceName::DEFAULT.to_owned(), commit_l.id().clone())?;
+
+    let repo_b = tx_b.commit("B").block_on()?;
+    let repo_c = tx_c.commit("C").block_on()?;
+
+    let mut left_op = repo_b.operation().clone();
+    let mut right_op = repo_c.operation().clone();
+    let op_store = repo_loader.op_store();
+    for _ in 0..num_levels {
+        let next_left_op = op_store::Operation {
+            view_id: left_op.view_id().clone(),
+            metadata: left_op.metadata().clone(),
+            parents: vec![left_op.id().clone(), right_op.id().clone()],
+            commit_predecessors: None,
+        };
+        let next_left_op_id = op_store.write_operation(&next_left_op).block_on()?;
+
+        let next_right_op = op_store::Operation {
+            view_id: right_op.view_id().clone(),
+            metadata: right_op.metadata().clone(),
+            parents: vec![left_op.id().clone(), right_op.id().clone()],
+            commit_predecessors: None,
+        };
+        let next_right_op_id = op_store.write_operation(&next_right_op).block_on()?;
+
+        left_op = Operation::new(op_store.clone(), next_left_op_id, next_left_op);
+        right_op = Operation::new(op_store.clone(), next_right_op_id, next_right_op);
+    }
+
+    let workspace_name = None;
+    let transaction_attributes = [];
+    let (merged_repo, _num_rebased) = Transaction::merge_operations(
+        repo_loader,
+        vec![left_op.clone(), right_op.clone()],
+        workspace_name,
+        Some("merge deep criss-cross"),
+        transaction_attributes,
+    )
+    .block_on()?;
+    assert!(!merged_repo.view().heads().is_empty());
+    Ok(())
+}

--- a/lib/tests/test_view.rs
+++ b/lib/tests/test_view.rs
@@ -37,6 +37,7 @@ use testutils::commit_transactions;
 use testutils::create_random_commit;
 use testutils::write_random_commit;
 use testutils::write_random_commit_with_parents;
+use testutils::write_random_commit_with_parents_and_description;
 
 fn remote_symbol<'a, N, M>(name: &'a N, remote: &'a M) -> RemoteRefSymbol<'a>
 where
@@ -709,6 +710,78 @@ fn test_merge_views_child_on_abandoned(child_first: bool) -> TestResult {
     Ok(())
 }
 
+#[test]
+fn test_merge_three_operations() -> TestResult {
+    // Operation graph:
+    // * Operation B rewrites commit K to K2
+    // * Operation C adds commit L as a child of K
+    // * Operation D adds commit M as a child of K
+    // * Operation E is the merge of B, C, and D (reconciliation)
+    //
+    // E
+    // |\
+    // |\ \
+    // | | D  wc: M->K
+    // | C |  wc: L->K
+    // B |/   wc: K2
+    // |/
+    // A      wc: K
+
+    let test_repo = TestRepo::init();
+
+    let mut tx_a = test_repo.repo.start_transaction();
+    let commit_k = write_random_commit(tx_a.repo_mut());
+    tx_a.repo_mut()
+        .set_wc_commit(WorkspaceName::DEFAULT.to_owned(), commit_k.id().clone())?;
+    let repo_a = tx_a.commit("K").block_on()?;
+
+    let mut tx_b = repo_a.start_transaction();
+    let commit_k2 = tx_b
+        .repo_mut()
+        .rewrite_commit(&commit_k)
+        .set_description("K2")
+        .write_unwrap();
+    tx_b.repo_mut().rebase_descendants().block_on()?;
+
+    let mut tx_c = repo_a.start_transaction();
+    let commit_l = write_random_commit_with_parents(tx_c.repo_mut(), &[&commit_k]);
+    tx_c.repo_mut()
+        .set_wc_commit(WorkspaceName::DEFAULT.to_owned(), commit_l.id().clone())?;
+
+    let mut tx_d = repo_a.start_transaction();
+    let commit_m = write_random_commit_with_parents(tx_d.repo_mut(), &[&commit_k]);
+    tx_d.repo_mut()
+        .set_wc_commit(WorkspaceName::DEFAULT.to_owned(), commit_m.id().clone())?;
+
+    let repo_b = tx_b.commit("B").block_on()?;
+    std::thread::sleep(Duration::from_millis(1));
+    let repo_c = tx_c.commit("C").block_on()?;
+    std::thread::sleep(Duration::from_millis(1));
+    let repo_d = tx_d.commit("D").block_on()?;
+
+    let (repo_e, _num_rebased) = repo_b
+        .loader()
+        .merge_operations(
+            vec![
+                repo_b.operation().clone(),
+                repo_c.operation().clone(),
+                repo_d.operation().clone(),
+            ],
+            None,
+            Some("merge B, C, D"),
+            [],
+        )
+        .block_on()?;
+    let operation_e = repo_e.operation().clone();
+    let view_e = operation_e.view().block_on()?;
+    assert_eq!(
+        view_e.get_wc_commit_id(WorkspaceName::DEFAULT).unwrap(),
+        commit_k2.id(),
+    );
+
+    Ok(())
+}
+
 #[test_case(false ; "operation C first")]
 #[test_case(true ; "operation B first")]
 fn test_merge_views_criss_cross(op_b_first: bool) -> TestResult {
@@ -784,5 +857,149 @@ fn test_merge_views_criss_cross(op_b_first: bool) -> TestResult {
             .unwrap(),
         commit_m.id(),
     );
+    Ok(())
+}
+
+#[test]
+fn test_merge_operations_back_to_back_criss_cross() -> TestResult {
+    // H
+    // |\
+    // F G
+    // |X|
+    // D E L2->K2(@)
+    // |X|
+    // | C L(@)->K
+    // B | K2(@)
+    // |/
+    // A   K(@)
+
+    let test_repo = TestRepo::init();
+
+    let mut tx_a = test_repo.repo.start_transaction();
+    let commit_k = write_random_commit(tx_a.repo_mut());
+    tx_a.repo_mut()
+        .set_wc_commit(WorkspaceName::DEFAULT.to_owned(), commit_k.id().clone())?;
+    let repo_a = tx_a.commit("TXA").block_on()?;
+
+    let mut tx_b = repo_a.start_transaction();
+    let _commit_k2 = tx_b
+        .repo_mut()
+        .rewrite_commit(&commit_k)
+        .set_description("K2")
+        .write_unwrap();
+    tx_b.repo_mut().rebase_descendants().block_on()?;
+
+    let mut tx_c = repo_a.start_transaction();
+    let commit_l =
+        write_random_commit_with_parents_and_description(tx_c.repo_mut(), &[&commit_k], "L");
+    tx_c.repo_mut().rebase_descendants().block_on()?;
+    tx_c.repo_mut()
+        .set_wc_commit(WorkspaceName::DEFAULT.to_owned(), commit_l.id().clone())?;
+
+    let repo_b = tx_b.commit("TXB").block_on()?;
+    std::thread::sleep(Duration::from_millis(1));
+    let repo_c = tx_c.commit("TXC").block_on()?;
+    std::thread::sleep(Duration::from_millis(1));
+
+    let (repo_d, _num_rebased) = repo_b
+        .loader()
+        .merge_operations(
+            vec![repo_b.operation().clone(), repo_c.operation().clone()],
+            None,
+            Some("merge B, C"),
+            [],
+        )
+        .block_on()?;
+    std::thread::sleep(Duration::from_millis(1));
+
+    let (repo_e, _num_rebased) = repo_b
+        .loader()
+        .merge_operations(
+            vec![repo_b.operation().clone(), repo_c.operation().clone()],
+            None,
+            Some("merge B, C again, concurrently"),
+            [],
+        )
+        .block_on()?;
+    std::thread::sleep(Duration::from_millis(1));
+
+    let view_d = repo_d.operation().view().block_on()?;
+    let view_e = repo_e.operation().view().block_on()?;
+    assert_eq!(view_d.heads().len(), 1);
+    assert_eq!(view_e.heads().len(), 1);
+
+    let commit_l2 = repo_d
+        .store()
+        .get_commit(view_d.heads().iter().next().unwrap())?;
+    let commit_l2_prime = repo_e
+        .store()
+        .get_commit(view_e.heads().iter().next().unwrap())?;
+    assert_eq!(commit_l2.description(), "L");
+    assert_eq!(commit_l2_prime.description(), "L");
+    assert!(commit_l2.id() != commit_l.id());
+    assert!(commit_l2.id() != commit_l2_prime.id());
+    assert_eq!(
+        repo_d
+            .store()
+            .get_commit(&commit_l2.parent_ids()[0])
+            .unwrap()
+            .description(),
+        "K2"
+    );
+    assert_eq!(
+        repo_e
+            .store()
+            .get_commit(&commit_l2_prime.parent_ids()[0])
+            .unwrap()
+            .description(),
+        "K2"
+    );
+    assert_eq!(
+        *view_d.get_wc_commit_id(WorkspaceName::DEFAULT).unwrap(),
+        commit_l2.parent_ids()[0],
+    );
+    assert_eq!(
+        *view_e.get_wc_commit_id(WorkspaceName::DEFAULT).unwrap(),
+        commit_l2_prime.parent_ids()[0],
+    );
+
+    let (repo_f, _num_rebased) = repo_d
+        .loader()
+        .merge_operations(
+            vec![repo_d.operation().clone(), repo_e.operation().clone()],
+            None,
+            Some("merge D, E"),
+            [],
+        )
+        .block_on()?;
+    std::thread::sleep(Duration::from_millis(1));
+
+    let (repo_g, _num_rebased) = repo_d
+        .loader()
+        .merge_operations(
+            vec![repo_d.operation().clone(), repo_e.operation().clone()],
+            None,
+            Some("merge D, E again, concurrently"),
+            [],
+        )
+        .block_on()?;
+    std::thread::sleep(Duration::from_millis(1));
+
+    let view_f = repo_f.operation().view().block_on()?;
+    let view_g = repo_g.operation().view().block_on()?;
+    assert_eq!(view_f.heads().len(), 2);
+    assert_eq!(view_g.heads().len(), 2);
+
+    let (repo_h, _num_rebased) = repo_f
+        .loader()
+        .merge_operations(
+            vec![repo_f.operation().clone(), repo_g.operation().clone()],
+            None,
+            Some("merge F, G"),
+            [],
+        )
+        .block_on()?;
+    assert_eq!(repo_h.view().heads().len(), 2);
+
     Ok(())
 }

--- a/lib/tests/test_view.rs
+++ b/lib/tests/test_view.rs
@@ -757,15 +757,13 @@ fn test_merge_views_criss_cross(op_b_first: bool) -> TestResult {
     };
 
     let mut tx_d = repo_b.start_transaction();
-    tx_d.merge_operation(repo_c.operation().clone())
+    tx_d.merge_operation(repo_a.operation(), repo_c.operation())
         .block_on()?;
-    tx_d.repo_mut().rebase_descendants().block_on()?;
     let repo_d = tx_d.commit("D").block_on()?;
 
     let mut tx_e = repo_b.start_transaction();
-    tx_e.merge_operation(repo_c.operation().clone())
+    tx_e.merge_operation(repo_a.operation(), repo_c.operation())
         .block_on()?;
-    tx_e.repo_mut().rebase_descendants().block_on()?;
     let _repo_e = tx_e.commit("E").block_on()?;
 
     let mut tx_f = repo_d.start_transaction();

--- a/lib/testutils/src/lib.rs
+++ b/lib/testutils/src/lib.rs
@@ -759,6 +759,22 @@ pub fn write_random_commit_with_parents(mut_repo: &mut MutableRepo, parents: &[&
         .write_unwrap()
 }
 
+pub fn write_random_commit_with_parents_and_description(
+    mut_repo: &mut MutableRepo,
+    parents: &[&Commit],
+    description: &str,
+) -> Commit {
+    let parents = if parents.is_empty() {
+        &[&mut_repo.store().root_commit()]
+    } else {
+        parents
+    };
+    create_random_commit(mut_repo)
+        .set_description(description)
+        .set_parents(parents.iter().map(|commit| commit.id().clone()).collect())
+        .write_unwrap()
+}
+
 pub fn write_working_copy_file(workspace_root: &Path, path: &RepoPath, contents: impl AsRef<[u8]>) {
     let path = path.to_fs_path(workspace_root).unwrap();
     if let Some(parent) = path.parent() {


### PR DESCRIPTION
This PR makes RepoLoader.merge_operations non-recursive to fix a stack-overflow issue.

In the process (and per review feedback) I also consolidated various call-sites in commands to use new unified helper functions for merging operations.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [ ] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
