### PR TITLE
fix: Replace `line-range-arg` with `line-range-args`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,12 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   you need to pass multiple arguments to the tool, such as Prettier which
   accepts separate args for the range start and range end.
 
+* Added `fix.tools.<name>.run-tool-per-line-range` to control whether the tool
+  is run one time total with all the modified line ranges as arguments, or one
+  time for each modified line range. The default is `false`, which matches the
+  previous behavior. This is to accommodate tools which do not accept multiple
+  line ranges in a single invocation, such as Prettier.
+
 ### Fixed bugs
 
 * `jj` now creates a new working-copy revision during snapshotting if the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Deprecations
 
+* `fix.tools.<name>.line-range-arg` is deprecated in favor of `line-range-args`,
+  which is an array of string template args instead of a single string template.
+
 ### New features
 
 * `jj show` now supports `--reversed` flag.
@@ -38,6 +41,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   own private working copy; the commands may update the working copy and
   changes/conflicts are propagated accordingly, e.g., `jj run -- cargo check
   --all-features` or `jj run -- cargo fix` behaves as one might expect.
+
+* `fix.tools.<name>.line-range-args` (replaces `line-range-arg`) is an array of
+  string template args to pass to the fix tool. This is more flexible in case
+  you need to pass multiple arguments to the tool, such as Prettier which
+  accepts separate args for the range start and range end.
 
 ### Fixed bugs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   removes it, allowing colocation to be toggled after workspace
   creation.
 
+* `fix.tools.<name>.line-range-args` (replaces `line-range-arg`) is an array of
+  string template args to pass to the fix tool. This is more flexible in cases
+  where you need to pass multiple arguments to the tool, such as separate args
+  for the range start and range end.
+
 ### Fixed bugs
 
 ## [0.45.1] - 2026-09-03

--- a/cli/src/commands/fix.rs
+++ b/cli/src/commands/fix.rs
@@ -333,43 +333,64 @@ async fn fix_one_file(
     };
 
     let new_content = matching_tools.fold(old_content.clone(), |prev_content, tool_config| {
-        let mut extra_args = Vec::new();
-
-        if !tool_config.line_range_args.is_empty() {
+        let mut invocation_args = Vec::new();
+        if tool_config.line_range_args.is_empty() {
+            // Run once without any line range args.
+            invocation_args.push(Vec::new());
+        } else {
             let RegionsToFormat::LineRanges(ranges) =
                 compute_regions_to_format(base_content.as_deref(), &prev_content);
-            if ranges.is_empty() && !tool_config.run_tool_if_zero_line_ranges {
-                // Don't run the tool if there are no line ranges to format and the tool is
-                // configured to not run in that case.
-                return prev_content;
-            }
-
-            for range in ranges {
-                for line_range_arg in &tool_config.line_range_args {
-                    extra_args.push(
+            let line_range_args_per_range = ranges.iter().map(|range| {
+                tool_config
+                    .line_range_args
+                    .iter()
+                    .map(|line_range_arg| {
                         line_range_arg
                             .replace("$first", &range.first.to_string())
-                            .replace("$last", &range.last.to_string()),
-                    );
+                            .replace("$last", &range.last.to_string())
+                    })
+                    .collect_vec()
+            });
+
+            if tool_config.run_tool_per_line_range {
+                // Iterate in reverse order for stable line numbers.
+                // (Note that no ranges means that the tool won't be run, even
+                // if `run_tool_if_zero_line_ranges` is also true.)
+                for line_range_args in line_range_args_per_range.rev() {
+                    // Run one invocation for each line range.
+                    invocation_args.push(line_range_args);
                 }
+            } else if !ranges.is_empty() || tool_config.run_tool_if_zero_line_ranges {
+                // Combine all args into a single invocation. If there were no
+                // ranges, then no "line range args" will be given to the tool,
+                // but it will still be called.
+                invocation_args.push(line_range_args_per_range.flatten().collect_vec());
+            } else {
+                // There are no ranges and the tool is not configured to run in
+                // this case, so skip it.
+                return prev_content;
             }
         }
 
-        match run_tool(
-            ui,
-            workspace_root,
-            path_converter,
-            &tool_config.command,
-            file_to_fix,
-            &prev_content,
-            &extra_args,
-        ) {
-            Ok(next_content) => next_content,
-            // TODO: Because the stderr is passed through, this isn't always failing
-            // silently, but it should do something better will the exit code, tool
-            // name, etc.
-            Err(()) => prev_content,
-        }
+        invocation_args
+            .iter()
+            .fold(prev_content, |prev_content, args_list| {
+                match run_tool(
+                    ui,
+                    workspace_root,
+                    path_converter,
+                    &tool_config.command,
+                    file_to_fix,
+                    &prev_content,
+                    args_list,
+                ) {
+                    Ok(next_content) => next_content,
+                    // TODO: Because stderr is passed through, this isn't always
+                    // failing silently, but it should do something better with
+                    // the exit code, tool name, etc.
+                    Err(()) => prev_content,
+                }
+            })
     });
 
     if new_content != old_content {
@@ -501,6 +522,14 @@ struct ToolConfig {
     /// For example, `"--lines=$first-$last"`. Each string will be passed as a
     /// separate argument to the tool.
     line_range_args: Vec<String>,
+    /// Whether to run the tool invocation once for each range of changed lines
+    /// or one time with all line range arguments.
+    ///
+    /// Defaults to `false`, meaning multiple `line_range_args` arguments will
+    /// be added to the tool argument list, and the tool will only be called
+    /// once. If `true`, then the tool will be called once for each line range
+    /// (in reverse order so that the line numbers are stable).
+    run_tool_per_line_range: bool,
     /// Whether to run the tool invocation for this tool on files that had
     /// zero line ranges to format in the revision being fixed.
     ///
@@ -538,6 +567,8 @@ struct RawToolConfig {
     #[serde(default)]
     line_range_args: Vec<String>,
     #[serde(default)]
+    run_tool_per_line_range: bool,
+    #[serde(default)]
     run_tool_if_zero_line_ranges: bool,
 }
 
@@ -568,10 +599,17 @@ fn get_tools_config(
                     .map(|arg| fileset::parse(&mut diagnostics, arg, fileset_context))
                     .try_collect()?,
             );
-            if tool.line_range_args.is_empty() && tool.run_tool_if_zero_line_ranges {
-                return Err(config_error(
-                    "run-tool-if-zero-line-ranges can only be set when line-range-args is set",
-                ));
+            if tool.line_range_args.is_empty() {
+                if tool.run_tool_per_line_range {
+                    return Err(config_error(
+                        "run-tool-per-line-range can only be set when line-range-args is set",
+                    ));
+                }
+                if tool.run_tool_if_zero_line_ranges {
+                    return Err(config_error(
+                        "run-tool-if-zero-line-ranges can only be set when line-range-args is set",
+                    ));
+                }
             }
             print_parse_diagnostics(ui, &format!("In `fix.tools.{name}`"), &diagnostics)?;
             Ok(ToolConfig {
@@ -579,6 +617,7 @@ fn get_tools_config(
                 matcher: expression.to_matcher(),
                 enabled: tool.enabled,
                 line_range_args: tool.line_range_args,
+                run_tool_per_line_range: tool.run_tool_per_line_range,
                 run_tool_if_zero_line_ranges: tool.run_tool_if_zero_line_ranges,
             })
         })

--- a/cli/src/commands/fix.rs
+++ b/cli/src/commands/fix.rs
@@ -316,7 +316,11 @@ async fn fix_one_file(
         None
     } else {
         match &file_to_fix.base_file_id {
-            Some(base_file_id) if matching_tools.clone().any(|t| t.line_range_arg.is_some()) => {
+            Some(base_file_id)
+                if matching_tools
+                    .clone()
+                    .any(|t| !t.line_range_args.is_empty()) =>
+            {
                 let mut content = vec![];
                 let mut read = store
                     .read_file(&file_to_fix.repo_path, base_file_id)
@@ -331,7 +335,7 @@ async fn fix_one_file(
     let new_content = matching_tools.fold(old_content.clone(), |prev_content, tool_config| {
         let mut extra_args = Vec::new();
 
-        if let Some(line_range_arg) = &tool_config.line_range_arg {
+        if !tool_config.line_range_args.is_empty() {
             let RegionsToFormat::LineRanges(ranges) =
                 compute_regions_to_format(base_content.as_deref(), &prev_content);
             if ranges.is_empty() && !tool_config.run_tool_if_zero_line_ranges {
@@ -341,11 +345,13 @@ async fn fix_one_file(
             }
 
             for range in ranges {
-                extra_args.push(
-                    line_range_arg
-                        .replace("$first", &range.first.to_string())
-                        .replace("$last", &range.last.to_string()),
-                );
+                for line_range_arg in &tool_config.line_range_args {
+                    extra_args.push(
+                        line_range_arg
+                            .replace("$first", &range.first.to_string())
+                            .replace("$last", &range.last.to_string()),
+                    );
+                }
             }
         }
 
@@ -490,10 +496,11 @@ struct ToolConfig {
     /// Whether the tool is enabled
     enabled: bool,
     /// Arguments to pass changed line ranges to the tool.
-    /// The string is a template where `$first` and `$last` are replaced by the
+    /// Each string is a template where `$first` and `$last` are replaced by the
     /// 1-based first and last inclusive line numbers of the changed range.
-    /// For example, `"--lines=$first-$last"`.
-    line_range_arg: Option<String>,
+    /// For example, `"--lines=$first-$last"`. Each string will be passed as a
+    /// separate argument to the tool.
+    line_range_args: Vec<String>,
     /// Whether to run the tool invocation for this tool on files that had
     /// zero line ranges to format in the revision being fixed.
     ///
@@ -501,7 +508,7 @@ struct ToolConfig {
     /// This default behavior serves two main purposes:
     /// - Avoiding unnecessary executions of tools when no line ranges are
     ///   modified.
-    /// - Preventing tools configured with `line-range-arg` from making overly
+    /// - Preventing tools configured with `line-range-args` from making overly
     ///   broad changes (formatting the whole file) when no line ranges are
     ///   available.
     ///
@@ -529,7 +536,7 @@ struct RawToolConfig {
     #[serde(default = "default_tool_enabled")]
     enabled: bool,
     #[serde(default)]
-    line_range_arg: Option<String>,
+    line_range_args: Vec<String>,
     #[serde(default)]
     run_tool_if_zero_line_ranges: bool,
 }
@@ -561,9 +568,9 @@ fn get_tools_config(
                     .map(|arg| fileset::parse(&mut diagnostics, arg, fileset_context))
                     .try_collect()?,
             );
-            if tool.line_range_arg.is_none() && tool.run_tool_if_zero_line_ranges {
+            if tool.line_range_args.is_empty() && tool.run_tool_if_zero_line_ranges {
                 return Err(config_error(
-                    "run-tool-if-zero-line-ranges can only be set when line-range-arg is set",
+                    "run-tool-if-zero-line-ranges can only be set when line-range-args is set",
                 ));
             }
             print_parse_diagnostics(ui, &format!("In `fix.tools.{name}`"), &diagnostics)?;
@@ -571,7 +578,7 @@ fn get_tools_config(
                 command: tool.command,
                 matcher: expression.to_matcher(),
                 enabled: tool.enabled,
-                line_range_arg: tool.line_range_arg,
+                line_range_args: tool.line_range_args,
                 run_tool_if_zero_line_ranges: tool.run_tool_if_zero_line_ranges,
             })
         })

--- a/cli/src/commands/fix.rs
+++ b/cli/src/commands/fix.rs
@@ -317,7 +317,11 @@ async fn fix_one_file(
         None
     } else {
         match &file_to_fix.base_file_id {
-            Some(base_file_id) if matching_tools.clone().any(|t| t.line_range_arg.is_some()) => {
+            Some(base_file_id)
+                if matching_tools
+                    .clone()
+                    .any(|t| !t.line_range_args.is_empty()) =>
+            {
                 let mut content = vec![];
                 let mut read = store
                     .read_file(&file_to_fix.repo_path, base_file_id)
@@ -332,7 +336,7 @@ async fn fix_one_file(
     let new_content = matching_tools.fold(old_content.clone(), |prev_content, tool_config| {
         let mut extra_args = Vec::new();
 
-        if let Some(line_range_arg) = &tool_config.line_range_arg {
+        if !tool_config.line_range_args.is_empty() {
             let RegionsToFormat::LineRanges(ranges) =
                 compute_regions_to_format(base_content.as_deref(), &prev_content);
             if ranges.is_empty() && !tool_config.run_tool_if_zero_line_ranges {
@@ -342,11 +346,13 @@ async fn fix_one_file(
             }
 
             for range in ranges {
-                extra_args.push(
-                    line_range_arg
-                        .replace("$first", &range.first.to_string())
-                        .replace("$last", &range.last.to_string()),
-                );
+                for line_range_arg in &tool_config.line_range_args {
+                    extra_args.push(
+                        line_range_arg
+                            .replace("$first", &range.first.to_string())
+                            .replace("$last", &range.last.to_string()),
+                    );
+                }
             }
         }
 
@@ -491,10 +497,11 @@ struct ToolConfig {
     /// Whether the tool is enabled
     enabled: bool,
     /// Arguments to pass changed line ranges to the tool.
-    /// The string is a template where `$first` and `$last` are replaced by the
-    /// 1-based first and last inclusive line numbers of the changed range.
-    /// For example, `"--lines=$first-$last"`.
-    line_range_arg: Option<String>,
+    /// Each string is a template where `$first` and `$last` are replaced by the
+    /// 1-based first and last inclusive line numbers of the changed range;
+    /// for example, `["--lines=$first:$last"]`. Each string will be passed as a
+    /// separate argument to the tool.
+    line_range_args: Vec<String>,
     /// Whether to run the tool invocation for this tool on files that had
     /// zero line ranges to format in the revision being fixed.
     ///
@@ -502,7 +509,7 @@ struct ToolConfig {
     /// This default behavior serves two main purposes:
     /// - Avoiding unnecessary executions of tools when no line ranges are
     ///   modified.
-    /// - Preventing tools configured with `line-range-arg` from making overly
+    /// - Preventing tools configured with `line-range-args` from making overly
     ///   broad changes (formatting the whole file) when no line ranges are
     ///   available.
     ///
@@ -530,7 +537,7 @@ struct RawToolConfig {
     #[serde(default = "default_tool_enabled")]
     enabled: bool,
     #[serde(default)]
-    line_range_arg: Option<String>,
+    line_range_args: Vec<String>,
     #[serde(default)]
     run_tool_if_zero_line_ranges: bool,
 }
@@ -562,9 +569,9 @@ fn get_tools_config(
                     .map(|arg| fileset::parse(&mut diagnostics, arg, fileset_context))
                     .try_collect()?,
             );
-            if tool.line_range_arg.is_none() && tool.run_tool_if_zero_line_ranges {
+            if tool.line_range_args.is_empty() && tool.run_tool_if_zero_line_ranges {
                 return Err(config_error(
-                    "run-tool-if-zero-line-ranges can only be set when line-range-arg is set",
+                    "run-tool-if-zero-line-ranges can only be set when line-range-args is set",
                 ));
             }
             print_parse_diagnostics(ui, &format!("In `fix.tools.{name}`"), &diagnostics)?;
@@ -572,7 +579,7 @@ fn get_tools_config(
                 command: tool.command,
                 matcher: expression.to_matcher(),
                 enabled: tool.enabled,
-                line_range_arg: tool.line_range_arg,
+                line_range_args: tool.line_range_args,
                 run_tool_if_zero_line_ranges: tool.run_tool_if_zero_line_ranges,
             })
         })

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -999,9 +999,12 @@
                                 "description": "Disables this tool if set to false",
                                 "default": true
                             },
-                            "line-range-arg": {
-                                "type": "string",
-                                "description": "Argument template for changed line ranges (e.g. '--lines=$first-$last')"
+                            "line-range-args": {
+                                "description": "Argument templates for changed line ranges (e.g. ['--lines', '$first-$last'])",
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
                             },
                             "run-tool-if-zero-line-ranges": {
                                 "type": "boolean",

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -1006,9 +1006,14 @@
                                     "type": "string"
                                 }
                             },
+                            "run-tool-per-line-range": {
+                                "type": "boolean",
+                                "description": "Whether to run the tool once for each line range for once with multiple line range arguments",
+                                "default": false
+                            },
                             "run-tool-if-zero-line-ranges": {
                                 "type": "boolean",
-                                "description": "Whether to run the tool if there are zero line ranges to format.",
+                                "description": "Whether to run the tool if there are zero line ranges to format",
                                 "default": false
                             }
                         }

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -1039,9 +1039,12 @@
                                 "description": "Disables this tool if set to false",
                                 "default": true
                             },
-                            "line-range-arg": {
-                                "type": "string",
-                                "description": "Argument template for changed line ranges (e.g. '--lines=$first-$last')"
+                            "line-range-args": {
+                                "description": "Argument templates for changed line ranges (e.g. ['--lines=$first:$last'])",
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
                             },
                             "run-tool-if-zero-line-ranges": {
                                 "type": "boolean",

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -877,7 +877,85 @@ fn parse_config_arg_item(item_str: &str) -> Result<(ConfigNamePathBuf, ConfigVal
 
 /// List of rules to migrate deprecated config variables.
 pub fn default_config_migrations() -> Vec<ConfigMigrationRule> {
-    vec![]
+    vec![
+        // TODO: Remove in jj 0.48+
+        ConfigMigrationRule::custom(
+            |layer| {
+                let Ok(Some(tools_table)) = layer.look_up_table("fix.tools") else {
+                    return false;
+                };
+                tools_table.iter().any(|(_, item)| {
+                    item.as_table_like()
+                        .is_some_and(|tool_config| tool_config.contains_key("line-range-arg"))
+                })
+            },
+            |layer| {
+                let bad_tool_names = if let Ok(Some(tools_table)) = layer.look_up_table("fix.tools")
+                {
+                    tools_table
+                        .iter()
+                        .filter_map(|(tool_name, item)| {
+                            if item.as_table_like()?.contains_key("line-range-arg") {
+                                Some(tool_name.to_string())
+                            } else {
+                                None
+                            }
+                        })
+                        .collect_vec()
+                } else {
+                    vec![]
+                };
+                if bad_tool_names.is_empty() {
+                    // Somehow no tools config needed to be migrated. Should
+                    // have been caught by `matches()`, but just return a
+                    // generic message.
+                    return Ok("`fix.tools.<name>.line-range-arg` is deprecated; use \
+                               `line-range-args` instead."
+                        .into());
+                }
+                let mut messages = vec![];
+                for tool_name in bad_tool_names {
+                    let old_name = &ConfigNamePathBuf::from_iter([
+                        "fix",
+                        "tools",
+                        &tool_name,
+                        "line-range-arg",
+                    ]);
+                    let new_name = &ConfigNamePathBuf::from_iter([
+                        "fix",
+                        "tools",
+                        &tool_name,
+                        "line-range-args",
+                    ]);
+
+                    let Ok(Some(old_value)) = layer.delete_value(old_name) else {
+                        // Failed to delete the value. Ignore it; it'll be tried
+                        // again later.
+                        continue;
+                    };
+                    if matches!(layer.look_up_item(new_name), Ok(Some(_))) {
+                        messages.push(format!("{old_name} is deleted (superseded by {new_name})"));
+                        continue;
+                    }
+                    let Some(old_value_str) = old_value.as_str() else {
+                        return Err(jj_lib::config::ConfigMigrateLayerError::Type {
+                            name: old_name.to_string(),
+                            error: format!(
+                                "Failed to migrate {old_name}, which was expected to be a string"
+                            )
+                            .into(),
+                        });
+                    };
+                    layer.set_value(new_name, toml_edit::Array::from_iter([old_value_str]))?;
+                    messages.push(format!(
+                        "{old_name} is updated to {new_name} = [{}]",
+                        old_value.decorated("", "")
+                    ));
+                }
+                Ok(messages.join(", "))
+            },
+        ),
+    ]
 }
 
 /// Command name and arguments specified by config.

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -963,7 +963,85 @@ fn parse_config_arg_item(item_str: &str) -> Result<(ConfigNamePathBuf, ConfigVal
 
 /// List of rules to migrate deprecated config variables.
 pub fn default_config_migrations() -> Vec<ConfigMigrationRule> {
-    vec![]
+    vec![
+        // TODO: Remove in jj 0.51+
+        ConfigMigrationRule::custom(
+            |layer| {
+                let Ok(Some(tools_table)) = layer.look_up_table("fix.tools") else {
+                    return false;
+                };
+                tools_table.iter().any(|(_, item)| {
+                    item.as_table_like()
+                        .is_some_and(|tool_config| tool_config.contains_key("line-range-arg"))
+                })
+            },
+            |layer| {
+                let bad_tool_names = if let Ok(Some(tools_table)) = layer.look_up_table("fix.tools")
+                {
+                    tools_table
+                        .iter()
+                        .filter_map(|(tool_name, item)| {
+                            if item.as_table_like()?.contains_key("line-range-arg") {
+                                Some(tool_name.to_string())
+                            } else {
+                                None
+                            }
+                        })
+                        .collect_vec()
+                } else {
+                    vec![]
+                };
+                if bad_tool_names.is_empty() {
+                    // Somehow no tools config needed to be migrated. Should
+                    // have been caught by `matches()`, but just return a
+                    // generic message.
+                    return Ok("`fix.tools.<name>.line-range-arg` is deprecated; use \
+                               `line-range-args` instead."
+                        .into());
+                }
+                let mut messages = vec![];
+                for tool_name in bad_tool_names {
+                    let old_name = &ConfigNamePathBuf::from_iter([
+                        "fix",
+                        "tools",
+                        &tool_name,
+                        "line-range-arg",
+                    ]);
+                    let new_name = &ConfigNamePathBuf::from_iter([
+                        "fix",
+                        "tools",
+                        &tool_name,
+                        "line-range-args",
+                    ]);
+
+                    let Ok(Some(old_value)) = layer.delete_value(old_name) else {
+                        // Failed to delete the value. Ignore it; it'll be tried
+                        // again later.
+                        continue;
+                    };
+                    if matches!(layer.look_up_item(new_name), Ok(Some(_))) {
+                        messages.push(format!("{old_name} is deleted (superseded by {new_name})"));
+                        continue;
+                    }
+                    let Some(old_value_str) = old_value.as_str() else {
+                        return Err(jj_lib::config::ConfigMigrateLayerError::Type {
+                            name: old_name.to_string(),
+                            error: format!(
+                                "Failed to migrate {old_name}, which was expected to be a string"
+                            )
+                            .into(),
+                        });
+                    };
+                    layer.set_value(new_name, ConfigValue::from_iter([old_value_str]))?;
+                    messages.push(format!(
+                        "{old_name} is updated to {new_name} = [{}]",
+                        old_value.decorated("", "")
+                    ));
+                }
+                Ok(messages.join(", "))
+            },
+        ),
+    ]
 }
 
 /// Command name and arguments specified by config.

--- a/cli/tests/test_fix_command.rs
+++ b/cli/tests/test_fix_command.rs
@@ -1755,6 +1755,139 @@ fn test_fix_with_line_ranges() {
 }
 
 #[test]
+fn test_fix_with_run_tool_per_line_range() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+    let formatter_path = assert_cmd::cargo::cargo_bin!("fake-formatter");
+    assert!(formatter_path.is_file());
+    let formatter = to_toml_value(formatter_path.to_str().unwrap());
+    test_env.add_config(format!(
+        r###"
+        [fix.tools.tool-1]
+        command = [{formatter}, "--uppercase", "--stderr=tool-1-invoked"]
+        patterns = ["all()"]
+        line-range-args = ["--line-ranges=$first-$last"]
+        run-tool-per-line-range = true
+        
+        [fix.tools.tool-2]
+        command = [{formatter}, "--lowercase", "--stderr=tool-2-invoked"]
+        patterns = ["all()"]
+        line-range-args = ["--line-ranges=$first-$last"]
+        run-tool-per-line-range = false
+        "###,
+    ));
+
+    // Initial commit.
+    work_dir.write_file("foo", "Foo1\nFoo2\nFoo3\n");
+    work_dir.write_file("bar", "unmodified\n");
+    work_dir
+        .run_jj(["bookmark", "create", "-r@", "c1"])
+        .success();
+
+    // Create a new commit with multiple modifications in `foo`, resulting in
+    // distinct line ranges.
+    work_dir.run_jj(["new"]).success();
+    work_dir.write_file("foo", "Foo1-modified\nFoo2\nFoo4-added\n");
+    work_dir.write_file("bar", "unmodified\n");
+    work_dir
+        .run_jj(["bookmark", "create", "-r@", "c2"])
+        .success();
+
+    // Run `jj fix` on the second commit.
+    let output = work_dir.run_jj(["fix", "-s", "c2"]).success();
+    // Tool 1 was invoked twice (once for each line range), but tool 2 was only
+    // invoked once. To ensure deterministic output order, the formatters must
+    // apply to the same file.
+    insta::assert_snapshot!(output, @r"
+    ------- stderr -------
+    foo:
+    tool-1-invoked
+    foo:
+    tool-1-invoked
+    foo:
+    tool-2-invoked
+    Fixed 1 commits of 1 checked.
+    Working copy  (@) now at: kkmpptxz 3bebd5d7 c2 | (no description set)
+    Parent commit (@-)      : qpvuntsm 78607d1a c1 | (no description set)
+    Added 0 files, modified 1 files, removed 0 files
+    [EOF]
+    ");
+
+    // Check that the formatters were not applied to the first commit.
+    let output = work_dir.run_jj(["file", "show", "foo", "-r", "c1"]);
+    insta::assert_snapshot!(output, @r"
+    Foo1
+    Foo2
+    Foo3
+    [EOF]
+    ");
+    let output = work_dir.run_jj(["file", "show", "bar", "-r", "c1"]);
+    insta::assert_snapshot!(output, @r"
+    unmodified
+    [EOF]
+    ");
+
+    // Check that the formatters were applied to the second commit. Since tool 2
+    // ran last, the modified lines should be lowercase.
+    let output = work_dir.run_jj(["file", "show", "foo", "-r", "c2"]);
+    insta::assert_snapshot!(output, @r"
+    foo1-modified
+    Foo2
+    foo4-added
+    [EOF]
+    ");
+    let output = work_dir.run_jj(["file", "show", "bar", "-r", "c2"]);
+    insta::assert_snapshot!(output, @r"
+    unmodified
+    [EOF]
+    ");
+}
+
+#[test]
+fn test_fix_with_run_tool_per_line_range_invalid() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+    let formatter_path = assert_cmd::cargo::cargo_bin!("fake-formatter");
+    assert!(formatter_path.is_file());
+    let formatter = to_toml_value(formatter_path.to_str().unwrap());
+    test_env.add_config(format!(
+        r###"
+        [fix.tools.tool-1]
+        command = [{formatter}, "--uppercase"]
+        patterns = ["foo"]
+        line-range-args = []
+        run-tool-per-line-range = true
+        "###,
+    ));
+
+    // Initial commit.
+    work_dir.write_file("foo", "Foo1\nFoo2\nFoo3\n");
+    work_dir
+        .run_jj(["bookmark", "create", "-r@", "c1"])
+        .success();
+
+    // Create a new commit modifying "foo".
+    work_dir.run_jj(["new"]).success();
+    work_dir.write_file("foo", "Foo1\nFoo3\n");
+    work_dir
+        .run_jj(["bookmark", "create", "-r@", "c2"])
+        .success();
+
+    // Run `jj fix` on the second commit. It should fail due to the invalid fix
+    // tools config.
+    let output = work_dir.run_jj(["fix", "-s", "c2"]);
+    insta::assert_snapshot!(output, @r"
+    ------- stderr -------
+    Config error: run-tool-per-line-range can only be set when line-range-args is set
+    For help, see https://docs.jj-vcs.dev/latest/config/ or use `jj help -k config`.
+    [EOF]
+    [exit status: 1]
+    ");
+}
+
+#[test]
 fn test_fix_with_run_tool_if_zero_line_ranges() {
     let test_env = TestEnvironment::default();
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();
@@ -1938,6 +2071,91 @@ fn test_fix_with_run_tool_if_zero_line_ranges_invalid() {
     For help, see https://docs.jj-vcs.dev/latest/config/ or use `jj help -k config`.
     [EOF]
     [exit status: 1]
+    ");
+}
+
+#[test]
+fn test_fix_with_run_tool_per_line_range_and_zero_line_ranges() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+    let formatter_path = assert_cmd::cargo::cargo_bin!("fake-formatter");
+    assert!(formatter_path.is_file());
+    let formatter = to_toml_value(formatter_path.to_str().unwrap());
+    test_env.add_config(format!(
+        r###"
+        [fix.tools.tool-1]
+        command = [{formatter}, "--uppercase", "--stderr=tool-invoked:$path"]
+        patterns = ["all()"]
+        line-range-args = ["--line-ranges=$first-$last"]
+        run-tool-per-line-range = true
+        run-tool-if-zero-line-ranges = true
+        "###,
+    ));
+
+    // Initial commit.
+    work_dir.write_file("foo", "Foo1\nFoo2\nFoo3\n");
+    work_dir.write_file("bar", "Bar1\nBar2\n");
+    work_dir
+        .run_jj(["bookmark", "create", "-r@", "c1"])
+        .success();
+
+    // Create a new commit with multiple modifications in `foo`, resulting in
+    // distinct line ranges.
+    work_dir.run_jj(["new"]).success();
+    work_dir.write_file("foo", "Foo1-modified\nFoo2\nFoo4-added\n");
+    work_dir.write_file("bar", "Bar1\nBar2\n");
+    work_dir
+        .run_jj(["bookmark", "create", "-r@", "c2"])
+        .success();
+
+    // Run `jj fix` on the second commit.
+    let output = work_dir.run_jj(["fix", "-s", "c2"]).success();
+    // The tool was invoked twice on `foo` (once for each line range), but never
+    // on `bar` because there were no line ranges, despite
+    // `run-tool-if-zero-line-ranges`.
+    insta::assert_snapshot!(output, @r"
+    ------- stderr -------
+    foo:
+    tool-invoked:foo
+    foo:
+    tool-invoked:foo
+    Fixed 1 commits of 1 checked.
+    Working copy  (@) now at: kkmpptxz cb6c708a c2 | (no description set)
+    Parent commit (@-)      : qpvuntsm aab8d4df c1 | (no description set)
+    Added 0 files, modified 1 files, removed 0 files
+    [EOF]
+    ");
+
+    // Check that the formatters were not applied to the first commit.
+    let output = work_dir.run_jj(["file", "show", "foo", "-r", "c1"]);
+    insta::assert_snapshot!(output, @r"
+    Foo1
+    Foo2
+    Foo3
+    [EOF]
+    ");
+    let output = work_dir.run_jj(["file", "show", "bar", "-r", "c1"]);
+    insta::assert_snapshot!(output, @r"
+    Bar1
+    Bar2
+    [EOF]
+    ");
+
+    // Check that the formatters were applied to `foo` in the second commit, but
+    // `bar` should be unchanged.
+    let output = work_dir.run_jj(["file", "show", "foo", "-r", "c2"]);
+    insta::assert_snapshot!(output, @r"
+    FOO1-MODIFIED
+    Foo2
+    FOO4-ADDED
+    [EOF]
+    ");
+    let output = work_dir.run_jj(["file", "show", "bar", "-r", "c2"]);
+    insta::assert_snapshot!(output, @r"
+    Bar1
+    Bar2
+    [EOF]
     ");
 }
 

--- a/cli/tests/test_fix_command.rs
+++ b/cli/tests/test_fix_command.rs
@@ -1647,12 +1647,12 @@ fn test_fix_with_line_ranges() {
         [fix.tools.tool-1]
         command = [{formatter}, "--uppercase"]
         patterns = ["foo", "baz", "qux"]
-        line-range-arg = "--line-ranges=$first-$last"
+        line-range-args = ["--line-ranges=$first-$last"]
 
         [fix.tools.tool-2]
         command = [{formatter}, "--lowercase"]
         patterns = ["bar", "baz"]
-        line-range-arg = "--line-ranges=$first-$last"
+        line-range-args = ["--line-ranges", "$first-$last"]
         "###,
     ));
 
@@ -1767,19 +1767,19 @@ fn test_fix_with_run_tool_if_zero_line_ranges() {
         [fix.tools.tool-1]
         command = [{formatter}, "--uppercase"]
         patterns = ["foo", "baz"]
-        line-range-arg = "--line-ranges=$first-$last"
+        line-range-args = ["--line-ranges=$first-$last"]
         run-tool-if-zero-line-ranges = true
 
         [fix.tools.tool-2]
         command = [{formatter}, "--lowercase"]
         patterns = ["bar"]
-        line-range-arg = "--line-ranges=$first-$last"
+        line-range-args = ["--line-ranges=$first-$last"]
         run-tool-if-zero-line-ranges = false
 
         [fix.tools.tool-3]
         command = [{formatter}, "--uppercase", "--split-even-length-lines"]
         patterns = ["qux"]
-        line-range-arg = "--line-ranges=$first-$last"
+        line-range-args = ["--line-ranges", "$first-$last"]
         run-tool-if-zero-line-ranges = true
         "###,
     ));
@@ -1899,6 +1899,49 @@ fn test_fix_with_run_tool_if_zero_line_ranges() {
 }
 
 #[test]
+fn test_fix_with_run_tool_if_zero_line_ranges_invalid() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+    let formatter_path = assert_cmd::cargo::cargo_bin!("fake-formatter");
+    assert!(formatter_path.is_file());
+    let formatter = to_toml_value(formatter_path.to_str().unwrap());
+    test_env.add_config(format!(
+        r###"
+        [fix.tools.tool-1]
+        command = [{formatter}, "--uppercase"]
+        patterns = ["foo"]
+        line-range-args = []
+        run-tool-if-zero-line-ranges = true
+        "###,
+    ));
+
+    // Initial commit.
+    work_dir.write_file("foo", "Foo1\nFoo2\nFoo3\n");
+    work_dir
+        .run_jj(["bookmark", "create", "-r@", "c1"])
+        .success();
+
+    // Create a new commit modifying "foo".
+    work_dir.run_jj(["new"]).success();
+    work_dir.write_file("foo", "Foo1\nFoo3\n");
+    work_dir
+        .run_jj(["bookmark", "create", "-r@", "c2"])
+        .success();
+
+    // Run `jj fix` on the second commit. It should fail due to the invalid fix
+    // tools config.
+    let output = work_dir.run_jj(["fix", "-s", "c2"]);
+    insta::assert_snapshot!(output, @r"
+    ------- stderr -------
+    Config error: run-tool-if-zero-line-ranges can only be set when line-range-args is set
+    For help, see https://docs.jj-vcs.dev/latest/config/ or use `jj help -k config`.
+    [EOF]
+    [exit status: 1]
+    ");
+}
+
+#[test]
 fn test_fix_with_all_lines_arg() {
     let test_env = TestEnvironment::default();
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();
@@ -1911,7 +1954,7 @@ fn test_fix_with_all_lines_arg() {
         [fix.tools.tool-1]
         command = [{formatter}, "--uppercase"]
         patterns = ["foo", "baz", "qux"]
-        line-range-arg = "--line-ranges=$first-$last"
+        line-range-args = ["--line-ranges=$first-$last"]
 
         [fix.tools.tool-2]
         command = [{formatter}, "--lowercase"]
@@ -2013,12 +2056,12 @@ fn test_fix_with_line_ranges_multiple_formatters() {
         [fix.tools.tool-1]
         command = [{formatter}, "--split-even-length-lines"]
         patterns = ["foo", "boo"]
-        line-range-arg = "--line-ranges=$first-$last"
+        line-range-args = ["--line-ranges=$first-$last"]
 
         [fix.tools.tool-2]
         command = [{formatter}, "--uppercase"]
         patterns = ["foo", "boo"]
-        line-range-arg = "--line-ranges=$first-$last"
+        line-range-args = ["--line-ranges=$first-$last"]
         "###,
     ));
 
@@ -2089,7 +2132,7 @@ fn test_fix_with_line_ranges_and_include_unchanged_files_all_lines() {
         [fix.tools.tool-1]
         command = [{formatter}, "--uppercase"]
         patterns = ["all()"]
-        line-range-arg = "--line-ranges=$first-$last"
+        line-range-args = ["--line-ranges=$first-$last"]
         "###,
     ));
 
@@ -2174,4 +2217,36 @@ fn test_fix_with_line_ranges_and_include_unchanged_files_all_lines() {
     ");
     let output = work_dir.run_jj(["file", "show", "empty.txt", "-r", "c2"]);
     insta::assert_snapshot!(output, @r"");
+}
+
+// TODO: Remove in jj 0.48+
+#[test]
+fn test_fix_line_range_args_migration() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+    let formatter_path = assert_cmd::cargo::cargo_bin!("fake-formatter");
+    assert!(formatter_path.is_file());
+    let formatter = to_toml_value(formatter_path.to_str().unwrap());
+    test_env.add_config(format!(
+        r###"
+        [fix.tools.tool-1]
+        command = [{formatter}, "--uppercase"]
+        patterns = ["all()"]
+        line-range-arg = "--line-ranges=$first-$last"
+        "###,
+    ));
+
+    work_dir.write_file("file.txt", "foo\n");
+
+    let output = work_dir.run_jj(["fix"]).success();
+    insta::assert_snapshot!(output, @r#"
+    ------- stderr -------
+    Warning: Deprecated user-level config: fix.tools.tool-1.line-range-arg is updated to fix.tools.tool-1.line-range-args = ["--line-ranges=$first-$last"]
+    Fixed 1 commits of 1 checked.
+    Working copy  (@) now at: qpvuntsm bce2043c (no description set)
+    Parent commit (@-)      : zzzzzzzz 00000000 (empty) (no description set)
+    Added 0 files, modified 1 files, removed 0 files
+    [EOF]
+    "#);
 }

--- a/cli/tests/test_fix_command.rs
+++ b/cli/tests/test_fix_command.rs
@@ -1647,12 +1647,12 @@ fn test_fix_with_line_ranges() {
         [fix.tools.tool-1]
         command = [{formatter}, "--uppercase"]
         patterns = ["foo", "baz", "qux"]
-        line-range-arg = "--line-ranges=$first-$last"
+        line-range-args = ["--line-ranges=$first-$last"]
 
         [fix.tools.tool-2]
         command = [{formatter}, "--lowercase"]
         patterns = ["bar", "baz"]
-        line-range-arg = "--line-ranges=$first-$last"
+        line-range-args = ["--line-ranges", "$first-$last"]
         "###,
     ));
 
@@ -1667,7 +1667,7 @@ fn test_fix_with_line_ranges() {
     // Create new commit modifying foo and bar.
     work_dir.run_jj(["new"]).success();
     work_dir.write_file("foo", "Foo1\nFoo2-Mod\nFoo3\n");
-    work_dir.write_file("bar", "Bar1-Mod\nBar2\nBar3\n");
+    work_dir.write_file("bar", "Bar1-Mod\nBar2\nBar3-Mod\n");
     work_dir.write_file("baz", "unmodified\n");
     work_dir
         .run_jj(["bookmark", "create", "-r@", "c2"])
@@ -1688,8 +1688,8 @@ fn test_fix_with_line_ranges() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Fixed 2 commits of 2 checked.
-    Working copy  (@) now at: mzvwutvl 7d52a6e8 c3 | (no description set)
-    Parent commit (@-)      : kkmpptxz a8e4c2e8 c2 | (no description set)
+    Working copy  (@) now at: mzvwutvl 56f659c4 c3 | (no description set)
+    Parent commit (@-)      : kkmpptxz a3b54db4 c2 | (no description set)
     Added 0 files, modified 2 files, removed 0 files
     [EOF]
     ");
@@ -1727,7 +1727,7 @@ fn test_fix_with_line_ranges() {
     insta::assert_snapshot!(output, @"
     bar1-mod
     Bar2
-    Bar3
+    bar3-mod
     [EOF]
     ");
     let output = work_dir.run_jj(["file", "show", "baz", "-r", "c2"]);
@@ -1767,19 +1767,19 @@ fn test_fix_with_run_tool_if_zero_line_ranges() {
         [fix.tools.tool-1]
         command = [{formatter}, "--uppercase"]
         patterns = ["foo", "baz"]
-        line-range-arg = "--line-ranges=$first-$last"
+        line-range-args = ["--line-ranges=$first-$last"]
         run-tool-if-zero-line-ranges = true
 
         [fix.tools.tool-2]
         command = [{formatter}, "--lowercase"]
         patterns = ["bar"]
-        line-range-arg = "--line-ranges=$first-$last"
+        line-range-args = ["--line-ranges=$first-$last"]
         run-tool-if-zero-line-ranges = false
 
         [fix.tools.tool-3]
         command = [{formatter}, "--uppercase", "--split-even-length-lines"]
         patterns = ["qux"]
-        line-range-arg = "--line-ranges=$first-$last"
+        line-range-args = ["--line-ranges", "$first-$last"]
         run-tool-if-zero-line-ranges = true
         "###,
     ));
@@ -1899,6 +1899,49 @@ fn test_fix_with_run_tool_if_zero_line_ranges() {
 }
 
 #[test]
+fn test_fix_with_run_tool_if_zero_line_ranges_invalid() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+    let formatter_path = assert_cmd::cargo::cargo_bin!("fake-formatter");
+    assert!(formatter_path.is_file());
+    let formatter = to_toml_value(formatter_path.to_str().unwrap());
+    test_env.add_config(format!(
+        r###"
+        [fix.tools.tool-1]
+        command = [{formatter}, "--uppercase"]
+        patterns = ["foo"]
+        line-range-args = []
+        run-tool-if-zero-line-ranges = true
+        "###,
+    ));
+
+    // Initial commit.
+    work_dir.write_file("foo", "Foo1\nFoo2\nFoo3\n");
+    work_dir
+        .run_jj(["bookmark", "create", "-r@", "c1"])
+        .success();
+
+    // Create a new commit modifying "foo".
+    work_dir.run_jj(["new"]).success();
+    work_dir.write_file("foo", "Foo1\nFoo3\n");
+    work_dir
+        .run_jj(["bookmark", "create", "-r@", "c2"])
+        .success();
+
+    // Run `jj fix` on the second commit. It should fail due to the invalid fix
+    // tools config.
+    let output = work_dir.run_jj(["fix", "-s", "c2"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    Config error: run-tool-if-zero-line-ranges can only be set when line-range-args is set
+    For help, see https://docs.jj-vcs.dev/latest/config/ or use `jj help -k config`.
+    [EOF]
+    [exit status: 1]
+    ");
+}
+
+#[test]
 fn test_fix_with_all_lines_arg() {
     let test_env = TestEnvironment::default();
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();
@@ -1911,7 +1954,7 @@ fn test_fix_with_all_lines_arg() {
         [fix.tools.tool-1]
         command = [{formatter}, "--uppercase"]
         patterns = ["foo", "baz", "qux"]
-        line-range-arg = "--line-ranges=$first-$last"
+        line-range-args = ["--line-ranges=$first-$last"]
 
         [fix.tools.tool-2]
         command = [{formatter}, "--lowercase"]
@@ -2013,12 +2056,12 @@ fn test_fix_with_line_ranges_multiple_formatters() {
         [fix.tools.tool-1]
         command = [{formatter}, "--split-even-length-lines"]
         patterns = ["foo", "boo"]
-        line-range-arg = "--line-ranges=$first-$last"
+        line-range-args = ["--line-ranges=$first-$last"]
 
         [fix.tools.tool-2]
         command = [{formatter}, "--uppercase"]
         patterns = ["foo", "boo"]
-        line-range-arg = "--line-ranges=$first-$last"
+        line-range-args = ["--line-ranges=$first-$last"]
         "###,
     ));
 
@@ -2089,7 +2132,7 @@ fn test_fix_with_line_ranges_and_include_unchanged_files_all_lines() {
         [fix.tools.tool-1]
         command = [{formatter}, "--uppercase"]
         patterns = ["all()"]
-        line-range-arg = "--line-ranges=$first-$last"
+        line-range-args = ["--line-ranges=$first-$last"]
         "###,
     ));
 
@@ -2174,4 +2217,36 @@ fn test_fix_with_line_ranges_and_include_unchanged_files_all_lines() {
     ");
     let output = work_dir.run_jj(["file", "show", "empty.txt", "-r", "c2"]);
     insta::assert_snapshot!(output, @"");
+}
+
+// TODO: Remove in jj 0.51+
+#[test]
+fn test_fix_line_range_args_migration() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+    let formatter_path = assert_cmd::cargo::cargo_bin!("fake-formatter");
+    assert!(formatter_path.is_file());
+    let formatter = to_toml_value(formatter_path.to_str().unwrap());
+    test_env.add_config(format!(
+        r###"
+        [fix.tools.tool-1]
+        command = [{formatter}, "--uppercase"]
+        patterns = ["all()"]
+        line-range-arg = "--line-ranges=$first-$last"
+        "###,
+    ));
+
+    work_dir.write_file("file.txt", "foo\n");
+
+    let output = work_dir.run_jj(["fix"]).success();
+    insta::assert_snapshot!(output, @r#"
+    ------- stderr -------
+    Warning: Deprecated user-level config: fix.tools.tool-1.line-range-arg is updated to fix.tools.tool-1.line-range-args = ["--line-ranges=$first-$last"]
+    Fixed 1 commits of 1 checked.
+    Working copy  (@) now at: qpvuntsm bce2043c (no description set)
+    Parent commit (@-)      : zzzzzzzz 00000000 (empty) (no description set)
+    Added 0 files, modified 1 files, removed 0 files
+    [EOF]
+    "#);
 }

--- a/docs/config.md
+++ b/docs/config.md
@@ -1394,44 +1394,44 @@ The file is only rewritten if the subprocess produces a successful exit code.
 
 ### Configuration
 
-Tools are defined in a table where the keys are arbitrary identifiers and
-the values have the following properties:
- - `command`: The arguments used to run the tool. The first argument is the
-   path to an executable file. Arguments can contain these variables that will
-   be replaced:
-   - `$root` will be replaced with the workspace root path (the directory
-     containing the .jj directory).
-   - `$path` will be replaced with the repo-relative path of the file being
-     fixed. It is useful to provide the path to tools that include the path
-     in error messages, or behave differently based on the directory or file
-     name.
- - `patterns`: List of filesets (see: `jj help -k filesets`), determining
-   which files the tool will affect based on their path. If this list is
-   empty, no files will be affected by the tool. If there are multiple
-   patterns, the tool is applied only once to each file in the union of the
-   patterns.
- - `enabled`: Enables or disables the tool. If omitted, the tool is enabled.
-   This is useful for defining disabled tools in user configuration that can
-   be enabled in individual repositories with one config setting.
- - `line-range-arg`: An optional template string specifying how to pass a line
-   range to the tool. It may include the variables `$first` and `$last`, which
-   will be replaced with the 1-based line numbers of, respectively, the first
-   and last lines inside the modified range. A range containing a single line
-   will have equal values for `$first` and `$last`. Empty ranges representing
-   deletions will be skipped because they cannot be represented this way.
-   If the tool does not support formatting specific line ranges, this setting
-   should be omitted, and the tool will always process the entire file.
-   Example: `line-range-arg = "--lines=$first:$last"`.
- - `run-tool-if-zero-line-ranges`: Whether to run the tool invocation for this tool on
-   files that had zero line ranges to format in the revision being fixed.
-   Defaults to `false`, meaning the tool is skipped for these files. This default
-   behavior serves two main purposes:
-   - Avoiding unnecessary executions of tools when no line ranges are modified.
-   - Preventing tools configured with `line-range-arg` from making overly
-     broad changes (formatting the whole file) when no line ranges are available.
+Tools are defined in a table where the keys are arbitrary identifiers and the
+values have the following properties:
 
-   Setting this to `true` is useful if the tool should run regardless of diffs
-   (e.g., to sort imports, or run with `--include-unchanged-files`).
+- `command`: The arguments used to run the tool. The first argument is the path
+  to an executable file. Arguments can contain these variables that will be
+  replaced:
+  - `$root` will be replaced with the workspace root path (the directory
+    containing the .jj directory).
+  - `$path` will be replaced with the repo-relative path of the file being
+    fixed. It is useful to provide the path to tools that include the path in
+    error messages, or behave differently based on the directory or file name.
+- `patterns`: List of filesets (see: `jj help -k filesets`), determining which
+  files the tool will affect based on their path. If this list is empty, no
+  files will be affected by the tool. If there are multiple patterns, the tool
+  is applied only once to each file in the union of the patterns.
+- `enabled`: Enables or disables the tool. If omitted, the tool is enabled. This
+  is useful for defining disabled tools in user configuration that can be
+  enabled in individual repositories with one config setting.
+- `line-range-args`: Optional array of template strings specifying how to pass a
+  line range to the tool. It may include the variables `$first` and `$last`,
+  which will be replaced with the 1-based line numbers of the first and last
+  lines inside the modified range, respectively. A range containing a single
+  line will have equal values for `$first` and `$last`. Empty ranges
+  representing deletions will be skipped because they cannot be represented this
+  way. If the tool does not support formatting specific line ranges, this
+  setting should be omitted, and the tool will always process the entire file.
+  - Example: `line-range-args = ["--lines", "$first:$last"]`
+  - Example: `line-range-args = ["--line-start=$first", "--line-end=$last"]`
+- `run-tool-if-zero-line-ranges`: Whether to run the tool invocation for this
+  tool on files that had zero line ranges to format in the revision being fixed.
+  Defaults to `false`, meaning the tool is skipped for these files. This default
+  behavior serves two main purposes:
+  - Avoiding unnecessary executions of tools when no line ranges are modified.
+  - Preventing tools configured with `line-range-args` from making overly broad
+    changes (formatting the whole file) when no line ranges are available.
+
+  Setting this to `true` is useful if the tool should run regardless of diffs
+  (e.g., to sort imports, or run with `--include-unchanged-files`).
 
 `jj fix` provides the file content anonymously on standard input, but the name
 of the file being formatted may be important for include sorting or other output
@@ -1469,9 +1469,9 @@ You can configure `jj fix` to run a formatter only on the modified lines of a
 file, rather than formatting the entire file. This is particularly useful for
 avoiding unrelated formatting changes in untouched parts of a file.
 
-To enable this, specify the `line-range-arg` configuration to match the line
+To enable this, specify the `line-range-args` configuration to match the line
 range argument format expected by your tool. The formatter will be invoked with
-this argument repeated for each modified line range (e.g. `--lines=10-20
+these arguments repeated for each modified line range (e.g. `--lines=10-20
 --lines=30-40`).
 
 Additionally, you can use `run-tool-if-zero-line-ranges` to control the
@@ -1492,7 +1492,7 @@ command = ["/usr/bin/clang-format", "--assume-filename=$path"]
 patterns = ["glob:'**/*.cc'",
             "glob:'**/*.h'"]
 enabled = true
-line-range-arg = "--lines=$first:$last"
+line-range-args = ["--lines=$first:$last"]
 run-tool-if-zero-line-ranges = false
 ```
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -1422,6 +1422,12 @@ values have the following properties:
   setting should be omitted, and the tool will always process the entire file.
   - Example: `line-range-args = ["--lines", "$first:$last"]`
   - Example: `line-range-args = ["--line-start=$first", "--line-end=$last"]`
+- `run-tool-per-line-range`: Whether to run the tool invocation once for each
+  range of changed lines or one time with all line range arguments. Defaults to
+  `false`, meaning multiple `line-range-args` arguments will be added to the
+  tool argument list, and the tool will only be called once. If `true`, then the
+  tool will be called once for each line range (in reverse order so that the
+  line numbers are stable).
 - `run-tool-if-zero-line-ranges`: Whether to run the tool invocation for this
   tool on files that had zero line ranges to format in the revision being fixed.
   Defaults to `false`, meaning the tool is skipped for these files. This default
@@ -1470,9 +1476,12 @@ file, rather than formatting the entire file. This is particularly useful for
 avoiding unrelated formatting changes in untouched parts of a file.
 
 To enable this, specify the `line-range-args` configuration to match the line
-range argument format expected by your tool. The formatter will be invoked with
-these arguments repeated for each modified line range (e.g. `--lines=10-20
---lines=30-40`).
+range argument format expected by your tool. If `run-tool-per-line-range` is
+`true`, the tool will be invoked once per line range with these arguments (in
+reverse order so line numbers are stable; e.g., once with `--lines=30-40`, then
+once with `--lines=10-20`, etc.). If `run-tool-per-line-range` is `false` (the
+default), the formatter will be invoked once with these arguments repeated for
+each modified line range (e.g., `--lines=10-20 --lines=30-40`).
 
 Additionally, you can use `run-tool-if-zero-line-ranges` to control the
 behavior when a diff results in zero line ranges (which can happen when lines

--- a/docs/config.md
+++ b/docs/config.md
@@ -1414,44 +1414,44 @@ The file is only rewritten if the subprocess produces a successful exit code.
 
 ### Configuration
 
-Tools are defined in a table where the keys are arbitrary identifiers and
-the values have the following properties:
- - `command`: The arguments used to run the tool. The first argument is the
-   path to an executable file. Arguments can contain these variables that will
-   be replaced:
-   - `$root` will be replaced with the workspace root path (the directory
-     containing the .jj directory).
-   - `$path` will be replaced with the repo-relative path of the file being
-     fixed. It is useful to provide the path to tools that include the path
-     in error messages, or behave differently based on the directory or file
-     name.
- - `patterns`: List of filesets (see: `jj help -k filesets`), determining
-   which files the tool will affect based on their path. If this list is
-   empty, no files will be affected by the tool. If there are multiple
-   patterns, the tool is applied only once to each file in the union of the
-   patterns.
- - `enabled`: Enables or disables the tool. If omitted, the tool is enabled.
-   This is useful for defining disabled tools in user configuration that can
-   be enabled in individual repositories with one config setting.
- - `line-range-arg`: An optional template string specifying how to pass a line
-   range to the tool. It may include the variables `$first` and `$last`, which
-   will be replaced with the 1-based line numbers of, respectively, the first
-   and last lines inside the modified range. A range containing a single line
-   will have equal values for `$first` and `$last`. Empty ranges representing
-   deletions will be skipped because they cannot be represented this way.
-   If the tool does not support formatting specific line ranges, this setting
-   should be omitted, and the tool will always process the entire file.
-   Example: `line-range-arg = "--lines=$first:$last"`.
- - `run-tool-if-zero-line-ranges`: Whether to run the tool invocation for this tool on
-   files that had zero line ranges to format in the revision being fixed.
-   Defaults to `false`, meaning the tool is skipped for these files. This default
-   behavior serves two main purposes:
-   - Avoiding unnecessary executions of tools when no line ranges are modified.
-   - Preventing tools configured with `line-range-arg` from making overly
-     broad changes (formatting the whole file) when no line ranges are available.
+Tools are defined in a table where the keys are arbitrary identifiers and the
+values have the following properties:
 
-   Setting this to `true` is useful if the tool should run regardless of diffs
-   (e.g., to sort imports, or run with `--include-unchanged-files`).
+- `command`: The arguments used to run the tool. The first argument is the path
+  to an executable file. Arguments can contain these variables that will be
+  replaced:
+  - `$root` will be replaced with the workspace root path (the directory
+    containing the .jj directory).
+  - `$path` will be replaced with the repo-relative path of the file being
+    fixed. It is useful to provide the path to tools that include the path in
+    error messages, or behave differently based on the directory or file name.
+- `patterns`: List of filesets (see: `jj help -k filesets`), determining which
+  files the tool will affect based on their path. If this list is empty, no
+  files will be affected by the tool. If there are multiple patterns, the tool
+  is applied only once to each file in the union of the patterns.
+- `enabled`: Enables or disables the tool. If omitted, the tool is enabled. This
+  is useful for defining disabled tools in user configuration that can be
+  enabled in individual repositories with one config setting.
+- `line-range-args`: Optional array of template strings specifying how to pass a
+  line range to the tool. It may include the variables `$first` and `$last`,
+  which will be replaced with the 1-based line numbers of the first and last
+  lines inside the modified range, respectively. A range containing a single
+  line will have equal values for `$first` and `$last`. Empty ranges
+  representing deletions will be skipped because they cannot be represented this
+  way. If the tool does not support formatting specific line ranges, this
+  setting should be omitted, and the tool will always process the entire file.
+  - Example: `line-range-args = ["--lines=$first:$last"]`
+  - Example: `line-range-args = ["--line-start=$first", "--line-end=$last"]`
+- `run-tool-if-zero-line-ranges`: Whether to run the tool invocation for this
+  tool on files that had zero line ranges to format in the revision being fixed.
+  Defaults to `false`, meaning the tool is skipped for these files. This default
+  behavior serves two main purposes:
+  - Avoiding unnecessary executions of tools when no line ranges are modified.
+  - Preventing tools configured with `line-range-args` from making overly broad
+    changes (formatting the whole file) when no line ranges are available.
+
+  Setting this to `true` is useful if the tool should run regardless of diffs
+  (e.g., to sort imports, or run with `--include-unchanged-files`).
 
 `jj fix` provides the file content anonymously on standard input, but the name
 of the file being formatted may be important for include sorting or other output
@@ -1489,9 +1489,9 @@ You can configure `jj fix` to run a formatter only on the modified lines of a
 file, rather than formatting the entire file. This is particularly useful for
 avoiding unrelated formatting changes in untouched parts of a file.
 
-To enable this, specify the `line-range-arg` configuration to match the line
+To enable this, specify the `line-range-args` configuration to match the line
 range argument format expected by your tool. The formatter will be invoked with
-this argument repeated for each modified line range (e.g. `--lines=10-20
+these arguments repeated for each modified line range (e.g. `--lines=10-20
 --lines=30-40`).
 
 Additionally, you can use `run-tool-if-zero-line-ranges` to control the
@@ -1512,7 +1512,7 @@ command = ["/usr/bin/clang-format", "--assume-filename=$path"]
 patterns = ["glob:'**/*.cc'",
             "glob:'**/*.h'"]
 enabled = true
-line-range-arg = "--lines=$first:$last"
+line-range-args = ["--lines=$first:$last"]
 run-tool-if-zero-line-ranges = false
 ```
 


### PR DESCRIPTION
Partially addresses #9585

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [x] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
