### PR TITLE
cli: create mutable working-copy commit only when needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed bugs
 
+* `jj` now creates a new working-copy revision during snapshotting if the
+  working copy was immutable. Previously, the new revision was created
+  immediately after the working copy became immutable.
+  [#7751](https://github.com/jj-vcs/jj/issues/7751)
+  [#9338](https://github.com/jj-vcs/jj/issues/9338)
+
 ## [0.42.0] - 2026-06-04
 
 ### Release highlights

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -2030,15 +2030,43 @@ to the current parents may contain changes from multiple commits.
                 self.env.command.string_args(),
             );
             tx.set_is_snapshot(true);
-            let mut_repo = tx.repo_mut();
-            let commit = mut_repo
-                .rewrite_commit(&wc_commit)
-                .set_tree(new_tree.clone())
-                .write()
-                .await
+            let immutable_expr = self
+                .env
+                .resolve_immutable_expression(tx.repo())
                 .map_err(snapshot_command_error)?;
+            let wc_immutable = immutable_expr
+                .intersection(&RevsetExpression::commit(wc_commit.id().clone()))
+                .evaluate(tx.repo())
+                .map_err(snapshot_command_error)?
+                .stream()
+                .try_next()
+                .await
+                .map_err(snapshot_command_error)?
+                .is_some();
+            let mut_repo = tx.repo_mut();
+            let new_wc_commit;
+            if wc_immutable {
+                new_wc_commit = mut_repo
+                    .new_commit(vec![wc_commit.id().clone()], new_tree.clone())
+                    .write()
+                    .await
+                    .map_err(snapshot_command_error)?;
+                writeln!(
+                    ui.warning_default(),
+                    "The working-copy commit is immutable; a new commit has been created on top \
+                     of it.",
+                )
+                .map_err(snapshot_command_error)?;
+            } else {
+                new_wc_commit = mut_repo
+                    .rewrite_commit(&wc_commit)
+                    .set_tree(new_tree.clone())
+                    .write()
+                    .await
+                    .map_err(snapshot_command_error)?;
+            }
             mut_repo
-                .set_wc_commit(workspace_name, commit.id().clone())
+                .set_wc_commit(workspace_name, new_wc_commit.id().clone())
                 .map_err(snapshot_command_error)?;
 
             // Rebase descendants
@@ -2057,7 +2085,7 @@ to the current parents may contain changes from multiple commits.
             #[cfg(feature = "git")]
             if self.working_copy_shared_with_git && self.env.command.should_commit_transaction() {
                 let old_tree = wc_commit.tree();
-                let new_tree = commit.tree();
+                let new_tree = new_wc_commit.tree();
                 export_working_copy_changes_to_git(ui, mut_repo, &old_tree, &new_tree)
                     .await
                     .map_err(snapshot_command_error)?;
@@ -2189,49 +2217,13 @@ to the current parents may contain changes from multiple commits.
             writeln!(ui.status(), "Rebased {num_rebased} descendant commits")?;
         }
 
-        // This can fail if trunk() bookmark gets deleted or conflicted. If the
-        // unresolvable trunk() issue gets addressed differently, it should be
-        // okay to propagate the error.
-        let immutable_expr = match self.env.resolve_immutable_expression(tx.repo()) {
-            Ok(expr) => expr,
-            Err(CommandError { error, .. }) => {
-                writeln!(
-                    ui.warning_default(),
-                    "Failed to check mutability of the new working-copy revision."
-                )?;
-                print_error_sources(ui, Some(&error))?;
-                RevsetExpression::root()
-            }
-        };
-        for (name, wc_commit_id) in &tx.repo().view().wc_commit_ids().clone() {
-            let is_immutable = immutable_expr
-                .intersection(&RevsetExpression::commit(wc_commit_id.clone()))
-                .evaluate(tx.repo())?
-                .stream()
-                .try_next()
-                .await?
-                .is_some();
-            if is_immutable {
-                let wc_commit = tx.repo().store().get_commit_async(wc_commit_id).await?;
-                tx.repo_mut().check_out(name.clone(), &wc_commit).await?;
-                writeln!(
-                    ui.warning_default(),
-                    "The working-copy commit in workspace '{name}' became immutable, so a new \
-                     commit has been created on top of it.",
-                    name = name.as_symbol()
-                )?;
-            }
-        }
         if let Err(err) =
             revset_util::try_resolve_trunk_alias(tx.repo(), &self.env.revset_parse_context())
         {
-            // The warning would be printed above if working copies exist.
-            if tx.repo().view().wc_commit_ids().is_empty() {
-                writeln!(
-                    ui.warning_default(),
-                    "Failed to resolve `revset-aliases.trunk()`: {err}"
-                )?;
-            }
+            writeln!(
+                ui.warning_default(),
+                "Failed to resolve `revset-aliases.trunk()`: {err}"
+            )?;
             writeln!(
                 ui.hint_default(),
                 "Use `jj config edit --repo` to adjust the `trunk()` alias."

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -1008,12 +1008,12 @@ impl WorkspaceCommandEnvironment {
         }
     }
 
-    /// Returns first immutable commit.
-    async fn find_immutable_commit(
+    /// Resolves the effective `immutable()` expression to test against commits
+    /// during a rewrite, taking the `--ignore-immutable` flag into account.
+    fn resolve_immutable_expression(
         &self,
         repo: &dyn Repo,
-        to_rewrite_expr: &Arc<ResolvedRevsetExpression>,
-    ) -> Result<Option<CommitId>, CommandError> {
+    ) -> Result<Arc<ResolvedRevsetExpression>, CommandError> {
         let immutable_expression = if self.command.global_args().ignore_immutable {
             UserRevsetExpression::root()
         } else {
@@ -1024,20 +1024,14 @@ impl WorkspaceCommandEnvironment {
         // must not be calculated and cached against arbitrary repo. It's also
         // unlikely that the immutable expression contains short hashes.
         let id_prefix_context = IdPrefixContext::new(self.command.revset_extensions().clone());
-        let immutable_expr = RevsetExpressionEvaluator::new(
+        RevsetExpressionEvaluator::new(
             repo,
             self.command.revset_extensions().clone(),
             &id_prefix_context,
             immutable_expression,
         )
         .resolve()
-        .map_err(|e| config_error_with_message("Invalid `revset-aliases.immutable_heads()`", e))?;
-
-        let mut commit_id_iter = immutable_expr
-            .intersection(to_rewrite_expr)
-            .evaluate(repo)?
-            .stream();
-        Ok(commit_id_iter.try_next().await?)
+        .map_err(|e| config_error_with_message("Invalid `revset-aliases.immutable_heads()`", e))
     }
 
     pub fn template_aliases_map(&self) -> &TemplateAliasesMap {
@@ -1948,9 +1942,12 @@ to the current parents may contain changes from multiple commits.
         to_rewrite_expr: &Arc<ResolvedRevsetExpression>,
     ) -> Result<(), CommandError> {
         let repo = self.repo().as_ref();
-        let Some(commit_id) = self
-            .env
-            .find_immutable_commit(repo, to_rewrite_expr)
+        let immutable_expr = self.env.resolve_immutable_expression(repo)?;
+        let Some(commit_id) = immutable_expr
+            .intersection(to_rewrite_expr)
+            .evaluate(repo)?
+            .stream()
+            .try_next()
             .await?
         else {
             return Ok(());
@@ -1971,20 +1968,10 @@ to the current parents may contain changes from multiple commits.
                       - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
                       - `jj help -k config`, \"Set of immutable commits\""});
 
-            // Not using self.id_prefix_context() for consistency with
-            // find_immutable_commit().
-            let id_prefix_context =
-                IdPrefixContext::new(self.env.command.revset_extensions().clone());
-            let (lower_bound, upper_bound) = RevsetExpressionEvaluator::new(
-                repo,
-                self.env.command.revset_extensions().clone(),
-                &id_prefix_context,
-                self.env.immutable_expression(),
-            )
-            .resolve()?
-            .intersection(&to_rewrite_expr.descendants())
-            .evaluate(repo)?
-            .count_estimate()?;
+            let (lower_bound, upper_bound) = immutable_expr
+                .intersection(&to_rewrite_expr.descendants())
+                .evaluate(repo)?
+                .count_estimate()?;
             let exact = upper_bound == Some(lower_bound);
             let or_more = if exact { "" } else { " or more" };
             error.add_hint(format!(
@@ -2202,23 +2189,28 @@ to the current parents may contain changes from multiple commits.
             writeln!(ui.status(), "Rebased {num_rebased} descendant commits")?;
         }
 
+        // This can fail if trunk() bookmark gets deleted or conflicted. If the
+        // unresolvable trunk() issue gets addressed differently, it should be
+        // okay to propagate the error.
+        let immutable_expr = match self.env.resolve_immutable_expression(tx.repo()) {
+            Ok(expr) => expr,
+            Err(CommandError { error, .. }) => {
+                writeln!(
+                    ui.warning_default(),
+                    "Failed to check mutability of the new working-copy revision."
+                )?;
+                print_error_sources(ui, Some(&error))?;
+                RevsetExpression::root()
+            }
+        };
         for (name, wc_commit_id) in &tx.repo().view().wc_commit_ids().clone() {
-            // This can fail if trunk() bookmark gets deleted or conflicted. If
-            // the unresolvable trunk() issue gets addressed differently, it
-            // should be okay to propagate the error.
-            let wc_expr = RevsetExpression::commit(wc_commit_id.clone());
-            let is_immutable = match self.env.find_immutable_commit(tx.repo(), &wc_expr).await {
-                Ok(commit_id) => commit_id.is_some(),
-                Err(CommandError { error, .. }) => {
-                    writeln!(
-                        ui.warning_default(),
-                        "Failed to check mutability of the new working-copy revision."
-                    )?;
-                    print_error_sources(ui, Some(&error))?;
-                    // Give up because the same error would occur repeatedly.
-                    break;
-                }
-            };
+            let is_immutable = immutable_expr
+                .intersection(&RevsetExpression::commit(wc_commit_id.clone()))
+                .evaluate(tx.repo())?
+                .stream()
+                .try_next()
+                .await?
+                .is_some();
             if is_immutable {
                 let wc_commit = tx.repo().store().get_commit_async(wc_commit_id).await?;
                 tx.repo_mut().check_out(name.clone(), &wc_commit).await?;

--- a/cli/tests/test_bookmark_command.rs
+++ b/cli/tests/test_bookmark_command.rs
@@ -1082,9 +1082,6 @@ fn test_bookmark_rename_colocated() {
     ------- stderr -------
     Warning: Tracking of remote bookmark bpushed@origin was dropped.
     Hint: Use `jj bookmark track` to re-track if needed.
-    Warning: The working-copy commit in workspace 'default' became immutable, so a new commit has been created on top of it.
-    Working copy  (@) now at: znkkpsqq cf8db4ba (empty) (no description set)
-    Parent commit (@-)      : royxmykx b6e46c10 bpushed@origin | (empty) commit-1
     [EOF]
     ");
     let output = work_dir.run_jj(["bookmark", "list", "--all", "bpushed"]);

--- a/cli/tests/test_git_clone.rs
+++ b/cli/tests/test_git_clone.rs
@@ -976,10 +976,7 @@ fn test_git_clone_trunk_deleted() {
     ------- stderr -------
     Forgot 1 local bookmarks.
     Forgot 1 remote bookmarks.
-    Warning: Failed to check mutability of the new working-copy revision.
-    Caused by:
-    1: Invalid `revset-aliases.immutable_heads()`
-    2: Revision `main@origin` doesn't exist
+    Warning: Failed to resolve `revset-aliases.trunk()`: Revision `main@origin` doesn't exist
     Hint: Use `jj config edit --repo` to adjust the `trunk()` alias.
     [EOF]
     ");
@@ -1130,26 +1127,14 @@ fn test_git_clone_invalid_immutable_heads() {
     // Suppress lengthy warnings in commit summary template
     test_env.add_config("revsets.short-prefixes = ''");
 
-    // The error shouldn't be counted as an immutable working-copy commit. It
-    // should be reported.
+    // Even if there were an error about the invalid immutable_heads(), the
+    // error shouldn't be counted as an immutable working-copy commit.
     let output = root_dir.run_jj(["git", "clone", "source", "clone"]);
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
-    Warning: Failed to check mutability of the new working-copy revision.
-    Caused by:
-    1: Invalid `revset-aliases.immutable_heads()`
-    2: Revision `unknown` doesn't exist
     Fetching into new repo in "$TEST_ENV/clone"
     bookmark: main@origin [new] tracked
-    Warning: Failed to check mutability of the new working-copy revision.
-    Caused by:
-    1: Invalid `revset-aliases.immutable_heads()`
-    2: Revision `unknown` doesn't exist
     Setting the revset alias `trunk()` to `main@origin`
-    Warning: Failed to check mutability of the new working-copy revision.
-    Caused by:
-    1: Invalid `revset-aliases.immutable_heads()`
-    2: Revision `unknown` doesn't exist
     Working copy  (@) now at: sqpuoqvx 1ca44815 (empty) (no description set)
     Parent commit (@-)      : qomsplrm ebeb70d8 main | message
     Added 1 files, modified 0 files, removed 0 files

--- a/cli/tests/test_git_private_commits.rs
+++ b/cli/tests/test_git_private_commits.rs
@@ -205,9 +205,6 @@ fn test_git_private_commits_can_be_overridden() {
     ------- stderr -------
     Changes to push to origin:
       bookmark: main [move forward from 95cc152cd086 to 7f665ca27d4e]
-    Warning: The working-copy commit in workspace 'default' became immutable, so a new commit has been created on top of it.
-    Working copy  (@) now at: znkkpsqq 8227d51b (empty) (no description set)
-    Parent commit (@-)      : yqosqzyt 7f665ca2 main | (empty) private 1
     [EOF]
     ");
 }
@@ -230,9 +227,6 @@ fn test_git_private_commits_are_not_checked_if_immutable() {
     ------- stderr -------
     Changes to push to origin:
       bookmark: main [move forward from 95cc152cd086 to 7f665ca27d4e]
-    Warning: The working-copy commit in workspace 'default' became immutable, so a new commit has been created on top of it.
-    Working copy  (@) now at: yostqsxw 17947f20 (empty) (no description set)
-    Parent commit (@-)      : yqosqzyt 7f665ca2 main | (empty) private 1
     [EOF]
     ");
 }
@@ -322,9 +316,6 @@ fn test_git_private_commits_already_on_the_remote_do_not_block_push() {
     Changes to push to origin:
       bookmark: bookmark1 [add to 95cc152cd086]
       bookmark: main [move forward from 95cc152cd086 to 03bc2bf271e0]
-    Warning: The working-copy commit in workspace 'default' became immutable, so a new commit has been created on top of it.
-    Working copy  (@) now at: kpqxywon 5308110d (empty) (no description set)
-    Parent commit (@-)      : yostqsxw 03bc2bf2 main | (empty) public 3
     [EOF]
     ");
 

--- a/cli/tests/test_git_remotes.rs
+++ b/cli/tests/test_git_remotes.rs
@@ -567,14 +567,11 @@ fn test_git_remote_with_preset_config() {
     "#);
 
     // Preset repo-level config should be updated automatically
-    // TODO: suppress warning about unresolvable immutable_heads()
+    // TODO: suppress warning about unresolvable trunk()
     let output = local_dir.run_jj(["git", "remote", "rename", "origin", "foo"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Warning: Failed to check mutability of the new working-copy revision.
-    Caused by:
-    1: Invalid `revset-aliases.immutable_heads()`
-    2: Revision `main@origin` doesn't exist
+    Warning: Failed to resolve `revset-aliases.trunk()`: Revision `main@origin` doesn't exist
     Hint: Use `jj config edit --repo` to adjust the `trunk()` alias.
     Updating the revset alias `trunk()` to `main@foo`.
     [EOF]
@@ -594,14 +591,11 @@ fn test_git_remote_with_preset_config() {
     "#);
 
     // Preset repo-level config should be removed automatically
-    // TODO: suppress warning about unresolvable immutable_heads()
+    // TODO: suppress warning about unresolvable trunk()
     let output = local_dir.run_jj(["git", "remote", "remove", "foo"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Warning: Failed to check mutability of the new working-copy revision.
-    Caused by:
-    1: Invalid `revset-aliases.immutable_heads()`
-    2: Revision `main@foo` doesn't exist
+    Warning: Failed to resolve `revset-aliases.trunk()`: Revision `main@foo` doesn't exist
     Hint: Use `jj config edit --repo` to adjust the `trunk()` alias.
     Resetting the revset alias `trunk()` to default value.
     [EOF]

--- a/cli/tests/test_immutable_commits.rs
+++ b/cli/tests/test_immutable_commits.rs
@@ -79,22 +79,18 @@ fn test_rewrite_immutable_generic() {
     [exit status: 1]
     ");
 
-    // Unresolvable immutable_heads() is warned. This can be an error, but we
-    // need to somehow deal with unresolvable `trunk() = <name>@<remote>`.
+    // Unresolvable immutable_heads()
     test_env.add_config(r#"revset-aliases."immutable_heads()" = "bookmark_that_does_not_exist""#);
     // Suppress warning in the commit summary template
     test_env.add_config("template-aliases.'format_short_id(id)' = 'id.short(8)'");
-    let output = work_dir.run_jj(["new", "main"]);
+    let output = work_dir.run_jj(["edit", "main"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Warning: Failed to check mutability of the new working-copy revision.
-    Caused by:
-    1: Invalid `revset-aliases.immutable_heads()`
-    2: Revision `bookmark_that_does_not_exist` doesn't exist
-    Working copy  (@) now at: znkkpsqq 4bd62ce9 (empty) (no description set)
-    Parent commit (@-)      : kkmpptxz 9d190342 main | b
-    Added 0 files, modified 1 files, removed 0 files
+    Config error: Invalid `revset-aliases.immutable_heads()`
+    Caused by: Revision `bookmark_that_does_not_exist` doesn't exist
+    For help, see https://docs.jj-vcs.dev/latest/config/ or use `jj help -k config`.
     [EOF]
+    [exit status: 1]
     ");
 
     // Can use --ignore-immutable to override
@@ -104,6 +100,7 @@ fn test_rewrite_immutable_generic() {
     ------- stderr -------
     Working copy  (@) now at: kkmpptxz 9d190342 main | b
     Parent commit (@-)      : qpvuntsm c8c8515a a
+    Added 0 files, modified 1 files, removed 0 files
     [EOF]
     ");
     // ... but not the root commit
@@ -152,9 +149,21 @@ fn test_new_wc_commit_when_wc_immutable() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Moved 1 bookmarks to kkmpptxz e1cb4cf3 main | (empty) a
-    Warning: The working-copy commit in workspace 'default' became immutable, so a new commit has been created on top of it.
-    Working copy  (@) now at: zsuskuln 19a353fe (empty) (no description set)
-    Parent commit (@-)      : kkmpptxz e1cb4cf3 main | (empty) a
+    [EOF]
+    ");
+    work_dir.write_file("file", "a");
+    let output = work_dir.run_jj(["log", "-r.."]);
+    insta::assert_snapshot!(output, @"
+    @  mzvwutvl test.user@example.com 2001-02-03 08:05:11 49ad4c46
+    │  (no description set)
+    ◆  kkmpptxz test.user@example.com 2001-02-03 08:05:09 main e1cb4cf3
+    │  (empty) a
+    ◆  qpvuntsm test.user@example.com 2001-02-03 08:05:07 e8849ae1
+    │  (empty) (no description set)
+    ~
+    [EOF]
+    ------- stderr -------
+    Warning: The working-copy commit is immutable; a new commit has been created on top of it.
     [EOF]
     ");
 }
@@ -171,9 +180,23 @@ fn test_immutable_heads_set_to_working_copy() {
     let output = work_dir.run_jj(["new", "-m=a"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Warning: The working-copy commit in workspace 'default' became immutable, so a new commit has been created on top of it.
-    Working copy  (@) now at: pmmvwywv 08e27304 (empty) (no description set)
-    Parent commit (@-)      : kkmpptxz e1cb4cf3 (empty) a
+    Working copy  (@) now at: kkmpptxz e1cb4cf3 (empty) a
+    Parent commit (@-)      : qpvuntsm e8849ae1 main | (empty) (no description set)
+    [EOF]
+    ");
+    work_dir.write_file("file", "a");
+    let output = work_dir.run_jj(["log", "-r.."]);
+    insta::assert_snapshot!(output, @"
+    @  zsuskuln test.user@example.com 2001-02-03 08:05:10 aa4d78a2
+    │  (no description set)
+    ◆  kkmpptxz test.user@example.com 2001-02-03 08:05:09 e1cb4cf3
+    │  (empty) a
+    ◆  qpvuntsm test.user@example.com 2001-02-03 08:05:07 main e8849ae1
+    │  (empty) (no description set)
+    ~
+    [EOF]
+    ------- stderr -------
+    Warning: The working-copy commit is immutable; a new commit has been created on top of it.
     [EOF]
     ");
 }
@@ -193,28 +216,44 @@ fn test_new_wc_commit_when_wc_immutable_multi_workspace() {
         .success();
     let workspace1_dir = test_env.work_dir("workspace1");
     workspace1_dir.run_jj(["edit", "default@"]).success();
+
     let output = work_dir.run_jj(["bookmark", "set", "main", "-r@"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Moved 1 bookmarks to kkmpptxz e1cb4cf3 main | (empty) a
-    Warning: The working-copy commit in workspace 'default' became immutable, so a new commit has been created on top of it.
-    Warning: The working-copy commit in workspace 'workspace1' became immutable, so a new commit has been created on top of it.
-    Working copy  (@) now at: royxmykx cec19492 (empty) (no description set)
-    Parent commit (@-)      : kkmpptxz e1cb4cf3 main | (empty) a
     [EOF]
     ");
-    workspace1_dir
-        .run_jj(["workspace", "update-stale"])
-        .success();
-    let output = workspace1_dir.run_jj(["log", "--no-graph"]);
+    work_dir.write_file("file", "a");
+    let output = work_dir.run_jj(["log", "-r.."]);
     insta::assert_snapshot!(output, @"
-    nppvrztz test.user@example.com 2001-02-03 08:05:12 workspace1@ e89ed162
-    (empty) (no description set)
-    royxmykx test.user@example.com 2001-02-03 08:05:12 default@ cec19492
-    (empty) (no description set)
-    kkmpptxz test.user@example.com 2001-02-03 08:05:09 main e1cb4cf3
-    (empty) a
-    zzzzzzzz root() 00000000
+    @  yqosqzyt test.user@example.com 2001-02-03 08:05:13 default@ 3386b5c7
+    │  (no description set)
+    ◆  kkmpptxz test.user@example.com 2001-02-03 08:05:09 main workspace1@ e1cb4cf3
+    │  (empty) a
+    ◆  qpvuntsm test.user@example.com 2001-02-03 08:05:07 e8849ae1
+    │  (empty) (no description set)
+    ~
+    [EOF]
+    ------- stderr -------
+    Warning: The working-copy commit is immutable; a new commit has been created on top of it.
+    [EOF]
+    ");
+
+    workspace1_dir.write_file("file", "a");
+    let output = workspace1_dir.run_jj(["log", "-r.."]);
+    insta::assert_snapshot!(output, @"
+    @  vruxwmqv test.user@example.com 2001-02-03 08:05:14 workspace1@ bbc55980
+    │  (no description set)
+    │ ○  yqosqzyt test.user@example.com 2001-02-03 08:05:13 default@ 3386b5c7
+    ├─╯  (no description set)
+    ◆  kkmpptxz test.user@example.com 2001-02-03 08:05:09 main e1cb4cf3
+    │  (empty) a
+    ◆  qpvuntsm test.user@example.com 2001-02-03 08:05:07 e8849ae1
+    │  (empty) (no description set)
+    ~
+    [EOF]
+    ------- stderr -------
+    Warning: The working-copy commit is immutable; a new commit has been created on top of it.
     [EOF]
     ");
 }
@@ -230,21 +269,18 @@ fn test_new_wc_commit_when_wc_immutable_multi_workspace_already_immutable() {
     let output = work_dir
         .run_jj(["workspace", "add", "../workspace1"])
         .success();
-    // TODO: The current workspace is immutable from the new workspace's
-    // perspective, but we should not create a new commit for it.
+    // The current workspace is immutable from the new workspace's perspective,
+    // but we should not create a new commit for it.
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Created workspace in "../workspace1"
-    Warning: The working-copy commit in workspace 'default' became immutable, so a new commit has been created on top of it.
     Working copy  (@) now at: pmmvwywv 1cd27236 (empty) (no description set)
     Parent commit (@-)      : qpvuntsm e8849ae1 (empty) (no description set)
     [EOF]
     "#);
     let output = work_dir.run_jj(["log", "-r=::"]);
-    insta::assert_snapshot!(output, @r"
-    @  yxszmlut test.user@example.com 2001-02-03 08:05:09 default@ 88a6c421
-    │  (empty) (no description set)
-    ○  rlvkpnrz test.user@example.com 2001-02-03 08:05:08 167b8dbf
+    insta::assert_snapshot!(output, @"
+    @  rlvkpnrz test.user@example.com 2001-02-03 08:05:08 default@ 167b8dbf
     │  (empty) a
     │ ◆  pmmvwywv test.user@example.com 2001-02-03 08:05:09 workspace1@ 1cd27236
     ├─╯  (empty) (no description set)
@@ -253,14 +289,13 @@ fn test_new_wc_commit_when_wc_immutable_multi_workspace_already_immutable() {
     ◆  zzzzzzzz root() 00000000
     [EOF]
     ");
-    // TODO: The other workspace was already immutable from the current workspace's
+    // The other workspace was already immutable from the current workspace's
     // perspective, so we don't create a new commit for it.
     let output = work_dir.run_jj(["new"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Warning: The working-copy commit in workspace 'workspace1' became immutable, so a new commit has been created on top of it.
-    Working copy  (@) now at: mzvwutvl c460fde3 (empty) (no description set)
-    Parent commit (@-)      : yxszmlut 88a6c421 (empty) (no description set)
+    Working copy  (@) now at: mzvwutvl b6d970c6 (empty) (no description set)
+    Parent commit (@-)      : rlvkpnrz 167b8dbf (empty) a
     [EOF]
     ");
 }

--- a/cli/tests/test_operations.rs
+++ b/cli/tests/test_operations.rs
@@ -1669,18 +1669,12 @@ fn test_op_diff() {
     ");
 
     // Test creation of tag.
-    work_dir.run_jj(["tag", "set", "tag1"]).success();
+    work_dir.run_jj(["new"]).success();
+    work_dir.run_jj(["tag", "set", "-r@-", "tag1"]).success();
     let output = work_dir.run_jj(["op", "diff"]);
     insta::assert_snapshot!(output, @"
-    From operation: 925fba501129 (2001-02-03 08:05:39) push all tracked bookmarks/tags to git remote origin
-      To operation: e8a160b1453e (2001-02-03 08:05:41) set tag tag1 to commit 96f3a57c9a4a4ae7bb45d1eafe32fe3b6e33f458
-
-    Changed commits:
-    ○  + wvmqtotl 56e74c8d (empty) (no description set)
-
-    Changed working copy default@:
-    + wvmqtotl 56e74c8d (empty) (no description set)
-    - qmkrwlvp 96f3a57c bookmark-1 | (empty) new commit
+    From operation: 63850be91e93 (2001-02-03 08:05:41) new empty commit
+      To operation: 2cb390841ae9 (2001-02-03 08:05:42) set tag tag1 to commit 96f3a57c9a4a4ae7bb45d1eafe32fe3b6e33f458
 
     Changed local tags:
     tag1:
@@ -1691,24 +1685,17 @@ fn test_op_diff() {
 
     // Test tag movement.
     work_dir
-        .run_jj(["tag", "set", "tag1", "-r=@-", "--allow-move"])
+        .run_jj(["tag", "set", "tag1", "-r=@--", "--allow-move"])
         .success();
     let output = work_dir.run_jj(["op", "diff"]);
     insta::assert_snapshot!(output, @"
-    From operation: 925fba501129 (2001-02-03 08:05:39) push all tracked bookmarks/tags to git remote origin
-      To operation: e8a160b1453e (2001-02-03 08:05:41) set tag tag1 to commit 96f3a57c9a4a4ae7bb45d1eafe32fe3b6e33f458
-
-    Changed commits:
-    ○  + wvmqtotl 56e74c8d (empty) (no description set)
-
-    Changed working copy default@:
-    + wvmqtotl 56e74c8d (empty) (no description set)
-    - qmkrwlvp 96f3a57c bookmark-1 | (empty) new commit
+    From operation: 2cb390841ae9 (2001-02-03 08:05:42) set tag tag1 to commit 96f3a57c9a4a4ae7bb45d1eafe32fe3b6e33f458
+      To operation: dda59985de35 (2001-02-03 08:05:44) set tag tag1 to commit 0dee631320b13c6a6542c80bced33b9dd29f6bf0
 
     Changed local tags:
     tag1:
-    + qmkrwlvp 96f3a57c bookmark-1 | (empty) new commit
-    - (absent)
+    + zkmtkqvo 0dee6313 Commit 4
+    - qmkrwlvp 96f3a57c bookmark-1 | (empty) new commit
     [EOF]
     ");
 
@@ -1716,13 +1703,13 @@ fn test_op_diff() {
     work_dir.run_jj(["tag", "delete", "tag1"]).success();
     let output = work_dir.run_jj(["op", "diff"]);
     insta::assert_snapshot!(output, @"
-    From operation: e8a160b1453e (2001-02-03 08:05:41) set tag tag1 to commit 96f3a57c9a4a4ae7bb45d1eafe32fe3b6e33f458
-      To operation: caca4db77509 (2001-02-03 08:05:45) delete tag tag1
+    From operation: dda59985de35 (2001-02-03 08:05:44) set tag tag1 to commit 0dee631320b13c6a6542c80bced33b9dd29f6bf0
+      To operation: 3d6fb6fecc79 (2001-02-03 08:05:46) delete tag tag1
 
     Changed local tags:
     tag1:
     + (absent)
-    - qmkrwlvp 96f3a57c bookmark-1 | (empty) new commit
+    - zkmtkqvo 0dee6313 Commit 4
     [EOF]
     ");
 }
@@ -3153,7 +3140,8 @@ fn test_op_immutable_revisions() {
             .run_jj(["new", "@", "-m", &format!("commit {i}")])
             .success();
     }
-    work_dir.run_jj(["tag", "set", "t1", "-r", "@"]).success();
+    work_dir.run_jj(["new"]).success();
+    work_dir.run_jj(["tag", "set", "t1", "-r", "@-"]).success();
 
     // Move working copy away
     work_dir.run_jj(["new", "root()"]).success();
@@ -3163,7 +3151,7 @@ fn test_op_immutable_revisions() {
         .run_jj(["abandon", "--ignore-immutable", "::t1 & ~root()"])
         .success();
     insta::assert_snapshot!(work_dir.run_jj(["op", "show"]), @"
-    52517772e194 test-username@host.example.com default@ 2001-02-03 04:05:15.000 +07:00 - 2001-02-03 04:05:15.000 +07:00
+    d86e21bb08c0 test-username@host.example.com default@ 2001-02-03 04:05:16.000 +07:00 - 2001-02-03 04:05:16.000 +07:00
     abandon commit 9c86781f3fe9097ffc530e65fd2ab4aff1e654bd and 5 more
     args: jj abandon --ignore-immutable '::t1 & ~root()'
 
@@ -3176,8 +3164,8 @@ fn test_op_immutable_revisions() {
     // Undo
     work_dir.run_jj(["op", "revert"]).success();
     insta::assert_snapshot!(work_dir.run_jj(["op", "show"]), @"
-    f9e504c0dd85 test-username@host.example.com default@ 2001-02-03 04:05:17.000 +07:00 - 2001-02-03 04:05:17.000 +07:00
-    revert operation 52517772e194b55d56c84c18b868306d9077e768cfe6e33f886ffb621bcc681f8e508e1fd53a8be18470f76c14d8fd00e6a2775c92fab8d6de6553f33a2de4fd
+    abbb2399227e test-username@host.example.com default@ 2001-02-03 04:05:18.000 +07:00 - 2001-02-03 04:05:18.000 +07:00
+    revert operation d86e21bb08c07020add3b8624a72211b087501d2cce3e1fc90ef0e37596385b73b5470b1754dfbaf1ec28df0df5d61dadb6cf338ceb1ae2a1974a3a473ec8230
     args: jj op revert
 
     Changed commits:
@@ -3190,12 +3178,14 @@ fn test_op_immutable_revisions() {
     work_dir.run_jj(["new", "t1", "-m", "f1 1"]).success();
     work_dir.run_jj(["new", "@", "-m", "f1 2"]).success();
     work_dir.run_jj(["new", "@", "-m", "f1 3"]).success();
-    work_dir.run_jj(["tag", "set", "f1", "-r", "@"]).success();
+    work_dir.run_jj(["new"]).success();
+    work_dir.run_jj(["tag", "set", "f1", "-r", "@-"]).success();
 
     work_dir.run_jj(["new", "t1", "-m", "f2 1"]).success();
     work_dir.run_jj(["new", "@", "-m", "f2 2"]).success();
     work_dir.run_jj(["new", "@", "-m", "f2 3"]).success();
-    work_dir.run_jj(["tag", "set", "f2", "-r", "@"]).success();
+    work_dir.run_jj(["new"]).success();
+    work_dir.run_jj(["tag", "set", "f2", "-r", "@-"]).success();
 
     // Move WC away
     work_dir.run_jj(["new", "root()"]).success();
@@ -3206,13 +3196,13 @@ fn test_op_immutable_revisions() {
         .success();
     let op_id_for_diff = work_dir.current_operation_id();
     insta::assert_snapshot!(work_dir.run_jj(["op", "show"]), @"
-    f90e225dba79 test-username@host.example.com default@ 2001-02-03 04:05:28.000 +07:00 - 2001-02-03 04:05:28.000 +07:00
-    abandon commit e7f51c58b0862dc0c255d9efd11fb9a89f07eb88 and 11 more
+    cf3d5f839512 test-username@host.example.com default@ 2001-02-03 04:05:31.000 +07:00 - 2001-02-03 04:05:31.000 +07:00
+    abandon commit 7c60d8fd187f77196d1def564b0d893d477b7e56 and 11 more
     args: jj abandon --ignore-immutable '(::f1 | ::f2) & ~root()'
 
     Changed commits:
-    ○  - xtnwkqum/0 e7f51c58 (hidden) (empty) f2 3
-    ╷ ○  - kxryzmor/0 c800ddaf (hidden) (empty) f1 3
+    ○  - tlkvzzqu/0 7c60d8fd (hidden) (empty) f2 3
+    ╷ ○  - nkmrtpmo/0 caf991b6 (hidden) (empty) f1 3
     ╭─╯
     ○  - royxmykx/0 9c86781f (hidden) (empty) commit 5
        (Elided 9 newly removed revisions)
@@ -3221,8 +3211,8 @@ fn test_op_immutable_revisions() {
 
     // Use `--show-changes-in none()` to see only elisions
     insta::assert_snapshot!(work_dir.run_jj(["op", "show", "--show-changes-in", "none()"]), @"
-    f90e225dba79 test-username@host.example.com default@ 2001-02-03 04:05:28.000 +07:00 - 2001-02-03 04:05:28.000 +07:00
-    abandon commit e7f51c58b0862dc0c255d9efd11fb9a89f07eb88 and 11 more
+    cf3d5f839512 test-username@host.example.com default@ 2001-02-03 04:05:31.000 +07:00 - 2001-02-03 04:05:31.000 +07:00
+    abandon commit 7c60d8fd187f77196d1def564b0d893d477b7e56 and 11 more
     args: jj abandon --ignore-immutable '(::f1 | ::f2) & ~root()'
 
     Changed commits:
@@ -3237,8 +3227,9 @@ fn test_op_immutable_revisions() {
             .run_jj(["new", "@", "-m", &format!("mix-a{i}")])
             .success();
     }
+    work_dir.run_jj(["new"]).success();
     work_dir
-        .run_jj(["bookmark", "set", "ba", "-r", "@"])
+        .run_jj(["bookmark", "set", "ba", "-r", "@-"])
         .success();
 
     work_dir.run_jj(["new", "root()", "-m", "mix-b1"]).success();
@@ -3247,8 +3238,9 @@ fn test_op_immutable_revisions() {
             .run_jj(["new", "@", "-m", &format!("mix-b{i}")])
             .success();
     }
+    work_dir.run_jj(["new"]).success();
     work_dir
-        .run_jj(["bookmark", "set", "bb", "-r", "@"])
+        .run_jj(["bookmark", "set", "bb", "-r", "@-"])
         .success();
 
     // Rebase bb chain onto ba head.
@@ -3256,45 +3248,45 @@ fn test_op_immutable_revisions() {
         .run_jj(["rebase", "--ignore-immutable", "-s", "bb----", "-d", "ba"])
         .success();
     insta::assert_snapshot!(work_dir.run_jj(["op", "show"]), @"
-    9d3cfa89448a test-username@host.example.com default@ 2001-02-03 04:05:43.000 +07:00 - 2001-02-03 04:05:43.000 +07:00
-    rebase commit c09af48da0b4dcbbe6be869823d17bf6cd73a4db and descendants
+    5139db3ae21c test-username@host.example.com default@ 2001-02-03 04:05:48.000 +07:00 - 2001-02-03 04:05:48.000 +07:00
+    rebase commit 6c3a9c2476ba8a8e5bac722f9c0e2ca914b9577d and descendants
     args: jj rebase --ignore-immutable -s bb---- -d ba
 
     Changed commits:
-    ○  + nsrwusvy caaf0759 (empty) (no description set)
-    │  - nsrwusvy/1 76ebe692 (hidden) (empty) (no description set)
-    ○  + wvmqtotl 44827d4a bb | (empty) mix-b5
-       - wvmqtotl/1 c117dbab (hidden) (empty) mix-b5
+    ○  + wtlqussy bf3146c8 (empty) (no description set)
+    │  - wtlqussy/1 371fd4fe (hidden) (empty) (no description set)
+    ○  + xpnwykqz 741a5187 bb | (empty) mix-b5
+       - xpnwykqz/1 1c52a7a2 (hidden) (empty) mix-b5
        (Elided 4 newly added and 4 newly removed revisions)
 
     Changed working copy default@:
-    + nsrwusvy caaf0759 (empty) (no description set)
-    - nsrwusvy/1 76ebe692 (hidden) (empty) (no description set)
+    + wtlqussy bf3146c8 (empty) (no description set)
+    - wtlqussy/1 371fd4fe (hidden) (empty) (no description set)
 
     Changed local bookmarks:
     bb:
-    + wvmqtotl 44827d4a bb | (empty) mix-b5
-    - wvmqtotl/1 c117dbab (hidden) (empty) mix-b5
+    + xpnwykqz 741a5187 bb | (empty) mix-b5
+    - xpnwykqz/1 1c52a7a2 (hidden) (empty) mix-b5
     [EOF]
     ");
 
     // Use `--show-changes-in none()` to see only elisions
     insta::assert_snapshot!(work_dir.run_jj(["op", "show", "--show-changes-in", "none()"]), @"
-    9d3cfa89448a test-username@host.example.com default@ 2001-02-03 04:05:43.000 +07:00 - 2001-02-03 04:05:43.000 +07:00
-    rebase commit c09af48da0b4dcbbe6be869823d17bf6cd73a4db and descendants
+    5139db3ae21c test-username@host.example.com default@ 2001-02-03 04:05:48.000 +07:00 - 2001-02-03 04:05:48.000 +07:00
+    rebase commit 6c3a9c2476ba8a8e5bac722f9c0e2ca914b9577d and descendants
     args: jj rebase --ignore-immutable -s bb---- -d ba
 
     Changed commits:
        (Elided 6 newly added and 6 newly removed revisions)
 
     Changed working copy default@:
-    + nsrwusvy caaf0759 (empty) (no description set)
-    - nsrwusvy/1 76ebe692 (hidden) (empty) (no description set)
+    + wtlqussy bf3146c8 (empty) (no description set)
+    - wtlqussy/1 371fd4fe (hidden) (empty) (no description set)
 
     Changed local bookmarks:
     bb:
-    + wvmqtotl 44827d4a bb | (empty) mix-b5
-    - wvmqtotl/1 c117dbab (hidden) (empty) mix-b5
+    + xpnwykqz 741a5187 bb | (empty) mix-b5
+    - xpnwykqz/1 1c52a7a2 (hidden) (empty) mix-b5
     [EOF]
     ");
 
@@ -3303,97 +3295,98 @@ fn test_op_immutable_revisions() {
         .run_jj(["new", "root()", "-m", "single-1"])
         .success();
     work_dir.run_jj(["new", "@", "-m", "single-2"]).success();
+    work_dir.run_jj(["new"]).success();
     work_dir
-        .run_jj(["tag", "set", "ts", "-r", "@", "--allow-move"])
+        .run_jj(["tag", "set", "ts", "-r", "@-", "--allow-move"])
         .success();
     // Abandon to see single removal elision
     work_dir
         .run_jj(["abandon", "--ignore-immutable", "::ts & ~root()"])
         .success();
     insta::assert_snapshot!(work_dir.run_jj(["op", "show"]), @"
-    f5a4f77da069 test-username@host.example.com default@ 2001-02-03 04:05:49.000 +07:00 - 2001-02-03 04:05:49.000 +07:00
-    abandon commit 0a2e24c8d8d8010243ed72f9c50ee69b57291eff and 1 more
+    e660cbda9711 test-username@host.example.com default@ 2001-02-03 04:05:55.000 +07:00 - 2001-02-03 04:05:55.000 +07:00
+    abandon commit 4ebd4aa1d0bfee524ccd21882606990e3b75fc12 and 1 more
     args: jj abandon --ignore-immutable '::ts & ~root()'
 
     Changed commits:
-    ○  + sryyqqkq 46f2f483 (empty) (no description set)
-       - sryyqqkq/1 d41cf466 (hidden) (empty) (no description set)
-    ○  - ukwxllxp/0 0a2e24c8 (hidden) (empty) single-2
+    ○  + ztnvrxlv 41578768 (empty) (no description set)
+       - ztnvrxlv/1 13887367 (hidden) (empty) (no description set)
+    ○  - wqxolloz/0 4ebd4aa1 (hidden) (empty) single-2
        (Elided 1 newly removed revisions)
 
     Changed working copy default@:
-    + sryyqqkq 46f2f483 (empty) (no description set)
-    - sryyqqkq/1 d41cf466 (hidden) (empty) (no description set)
+    + ztnvrxlv 41578768 (empty) (no description set)
+    - ztnvrxlv/1 13887367 (hidden) (empty) (no description set)
     [EOF]
     ");
 
     // Undo to see single addition elision
     work_dir.run_jj(["op", "revert"]).success();
     insta::assert_snapshot!(work_dir.run_jj(["op", "show"]), @"
-    3d2e63a4b374 test-username@host.example.com default@ 2001-02-03 04:05:51.000 +07:00 - 2001-02-03 04:05:51.000 +07:00
-    revert operation f5a4f77da0696b42e0acbd785ebe11040e31e15bebf4d2bd4b09a521af16dba25d9df24e4ce06185485edfcfe8a634dc1853e3542a9baeb6c5b7606e4b3f6d0a
+    d4f2cba9248e test-username@host.example.com default@ 2001-02-03 04:05:57.000 +07:00 - 2001-02-03 04:05:57.000 +07:00
+    revert operation e660cbda9711f6258fca5dffa47b356ace070baff91ee1ff29dee57432d2d44a65cc96375ef6a6e0f0c17171a3a4e209df9f8613790abb28c87acb6fbe107f8d
     args: jj op revert
 
     Changed commits:
-    ○  + sryyqqkq d41cf466 (empty) (no description set)
-    │  - sryyqqkq/0 46f2f483 (hidden) (empty) (no description set)
-    ○  + ukwxllxp 0a2e24c8 (empty) single-2
+    ○  + ztnvrxlv 13887367 (empty) (no description set)
+    │  - ztnvrxlv/0 41578768 (hidden) (empty) (no description set)
+    ○  + wqxolloz 4ebd4aa1 (empty) single-2
        (Elided 1 newly added revisions)
 
     Changed working copy default@:
-    + sryyqqkq d41cf466 (empty) (no description set)
-    - sryyqqkq/0 46f2f483 (hidden) (empty) (no description set)
+    + ztnvrxlv 13887367 (empty) (no description set)
+    - ztnvrxlv/0 41578768 (hidden) (empty) (no description set)
     [EOF]
     ");
 
     // 5. op diff and op log tests
     insta::assert_snapshot!(work_dir.run_jj(["op", "diff", "--from", &op_id_for_diff]), @"
-    From operation: f90e225dba79 (2001-02-03 08:05:28) abandon commit e7f51c58b0862dc0c255d9efd11fb9a89f07eb88 and 11 more
-      To operation: 3d2e63a4b374 (2001-02-03 08:05:51) revert operation f5a4f77da0696b42e0acbd785ebe11040e31e15bebf4d2bd4b09a521af16dba25d9df24e4ce06185485edfcfe8a634dc1853e3542a9baeb6c5b7606e4b3f6d0a
+    From operation: cf3d5f839512 (2001-02-03 08:05:31) abandon commit 7c60d8fd187f77196d1def564b0d893d477b7e56 and 11 more
+      To operation: d4f2cba9248e (2001-02-03 08:05:57) revert operation e660cbda9711f6258fca5dffa47b356ace070baff91ee1ff29dee57432d2d44a65cc96375ef6a6e0f0c17171a3a4e209df9f8613790abb28c87acb6fbe107f8d
 
     Changed commits:
-    ○  + sryyqqkq d41cf466 (empty) (no description set)
-    ○  + ukwxllxp 0a2e24c8 (empty) single-2
-    ○  + wvmqtotl 44827d4a bb | (empty) mix-b5
-    ○  + pkstwlsy 2e898f29 ba | (empty) mix-a5
-    ○  - tlkvzzqu/0 3f6d698d (hidden) (empty) (no description set)
+    ○  + ztnvrxlv 13887367 (empty) (no description set)
+    ○  + wqxolloz 4ebd4aa1 (empty) single-2
+    ○  + xpnwykqz 741a5187 bb | (empty) mix-b5
+    ○  + zowrlwsv 5653a1de ba | (empty) mix-a5
+    ○  - pzsxstzt/0 8192fa83 (hidden) (empty) (no description set)
        (Elided 9 newly added revisions)
 
     Changed working copy default@:
-    + sryyqqkq d41cf466 (empty) (no description set)
-    - tlkvzzqu/0 3f6d698d (hidden) (empty) (no description set)
+    + ztnvrxlv 13887367 (empty) (no description set)
+    - pzsxstzt/0 8192fa83 (hidden) (empty) (no description set)
 
     Changed local bookmarks:
     ba:
-    + pkstwlsy 2e898f29 ba | (empty) mix-a5
+    + zowrlwsv 5653a1de ba | (empty) mix-a5
     - (absent)
     bb:
-    + wvmqtotl 44827d4a bb | (empty) mix-b5
+    + xpnwykqz 741a5187 bb | (empty) mix-b5
     - (absent)
 
     Changed local tags:
     ts:
-    + ukwxllxp 0a2e24c8 (empty) single-2
+    + wqxolloz 4ebd4aa1 (empty) single-2
     - (absent)
     [EOF]
     ");
 
     insta::assert_snapshot!(work_dir.run_jj(["op", "log", "-p", "--limit", "1"]), @"
-    @  3d2e63a4b374 test-username@host.example.com default@ 2001-02-03 04:05:51.000 +07:00 - 2001-02-03 04:05:51.000 +07:00
-    │  revert operation f5a4f77da0696b42e0acbd785ebe11040e31e15bebf4d2bd4b09a521af16dba25d9df24e4ce06185485edfcfe8a634dc1853e3542a9baeb6c5b7606e4b3f6d0a
+    @  d4f2cba9248e test-username@host.example.com default@ 2001-02-03 04:05:57.000 +07:00 - 2001-02-03 04:05:57.000 +07:00
+    │  revert operation e660cbda9711f6258fca5dffa47b356ace070baff91ee1ff29dee57432d2d44a65cc96375ef6a6e0f0c17171a3a4e209df9f8613790abb28c87acb6fbe107f8d
     │  args: jj op revert
     │
     │  Changed commits:
-    │  ○  + sryyqqkq d41cf466 (empty) (no description set)
-    │  │  - sryyqqkq/0 46f2f483 (hidden) (empty) (no description set)
-    │  ○  + ukwxllxp 0a2e24c8 (empty) single-2
+    │  ○  + ztnvrxlv 13887367 (empty) (no description set)
+    │  │  - ztnvrxlv/0 41578768 (hidden) (empty) (no description set)
+    │  ○  + wqxolloz 4ebd4aa1 (empty) single-2
     │     Modified commit description:
     │             1: single-2
     │     (Elided 1 newly added revisions)
     │
     │  Changed working copy default@:
-    │  + sryyqqkq d41cf466 (empty) (no description set)
-    │  - sryyqqkq/0 46f2f483 (hidden) (empty) (no description set)
+    │  + ztnvrxlv 13887367 (empty) (no description set)
+    │  - ztnvrxlv/0 41578768 (hidden) (empty) (no description set)
     [EOF]
     ");
 
@@ -3421,6 +3414,7 @@ fn test_op_immutable_revisions() {
         .raw()
         .trim()
         .to_string();
+    work_dir.run_jj(["new"]).success();
 
     // Use c2_id to ensure the hidden c2 is shown.
     test_env.add_config(format!(
@@ -3467,20 +3461,20 @@ fn test_op_immutable_revisions() {
         "all()",
     ]);
     insta::assert_snapshot!(output, @"
-    From operation: db293dfe6244 (2001-02-03 08:06:05) abandon commit 5ff32b4e633551c9d0e40760cd4f8b61937395c6
-      To operation: 10ca7b3a86f8 (2001-02-03 08:06:06) abandon commit 61c625114e83805c3b25709d71cebedcf2be7406 and 1 more
+    From operation: 6065717c85c3 (2001-02-03 08:06:12) abandon commit 65f87c2d667d5088987ce6bed60f31f783b9e2ba
+      To operation: 15571d49e1b7 (2001-02-03 08:06:13) abandon commit 7d9fcee9d7dedaa91bee64d976a4252c74750905 and 1 more
 
     Changed commits:
-    ○  - knltnxnu/0 61c62511 (hidden) (empty) acc-c2
-    ○  - vkywoywq/0 a35cc4a3 (hidden) (empty) acc-c1
+    ○  - quyylypw/0 7d9fcee9 (hidden) (empty) acc-c2
+    ○  - uzontzmm/0 593e25d0 (hidden) (empty) acc-c1
 
     Changed local bookmarks:
     ba1:
     + (absent)
-    - vkywoywq/0 a35cc4a3 (hidden) (empty) acc-c1
+    - uzontzmm/0 593e25d0 (hidden) (empty) acc-c1
     ba2:
     + (absent)
-    - knltnxnu/0 61c62511 (hidden) (empty) acc-c2
+    - quyylypw/0 7d9fcee9 (hidden) (empty) acc-c2
     [EOF]
     ");
 
@@ -3488,20 +3482,20 @@ fn test_op_immutable_revisions() {
     // of the newly hidden set and elide c1.
     let output = work_dir.run_jj(["op", "diff", "--from", &op_a, "--to", &op_b]);
     insta::assert_snapshot!(output, @"
-    From operation: db293dfe6244 (2001-02-03 08:06:05) abandon commit 5ff32b4e633551c9d0e40760cd4f8b61937395c6
-      To operation: 10ca7b3a86f8 (2001-02-03 08:06:06) abandon commit 61c625114e83805c3b25709d71cebedcf2be7406 and 1 more
+    From operation: 6065717c85c3 (2001-02-03 08:06:12) abandon commit 65f87c2d667d5088987ce6bed60f31f783b9e2ba
+      To operation: 15571d49e1b7 (2001-02-03 08:06:13) abandon commit 7d9fcee9d7dedaa91bee64d976a4252c74750905 and 1 more
 
     Changed commits:
-    ○  - knltnxnu/0 61c62511 (hidden) (empty) acc-c2
+    ○  - quyylypw/0 7d9fcee9 (hidden) (empty) acc-c2
        (Elided 1 newly removed revisions)
 
     Changed local bookmarks:
     ba1:
     + (absent)
-    - vkywoywq/0 a35cc4a3 (hidden) (empty) acc-c1
+    - uzontzmm/0 593e25d0 (hidden) (empty) acc-c1
     ba2:
     + (absent)
-    - knltnxnu/0 61c62511 (hidden) (empty) acc-c2
+    - quyylypw/0 7d9fcee9 (hidden) (empty) acc-c2
     [EOF]
     ");
 }

--- a/cli/tests/test_tag_command.rs
+++ b/cli/tests/test_tag_command.rs
@@ -57,14 +57,10 @@ fn test_tag_set_delete() {
     Warning: Target revision is empty.
     Created 1 tags pointing to rlvkpnrz bbc74930 (empty) (no description set)
     Moved 1 tags to rlvkpnrz bbc74930 (empty) (no description set)
-    Warning: The working-copy commit in workspace 'default' became immutable, so a new commit has been created on top of it.
-    Working copy  (@) now at: yqosqzyt 13cbd515 (empty) (no description set)
-    Parent commit (@-)      : rlvkpnrz bbc74930 (empty) (no description set)
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  13cbd51558a6
-    ◆  bbc749308d7f baz foo
+    @  bbc749308d7f baz foo
     ◆  b876c5f49546 bar
     ◆  000000000000
     [EOF]
@@ -77,14 +73,13 @@ fn test_tag_set_delete() {
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  13cbd51558a6
-    ◆  bbc749308d7f baz
+    @  bbc749308d7f baz
     ◆  b876c5f49546 bar
     ◆  000000000000
     [EOF]
     ");
 
-    let output = work_dir.run_jj(["tag", "set", "--allow-move", "-r@-", "baz"]);
+    let output = work_dir.run_jj(["tag", "set", "--allow-move", "-r@", "baz"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Warning: Target revision is empty.
@@ -92,8 +87,7 @@ fn test_tag_set_delete() {
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  13cbd51558a6
-    ◆  bbc749308d7f baz
+    @  bbc749308d7f baz
     ◆  b876c5f49546 bar
     ◆  000000000000
     [EOF]
@@ -106,8 +100,7 @@ fn test_tag_set_delete() {
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  13cbd51558a6
-    ○  bbc749308d7f
+    @  bbc749308d7f
     ○  b876c5f49546
     ◆  000000000000
     [EOF]
@@ -280,7 +273,7 @@ fn test_tag_list() {
     [38;5;5mconflicted_tag[39m [38;5;1m(conflicted)[39m:
       - [1m[38;5;5mrl[0m[38;5;8mvkpnrz[39m [1m[38;5;4m8[0m[38;5;8m93e67dc[39m [38;5;2m(empty)[39m commit1
       + [1m[38;5;5mzs[0m[38;5;8muskuln[39m [1m[38;5;4m7[0m[38;5;8m6abdd20[39m [38;5;2m(empty)[39m commit2
-      + [1m[38;5;5mr[0m[38;5;8moyxmykx[39m [1m[38;5;4m1[0m[38;5;8m3c4e819[39m [38;5;2m(empty)[39m commit3
+      + [1m[38;5;13mr[38;5;8moyxmykx[39m [38;5;12m1[38;5;8m3c4e819[39m [38;5;10m(empty)[39m commit3[0m
     [38;5;5mtest_tag[39m: [1m[38;5;5mrl[0m[38;5;8mvkpnrz[39m [1m[38;5;4m8[0m[38;5;8m93e67dc[39m [38;5;2m(empty)[39m commit1
     [38;5;5mtest_tag2[39m: [1m[38;5;5mzs[0m[38;5;8muskuln[39m [1m[38;5;4m7[0m[38;5;8m6abdd20[39m [38;5;2m(empty)[39m commit2
     [EOF]


### PR DESCRIPTION
Closes #9338
Closes #7751


# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [ ] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
