### PR TITLE
github: Enable Dependabot cooldowns

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
   directory: "/"
   schedule:
     interval: "weekly"
+  cooldown:
+    default-days: 7
   open-pull-requests-limit: 10
   commit-message:
     prefix: "cargo:"
@@ -15,6 +17,8 @@ updates:
   directory: "/"
   schedule:
     interval: "weekly"
+  cooldown:
+    default-days: 7
   open-pull-requests-limit: 10
   commit-message:
     prefix: "github:"
@@ -26,6 +30,8 @@ updates:
   directory: "/"
   schedule:
     interval: "weekly"
+  cooldown:
+    default-days: 7
   open-pull-requests-limit: 10
   commit-message:
     prefix: "npm:"


### PR DESCRIPTION
This enables a 7-day Dependabot cooldown for all configured version update ecosystems:

- Cargo
- GitHub Actions
- npm

Dependabot normally considers newly released versions immediately when its scheduled update job runs. A cooldown reduces supply chain risk by giving external tooling, package indexes, maintainers, and downstream users time to detect compromised, malicious, yanked, or broken releases before automation opens an update PR for them.

This addresses the `zizmor/dependabot-cooldown` code scanning finding and follows the mitigation recommended by zizmor:

- Code scanning alert: https://github.com/jj-vcs/jj/security/code-scanning/226
- zizmor audit docs: https://docs.zizmor.sh/audits/#dependabot-cooldown
- GitHub Dependabot `cooldown` docs: https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown

The GitHub Actions cooldown also covers updates to pinned workflow actions, including `taiki-e/install-action`. The current CI use is pinned to commit `d9be7d8cda89035c9c843f78bd44d4f72d8403d4`, which corresponds to `taiki-e/install-action@v2.79.7`. Its unversioned `tool: nextest` input resolves through that pinned action’s manifest, currently to `cargo-nextest 0.9.136`, rather than fetching live latest on every CI run. Future Dependabot PRs that advance `install-action` will now wait 7 days after release.

Security updates are not delayed by this setting; GitHub documents `cooldown` as applying to Dependabot version updates, not security updates.

Validation:

- Parsed `.github/dependabot.yml` successfully.
- Ran `uvx zizmor --format sarif .`; the cooldown finding is resolved.
- Remaining zizmor SARIF findings are pre-existing and unrelated `release.yml` findings.