### PR TITLE
Allow user to choose which side of the diff to edit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### New features
 
+* Added `edit-side` config option for diff editors (e.g. `jj diffedit`, `jj
+  split`).  The default behaviour is for `$right` to be modifiable, but with
+  this setting you can choose to edit `$left` instead.  This will feel much more
+  familiar to users of fugitive.vim.
+
 ### Fixed bugs
 
 ## [0.42.0] - 2026-06-04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### New features
+
+* Added `edit-side` config option for diff editors (e.g. `jj diffedit`, `jj
+  split`).  The default behaviour is for `$right` to be modifiable, but with
+  this setting you can choose to edit `$left` instead.  This will feel much more
+  familiar to users of fugitive.vim.
+
 ### Release highlights
 
 ### Breaking changes

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -181,6 +181,7 @@ use crate::diff_util::DiffRenderer;
 use crate::formatter::FormatRecorder;
 use crate::formatter::Formatter;
 use crate::formatter::FormatterExt as _;
+use crate::merge_tools::DiffEditSide;
 use crate::merge_tools::DiffEditor;
 use crate::merge_tools::MergeEditor;
 use crate::merge_tools::MergeToolConfigError;
@@ -3358,7 +3359,7 @@ impl DiffSelector {
         trees: Diff<&MergedTree>,
         tree_labels: Diff<String>,
         matcher: &dyn Matcher,
-        format_instructions: impl FnOnce() -> String,
+        format_instructions: impl FnOnce(DiffEditSide) -> String,
     ) -> Result<MergedTree, CommandError> {
         let selected_tree = restore_tree(
             trees.after,

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -184,6 +184,7 @@ use crate::diff_util::DiffRenderer;
 use crate::formatter::FormatRecorder;
 use crate::formatter::Formatter;
 use crate::formatter::FormatterExt as _;
+use crate::merge_tools::DiffEditSide;
 use crate::merge_tools::DiffEditor;
 use crate::merge_tools::MergeEditor;
 use crate::merge_tools::MergeToolConfigError;
@@ -3574,7 +3575,7 @@ impl DiffSelector {
         trees: Diff<&MergedTree>,
         tree_labels: Diff<String>,
         matcher: &dyn Matcher,
-        format_instructions: impl FnOnce() -> String,
+        format_instructions: impl FnOnce(DiffEditSide) -> String,
     ) -> Result<MergedTree, CommandError> {
         let selected_tree = restore_tree(
             trees.after,

--- a/cli/src/commands/absorb.rs
+++ b/cli/src/commands/absorb.rs
@@ -113,7 +113,7 @@ pub(crate) async fn cmd_absorb(
     let source = if diff_selector.is_interactive() {
         let parent_tree = source_commit.parent_tree(repo).await?;
         let source_tree = source_commit.tree();
-        let format_instructions = || {
+        let format_instructions = |edit_side| {
             formatdoc! {"
                 You are selecting changes from: {source} to be considered for
                 absorption into ancestors.
@@ -121,7 +121,7 @@ pub(crate) async fn cmd_absorb(
                 The left side of the diff shows the parent commit. The right side
                 initially shows the contents of the commit you're absorbing from.
 
-                Adjust the right side until the diff shows the changes you want to
+                Adjust the {edit_side} side until the diff shows the changes you want to
                 absorb. Selected hunks will be considered for assignment to the
                 closest ancestor where the corresponding lines were last modified
                 (using annotation). Any hunks that cannot be absorbed unambiguously

--- a/cli/src/commands/commit.rs
+++ b/cli/src/commands/commit.rs
@@ -105,12 +105,12 @@ pub(crate) async fn cmd_commit(
     let text_editor = workspace_command.text_editor()?;
     let mut tx = workspace_command.start_transaction();
     let base_tree = commit.parent_tree(tx.repo()).await?;
-    let format_instructions = || {
+    let format_instructions = |edit_side| {
         format!(
             "\
 You are splitting the working-copy commit: {}
 
-The diff initially shows all changes. Adjust the right side until it shows the
+The diff initially shows all changes. Adjust the {edit_side} side until it shows the
 contents you want for the first commit. The remainder will be included in the
 new working-copy commit.
 ",

--- a/cli/src/commands/diffedit.rs
+++ b/cli/src/commands/diffedit.rs
@@ -125,14 +125,14 @@ pub(crate) async fn cmd_diffedit(
 
     let diff_editor = workspace_command.diff_editor(ui, args.tool.as_deref())?;
     let mut tx = workspace_command.start_transaction();
-    let format_instructions = || {
+    let format_instructions = |edit_side| {
         format!(
             "\
 You are editing changes in: {}
 
 {diff_description}
 
-Adjust the right side until it shows the contents you want. If you
+Adjust the {edit_side} side until it shows the contents you want. If you
 don't make any changes, then the operation will be aborted.",
             tx.format_commit_summary(&target_commit),
         )

--- a/cli/src/commands/restore.rs
+++ b/cli/src/commands/restore.rs
@@ -142,12 +142,12 @@ pub(crate) async fn cmd_restore(
     let diff_selector =
         workspace_command.diff_selector(ui, args.tool.as_deref(), args.interactive)?;
     let to_tree = to_commit.tree();
-    let format_instructions = || {
+    let format_instructions = |edit_side| {
         formatdoc! {"
             You are restoring changes from: {from_commits}
             to commit: {to_commit}
 
-            The diff initially shows all changes restored. Adjust the right side until it
+            The diff initially shows all changes restored. Adjust the {edit_side} side until it
             shows the contents you want for the destination commit.
             ",
             from_commits = from_commits

--- a/cli/src/commands/split.rs
+++ b/cli/src/commands/split.rs
@@ -552,14 +552,14 @@ async fn select_diff(
     matcher: &dyn Matcher,
     diff_selector: &DiffSelector,
 ) -> Result<CommitWithSelection, CommandError> {
-    let format_instructions = || {
+    let format_instructions = |edit_side| {
         format!(
             "\
 You are splitting a commit into two: {}
 
 The diff initially shows the changes in the commit you're splitting.
 
-Adjust the right side until it shows the contents you want to split into the
+Adjust the {edit_side} side until it shows the contents you want to split into the
 new commit.
 The changes that are not selected will replace the original commit.
 ",

--- a/cli/src/commands/split.rs
+++ b/cli/src/commands/split.rs
@@ -553,14 +553,14 @@ async fn select_diff(
     matcher: &dyn Matcher,
     diff_selector: &DiffSelector,
 ) -> Result<CommitWithSelection, CommandError> {
-    let format_instructions = || {
+    let format_instructions = |edit_side| {
         format!(
             "\
 You are splitting a commit into two: {}
 
 The diff initially shows the changes in the commit you're splitting.
 
-Adjust the right side until it shows the contents you want to split into the
+Adjust the {edit_side} side until it shows the contents you want to split into the
 new commit.
 The changes that are not selected will replace the original commit.
 ",

--- a/cli/src/commands/squash.rs
+++ b/cli/src/commands/squash.rs
@@ -475,7 +475,7 @@ async fn select_diff(
     for source in sources {
         let parent_tree = source.parent_tree(tx.repo()).await?;
         let source_tree = source.tree();
-        let format_instructions = || {
+        let format_instructions = |edit_side| {
             formatdoc! {"
                 You are moving changes from: {source}
                 into commit: {destination}
@@ -484,10 +484,14 @@ async fn select_diff(
                 right side initially shows the contents of the commit you're moving
                 changes from.
 
-                Adjust the right side until the diff shows the changes you want to move
-                to the destination. If you don't make any changes, then all the changes
+                Adjust the {edit_side} side until the diff shows the changes you want to move
+                to the destination. If you don't make any changes, then {} of the changes
                 from the source will be moved into the destination.
                 ",
+                match edit_side {
+                    crate::merge_tools::DiffEditSide::Left => "none",
+                    crate::merge_tools::DiffEditSide::Right => "all",
+                },
                 source = tx.format_commit_summary(source),
                 destination = tx.format_commit_summary(destination),
             }

--- a/cli/src/commands/squash.rs
+++ b/cli/src/commands/squash.rs
@@ -494,7 +494,7 @@ async fn select_diff(
     for source in sources {
         let parent_tree = source.parent_tree(tx.repo()).await?;
         let source_tree = source.tree();
-        let format_instructions = || {
+        let format_instructions = |edit_side| {
             formatdoc! {"
                 You are moving changes from: {source}
                 into commit: {destination}
@@ -503,10 +503,14 @@ async fn select_diff(
                 right side initially shows the contents of the commit you're moving
                 changes from.
 
-                Adjust the right side until the diff shows the changes you want to move
-                to the destination. If you don't make any changes, then all the changes
+                Adjust the {edit_side} side until the diff shows the changes you want to move
+                to the destination. If you don't make any changes, then {} of the changes
                 from the source will be moved into the destination.
                 ",
+                match edit_side {
+                    crate::merge_tools::DiffEditSide::Left => "none",
+                    crate::merge_tools::DiffEditSide::Right => "all",
+                },
                 source = tx.format_commit_summary(source),
                 destination = tx.format_commit_summary(destination),
             }

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -669,6 +669,11 @@
                         ],
                         "default": "dir"
                     },
+                    "edit-side": {
+                        "enum": ["left", "right"],
+                        "description": "Which side of the diff is editable",
+                        "default": "right"
+                    },
                     "merge-args": {
                         "type": "array",
                         "items": {

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -683,6 +683,11 @@
                         ],
                         "default": "dir"
                     },
+                    "edit-side": {
+                        "enum": ["left", "right"],
+                        "description": "Which side of the diff is editable",
+                        "default": "right"
+                    },
                     "merge-args": {
                         "type": "array",
                         "items": {

--- a/cli/src/merge_tools/diff_working_copies.rs
+++ b/cli/src/merge_tools/diff_working_copies.rs
@@ -29,6 +29,7 @@ use tempfile::TempDir;
 use thiserror::Error;
 
 use super::DiffEditError;
+use super::external::DiffEditSide;
 use super::external::ExternalToolError;
 
 #[derive(Debug, Error)]
@@ -155,6 +156,7 @@ pub(crate) async fn check_out_trees(
     trees: Diff<&MergedTree>,
     matcher: &dyn Matcher,
     diff_type: DiffType,
+    edit_side: DiffEditSide,
     conflict_marker_style: ConflictMarkerStyle,
 ) -> Result<DiffWorkingCopies, DiffCheckoutError> {
     let store = trees.before.store();
@@ -190,7 +192,10 @@ pub(crate) async fn check_out_trees(
     let right = check_out("right", trees.after)?;
     let output = match diff_type {
         DiffType::TwoWay => None,
-        DiffType::ThreeWay => Some(check_out("output", trees.after)?),
+        DiffType::ThreeWay => match edit_side {
+            DiffEditSide::Left => Some(check_out("output", trees.before)?),
+            DiffEditSide::Right => Some(check_out("output", trees.after)?),
+        },
     };
     Ok(DiffWorkingCopies {
         temp_dir,
@@ -212,14 +217,21 @@ impl DiffEditWorkingCopies {
         trees: Diff<&MergedTree>,
         matcher: &dyn Matcher,
         diff_type: DiffType,
+        edit_side: DiffEditSide,
         instructions: Option<&str>,
         conflict_marker_style: ConflictMarkerStyle,
     ) -> Result<Self, DiffEditError> {
         let working_copies =
-            check_out_trees(trees, matcher, diff_type, conflict_marker_style).await?;
-        working_copies.set_left_readonly()?;
-        if diff_type == DiffType::ThreeWay {
-            working_copies.set_right_readonly()?;
+            check_out_trees(trees, matcher, diff_type, edit_side, conflict_marker_style).await?;
+        match diff_type {
+            DiffType::ThreeWay => {
+                working_copies.set_left_readonly()?;
+                working_copies.set_right_readonly()?;
+            }
+            DiffType::TwoWay => match edit_side {
+                DiffEditSide::Left => working_copies.set_right_readonly()?,
+                DiffEditSide::Right => working_copies.set_left_readonly()?,
+            },
         }
         let instructions_path_to_cleanup =
             Self::write_edit_instructions(&working_copies, instructions)?;
@@ -297,6 +309,7 @@ diff editing in mind and be a little inaccurate.
     pub async fn snapshot_results(
         self,
         base_ignores: Arc<GitIgnoreFile>,
+        side_to_snapshot: DiffEditSide,
     ) -> Result<MergedTree, DiffEditError> {
         if let Some(path) = self.instructions_path_to_cleanup {
             std::fs::remove_file(path).ok();
@@ -304,7 +317,10 @@ diff editing in mind and be a little inaccurate.
 
         let diff_wc = self.working_copies;
         // Snapshot changes in the temporary output directory.
-        let mut output_tree_state = diff_wc.output.unwrap_or(diff_wc.right);
+        let mut output_tree_state = diff_wc.output.unwrap_or(match side_to_snapshot {
+            DiffEditSide::Left => diff_wc.left,
+            DiffEditSide::Right => diff_wc.right,
+        });
         output_tree_state
             .snapshot(&SnapshotOptions {
                 base_ignores,

--- a/cli/src/merge_tools/external.rs
+++ b/cli/src/merge_tools/external.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::fmt;
 use std::io;
 use std::io::Write;
 use std::path::Path;
@@ -57,6 +58,7 @@ pub struct ExternalMergeTool {
     /// Whether to execute the tool with a pair of directories or individual
     /// files when generating diffs.
     pub diff_invocation_mode: DiffToolMode,
+    pub edit_side: DiffEditSide,
     /// Whether to execute the tool in the temporary diff directory
     pub diff_do_chdir: bool,
     /// Arguments to pass to the program when editing diffs.
@@ -100,6 +102,24 @@ pub enum DiffToolMode {
     FileByFile,
 }
 
+#[derive(serde::Deserialize, Copy, Clone, Debug, Eq, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+pub enum DiffEditSide {
+    /// Invoke the diff tool with `$left` as the editable tree
+    Left,
+    /// Invoke the diff tool with `$right` as the editable tree
+    Right,
+}
+
+impl fmt::Display for DiffEditSide {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Left => f.write_str("left"),
+            Self::Right => f.write_str("right"),
+        }
+    }
+}
+
 impl Default for ExternalMergeTool {
     fn default() -> Self {
         Self {
@@ -119,6 +139,7 @@ impl Default for ExternalMergeTool {
             conflict_marker_style: None,
             diff_do_chdir: true,
             diff_invocation_mode: DiffToolMode::Dir,
+            edit_side: DiffEditSide::Right,
         }
     }
 }
@@ -402,6 +423,7 @@ pub async fn edit_diff_external(
         trees,
         matcher,
         diff_type,
+        editor.edit_side,
         instructions,
         conflict_marker_style,
     )
@@ -439,7 +461,9 @@ pub async fn edit_diff_external(
         }
     }
 
-    diffedit_wc.snapshot_results(base_ignores).await
+    diffedit_wc
+        .snapshot_results(base_ignores, editor.edit_side)
+        .await
 }
 
 /// Generates textual diff by the specified `tool` and writes into `writer`.
@@ -455,7 +479,14 @@ pub async fn generate_diff(
     let conflict_marker_style = tool
         .conflict_marker_style
         .unwrap_or(default_conflict_marker_style);
-    let diff_wc = check_out_trees(trees, matcher, DiffType::TwoWay, conflict_marker_style).await?;
+    let diff_wc = check_out_trees(
+        trees,
+        matcher,
+        DiffType::TwoWay,
+        DiffEditSide::Right,
+        conflict_marker_style,
+    )
+    .await?;
     diff_wc.set_left_readonly()?;
     diff_wc.set_right_readonly()?;
     let mut patterns = diff_wc.to_command_variables(true);

--- a/cli/src/merge_tools/external.rs
+++ b/cli/src/merge_tools/external.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::fmt;
 use std::io;
 use std::io::Write;
 use std::path::Path;
@@ -58,6 +59,7 @@ pub struct ExternalMergeTool {
     /// Whether to execute the tool with a pair of directories or individual
     /// files when generating diffs.
     pub diff_invocation_mode: DiffToolMode,
+    pub edit_side: DiffEditSide,
     /// Whether to execute the tool in the temporary diff directory
     pub diff_do_chdir: bool,
     /// Arguments to pass to the program when editing diffs.
@@ -101,6 +103,24 @@ pub enum DiffToolMode {
     FileByFile,
 }
 
+#[derive(serde::Deserialize, Copy, Clone, Debug, Eq, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+pub enum DiffEditSide {
+    /// Invoke the diff tool with `$left` as the editable tree
+    Left,
+    /// Invoke the diff tool with `$right` as the editable tree
+    Right,
+}
+
+impl fmt::Display for DiffEditSide {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Left => f.write_str("left"),
+            Self::Right => f.write_str("right"),
+        }
+    }
+}
+
 impl Default for ExternalMergeTool {
     fn default() -> Self {
         Self {
@@ -120,6 +140,7 @@ impl Default for ExternalMergeTool {
             conflict_marker_style: None,
             diff_do_chdir: true,
             diff_invocation_mode: DiffToolMode::Dir,
+            edit_side: DiffEditSide::Right,
         }
     }
 }
@@ -403,6 +424,7 @@ pub async fn edit_diff_external(
         trees,
         matcher,
         diff_type,
+        editor.edit_side,
         instructions,
         conflict_marker_style,
     )
@@ -440,7 +462,9 @@ pub async fn edit_diff_external(
         }
     }
 
-    diffedit_wc.snapshot_results(base_ignores).await
+    diffedit_wc
+        .snapshot_results(base_ignores, editor.edit_side)
+        .await
 }
 
 /// Generates textual diff by the specified `tool` and writes into `writer`.
@@ -456,7 +480,14 @@ pub async fn generate_diff(
     let conflict_marker_style = tool
         .conflict_marker_style
         .unwrap_or(default_conflict_marker_style);
-    let diff_wc = check_out_trees(trees, matcher, DiffType::TwoWay, conflict_marker_style).await?;
+    let diff_wc = check_out_trees(
+        trees,
+        matcher,
+        DiffType::TwoWay,
+        DiffEditSide::Right,
+        conflict_marker_style,
+    )
+    .await?;
     diff_wc.set_left_readonly()?;
     diff_wc.set_right_readonly()?;
     let mut patterns = diff_wc.to_command_variables(true);

--- a/cli/src/merge_tools/mod.rs
+++ b/cli/src/merge_tools/mod.rs
@@ -48,6 +48,7 @@ use self::builtin::edit_diff_builtin;
 use self::builtin::edit_merge_builtin;
 use self::diff_working_copies::DiffCheckoutError;
 pub(crate) use self::diff_working_copies::new_utf8_temp_dir;
+pub use self::external::DiffEditSide;
 pub use self::external::DiffToolMode;
 pub use self::external::ExternalMergeTool;
 use self::external::ExternalToolError;
@@ -296,7 +297,7 @@ impl DiffEditor {
         &self,
         trees: Diff<&MergedTree>,
         matcher: &dyn Matcher,
-        format_instructions: impl FnOnce() -> String,
+        format_instructions: impl FnOnce(DiffEditSide) -> String,
     ) -> Result<MergedTree, DiffEditError> {
         match &self.tool {
             DiffEditTool::Builtin => {
@@ -307,7 +308,9 @@ impl DiffEditor {
                 )
             }
             DiffEditTool::External(editor) => {
-                let instructions = self.use_instructions.then(format_instructions);
+                let instructions = self
+                    .use_instructions
+                    .then(|| format_instructions(editor.edit_side));
                 edit_diff_external(
                     editor,
                     trees,
@@ -537,6 +540,7 @@ mod tests {
                     0,
                 ],
                 diff_invocation_mode: Dir,
+                edit_side: Right,
                 diff_do_chdir: true,
                 edit_args: [
                     "$left",
@@ -569,6 +573,7 @@ mod tests {
                     0,
                 ],
                 diff_invocation_mode: Dir,
+                edit_side: Right,
                 diff_do_chdir: true,
                 edit_args: [
                     "--edit",
@@ -617,6 +622,7 @@ mod tests {
                     0,
                 ],
                 diff_invocation_mode: Dir,
+                edit_side: Right,
                 diff_do_chdir: true,
                 edit_args: [
                     "$left",
@@ -645,6 +651,7 @@ mod tests {
                     0,
                 ],
                 diff_invocation_mode: Dir,
+                edit_side: Right,
                 diff_do_chdir: true,
                 edit_args: [
                     "-l",
@@ -675,6 +682,7 @@ mod tests {
                     0,
                 ],
                 diff_invocation_mode: Dir,
+                edit_side: Right,
                 diff_do_chdir: true,
                 edit_args: [
                     "--diff",
@@ -707,6 +715,7 @@ mod tests {
                     0,
                 ],
                 diff_invocation_mode: Dir,
+                edit_side: Right,
                 diff_do_chdir: true,
                 edit_args: [
                     "--edit",
@@ -742,6 +751,7 @@ mod tests {
                     0,
                 ],
                 diff_invocation_mode: Dir,
+                edit_side: Right,
                 diff_do_chdir: true,
                 edit_args: [
                     "$left",
@@ -769,6 +779,7 @@ mod tests {
                     0,
                 ],
                 diff_invocation_mode: Dir,
+                edit_side: Right,
                 diff_do_chdir: true,
                 edit_args: [
                     "$left",
@@ -843,6 +854,7 @@ mod tests {
                     0,
                 ],
                 diff_invocation_mode: Dir,
+                edit_side: Right,
                 diff_do_chdir: true,
                 edit_args: [
                     "$left",
@@ -901,6 +913,7 @@ mod tests {
                     0,
                 ],
                 diff_invocation_mode: Dir,
+                edit_side: Right,
                 diff_do_chdir: true,
                 edit_args: [
                     "$left",
@@ -936,6 +949,7 @@ mod tests {
                     0,
                 ],
                 diff_invocation_mode: Dir,
+                edit_side: Right,
                 diff_do_chdir: true,
                 edit_args: [
                     "$left",
@@ -974,6 +988,7 @@ mod tests {
                     0,
                 ],
                 diff_invocation_mode: Dir,
+                edit_side: Right,
                 diff_do_chdir: true,
                 edit_args: [
                     "$left",

--- a/cli/src/merge_tools/mod.rs
+++ b/cli/src/merge_tools/mod.rs
@@ -49,6 +49,7 @@ use self::builtin::edit_diff_builtin;
 use self::builtin::edit_merge_builtin;
 use self::diff_working_copies::DiffCheckoutError;
 pub(crate) use self::diff_working_copies::new_utf8_temp_dir;
+pub use self::external::DiffEditSide;
 pub use self::external::DiffToolMode;
 pub use self::external::ExternalMergeTool;
 use self::external::ExternalToolError;
@@ -297,7 +298,7 @@ impl DiffEditor {
         &self,
         trees: Diff<&MergedTree>,
         matcher: &dyn Matcher,
-        format_instructions: impl FnOnce() -> String,
+        format_instructions: impl FnOnce(DiffEditSide) -> String,
     ) -> Result<MergedTree, DiffEditError> {
         match &self.tool {
             DiffEditTool::Builtin => {
@@ -308,7 +309,9 @@ impl DiffEditor {
                 )
             }
             DiffEditTool::External(editor) => {
-                let instructions = self.use_instructions.then(format_instructions);
+                let instructions = self
+                    .use_instructions
+                    .then(|| format_instructions(editor.edit_side));
                 edit_diff_external(
                     editor,
                     trees,
@@ -538,6 +541,7 @@ mod tests {
                     0,
                 ],
                 diff_invocation_mode: Dir,
+                edit_side: Right,
                 diff_do_chdir: true,
                 edit_args: [
                     "$left",
@@ -570,6 +574,7 @@ mod tests {
                     0,
                 ],
                 diff_invocation_mode: Dir,
+                edit_side: Right,
                 diff_do_chdir: true,
                 edit_args: [
                     "--edit",
@@ -618,6 +623,7 @@ mod tests {
                     0,
                 ],
                 diff_invocation_mode: Dir,
+                edit_side: Right,
                 diff_do_chdir: true,
                 edit_args: [
                     "$left",
@@ -646,6 +652,7 @@ mod tests {
                     0,
                 ],
                 diff_invocation_mode: Dir,
+                edit_side: Right,
                 diff_do_chdir: true,
                 edit_args: [
                     "-l",
@@ -676,6 +683,7 @@ mod tests {
                     0,
                 ],
                 diff_invocation_mode: Dir,
+                edit_side: Right,
                 diff_do_chdir: true,
                 edit_args: [
                     "--diff",
@@ -708,6 +716,7 @@ mod tests {
                     0,
                 ],
                 diff_invocation_mode: Dir,
+                edit_side: Right,
                 diff_do_chdir: true,
                 edit_args: [
                     "--edit",
@@ -743,6 +752,7 @@ mod tests {
                     0,
                 ],
                 diff_invocation_mode: Dir,
+                edit_side: Right,
                 diff_do_chdir: true,
                 edit_args: [
                     "$left",
@@ -770,6 +780,7 @@ mod tests {
                     0,
                 ],
                 diff_invocation_mode: Dir,
+                edit_side: Right,
                 diff_do_chdir: true,
                 edit_args: [
                     "$left",
@@ -844,6 +855,7 @@ mod tests {
                     0,
                 ],
                 diff_invocation_mode: Dir,
+                edit_side: Right,
                 diff_do_chdir: true,
                 edit_args: [
                     "$left",
@@ -902,6 +914,7 @@ mod tests {
                     0,
                 ],
                 diff_invocation_mode: Dir,
+                edit_side: Right,
                 diff_do_chdir: true,
                 edit_args: [
                     "$left",
@@ -937,6 +950,7 @@ mod tests {
                     0,
                 ],
                 diff_invocation_mode: Dir,
+                edit_side: Right,
                 diff_do_chdir: true,
                 edit_args: [
                     "$left",
@@ -975,6 +989,7 @@ mod tests {
                     0,
                 ],
                 diff_invocation_mode: Dir,
+                edit_side: Right,
                 diff_do_chdir: true,
                 edit_args: [
                     "$left",

--- a/docs/config.md
+++ b/docs/config.md
@@ -1148,6 +1148,14 @@ diff-invocation-mode = "dir"
 edit-invocation-mode = "file-by-file"
 ```
 
+By default, `$left` will be read-only, and you'll edit `$right` until the diff is as desired.
+This can be inverted like so:
+
+```toml
+[merge-tools.my-tool]
+edit-side = "left"
+```
+
 Finally, `ui.diff-editor` can be a list that specifies a command and its arguments.
 
 Some examples:
@@ -1230,7 +1238,8 @@ To configure other diff editors in this way, you can include `$output` together
 with `$left` and `$right` in `merge-tools.TOOL.edit-args`. `jj` will replace
 `$output` with the directory where the diff editor will be expected to put the
 result of the user's edits. Initially, the contents of `$output` will be the
-same as the contents of `$right`.
+same as the contents of `$right`, although this can be changed by setting
+`merge-tools.TOOL.edit-side`.
 
 ### `JJ-INSTRUCTIONS`
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -1168,6 +1168,14 @@ diff-invocation-mode = "dir"
 edit-invocation-mode = "file-by-file"
 ```
 
+By default, `$left` will be read-only, and you'll edit `$right` until the diff is as desired.
+This can be inverted like so:
+
+```toml
+[merge-tools.my-tool]
+edit-side = "left"
+```
+
 Finally, `ui.diff-editor` can be a list that specifies a command and its arguments.
 
 Some examples:
@@ -1250,7 +1258,8 @@ To configure other diff editors in this way, you can include `$output` together
 with `$left` and `$right` in `merge-tools.TOOL.edit-args`. `jj` will replace
 `$output` with the directory where the diff editor will be expected to put the
 result of the user's edits. Initially, the contents of `$output` will be the
-same as the contents of `$right`.
+same as the contents of `$right`, although this can be changed by setting
+`merge-tools.TOOL.edit-side`.
 
 ### `JJ-INSTRUCTIONS`
 


### PR DESCRIPTION
# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [x] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
