### PR TITLE
fileset: add `sparse()` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### New features
 
+* The fileset DSL has a new `sparse()` function that evaluates to the files
+  within the current working copy's sparse-checkout patterns. For example,
+  `jj log 'sparse()' -p` will show only the revisions that touch files you
+  currently have checked out.
+  [#7816](https://github.com/jj-vcs/jj/issues/7816)
+
 ### Fixed bugs
 
 ## [0.42.0] - 2026-06-04

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -507,7 +507,7 @@ impl CommandHelper {
         let repo = workspace.repo_loader().load_at(&op_head).await?;
         let mut env = self.workspace_environment(ui, &workspace)?;
         if let Err(err) =
-            revset_util::try_resolve_trunk_alias(repo.as_ref(), &env.revset_parse_context())
+            revset_util::try_resolve_trunk_alias(repo.as_ref(), &env.revset_parse_context(None))
         {
             // The fallback can be builtin_trunk() if we're willing to support
             // inferred trunk forever. (#7990)
@@ -890,10 +890,17 @@ impl WorkspaceCommandEnvironment {
     }
 
     /// Parsing context for fileset expressions specified by command arguments.
-    pub(crate) fn fileset_parse_context(&self) -> FilesetParseContext<'_> {
+    ///
+    /// `sparse_patterns` is the sparse-checkout patterns of the current
+    /// working copy, if any, used to resolve the `sparse()` builtin.
+    pub(crate) fn fileset_parse_context<'a>(
+        &'a self,
+        sparse_patterns: Option<&'a [RepoPathBuf]>,
+    ) -> FilesetParseContext<'a> {
         FilesetParseContext {
             aliases_map: &self.fileset_aliases_map,
             path_converter: &self.path_converter,
+            sparse_patterns,
         }
     }
 
@@ -908,13 +915,18 @@ impl WorkspaceCommandEnvironment {
         FilesetParseContext {
             aliases_map: &self.fileset_aliases_map,
             path_converter: &ROOT_PATH_CONVERTER,
+            sparse_patterns: None,
         }
     }
 
-    pub(crate) fn revset_parse_context(&self) -> RevsetParseContext<'_> {
+    pub(crate) fn revset_parse_context<'a>(
+        &'a self,
+        sparse_patterns: Option<&'a [RepoPathBuf]>,
+    ) -> RevsetParseContext<'a> {
         let workspace_context = RevsetWorkspaceContext {
             path_converter: &self.path_converter,
             workspace_name: &self.workspace_name,
+            sparse_patterns,
         };
         let now = if let Some(timestamp) = self.settings.commit_timestamp() {
             chrono::Local
@@ -977,7 +989,7 @@ impl WorkspaceCommandEnvironment {
         let mut diagnostics = RevsetDiagnostics::new();
         let expression = revset_util::parse_immutable_heads_expression(
             &mut diagnostics,
-            &self.revset_parse_context(),
+            &self.revset_parse_context(None),
         )
         .map_err(|e| config_error_with_message("Invalid `revset-aliases.immutable_heads()`", e))?;
         print_parse_diagnostics(ui, "In `revset-aliases.immutable_heads()`", &diagnostics)?;
@@ -1000,7 +1012,7 @@ impl WorkspaceCommandEnvironment {
             let expression = revset::parse(
                 &mut diagnostics,
                 &revset_string,
-                &self.revset_parse_context(),
+                &self.revset_parse_context(None),
             )
             .map_err(|err| config_error_with_message("Invalid `revsets.short-prefixes`", err))?;
             print_parse_diagnostics(ui, "In `revsets.short-prefixes`", &diagnostics)?;
@@ -1074,11 +1086,14 @@ impl WorkspaceCommandEnvironment {
         repo: &'a dyn Repo,
         id_prefix_context: &'a IdPrefixContext,
     ) -> CommitTemplateLanguage<'a> {
+        // No working-copy handle at the env level, so `sparse()` won't
+        // resolve inside templates. Call sites needing it can route
+        // through the helper-level fileset/revset parsers.
         CommitTemplateLanguage::new(
             repo,
             &self.path_converter,
             &self.workspace_name,
-            self.revset_parse_context(),
+            self.revset_parse_context(None),
             id_prefix_context,
             self.immutable_expression(),
             self.conflict_marker_style,
@@ -1521,6 +1536,28 @@ to the current parents may contain changes from multiple commits.
         }
     }
 
+    /// Reads the working copy's sparse patterns for fileset/revset parsing.
+    ///
+    /// Returns `Ok(None)` if the working copy can't be read (corrupt state,
+    /// `--ignore-working-copy` semantics, etc.) so plain expressions without
+    /// `sparse()` still parse. The read error is surfaced as a warning rather
+    /// than silently swallowed: if it were dropped, `sparse()` would fail with
+    /// a misleading "cannot be used in this context" error in a context where
+    /// it should be usable.
+    fn sparse_patterns_for_parsing(&self, ui: &Ui) -> Result<Option<&[RepoPathBuf]>, CommandError> {
+        match self.working_copy().sparse_patterns() {
+            Ok(patterns) => Ok(Some(patterns)),
+            Err(err) => {
+                writeln!(
+                    ui.warning_default(),
+                    "Failed to read the working copy's sparse patterns; `sparse()` will be \
+                     unavailable. Error: {err}"
+                )?;
+                Ok(None)
+            }
+        }
+    }
+
     /// Parses the given fileset expressions and concatenates them all.
     pub fn parse_union_filesets(
         &self,
@@ -1528,7 +1565,8 @@ to the current parents may contain changes from multiple commits.
         file_args: &[String], // TODO: introduce FileArg newtype?
     ) -> Result<FilesetExpression, CommandError> {
         let mut diagnostics = FilesetDiagnostics::new();
-        let context = self.env.fileset_parse_context();
+        let sparse_patterns = self.sparse_patterns_for_parsing(ui)?;
+        let context = self.env.fileset_parse_context(sparse_patterns);
         let expressions: Vec<_> = file_args
             .iter()
             .map(|arg| fileset::parse_maybe_bare(&mut diagnostics, arg, &context))
@@ -1782,7 +1820,8 @@ to the current parents may contain changes from multiple commits.
         revision_arg: &RevisionArg,
     ) -> Result<RevsetExpressionEvaluator<'_>, CommandError> {
         let mut diagnostics = RevsetDiagnostics::new();
-        let context = self.env.revset_parse_context();
+        let sparse_patterns = self.sparse_patterns_for_parsing(ui)?;
+        let context = self.env.revset_parse_context(sparse_patterns);
         let expression = revset::parse(&mut diagnostics, revision_arg.as_ref(), &context)?;
         print_parse_diagnostics(ui, "In revset expression", &diagnostics)?;
         Ok(self.attach_revset_evaluator(expression))
@@ -1795,7 +1834,8 @@ to the current parents may contain changes from multiple commits.
         revision_args: &[RevisionArg],
     ) -> Result<RevsetExpressionEvaluator<'_>, CommandError> {
         let mut diagnostics = RevsetDiagnostics::new();
-        let context = self.env.revset_parse_context();
+        let sparse_patterns = self.sparse_patterns_for_parsing(ui)?;
+        let context = self.env.revset_parse_context(sparse_patterns);
         let expressions: Vec<_> = revision_args
             .iter()
             .map(|arg| revset::parse(&mut diagnostics, arg.as_ref(), &context))
@@ -2231,7 +2271,7 @@ to the current parents may contain changes from multiple commits.
             }
         }
         if let Err(err) =
-            revset_util::try_resolve_trunk_alias(tx.repo(), &self.env.revset_parse_context())
+            revset_util::try_resolve_trunk_alias(tx.repo(), &self.env.revset_parse_context(None))
         {
             // The warning would be printed above if working copies exist.
             if tx.repo().view().wc_commit_ids().is_empty() {

--- a/cli/src/commands/bookmark/advance.rs
+++ b/cli/src/commands/bookmark/advance.rs
@@ -122,7 +122,9 @@ pub async fn cmd_bookmark_advance(
                 let from_revset_str = workspace_command
                     .settings()
                     .get_string("revsets.bookmark-advance-from")?;
-                let mut context = workspace_command.env().revset_parse_context();
+                let mut context = workspace_command
+                    .env()
+                    .revset_parse_context(workspace_command.working_copy().sparse_patterns().ok());
                 let commit_hex = target_commit.id().hex();
                 context.local_variables.insert(
                     "to",

--- a/cli/src/commands/debug/fileset.rs
+++ b/cli/src/commands/debug/fileset.rs
@@ -38,7 +38,9 @@ pub async fn cmd_debug_fileset(
     let workspace_command = command.workspace_helper(ui).await?;
 
     let mut diagnostics = FilesetDiagnostics::new();
-    let context = workspace_command.env().fileset_parse_context();
+    let context = workspace_command
+        .env()
+        .fileset_parse_context(workspace_command.working_copy().sparse_patterns().ok());
     let expression = fileset::parse_maybe_bare(&mut diagnostics, &args.path, &context)?;
     print_parse_diagnostics(ui, "In fileset expression", &diagnostics)?;
     writeln!(ui.stdout(), "-- Parsed:")?;

--- a/cli/src/commands/debug/revset.rs
+++ b/cli/src/commands/debug/revset.rs
@@ -46,7 +46,9 @@ pub async fn cmd_debug_revset(
     args: &DebugRevsetArgs,
 ) -> Result<(), CommandError> {
     let workspace_command = command.workspace_helper(ui).await?;
-    let workspace_ctx = workspace_command.env().revset_parse_context();
+    let workspace_ctx = workspace_command
+        .env()
+        .revset_parse_context(workspace_command.working_copy().sparse_patterns().ok());
     let repo = workspace_command.repo().as_ref();
 
     let mut diagnostics = RevsetDiagnostics::new();

--- a/cli/src/commands/operation/diff.rs
+++ b/cli/src/commands/operation/diff.rs
@@ -203,7 +203,7 @@ pub fn parse_op_diff_changes_in(
     let op_diff_changes_expr = revset::parse(
         &mut diagnostics,
         &expression_str,
-        &workspace_env.revset_parse_context(),
+        &workspace_env.revset_parse_context(None),
     )
     .map_err(|err| {
         if is_config {
@@ -233,7 +233,7 @@ fn resolve_op_diff_changes_exprs(
     to_repo: &ReadonlyRepo,
 ) -> Result<(Arc<ResolvedRevsetExpression>, Arc<ResolvedRevsetExpression>), RevsetResolutionError> {
     let extensions = workspace_env
-        .revset_parse_context()
+        .revset_parse_context(None)
         .extensions
         .symbol_resolvers();
     let from_repo_symbol_resolver = SymbolResolver::new(from_repo, extensions);

--- a/cli/src/commit_templater.rs
+++ b/cli/src/commit_templater.rs
@@ -196,6 +196,11 @@ impl<'repo> CommitTemplateLanguage<'repo> {
         FilesetParseContext {
             aliases_map: self.revset_parse_context.fileset_aliases_map,
             path_converter: self.path_converter,
+            sparse_patterns: self
+                .revset_parse_context
+                .workspace
+                .as_ref()
+                .and_then(|w| w.sparse_patterns),
         }
     }
 }
@@ -3131,6 +3136,7 @@ mod tests {
                 workspace: Some(RevsetWorkspaceContext {
                     path_converter: &self.path_converter,
                     workspace_name: self.test_workspace.workspace.workspace_name(),
+                    sparse_patterns: None,
                 }),
             };
             let mut language = CommitTemplateLanguage::new(

--- a/cli/tests/test_sparse_command.rs
+++ b/cli/tests/test_sparse_command.rs
@@ -196,6 +196,150 @@ fn test_sparse_manage_patterns() {
 }
 
 #[test]
+fn test_sparse_fileset_function() {
+    // Covers the `sparse()` fileset builtin in `jj file list`:
+    //   - default (full) sparse pattern matches everything,
+    //   - after `jj sparse set --clear --add file1` it narrows to file1,
+    //   - it composes with other fileset operators (`|`, `~`),
+    //   - empty patterns match nothing without erroring.
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    work_dir.write_file("file1", "contents");
+    work_dir.write_file("file2", "contents");
+    work_dir.write_file("file3", "contents");
+
+    // Default sparse pattern is `.`, so `sparse()` matches every tracked path.
+    let output = work_dir.run_jj(["file", "list", "sparse()"]);
+    insta::assert_snapshot!(output, @"
+    file1
+    file2
+    file3
+    [EOF]
+    ");
+
+    // Narrow the working copy to just file1.
+    let output = work_dir.run_jj(["sparse", "set", "--clear", "--add", "file1"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    Added 0 files, modified 0 files, removed 2 files
+    [EOF]
+    ");
+
+    // `sparse()` now resolves to just file1.
+    let output = work_dir.run_jj(["file", "list", "sparse()"]);
+    insta::assert_snapshot!(output, @"
+    file1
+    [EOF]
+    ");
+
+    // Composes with `|`: union of sparse() and an explicit path.
+    let output = work_dir.run_jj(["file", "list", "sparse() | file2"]);
+    insta::assert_snapshot!(output, @"
+    file1
+    file2
+    [EOF]
+    ");
+
+    // Composes with `~`: complement of sparse().
+    let output = work_dir.run_jj(["file", "list", "~sparse()"]);
+    insta::assert_snapshot!(output, @"
+    file2
+    file3
+    [EOF]
+    ");
+
+    // After `--clear` with no `--add`, the working copy has zero patterns.
+    // `sparse()` is then a union of zero prefix-paths => matches nothing,
+    // and prints empty stdout/stderr (no error).
+    let output = work_dir.run_jj(["sparse", "set", "--clear"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    Added 0 files, modified 0 files, removed 1 files
+    [EOF]
+    ");
+    let output = work_dir.run_jj(["file", "list", "sparse()"]);
+    insta::assert_snapshot!(output, @"");
+}
+
+#[test]
+fn test_sparse_fileset_function_in_revset() {
+    // Covers the `files(sparse())` revset plumbing: after narrowing the
+    // working copy to file1, `jj log -r 'files(sparse())'` should only
+    // include the commit that touched file1.
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    // Build a small history: each commit touches a different file.
+    work_dir.write_file("file1", "first\n");
+    work_dir.run_jj(["describe", "-m", "first"]).success();
+    work_dir.run_jj(["new", "-m", "second"]).success();
+    work_dir.write_file("file2", "second\n");
+    work_dir.run_jj(["new", "-m", "third"]).success();
+    work_dir.write_file("file3", "third\n");
+    // Park the working copy on a separate empty commit so the snapshot
+    // for @ doesn't add a fourth file to any of the historical commits.
+    work_dir.run_jj(["new", "-m", "wc"]).success();
+
+    // Narrow the working copy to file1, then `files(sparse())` should
+    // resolve to the single ancestor commit that introduced file1.
+    work_dir
+        .run_jj(["sparse", "set", "--clear", "--add", "file1"])
+        .success();
+    let output = work_dir.run_jj([
+        "log",
+        "-r",
+        "files(sparse())",
+        "--no-graph",
+        "-T",
+        r#"description ++ "\n""#,
+    ]);
+    insta::assert_snapshot!(output, @"
+    first
+
+    [EOF]
+    ");
+}
+
+#[test]
+fn test_sparse_fileset_function_no_working_copy() {
+    // `sparse()` requires a working copy to be in scope. When it's used in
+    // a context where the parser is fed `sparse_patterns: None` (e.g. a
+    // `revset-aliases.\"immutable_heads()\"` definition, which is parsed at
+    // config-load time before any working-copy handle exists), parsing
+    // must surface the dedicated error message.
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    test_env.add_config(r#"revset-aliases."immutable_heads()" = "files(sparse())""#);
+
+    let output = work_dir.run_jj(["log", "-r", "@"]);
+    insta::assert_snapshot!(output, @r"
+    ------- stderr -------
+    Config error: Invalid `revset-aliases.immutable_heads()`
+    Caused by:
+    1:  --> 1:7
+      |
+    1 | files(sparse())
+      |       ^------^
+      |
+      = In fileset expression
+    2:  --> 1:1
+      |
+    1 | sparse()
+      | ^----^
+      |
+      = `sparse()` cannot be used in this context
+    For help, see https://docs.jj-vcs.dev/latest/config/ or use `jj help -k config`.
+    [EOF]
+    [exit status: 1]
+    ");
+}
+
+#[test]
 fn test_sparse_editor_avoids_unc() -> TestResult {
     use std::path::PathBuf;
 

--- a/docs/filesets.md
+++ b/docs/filesets.md
@@ -85,6 +85,11 @@ You can also specify patterns by using functions.
 
 * `all()`: Matches everything.
 * `none()`: Matches nothing.
+* `sparse()`: Matches files within the working copy's sparse-checkout
+  patterns. Errors when there's no working copy in scope (e.g. inside config
+  files). Pair with `jj log` to filter history by what's checked out:
+  `jj log 'sparse()' -p` shows only revisions touching files in the current
+  sparse view; `files(sparse())` lifts the same set into a revset.
 
 ## Aliases
 

--- a/lib/src/fileset.rs
+++ b/lib/src/fileset.rs
@@ -506,7 +506,7 @@ fn union_all_matchers(matchers: &mut [Option<Box<dyn Matcher>>]) -> Box<dyn Matc
 
 type FilesetFunction = fn(
     &mut FilesetDiagnostics,
-    &RepoPathUiConverter,
+    &FilesetParseContext,
     &FunctionCallNode,
 ) -> FilesetParseResult<FilesetExpression>;
 
@@ -514,24 +514,38 @@ static BUILTIN_FUNCTION_MAP: LazyLock<HashMap<&str, FilesetFunction>> = LazyLock
     // Not using maplit::hashmap!{} or custom declarative macro here because
     // code completion inside macro is quite restricted.
     let mut map: HashMap<&str, FilesetFunction> = HashMap::new();
-    map.insert("none", |_diagnostics, _path_converter, function| {
+    map.insert("none", |_diagnostics, _context, function| {
         function.expect_no_arguments()?;
         Ok(FilesetExpression::none())
     });
-    map.insert("all", |_diagnostics, _path_converter, function| {
+    map.insert("all", |_diagnostics, _context, function| {
         function.expect_no_arguments()?;
         Ok(FilesetExpression::all())
+    });
+    map.insert("sparse", |_diagnostics, context, function| {
+        function.expect_no_arguments()?;
+        let patterns = context.sparse_patterns.ok_or_else(|| {
+            FilesetParseError::expression(
+                "`sparse()` cannot be used in this context",
+                function.name_span,
+            )
+        })?;
+        let expressions = patterns
+            .iter()
+            .map(|path| FilesetExpression::prefix_path(path.to_owned()))
+            .collect();
+        Ok(FilesetExpression::union_all(expressions))
     });
     map
 });
 
 fn resolve_function(
     diagnostics: &mut FilesetDiagnostics,
-    path_converter: &RepoPathUiConverter,
+    context: &FilesetParseContext,
     function: &FunctionCallNode,
 ) -> FilesetParseResult<FilesetExpression> {
     if let Some(func) = BUILTIN_FUNCTION_MAP.get(function.name) {
-        func(diagnostics, path_converter, function)
+        func(diagnostics, context, function)
     } else {
         Err(FilesetParseError::new(
             FilesetParseErrorKind::NoSuchFunction {
@@ -545,7 +559,7 @@ fn resolve_function(
 
 fn resolve_expression(
     diagnostics: &mut FilesetDiagnostics,
-    path_converter: &RepoPathUiConverter,
+    context: &FilesetParseContext,
     node: &ExpressionNode,
 ) -> FilesetParseResult<FilesetExpression> {
     fileset_parser::catch_aliases(diagnostics, node, |diagnostics, node| {
@@ -553,30 +567,31 @@ fn resolve_expression(
             |err| FilesetParseError::expression("Invalid file pattern", node.span).with_source(err);
         match &node.kind {
             ExpressionKind::Identifier(name) => {
-                let pattern = FilePattern::cwd_prefix_glob(path_converter, name)
+                let pattern = FilePattern::cwd_prefix_glob(context.path_converter, name)
                     .map_err(wrap_pattern_error)?;
                 Ok(FilesetExpression::pattern(pattern))
             }
             ExpressionKind::String(name) => {
-                let pattern = FilePattern::cwd_prefix_glob(path_converter, name)
+                let pattern = FilePattern::cwd_prefix_glob(context.path_converter, name)
                     .map_err(wrap_pattern_error)?;
                 Ok(FilesetExpression::pattern(pattern))
             }
             ExpressionKind::Pattern(pattern) => {
                 let value = fileset_parser::expect_string_literal("string", &pattern.value)?;
-                let pattern = FilePattern::from_str_kind(path_converter, value, pattern.name)
-                    .map_err(wrap_pattern_error)?;
+                let pattern =
+                    FilePattern::from_str_kind(context.path_converter, value, pattern.name)
+                        .map_err(wrap_pattern_error)?;
                 Ok(FilesetExpression::pattern(pattern))
             }
             ExpressionKind::Unary(op, arg_node) => {
-                let arg = resolve_expression(diagnostics, path_converter, arg_node)?;
+                let arg = resolve_expression(diagnostics, context, arg_node)?;
                 match op {
                     UnaryOp::Negate => Ok(FilesetExpression::all().difference(arg)),
                 }
             }
             ExpressionKind::Binary(op, lhs_node, rhs_node) => {
-                let lhs = resolve_expression(diagnostics, path_converter, lhs_node)?;
-                let rhs = resolve_expression(diagnostics, path_converter, rhs_node)?;
+                let lhs = resolve_expression(diagnostics, context, lhs_node)?;
+                let rhs = resolve_expression(diagnostics, context, rhs_node)?;
                 match op {
                     BinaryOp::Intersection => Ok(lhs.intersection(rhs)),
                     BinaryOp::Difference => Ok(lhs.difference(rhs)),
@@ -585,12 +600,12 @@ fn resolve_expression(
             ExpressionKind::UnionAll(nodes) => {
                 let expressions = nodes
                     .iter()
-                    .map(|node| resolve_expression(diagnostics, path_converter, node))
+                    .map(|node| resolve_expression(diagnostics, context, node))
                     .try_collect()?;
                 Ok(FilesetExpression::union_all(expressions))
             }
             ExpressionKind::FunctionCall(function) => {
-                resolve_function(diagnostics, path_converter, function)
+                resolve_function(diagnostics, context, function)
             }
             ExpressionKind::AliasExpanded(..) => unreachable!(),
         }
@@ -604,6 +619,12 @@ pub struct FilesetParseContext<'a> {
     pub aliases_map: &'a FilesetAliasesMap,
     /// Context to resolve cwd-relative paths.
     pub path_converter: &'a RepoPathUiConverter,
+    /// Sparse-checkout patterns of the current working copy, if any.
+    ///
+    /// Set to `None` when no working copy is available (e.g. when parsing
+    /// fileset expressions from config files). Functions that require a
+    /// working copy (such as `sparse()`) will fail to resolve in that case.
+    pub sparse_patterns: Option<&'a [RepoPathBuf]>,
 }
 
 /// Parses text into `FilesetExpression` without bare string fallback.
@@ -615,7 +636,7 @@ pub fn parse(
     let node = fileset_parser::parse_program(text)?;
     let node = fileset_parser::expand_aliases(node, context.aliases_map)?;
     // TODO: add basic tree substitution pass to eliminate redundant expressions
-    resolve_expression(diagnostics, context.path_converter, &node)
+    resolve_expression(diagnostics, context, &node)
 }
 
 /// Parses text into `FilesetExpression` with bare string fallback.
@@ -630,7 +651,7 @@ pub fn parse_maybe_bare(
     let node = fileset_parser::parse_program_or_bare_string(text)?;
     let node = fileset_parser::expand_aliases(node, context.aliases_map)?;
     // TODO: add basic tree substitution pass to eliminate redundant expressions
-    resolve_expression(diagnostics, context.path_converter, &node)
+    resolve_expression(diagnostics, context, &node)
 }
 
 #[cfg(test)]
@@ -679,6 +700,7 @@ mod tests {
                 cwd: PathBuf::from("/ws/cur"),
                 base: PathBuf::from("/ws"),
             },
+            sparse_patterns: None,
         };
         let parse = |text| parse_maybe_bare(&mut FilesetDiagnostics::new(), text, &context);
 
@@ -747,6 +769,7 @@ mod tests {
                 cwd: PathBuf::from("/ws/cur*"),
                 base: PathBuf::from("/ws"),
             },
+            sparse_patterns: None,
         };
         let parse = |text| parse_maybe_bare(&mut FilesetDiagnostics::new(), text, &context);
 
@@ -969,6 +992,7 @@ mod tests {
                 cwd: PathBuf::from("/ws/cur"),
                 base: PathBuf::from("/ws"),
             },
+            sparse_patterns: None,
         };
         let parse = |text| parse_maybe_bare(&mut FilesetDiagnostics::new(), text, &context);
 
@@ -1097,6 +1121,7 @@ mod tests {
                 cwd: PathBuf::from("/ws/cur*"),
                 base: PathBuf::from("/ws"),
             },
+            sparse_patterns: None,
         };
         let parse = |text| parse_maybe_bare(&mut FilesetDiagnostics::new(), text, &context);
 
@@ -1198,6 +1223,7 @@ mod tests {
                 cwd: PathBuf::from("/ws/cur"),
                 base: PathBuf::from("/ws"),
             },
+            sparse_patterns: None,
         };
         let parse = |text| parse_maybe_bare(&mut FilesetDiagnostics::new(), text, &context);
 
@@ -1217,6 +1243,69 @@ mod tests {
             ],
         }
         "#);
+
+        // `sparse()` errors when no working copy is bound to the parse
+        // context (e.g. config-time parsing).
+        insta::assert_debug_snapshot!(
+            parse("sparse()").unwrap_err().kind(),
+            @r#"Expression("`sparse()` cannot be used in this context")"#);
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_sparse_function() -> TestResult {
+        let settings = insta_settings();
+        let _guard = settings.bind_to_scope();
+        let parse_with = |patterns: &[RepoPathBuf]| {
+            let context = FilesetParseContext {
+                aliases_map: &FilesetAliasesMap::new(),
+                path_converter: &RepoPathUiConverter::Fs {
+                    cwd: PathBuf::from("/ws/cur"),
+                    base: PathBuf::from("/ws"),
+                },
+                sparse_patterns: Some(patterns),
+            };
+            parse_maybe_bare(&mut FilesetDiagnostics::new(), "sparse()", &context)
+        };
+
+        // Empty sparse patterns -> matches nothing (union of zero
+        // expressions).
+        insta::assert_debug_snapshot!(parse_with(&[])?, @"None");
+
+        // Root path (the default sparse pattern jj uses for new repos)
+        // expands to a single prefix on the workspace root, which the
+        // matcher treats as "everything".
+        insta::assert_debug_snapshot!(parse_with(&[repo_path_buf("")])?, @r#"Pattern(PrefixPath(""))"#);
+
+        // Multiple specific paths -> union of prefix patterns.
+        insta::assert_debug_snapshot!(
+            parse_with(&[repo_path_buf("foo.txt"), repo_path_buf("dir/sub")])?,
+            @r#"
+        UnionAll(
+            [
+                Pattern(PrefixPath("foo.txt")),
+                Pattern(PrefixPath("dir/sub")),
+            ],
+        )
+        "#);
+
+        // Argument list must be empty.
+        let context = FilesetParseContext {
+            aliases_map: &FilesetAliasesMap::new(),
+            path_converter: &RepoPathUiConverter::Fs {
+                cwd: PathBuf::from("/ws/cur"),
+                base: PathBuf::from("/ws"),
+            },
+            sparse_patterns: Some(&[]),
+        };
+        insta::assert_debug_snapshot!(
+            parse_maybe_bare(&mut FilesetDiagnostics::new(), "sparse(x)", &context).unwrap_err().kind(),
+            @r#"
+        InvalidArguments {
+            name: "sparse",
+            message: "Expected 0 arguments",
+        }
+        "#);
         Ok(())
     }
 
@@ -1230,6 +1319,7 @@ mod tests {
                 cwd: PathBuf::from("/ws/cur"),
                 base: PathBuf::from("/ws"),
             },
+            sparse_patterns: None,
         };
         let parse = |text| parse_maybe_bare(&mut FilesetDiagnostics::new(), text, &context);
 

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -61,6 +61,7 @@ use crate::ref_name::WorkspaceNameBuf;
 use crate::repo::ReadonlyRepo;
 use crate::repo::Repo;
 use crate::repo::RepoLoaderError;
+use crate::repo_path::RepoPathBuf;
 use crate::repo_path::RepoPathUiConverter;
 use crate::revset_parser;
 pub use crate::revset_parser::BinaryOp;
@@ -3586,9 +3587,11 @@ impl<'a> LoweringContext<'a> {
     }
 
     pub fn fileset_parse_context(&self) -> Option<FilesetParseContext<'_>> {
+        let workspace = self.workspace?;
         Some(FilesetParseContext {
             aliases_map: self.fileset_aliases_map,
-            path_converter: self.workspace?.path_converter,
+            path_converter: workspace.path_converter,
+            sparse_patterns: workspace.sparse_patterns,
         })
     }
 
@@ -3602,6 +3605,11 @@ impl<'a> LoweringContext<'a> {
 pub struct RevsetWorkspaceContext<'a> {
     pub path_converter: &'a RepoPathUiConverter,
     pub workspace_name: &'a WorkspaceName,
+    /// Sparse-checkout patterns of the current working copy.
+    ///
+    /// Set to `None` when no working copy is available; the `sparse()`
+    /// fileset function won't be resolvable in that case.
+    pub sparse_patterns: Option<&'a [RepoPathBuf]>,
 }
 
 /// Formats a string as symbol by quoting and escaping it if necessary.
@@ -3688,6 +3696,7 @@ mod tests {
         let workspace_ctx = RevsetWorkspaceContext {
             path_converter: &path_converter,
             workspace_name,
+            sparse_patterns: None,
         };
         let mut aliases_map = RevsetAliasesMap::new();
         for (decl, defn) in aliases {

--- a/lib/tests/test_revset.rs
+++ b/lib/tests/test_revset.rs
@@ -1222,6 +1222,7 @@ fn resolve_commit_ids_in_workspace(
     let workspace_ctx = RevsetWorkspaceContext {
         path_converter: &path_converter,
         workspace_name: workspace.workspace_name(),
+        sparse_patterns: None,
     };
     let context = RevsetParseContext {
         aliases_map: &RevsetAliasesMap::default(),


### PR DESCRIPTION
Closes #7816.

Adds a `sparse()` fileset builtin that evaluates to the files within the current working copy's sparse-checkout patterns. The headline use case is `jj log 'sparse()' -p` to filter long histories down to revisions touching files in the current sparse view; `files(sparse())` plugs the same set into a revset for more complex queries.

The full design rationale, plumbing notes, and error-handling choices are in the commit body. Calling out one decision worth a maintainer's eye:

**`working_copy().sparse_patterns().ok()` instead of `?`** at the helper-level callers. The previous code path didn't read working-copy state at all to parse a fileset/revset; eagerly propagating that error would regress unrelated commands when `--ignore-working-copy` is in effect or the WC is in a weird state. Falling back to `None` lets plain expressions parse, and `sparse()` itself surfaces a span-anchored error ("`sparse()` cannot be used in this context") if the user actually references it. Happy to flip if you'd prefer eager propagation.

### Tests

- `lib/src/fileset.rs`: extended `test_parse_function` (no-context error) and added `test_parse_sparse_function` (empty patterns → `None`, root path → `PrefixPath("")`, multi-pattern → `UnionAll`, arity check)
- `cli/tests/test_sparse_command.rs`: 3 new integration tests covering `jj file list 'sparse()'` after narrowing, `~`/`|` composition, `jj log -r 'files(sparse())'`, and the no-WC error path through a `revset-aliases."immutable_heads()"` config reference

### Verification

```
cargo +nightly fmt --check       # clean
cargo clippy --workspace --all-targets   # clean
cargo test -p jj-lib             # 1,894 tests pass
cargo test -p jj-cli             # 1,311 tests pass
```

### Related but out of scope

Issue #5213 (the broader fileset-status family: `added()`, `deleted()`, `clean()`, etc.) was linked from #7816 by @yuja. `sparse()` is structurally separate from that family — it reads sparse-checkout patterns, not commit/working-copy status — so I scoped this PR to just `sparse()` to keep the surface small. Happy to follow up on #5213 if there's interest.
