### PR TITLE
revset: define `latest()` based on heads and committer timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Breaking changes
 
+* The `latest()` revset function now considers ancestor relationships while
+  finding the latest commits. This change only affects unusual cases where one
+  of the commits in the input revset has a later committer timestamp than one of
+  its children.
+
 ### Deprecations
 
 ### New features

--- a/docs/revsets.md
+++ b/docs/revsets.md
@@ -342,8 +342,12 @@ revsets (expressions) as arguments.
   [Mercurial's](https://repo.mercurial-scm.org/hg/help/revsets) `roots(x)`
   function, which is equivalent to `x ~ x+`.
 
-* `latest(x, [count])`: Latest `count` commits in `x`, based on committer
-  timestamp. The default `count` is 1.
+* `latest(x, [count])`: Latest `count` commits in `x`. The default `count` is 1.
+
+  If `count` is 0, then no commits are returned. Otherwise, to find the latest
+  commits, the commit with the latest committer timestamp in `heads(x)` is
+  repeatedly taken from `x`. Formally, `latest(x, n)` is defined recursively as
+  `h(x) | latest(x ~ h(x), n-1)` where `h(x)` is the latest commit in `heads(x)`.
 
 * `fork_point(x)`: The fork point of all commits in `x`. The fork point is the
   common ancestor(s) of all commits in `x` which do not have any descendants

--- a/docs/revsets.md
+++ b/docs/revsets.md
@@ -340,8 +340,12 @@ revsets (expressions) as arguments.
   [Mercurial's](https://repo.mercurial-scm.org/hg/help/revsets) `roots(x)`
   function, which is equivalent to `x ~ x+`.
 
-* `latest(x, [count])`: Latest `count` commits in `x`, based on committer
-  timestamp. The default `count` is 1.
+* `latest(x, [count])`: Latest `count` commits in `x`. The default `count` is 1.
+
+  If `count` is 0, then no commits are returned. Otherwise, to find the latest
+  commits, the commit with the latest committer timestamp in `heads(x)` is
+  repeatedly taken from `x`. Formally, `latest(x, n)` is defined recursively as
+  `h(x) | latest(x ~ h(x), n-1)` where `h(x)` is the latest commit in `heads(x)`.
 
 * `fork_point(x)`: The fork point of all commits in `x`. The fork point is the
   common ancestor(s) of all commits in `x` which do not have any descendants

--- a/lib/src/default_index/rev_walk.rs
+++ b/lib/src/default_index/rev_walk.rs
@@ -615,7 +615,7 @@ impl RevWalkItemGenerationRange {
 }
 
 /// Walks queue items until `bottom_pos`. Returns item if found at `bottom_pos`.
-fn flush_queue_until<I: RevWalkIndex + ?Sized>(
+pub(super) fn flush_queue_until<I: RevWalkIndex + ?Sized>(
     queue: &mut RevWalkQueue<I::Position, ()>,
     index: &I,
     bottom_pos: I::Position,

--- a/lib/src/default_index/rev_walk_queue.rs
+++ b/lib/src/default_index/rev_walk_queue.rs
@@ -102,6 +102,12 @@ impl<P: Ord, T: Ord> RevWalkQueue<P, T> {
         self.pop_if(|next| next.pos == *pos)
     }
 
+    pub fn skip_while(&mut self, mut predicate: impl FnMut(&RevWalkWorkItem<P, T>) -> bool) {
+        while self.pop_if(&mut predicate).is_some() {
+            continue;
+        }
+    }
+
     pub fn skip_while_eq(&mut self, pos: &P) {
         while self.pop_eq(pos).is_some() {
             continue;

--- a/lib/src/default_index/revset_engine.rs
+++ b/lib/src/default_index/revset_engine.rs
@@ -15,6 +15,7 @@
 use std::cell::RefCell;
 use std::cmp::Ordering;
 use std::cmp::Reverse;
+use std::collections::BTreeMap;
 use std::collections::BinaryHeap;
 use std::collections::HashSet;
 use std::collections::hash_map::HashMap;
@@ -48,6 +49,9 @@ use crate::conflict_labels::ConflictLabels;
 use crate::conflicts::MaterializedTreeValue;
 use crate::conflicts::materialize_tree_value;
 use crate::default_index::bit_set::AncestorsBitSet;
+use crate::default_index::entry::SmallGlobalCommitPositionsVec;
+use crate::default_index::rev_walk::flush_queue_until;
+use crate::default_index::rev_walk_queue::RevWalkQueue;
 use crate::diff::ContentDiff;
 use crate::diff::DiffHunkKind;
 use crate::files;
@@ -1058,8 +1062,21 @@ impl EvaluationContext<'_> {
                 Ok(Box::new(EagerRevset { positions }))
             }
             ResolvedExpression::Latest { candidates, count } => {
-                let candidate_set = self.evaluate(candidates)?;
-                Ok(Box::new(self.take_latest_revset(&*candidate_set, *count)?))
+                if *count == 0 {
+                    return Ok(Box::new(EagerRevset::empty()));
+                }
+                let max_depth = u32::try_from(count - 1).unwrap_or(u32::MAX);
+
+                let candidates: Vec<_> = self
+                    .evaluate(candidates)?
+                    .positions()
+                    .attach(self.index)
+                    .try_collect()?;
+
+                let (subgraph, heads) =
+                    subgraph_and_heads_from_positions(index, &candidates, max_depth);
+
+                Ok(Box::new(self.take_latest_revset(subgraph, &heads, *count)?))
             }
             ResolvedExpression::HasSize { candidates, count } => {
                 let set = self.evaluate(candidates)?;
@@ -1206,50 +1223,45 @@ impl EvaluationContext<'_> {
 
     fn take_latest_revset(
         &self,
-        candidate_set: &dyn InternalRevset,
+        mut subgraph: Subgraph,
+        heads: &[GlobalCommitPosition],
         count: usize,
     ) -> Result<EagerRevset, RevsetEvaluationError> {
-        if count == 0 {
-            return Ok(EagerRevset::empty());
-        }
-
         #[derive(Clone, Eq, Ord, PartialEq, PartialOrd)]
         struct Item {
             timestamp: MillisSinceEpoch,
             pos: GlobalCommitPosition, // tie-breaker
         }
 
-        let make_rev_item = |pos| -> Result<_, RevsetEvaluationError> {
-            let entry = self.index.commits().entry_by_pos(pos?);
+        let make_rev_item = |pos: GlobalCommitPosition| -> Result<_, RevsetEvaluationError> {
+            let entry = self.index.commits().entry_by_pos(pos);
             let commit = self.store.get_commit(&entry.commit_id())?;
-            Ok(Reverse(Item {
+            Ok(Item {
                 timestamp: commit.committer().timestamp.timestamp,
                 pos: entry.position(),
-            }))
+            })
         };
 
-        // Maintain min-heap containing the latest (greatest) count items. For small
-        // count and large candidate set, this is probably cheaper than building vec
-        // and applying selection algorithm.
-        let mut candidate_iter = candidate_set
-            .positions()
-            .attach(self.index)
-            .map(make_rev_item)
-            .fuse();
-        let mut latest_items: BinaryHeap<_> = candidate_iter.by_ref().take(count).try_collect()?;
-        for item in candidate_iter {
-            let item = item?;
-            let mut earliest = latest_items.peek_mut().unwrap();
-            if earliest.0 < item.0 {
-                *earliest = item;
+        let mut current_heads = BinaryHeap::new();
+        for &head in heads {
+            current_heads.push(make_rev_item(head)?);
+        }
+
+        // Repeatedly take the latest head, and then push any new heads exposed by
+        // removing the old one.
+        let mut positions: Vec<GlobalCommitPosition> = Vec::with_capacity(count);
+        while let Some(latest_item) = current_heads.pop() {
+            positions.push(latest_item.pos);
+            if positions.len() == count {
+                break;
+            }
+
+            for new_head in subgraph.remove_head(latest_item.pos) {
+                current_heads.push(make_rev_item(new_head)?);
             }
         }
 
-        assert!(latest_items.len() <= count);
-        let mut positions = latest_items
-            .into_iter()
-            .map(|item| item.0.pos)
-            .collect_vec();
+        debug_assert!(positions.len() <= count);
         positions.sort_unstable_by_key(|&pos| Reverse(pos));
         Ok(EagerRevset { positions })
     }
@@ -1564,6 +1576,134 @@ async fn to_file_content(
             panic!("Unexpected tree with id {id:?} in diff at path {path:?}");
         }
     }
+}
+
+/// Represents a subgraph of commits from the index.
+#[derive(Default)]
+struct Subgraph {
+    commits: BTreeMap<GlobalCommitPosition, SubgraphCommitData>,
+}
+
+impl Subgraph {
+    /// Remove a head from the subgraph. Returns any new heads which were
+    /// exposed by removing the old head.
+    fn remove_head(&mut self, pos: GlobalCommitPosition) -> Vec<GlobalCommitPosition> {
+        let data = self
+            .commits
+            .remove(&pos)
+            .expect("should be commit in subgraph");
+
+        debug_assert_eq!(data.num_children, 0);
+
+        let mut new_heads = Vec::new();
+        for parent in data.parents {
+            let parent_data = self
+                .commits
+                .get_mut(&parent)
+                .expect("should be commit in subgraph");
+            parent_data.num_children -= 1;
+            if parent_data.num_children == 0 {
+                new_heads.push(parent);
+            }
+        }
+        new_heads
+    }
+}
+
+#[derive(Default)]
+struct SubgraphCommitData {
+    parents: SmallGlobalCommitPositionsVec,
+    num_children: u32,
+}
+
+/// Build a `Subgraph` from a slice of commit positions. Use `max_depth` to
+/// limit the depth of the subgraph from the heads. Returns the subgraph and a
+/// list of heads.
+fn subgraph_and_heads_from_positions(
+    index: &CompositeIndex,
+    positions: &[GlobalCommitPosition],
+    max_depth: u32,
+) -> (Subgraph, Vec<GlobalCommitPosition>) {
+    let Some(&min_pos) = positions.last() else {
+        return Default::default();
+    };
+    let commit_index = index.commits();
+
+    // For each commit position, keep track of the child commit positions.
+    let mut wanted_queue: RevWalkQueue<GlobalCommitPosition, GlobalCommitPosition> =
+        RevWalkQueue::with_min_pos(min_pos);
+    // When we've reached a depth limit, keep track of the unwanted heads to allow
+    // efficiently skipping unwanted commits.
+    let mut unwanted_queue: RevWalkQueue<GlobalCommitPosition, ()> =
+        RevWalkQueue::with_min_pos(min_pos);
+
+    let mut heads = Vec::new();
+    let mut depths: BTreeMap<GlobalCommitPosition, u32> = BTreeMap::new();
+    let mut commits: BTreeMap<GlobalCommitPosition, SubgraphCommitData> = BTreeMap::new();
+
+    for &pos in positions {
+        // Advance the queue until the next position from the input.
+        while let Some(item) = wanted_queue.peek().filter(|x| x.pos > pos).cloned() {
+            if flush_queue_until(&mut unwanted_queue, index, item.pos).is_some() {
+                wanted_queue.skip_while_eq(&item.pos);
+                continue;
+            }
+
+            let parent_positions = commit_index.entry_by_pos(item.pos).parent_positions();
+
+            while let Some(item) = wanted_queue.pop_eq(&item.pos) {
+                wanted_queue.skip_while(|x| *x == item);
+                for &parent_pos in &parent_positions {
+                    wanted_queue.push(parent_pos, item.value);
+                }
+            }
+        }
+
+        if flush_queue_until(&mut unwanted_queue, index, pos).is_some() {
+            wanted_queue.skip_while_eq(&pos);
+            continue;
+        }
+
+        let mut num_children = 0;
+        let mut depth = 0;
+        while let Some(item) = wanted_queue.pop_eq(&pos) {
+            let child_pos = item.value;
+            let child_data = commits
+                .get_mut(&child_pos)
+                .expect("child commit should be in subgraph");
+            if child_data.parents.last() == Some(&pos) {
+                continue;
+            }
+
+            child_data.parents.push(pos);
+            num_children += 1;
+            depth = depth.max(depths[&child_pos] + 1);
+        }
+
+        depths.insert(pos, depth);
+        commits.insert(
+            pos,
+            SubgraphCommitData {
+                parents: SmallGlobalCommitPositionsVec::new(),
+                num_children,
+            },
+        );
+
+        if num_children == 0 {
+            heads.push(pos);
+        }
+
+        let parent_positions = commit_index.entry_by_pos(pos).parent_positions();
+        if depth >= max_depth {
+            unwanted_queue.extend(parent_positions, ());
+            continue;
+        }
+
+        for parent_pos in parent_positions {
+            wanted_queue.push(parent_pos, pos);
+        }
+    }
+    (Subgraph { commits }, heads)
 }
 
 #[cfg(test)]

--- a/lib/src/default_index/revset_engine.rs
+++ b/lib/src/default_index/revset_engine.rs
@@ -15,6 +15,7 @@
 use std::cell::RefCell;
 use std::cmp::Ordering;
 use std::cmp::Reverse;
+use std::collections::BTreeMap;
 use std::collections::BinaryHeap;
 use std::collections::HashSet;
 use std::collections::hash_map::HashMap;
@@ -49,6 +50,9 @@ use crate::conflict_labels::ConflictLabels;
 use crate::conflicts::MaterializedTreeValue;
 use crate::conflicts::materialize_tree_value;
 use crate::default_index::bit_set::AncestorsBitSet;
+use crate::default_index::entry::SmallGlobalCommitPositionsVec;
+use crate::default_index::rev_walk::flush_queue_until;
+use crate::default_index::rev_walk_queue::RevWalkQueue;
 use crate::diff::ContentDiff;
 use crate::diff::DiffHunkKind;
 use crate::files;
@@ -1062,8 +1066,21 @@ impl EvaluationContext<'_> {
                 Ok(Box::new(EagerRevset { positions }))
             }
             ResolvedExpression::Latest { candidates, count } => {
-                let candidate_set = self.evaluate(candidates)?;
-                Ok(Box::new(self.take_latest_revset(&*candidate_set, *count)?))
+                if *count == 0 {
+                    return Ok(Box::new(EagerRevset::empty()));
+                }
+                let max_depth = u32::try_from(count - 1).unwrap_or(u32::MAX);
+
+                let candidates: Vec<_> = self
+                    .evaluate(candidates)?
+                    .positions()
+                    .attach(self.index)
+                    .try_collect()?;
+
+                let (subgraph, heads) =
+                    subgraph_and_heads_from_positions(index, &candidates, max_depth);
+
+                Ok(Box::new(self.take_latest_revset(subgraph, &heads, *count)?))
             }
             ResolvedExpression::HasSize { candidates, count } => {
                 let set = self.evaluate(candidates)?;
@@ -1210,50 +1227,45 @@ impl EvaluationContext<'_> {
 
     fn take_latest_revset(
         &self,
-        candidate_set: &dyn InternalRevset,
+        mut subgraph: Subgraph,
+        heads: &[GlobalCommitPosition],
         count: usize,
     ) -> Result<EagerRevset, RevsetEvaluationError> {
-        if count == 0 {
-            return Ok(EagerRevset::empty());
-        }
-
         #[derive(Clone, Eq, Ord, PartialEq, PartialOrd)]
         struct Item {
             timestamp: MillisSinceEpoch,
             pos: GlobalCommitPosition, // tie-breaker
         }
 
-        let make_rev_item = |pos| -> Result<_, RevsetEvaluationError> {
-            let entry = self.index.commits().entry_by_pos(pos?);
+        let make_rev_item = |pos: GlobalCommitPosition| -> Result<_, RevsetEvaluationError> {
+            let entry = self.index.commits().entry_by_pos(pos);
             let commit = self.store.get_commit(&entry.commit_id())?;
-            Ok(Reverse(Item {
+            Ok(Item {
                 timestamp: commit.committer().timestamp.timestamp,
                 pos: entry.position(),
-            }))
+            })
         };
 
-        // Maintain min-heap containing the latest (greatest) count items. For small
-        // count and large candidate set, this is probably cheaper than building vec
-        // and applying selection algorithm.
-        let mut candidate_iter = candidate_set
-            .positions()
-            .attach(self.index)
-            .map(make_rev_item)
-            .fuse();
-        let mut latest_items: BinaryHeap<_> = candidate_iter.by_ref().take(count).try_collect()?;
-        for item in candidate_iter {
-            let item = item?;
-            let mut earliest = latest_items.peek_mut().unwrap();
-            if earliest.0 < item.0 {
-                *earliest = item;
+        let mut current_heads = BinaryHeap::new();
+        for &head in heads {
+            current_heads.push(make_rev_item(head)?);
+        }
+
+        // Repeatedly take the latest head, and then push any new heads exposed by
+        // removing the old one.
+        let mut positions: Vec<GlobalCommitPosition> = Vec::with_capacity(count);
+        while let Some(latest_item) = current_heads.pop() {
+            positions.push(latest_item.pos);
+            if positions.len() == count {
+                break;
+            }
+
+            for new_head in subgraph.remove_head(latest_item.pos) {
+                current_heads.push(make_rev_item(new_head)?);
             }
         }
 
-        assert!(latest_items.len() <= count);
-        let mut positions = latest_items
-            .into_iter()
-            .map(|item| item.0.pos)
-            .collect_vec();
+        debug_assert!(positions.len() <= count);
         positions.sort_unstable_by_key(|&pos| Reverse(pos));
         Ok(EagerRevset { positions })
     }
@@ -1568,6 +1580,134 @@ async fn to_file_content(
             panic!("Unexpected tree with id {id:?} in diff at path {path:?}");
         }
     }
+}
+
+/// Represents a subgraph of commits from the index.
+#[derive(Default)]
+struct Subgraph {
+    commits: BTreeMap<GlobalCommitPosition, SubgraphCommitData>,
+}
+
+impl Subgraph {
+    /// Remove a head from the subgraph. Returns any new heads which were
+    /// exposed by removing the old head.
+    fn remove_head(&mut self, pos: GlobalCommitPosition) -> Vec<GlobalCommitPosition> {
+        let data = self
+            .commits
+            .remove(&pos)
+            .expect("should be commit in subgraph");
+
+        debug_assert_eq!(data.num_children, 0);
+
+        let mut new_heads = Vec::new();
+        for parent in data.parents {
+            let parent_data = self
+                .commits
+                .get_mut(&parent)
+                .expect("should be commit in subgraph");
+            parent_data.num_children -= 1;
+            if parent_data.num_children == 0 {
+                new_heads.push(parent);
+            }
+        }
+        new_heads
+    }
+}
+
+#[derive(Default)]
+struct SubgraphCommitData {
+    parents: SmallGlobalCommitPositionsVec,
+    num_children: u32,
+}
+
+/// Build a `Subgraph` from a slice of commit positions. Use `max_depth` to
+/// limit the depth of the subgraph from the heads. Returns the subgraph and a
+/// list of heads.
+fn subgraph_and_heads_from_positions(
+    index: &CompositeIndex,
+    positions: &[GlobalCommitPosition],
+    max_depth: u32,
+) -> (Subgraph, Vec<GlobalCommitPosition>) {
+    let Some(&min_pos) = positions.last() else {
+        return Default::default();
+    };
+    let commit_index = index.commits();
+
+    // For each commit position, keep track of the child commit positions.
+    let mut wanted_queue: RevWalkQueue<GlobalCommitPosition, GlobalCommitPosition> =
+        RevWalkQueue::with_min_pos(min_pos);
+    // When we've reached a depth limit, keep track of the unwanted heads to allow
+    // efficiently skipping unwanted commits.
+    let mut unwanted_queue: RevWalkQueue<GlobalCommitPosition, ()> =
+        RevWalkQueue::with_min_pos(min_pos);
+
+    let mut heads = Vec::new();
+    let mut depths: BTreeMap<GlobalCommitPosition, u32> = BTreeMap::new();
+    let mut commits: BTreeMap<GlobalCommitPosition, SubgraphCommitData> = BTreeMap::new();
+
+    for &pos in positions {
+        // Advance the queue until the next position from the input.
+        while let Some(item) = wanted_queue.peek().filter(|x| x.pos > pos).cloned() {
+            if flush_queue_until(&mut unwanted_queue, index, item.pos).is_some() {
+                wanted_queue.skip_while_eq(&item.pos);
+                continue;
+            }
+
+            let parent_positions = commit_index.entry_by_pos(item.pos).parent_positions();
+
+            while let Some(item) = wanted_queue.pop_eq(&item.pos) {
+                wanted_queue.skip_while(|x| *x == item);
+                for &parent_pos in &parent_positions {
+                    wanted_queue.push(parent_pos, item.value);
+                }
+            }
+        }
+
+        if flush_queue_until(&mut unwanted_queue, index, pos).is_some() {
+            wanted_queue.skip_while_eq(&pos);
+            continue;
+        }
+
+        let mut num_children = 0;
+        let mut depth = 0;
+        while let Some(item) = wanted_queue.pop_eq(&pos) {
+            let child_pos = item.value;
+            let child_data = commits
+                .get_mut(&child_pos)
+                .expect("child commit should be in subgraph");
+            if child_data.parents.last() == Some(&pos) {
+                continue;
+            }
+
+            child_data.parents.push(pos);
+            num_children += 1;
+            depth = depth.max(depths[&child_pos] + 1);
+        }
+
+        depths.insert(pos, depth);
+        commits.insert(
+            pos,
+            SubgraphCommitData {
+                parents: SmallGlobalCommitPositionsVec::new(),
+                num_children,
+            },
+        );
+
+        if num_children == 0 {
+            heads.push(pos);
+        }
+
+        let parent_positions = commit_index.entry_by_pos(pos).parent_positions();
+        if depth >= max_depth {
+            unwanted_queue.extend(parent_positions, ());
+            continue;
+        }
+
+        for parent_pos in parent_positions {
+            wanted_queue.push(parent_pos, pos);
+        }
+    }
+    (Subgraph { commits }, heads)
 }
 
 #[cfg(test)]

--- a/lib/tests/test_revset.rs
+++ b/lib/tests/test_revset.rs
@@ -3029,76 +3029,115 @@ fn test_evaluate_expression_latest() {
     let mut tx = repo.start_transaction();
     let mut_repo = tx.repo_mut();
 
-    let mut write_commit_with_committer_timestamp = |sec: i64| {
+    let mut write_commit_with_committer_timestamp = |sec: i64, parents: Vec<CommitId>| {
         let builder = create_random_commit(mut_repo);
         let mut committer = builder.committer().clone();
         committer.timestamp.timestamp = MillisSinceEpoch(sec * 1000);
-        builder.set_committer(committer).write_unwrap()
+        builder
+            .set_parents(parents)
+            .set_committer(committer)
+            .write_unwrap()
     };
-    let commit1_t3 = write_commit_with_committer_timestamp(3);
-    let commit2_t2 = write_commit_with_committer_timestamp(2);
-    let commit3_t2 = write_commit_with_committer_timestamp(2);
-    let commit4_t1 = write_commit_with_committer_timestamp(1);
+    // 6
+    // |\
+    // | 5
+    // | |
+    // | 3
+    // | |
+    // 5 |
+    // | |
+    // 1 |
+    // | |
+    // 4 |
+    // |/
+    // 2
+    let root_commit_id = repo.store().root_commit_id();
+    let commit_t2 = write_commit_with_committer_timestamp(2, vec![root_commit_id.clone()]);
+    let commit_t4 = write_commit_with_committer_timestamp(4, vec![commit_t2.id().clone()]);
+    let commit_t1 = write_commit_with_committer_timestamp(1, vec![commit_t4.id().clone()]);
+    let commit_t5_1 = write_commit_with_committer_timestamp(5, vec![commit_t1.id().clone()]);
+    let commit_t3 = write_commit_with_committer_timestamp(3, vec![commit_t2.id().clone()]);
+    let commit_t5_2 = write_commit_with_committer_timestamp(5, vec![commit_t3.id().clone()]);
+    let commit_t6 = write_commit_with_committer_timestamp(
+        6,
+        vec![commit_t5_1.id().clone(), commit_t5_2.id().clone()],
+    );
 
-    // Pick the latest entry by default (count = 1)
+    // Pick the latest head by default (count = 1)
     assert_eq!(
         resolve_commit_ids(mut_repo, "latest(all())"),
-        vec![commit1_t3.id().clone()],
+        vec![commit_t6.id().clone()],
+    );
+    assert_eq!(
+        resolve_commit_ids(
+            mut_repo,
+            &format!("latest({} | {})", commit_t4.id(), commit_t3.id())
+        ),
+        vec![commit_t4.id().clone()],
     );
 
     // Should not panic with count = 0 or empty set
     assert_eq!(resolve_commit_ids(mut_repo, "latest(all(), 0)"), vec![]);
     assert_eq!(resolve_commit_ids(mut_repo, "latest(none())"), vec![]);
 
-    assert_eq!(
-        resolve_commit_ids(mut_repo, "latest(all(), 1)"),
-        vec![commit1_t3.id().clone()],
-    );
+    // Test that `latest(all(), N)` returns the correct values for all `N`.
+    let expected_order = &[
+        commit_t6.id().clone(),
+        // Tie-breaking: pick the later index position first
+        commit_t5_2.id().clone(),
+        commit_t5_1.id().clone(),
+        // Since the commit with timestamp 1 is out of order, it blocks its ancestors from being
+        // included even though they have later timestamps, so the timestamp 3 must be next.
+        commit_t3.id().clone(),
+        // Now the commit with timestamp 1 can be included since there are no more available
+        // commits with later timestamps.
+        commit_t1.id().clone(),
+        // Since the commit with timestamp 1 is included, now its ancestors can be included.
+        commit_t4.id().clone(),
+        commit_t2.id().clone(),
+        root_commit_id.clone(),
+    ];
 
-    // Tie-breaking: pick the later entry in position
-    assert_eq!(
-        resolve_commit_ids(mut_repo, "latest(all(), 2)"),
-        vec![commit3_t2.id().clone(), commit1_t3.id().clone()],
-    );
+    for count in 1..=expected_order.len() {
+        let result = resolve_commit_ids(mut_repo, &format!("latest(all(), {count})"));
+        assert_eq!(result.len(), count);
+        for expected_item in &expected_order[0..count] {
+            assert!(result.contains(expected_item));
+        }
+    }
 
+    // Since only the commit with timestamp 1 is out of order, if we exclude it from
+    // the input revset, the result will be in the normal timestamp order again.
     assert_eq!(
-        resolve_commit_ids(mut_repo, "latest(all(), 3)"),
+        resolve_commit_ids(mut_repo, &format!("latest(~{}, 4)", commit_t1.id())),
         vec![
-            commit3_t2.id().clone(),
-            commit2_t2.id().clone(),
-            commit1_t3.id().clone(),
+            commit_t6.id().clone(),
+            commit_t5_2.id().clone(),
+            commit_t5_1.id().clone(),
+            commit_t4.id().clone(),
         ],
     );
 
+    // Ancestry still matters for sparse revsets.
     assert_eq!(
-        resolve_commit_ids(mut_repo, "latest(all(), 4)"),
-        vec![
-            commit4_t1.id().clone(),
-            commit3_t2.id().clone(),
-            commit2_t2.id().clone(),
-            commit1_t3.id().clone(),
-        ],
-    );
-
-    assert_eq!(
-        resolve_commit_ids(mut_repo, "latest(all(), 5)"),
-        vec![
-            commit4_t1.id().clone(),
-            commit3_t2.id().clone(),
-            commit2_t2.id().clone(),
-            commit1_t3.id().clone(),
-            mut_repo.store().root_commit_id().clone(),
-        ],
+        resolve_commit_ids(
+            mut_repo,
+            &format!("latest({} | {})", commit_t1.id(), commit_t2.id())
+        ),
+        vec![commit_t1.id().clone()],
     );
 
     // Should not panic if count is larger than the candidates size
     assert_eq!(
-        resolve_commit_ids(mut_repo, "latest(~root(), 5)"),
+        resolve_commit_ids(mut_repo, "latest(~root(), 100)"),
         vec![
-            commit4_t1.id().clone(),
-            commit3_t2.id().clone(),
-            commit2_t2.id().clone(),
-            commit1_t3.id().clone(),
+            commit_t6.id().clone(),
+            commit_t5_2.id().clone(),
+            commit_t3.id().clone(),
+            commit_t5_1.id().clone(),
+            commit_t1.id().clone(),
+            commit_t4.id().clone(),
+            commit_t2.id().clone(),
         ],
     );
 }

--- a/lib/tests/test_revset.rs
+++ b/lib/tests/test_revset.rs
@@ -3037,76 +3037,115 @@ fn test_evaluate_expression_latest() {
     let mut tx = repo.start_transaction();
     let mut_repo = tx.repo_mut();
 
-    let mut write_commit_with_committer_timestamp = |sec: i64| {
+    let mut write_commit_with_committer_timestamp = |sec: i64, parents: Vec<CommitId>| {
         let builder = create_random_commit(mut_repo);
         let mut committer = builder.committer().clone();
         committer.timestamp.timestamp = MillisSinceEpoch(sec * 1000);
-        builder.set_committer(committer).write_unwrap()
+        builder
+            .set_parents(parents)
+            .set_committer(committer)
+            .write_unwrap()
     };
-    let commit1_t3 = write_commit_with_committer_timestamp(3);
-    let commit2_t2 = write_commit_with_committer_timestamp(2);
-    let commit3_t2 = write_commit_with_committer_timestamp(2);
-    let commit4_t1 = write_commit_with_committer_timestamp(1);
+    // 6
+    // |\
+    // | 5
+    // | |
+    // | 3
+    // | |
+    // 5 |
+    // | |
+    // 1 |
+    // | |
+    // 4 |
+    // |/
+    // 2
+    let root_commit_id = repo.store().root_commit_id();
+    let commit_t2 = write_commit_with_committer_timestamp(2, vec![root_commit_id.clone()]);
+    let commit_t4 = write_commit_with_committer_timestamp(4, vec![commit_t2.id().clone()]);
+    let commit_t1 = write_commit_with_committer_timestamp(1, vec![commit_t4.id().clone()]);
+    let commit_t5_1 = write_commit_with_committer_timestamp(5, vec![commit_t1.id().clone()]);
+    let commit_t3 = write_commit_with_committer_timestamp(3, vec![commit_t2.id().clone()]);
+    let commit_t5_2 = write_commit_with_committer_timestamp(5, vec![commit_t3.id().clone()]);
+    let commit_t6 = write_commit_with_committer_timestamp(
+        6,
+        vec![commit_t5_1.id().clone(), commit_t5_2.id().clone()],
+    );
 
-    // Pick the latest entry by default (count = 1)
+    // Pick the latest head by default (count = 1)
     assert_eq!(
         resolve_commit_ids(mut_repo, "latest(all())"),
-        vec![commit1_t3.id().clone()],
+        vec![commit_t6.id().clone()],
+    );
+    assert_eq!(
+        resolve_commit_ids(
+            mut_repo,
+            &format!("latest({} | {})", commit_t4.id(), commit_t3.id())
+        ),
+        vec![commit_t4.id().clone()],
     );
 
     // Should not panic with count = 0 or empty set
     assert_eq!(resolve_commit_ids(mut_repo, "latest(all(), 0)"), vec![]);
     assert_eq!(resolve_commit_ids(mut_repo, "latest(none())"), vec![]);
 
-    assert_eq!(
-        resolve_commit_ids(mut_repo, "latest(all(), 1)"),
-        vec![commit1_t3.id().clone()],
-    );
+    // Test that `latest(all(), N)` returns the correct values for all `N`.
+    let expected_order = &[
+        commit_t6.id().clone(),
+        // Tie-breaking: pick the later index position first
+        commit_t5_2.id().clone(),
+        commit_t5_1.id().clone(),
+        // Since the commit with timestamp 1 is out of order, it blocks its ancestors from being
+        // included even though they have later timestamps, so the timestamp 3 must be next.
+        commit_t3.id().clone(),
+        // Now the commit with timestamp 1 can be included since there are no more available
+        // commits with later timestamps.
+        commit_t1.id().clone(),
+        // Since the commit with timestamp 1 is included, now its ancestors can be included.
+        commit_t4.id().clone(),
+        commit_t2.id().clone(),
+        root_commit_id.clone(),
+    ];
 
-    // Tie-breaking: pick the later entry in position
-    assert_eq!(
-        resolve_commit_ids(mut_repo, "latest(all(), 2)"),
-        vec![commit3_t2.id().clone(), commit1_t3.id().clone()],
-    );
+    for count in 1..=expected_order.len() {
+        let result = resolve_commit_ids(mut_repo, &format!("latest(all(), {count})"));
+        assert_eq!(result.len(), count);
+        for expected_item in &expected_order[0..count] {
+            assert!(result.contains(expected_item));
+        }
+    }
 
+    // Since only the commit with timestamp 1 is out of order, if we exclude it from
+    // the input revset, the result will be in the normal timestamp order again.
     assert_eq!(
-        resolve_commit_ids(mut_repo, "latest(all(), 3)"),
+        resolve_commit_ids(mut_repo, &format!("latest(~{}, 4)", commit_t1.id())),
         vec![
-            commit3_t2.id().clone(),
-            commit2_t2.id().clone(),
-            commit1_t3.id().clone(),
+            commit_t6.id().clone(),
+            commit_t5_2.id().clone(),
+            commit_t5_1.id().clone(),
+            commit_t4.id().clone(),
         ],
     );
 
+    // Ancestry still matters for sparse revsets.
     assert_eq!(
-        resolve_commit_ids(mut_repo, "latest(all(), 4)"),
-        vec![
-            commit4_t1.id().clone(),
-            commit3_t2.id().clone(),
-            commit2_t2.id().clone(),
-            commit1_t3.id().clone(),
-        ],
-    );
-
-    assert_eq!(
-        resolve_commit_ids(mut_repo, "latest(all(), 5)"),
-        vec![
-            commit4_t1.id().clone(),
-            commit3_t2.id().clone(),
-            commit2_t2.id().clone(),
-            commit1_t3.id().clone(),
-            mut_repo.store().root_commit_id().clone(),
-        ],
+        resolve_commit_ids(
+            mut_repo,
+            &format!("latest({} | {})", commit_t1.id(), commit_t2.id())
+        ),
+        vec![commit_t1.id().clone()],
     );
 
     // Should not panic if count is larger than the candidates size
     assert_eq!(
-        resolve_commit_ids(mut_repo, "latest(~root(), 5)"),
+        resolve_commit_ids(mut_repo, "latest(~root(), 100)"),
         vec![
-            commit4_t1.id().clone(),
-            commit3_t2.id().clone(),
-            commit2_t2.id().clone(),
-            commit1_t3.id().clone(),
+            commit_t6.id().clone(),
+            commit_t5_2.id().clone(),
+            commit_t3.id().clone(),
+            commit_t5_1.id().clone(),
+            commit_t1.id().clone(),
+            commit_t4.id().clone(),
+            commit_t2.id().clone(),
         ],
     );
 }


### PR DESCRIPTION
I think introducing the `Subgraph` type makes the code simpler, although it probably adds some overhead that could be avoided by a more complex implementation. On large input revsets, the current implementation is IO-bound due to reading commits from the Git store, so this implementation is still significantly faster. On small, sparse revsets in large repos, the old implementation still performs better because it doesn't need to traverse the index.

Benchmark results on git repo:

```
latest(tags(), 5)        1.5x faster
latest(merges(), 5)      7.8x faster
latest(all(), 5)        25.6x faster
```

Benchmark results on nixpkgs repo:

```
latest(tags(), 5)        2.2x slower (regression)
latest(merges(), 5)     16.1x faster
latest(all(), 5)        37.4x faster
```

Closes #9584

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [X] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [X] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [X] ~~For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.~~
