### PR TITLE
absorb: add option to match commits on files instead of lines

### DIFF
--- a/cli/src/commands/absorb.rs
+++ b/cli/src/commands/absorb.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use clap_complete::ArgValueCompleter;
+use jj_lib::absorb::AbsorbScope;
 use jj_lib::absorb::AbsorbSource;
 use jj_lib::absorb::absorb_hunks;
 use jj_lib::absorb::split_hunks_to_trees;
@@ -31,9 +32,9 @@ use crate::ui::Ui;
 /// Move changes from a revision into the stack of mutable revisions
 ///
 /// This command splits changes in the source revision and moves each change to
-/// the closest mutable ancestor where the corresponding lines were modified
-/// last. If the destination revision cannot be determined unambiguously, the
-/// change will be left in the source revision.
+/// the closest mutable ancestor where the corresponding lines (or files) were
+/// modified last. If the destination revision cannot be determined
+/// unambiguously, the change will be left in the source revision.
 ///
 /// The source revision will be abandoned if all changes are absorbed into the
 /// destination revisions, and if the source revision has no description.
@@ -59,10 +60,23 @@ pub(crate) struct AbsorbArgs {
     #[arg(add = ArgValueCompleter::new(complete::revset_expression_mutable))]
     into: Vec<RevisionArg>,
 
+    /// Condition for when to move changes into an ancestor
+    #[arg(long, short, value_enum, default_value_t = AbsorbScopeArg::Lines)]
+    scope: AbsorbScopeArg,
+
     /// Move only changes to these paths (instead of all paths)
     #[arg(value_name = "FILESETS", value_hint = clap::ValueHint::AnyPath)]
     #[arg(add = ArgValueCompleter::new(complete::modified_from_files))]
     paths: Vec<String>,
+}
+
+/// Condition for when to move changes into an ancestor
+#[derive(clap::ValueEnum, Clone, Debug)]
+pub(crate) enum AbsorbScopeArg {
+    /// The same lines are modified.
+    Lines,
+    /// The same file is modified.
+    File,
 }
 
 #[instrument(skip_all)]
@@ -81,9 +95,15 @@ pub(crate) async fn cmd_absorb(
     let fileset_expression = workspace_command.parse_file_patterns(ui, &args.paths)?;
     let matcher = fileset_expression.to_matcher();
 
+    let scope = match args.scope {
+        AbsorbScopeArg::File => AbsorbScope::File,
+        AbsorbScopeArg::Lines => AbsorbScope::Lines,
+    };
+
     let repo = workspace_command.repo().as_ref();
     let source = AbsorbSource::from_commit(repo, source_commit.clone()).await?;
-    let selected_trees = split_hunks_to_trees(repo, &source, &destinations, &matcher).await?;
+    let selected_trees =
+        split_hunks_to_trees(repo, &source, &destinations, &matcher, scope).await?;
 
     print_unmatched_explicit_paths(
         ui,

--- a/lib/src/absorb.rs
+++ b/lib/src/absorb.rs
@@ -38,6 +38,7 @@ use crate::conflicts::materialized_diff_stream;
 use crate::copies::CopyRecords;
 use crate::diff::ContentDiff;
 use crate::diff::DiffHunkKind;
+use crate::fileset::FilesetExpression;
 use crate::matchers::Matcher;
 use crate::merge::Diff;
 use crate::merge::Merge;
@@ -48,6 +49,8 @@ use crate::repo::Repo;
 use crate::repo_path::RepoPathBuf;
 use crate::revset::ResolvedRevsetExpression;
 use crate::revset::RevsetEvaluationError;
+use crate::revset::RevsetExpression;
+use crate::revset::RevsetFilterPredicate;
 
 /// The source commit to absorb into its ancestry.
 #[derive(Clone, Debug)]
@@ -91,6 +94,16 @@ pub struct SelectedTrees {
     pub skipped_paths: Vec<(RepoPathBuf, String)>,
 }
 
+/// Decides the scope used for matching changes in the source revision to
+/// destination revisions.
+#[derive(Debug, Clone, Copy)]
+pub enum AbsorbScope {
+    /// Match if overlapping lines are modified.
+    Lines,
+    /// Match if the same file is modified.
+    File,
+}
+
 /// Builds trees to be merged into destination commits by splitting source
 /// changes based on file annotation.
 pub async fn split_hunks_to_trees(
@@ -98,6 +111,7 @@ pub async fn split_hunks_to_trees(
     source: &AbsorbSource,
     destinations: &Arc<ResolvedRevsetExpression>,
     matcher: &dyn Matcher,
+    scope: AbsorbScope,
 ) -> Result<SelectedTrees, AbsorbError> {
     let mut selected_trees = SelectedTrees::default();
 
@@ -111,6 +125,7 @@ pub async fn split_hunks_to_trees(
         tree_diff,
         Diff::new(left_tree.labels(), right_tree.labels()),
     );
+    // Go through all the diffs from the source commit (the one to be absorbed)
     while let Some(entry) = diff_stream.next().await {
         let left_path = entry.path.source();
         let right_path = entry.path.target();
@@ -146,37 +161,71 @@ pub async fn split_hunks_to_trees(
             FileAnnotator::with_file_content(source.commit.id(), left_path, left_text.clone());
         annotator.compute(repo, destinations).await?;
         let annotation = annotator.to_annotation();
-        let annotation_ranges = annotation
-            .compact_line_ranges()
-            .filter_map(|(commit_id, range)| Some((commit_id.ok()?, range)))
-            .collect_vec();
-        let diff = ContentDiff::by_line([&left_text, &right_text]);
-        let selected_ranges = split_file_hunks(&annotation_ranges, &diff);
-        // Build trees containing parent (= left) contents + selected hunks
-        for (&commit_id, ranges) in &selected_ranges {
-            let tree_builder = selected_trees
-                .target_commits
-                .entry(commit_id.clone())
-                .or_insert_with(|| MergedTreeBuilder::new(left_tree.clone()));
-            let new_text = combine_texts(&left_text, &right_text, ranges);
-            // Since changes to be absorbed are represented as diffs relative to
-            // the source parent, we can propagate file deletion only if the
-            // whole file content is deleted at a single destination commit.
-            let new_tree_value = if new_text.is_empty() && deleted {
-                Merge::absent()
-            } else {
-                let id = repo
-                    .store()
-                    .write_file(left_path, &mut new_text.as_slice())
-                    .await?;
-                Merge::normal(TreeValue::File {
-                    id,
-                    executable,
-                    copy_id: copy_id.clone(),
-                })
+
+        let add_tree =
+            async |selected_trees: &mut SelectedTrees, commit_id: CommitId, new_text: BString| {
+                let tree_builder = selected_trees
+                    .target_commits
+                    .entry(commit_id)
+                    .or_insert_with(|| MergedTreeBuilder::new(left_tree.clone()));
+                // Since changes to be absorbed are represented as diffs relative to
+                // the source parent, we can propagate file deletion only if the
+                // whole file content is deleted at a single destination commit.
+                let new_tree_value = if new_text.is_empty() && deleted {
+                    Merge::absent()
+                } else {
+                    let id = repo
+                        .store()
+                        .write_file(left_path, &mut new_text.as_slice())
+                        .await?;
+                    Merge::normal(TreeValue::File {
+                        id,
+                        executable,
+                        copy_id: copy_id.clone(),
+                    })
+                };
+                tree_builder.set_or_remove(left_path.to_owned(), new_tree_value);
+                Ok::<(), AbsorbError>(())
             };
-            tree_builder.set_or_remove(left_path.to_owned(), new_tree_value);
-        }
+
+        match scope {
+            AbsorbScope::Lines => {
+                let annotation_ranges = annotation
+                    .compact_line_ranges()
+                    .filter_map(|(commit_id, range)| Some((commit_id.ok()?, range)))
+                    .collect_vec();
+                let diff = ContentDiff::by_line([&left_text, &right_text]);
+                let selected_ranges = split_file_hunks(&annotation_ranges, &diff);
+                // Build trees containing parent (= left) contents + selected hunks
+                for (&commit_id, ranges) in &selected_ranges {
+                    let new_text = combine_texts(&left_text, &right_text, ranges);
+                    add_tree(&mut selected_trees, commit_id.clone(), new_text).await?;
+                }
+            }
+            AbsorbScope::File => {
+                let file_filter =
+                    RevsetFilterPredicate::File(FilesetExpression::file_path(left_path.to_owned()));
+                let source_commit = RevsetExpression::commit(source.commit.id().to_owned());
+                let mut target_commits = destinations
+                    .intersection(&source_commit.ancestors())
+                    // We pick up the source_commit when looking for ancestors
+                    // and it can also have been included in the user-provided
+                    // `destinations`. Remove it from the set of absorb target
+                    // commits.
+                    .minus(&source_commit)
+                    .filtered(file_filter)
+                    .evaluate(repo)?
+                    .stream();
+
+                let commit_id = target_commits.next().await;
+                let other_commit_id = target_commits.next().await;
+                if let (Some(Ok(commit_id)), None) = (commit_id, other_commit_id) {
+                    // Only one commit in the destination set modified the file,
+                    // so we can unambiguously select it.
+                    add_tree(&mut selected_trees, commit_id.clone(), right_text.into()).await?;
+                }
+            }
+        };
     }
 
     Ok(selected_trees)


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

Adds `--scope` to `jj absorb`.

I also have an idea for an optional expanision of the absorb lines, which would affect the ranges in `split_file_hunks()`. Maybe `--lines=<num>` or `-C/--context <num>` (like `grep` and `diff` context).

Related: #5710


# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [ ] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
