### PR TITLE
revert: use "Reapply" when reverting a reversion if appropriate

### DIFF
--- a/cli/src/config/templates.toml
+++ b/cli/src/config/templates.toml
@@ -36,7 +36,12 @@ op_show = 'builtin_op_log_compact'
 
 revert_description = '''
 concat(
-  'Revert "' ++ description.first_line() ++ '"' ++ "\n",
+  if(
+    description.first_line().starts_with('Revert "') &&
+    !description.first_line().remove_prefix('Revert "').starts_with('Revert "'),
+    'Reapply "' ++ description.first_line().remove_prefix('Revert "') ++ "\n",
+    'Revert "' ++ description.first_line() ++ '"' ++ "\n",
+  ),
   "\n",
   "This reverts commit " ++ commit_id ++ ".\n",
 )

--- a/cli/tests/test_revert_command.rs
+++ b/cli/tests/test_revert_command.rs
@@ -87,11 +87,11 @@ fn test_revert() {
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Reverted 1 commits as follows:
-      nkmrtpmo 90d12316 Revert "Revert "a""
+      nkmrtpmo daeff575 Reapply "a"
     [EOF]
     "#);
     insta::assert_snapshot!(get_log_output(&work_dir), @r#"
-    ○  90d123162199 Revert "Revert "a""
+    ○  daeff575375b Reapply "a"
     │
     │  This reverts commit 64910788f8a5d322739e1e38ef35f7d06ea4b38d.
     ○  64910788f8a5 Revert "a"


### PR DESCRIPTION
Use "Reapply" when reverting an reversion to match the behavior of Git. Skips if the subject lines is already nested more than once.

Fixes #9620.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
