### PR TITLE
revset: PoC for string concat function

### DIFF
--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -1281,8 +1281,8 @@ fn expect_string_expression_inner(
             ExpressionKind::Identifier(value) => default_pattern(diagnostics, value),
             ExpressionKind::String(value) => default_pattern(diagnostics, value),
             ExpressionKind::Pattern(pattern) => {
-                let value = revset_parser::expect_string_literal("string", &pattern.value)?;
-                let pattern = StringPattern::from_str_kind(value, pattern.name)
+                let value = expect_pattern_value_string(diagnostics, &pattern.value)?;
+                let pattern = StringPattern::from_str_kind(&value, pattern.name)
                     .map_err(|err| pattern_error().with_source(err))?;
                 Ok(StringExpression::pattern(pattern))
             }
@@ -1319,9 +1319,44 @@ fn expect_string_expression_inner(
                     .try_collect()?;
                 Ok(StringExpression::union_all(expressions))
             }
+            // PoC note: a real implementation should probably report unknown string functions like
+            //          `cocnat` and suggest `concat` perhaps via a string-function map even though
+            //          there is only one function today.
+            ExpressionKind::FunctionCall(function) if function.name == "concat" => {
+                let value = expect_static_string(diagnostics, node)?;
+                default_pattern(diagnostics, &value)
+            }
             ExpressionKind::FunctionCall(_) => Err(expr_error()),
             ExpressionKind::AliasExpanded(..) => unreachable!(),
         }
+    })
+}
+
+fn expect_pattern_value_string(
+    diagnostics: &mut RevsetDiagnostics,
+    node: &ExpressionNode,
+) -> Result<String, RevsetParseError> {
+    revset_parser::catch_aliases(diagnostics, node, |diagnostics, node| match &node.kind {
+        ExpressionKind::Identifier(value) => Ok((*value).to_owned()),
+        _ => expect_static_string(diagnostics, node),
+    })
+}
+
+fn expect_static_string(
+    diagnostics: &mut RevsetDiagnostics,
+    node: &ExpressionNode,
+) -> Result<String, RevsetParseError> {
+    revset_parser::catch_aliases(diagnostics, node, |diagnostics, node| match &node.kind {
+        ExpressionKind::String(value) => Ok(value.clone()),
+        ExpressionKind::FunctionCall(function) if function.name == "concat" => {
+            let ([], args) = function.expect_some_arguments()?;
+            let parts: Vec<_> = args
+                .iter()
+                .map(|arg| expect_static_string(diagnostics, arg))
+                .try_collect()?;
+            Ok(parts.concat())
+        }
+        _ => Err(RevsetParseError::expression("Expected string", node.span)),
     })
 }
 
@@ -4117,6 +4152,20 @@ mod tests {
             parse(r#"bookmarks(substring:"foo")"#)?,
             @r#"CommitRef(Bookmarks(Pattern(Substring("foo"))))"#);
         insta::assert_debug_snapshot!(
+            parse(r#"bookmarks(glob:concat("foo", "-", "bar*"))"#)?,
+            @r#"
+        CommitRef(
+            Bookmarks(Pattern(Glob(GlobPattern("foo-bar*")))),
+        )
+        "#);
+        insta::assert_debug_snapshot!(
+            parse(r#"bookmarks(concat("foo", concat("-", "bar*")))"#)?,
+            @r#"
+        CommitRef(
+            Bookmarks(Pattern(Glob(GlobPattern("foo-bar*")))),
+        )
+        "#);
+        insta::assert_debug_snapshot!(
             parse(r#"bookmarks(bad:"foo")"#).unwrap_err().kind(),
             @r#"Expression("Invalid string pattern")"#);
         insta::assert_debug_snapshot!(
@@ -4124,6 +4173,16 @@ mod tests {
             @r#"Expression("Invalid string expression")"#);
         insta::assert_debug_snapshot!(
             parse(r#"bookmarks(exact:"foo"+)"#).unwrap_err().kind(),
+            @r#"Expression("Expected string")"#);
+        insta::assert_debug_snapshot!(
+            parse(r#"bookmarks(glob:concat("foo", visible_heads()))"#)
+                .unwrap_err()
+                .kind(),
+            @r#"Expression("Expected string")"#);
+        insta::assert_debug_snapshot!(
+            parse(r#"bookmarks(glob:concat(foo, "bar"))"#)
+                .unwrap_err()
+                .kind(),
             @r#"Expression("Expected string")"#);
 
         insta::assert_debug_snapshot!(
@@ -4150,6 +4209,17 @@ mod tests {
             parse(r#"(exact:"foo")"#).unwrap_err().kind(),
             RevsetParseErrorKind::NotInfixOperator { .. }
         );
+        insta::assert_debug_snapshot!(
+            parse(r#"concat("foo", "bar")"#).unwrap_err().kind(),
+            @r#"
+        NoSuchFunction {
+            name: "concat",
+            candidates: [
+                "conflicts",
+                "connected",
+            ],
+        }
+        "#);
         Ok(())
     }
 
@@ -4273,6 +4343,9 @@ mod tests {
         insta::assert_debug_snapshot!(
             parse("description(foo)")?,
             @r#"Filter(Description(Pattern(Exact("foo"))))"#);
+        insta::assert_debug_snapshot!(
+            parse(r#"description(substring:concat("[", "topic", "]"))"#)?,
+            @r#"Filter(Description(Pattern(Substring("[topic]"))))"#);
         insta::assert_debug_snapshot!(
             parse("description(visible_heads())").unwrap_err().kind(),
             @r#"Expression("Invalid string expression")"#);
@@ -4525,6 +4598,43 @@ mod tests {
             Filter(AuthorName(Pattern(Exact("a")))),
             Filter(CommitterName(Pattern(Exact("a")))),
         )
+        "#);
+        insta::assert_debug_snapshot!(
+            parse_with_aliases(
+                r#"has_label("blue")"#,
+                [("has_label(s)", r#"description(substring:concat("[", s, "]"))"#)],
+            )?,
+            @r#"
+        Filter(Description(Pattern(Substring("[blue]"))))
+        "#);
+        let err = parse_with_aliases(
+            r#"has_label(blue)"#,
+            [(
+                "has_label(s)",
+                r#"description(substring:concat("[", s, "]"))"#,
+            )],
+        )
+        .unwrap_err();
+        insta::assert_debug_snapshot!(
+            err.kind(),
+            @r#"InAliasExpansion("has_label(s)")"#);
+        let err = err.origin().unwrap();
+        insta::assert_debug_snapshot!(
+            err.kind(),
+            @r#"InParameterExpansion("s")"#);
+        insta::assert_debug_snapshot!(
+            err.origin().unwrap().kind(),
+            @r#"Expression("Expected string")"#);
+        insta::assert_debug_snapshot!(
+            parse_with_aliases(
+                r#"has_label(blue)"#,
+                [
+                    ("blue", r#""blue""#),
+                    ("has_label(s)", r#"description(substring:concat("[", s, "]"))"#),
+                ],
+            )?,
+            @r#"
+        Filter(Description(Pattern(Substring("[blue]"))))
         "#);
         Ok(())
     }


### PR DESCRIPTION
Add variadic `concat(...)` as a possible implementation approach for #5895. `concat` is only allowed in contexts that expect a static string.

Example revset aliases enabled by this:

    [revset-aliases]
    'bookmark_prefix(prefix)' = 'bookmarks(glob:concat(prefix, "/*"))'
    'release_tags(series)' = 'tags(glob:concat("v", series, ".*"))'

with usage `bookmark_prefix("release")` or `release_tags("0.40")`.

# Checklist

*Note*: I'll actually fill this out if this graduates to a real PR.

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [ ] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
