### PR TITLE
absorb: add `-i` / `--interactive` (and `--tool`) flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,6 +154,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   you only want to absorb *part* of a commit without first splitting it. Any
   hunks that are not selected or cannot be absorbed remain in the source commit.
 
+* `jj absorb` now supports the `--tool` option to choose a specific diff editor
+  for use with `--interactive` / `-i` (consistent with `squash --tool`,
+  `split --tool`, etc.).
+
 * `jj show` now supports `--reversed` flag.
 
 * `jj` now looks for config files in `/etc/jj`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,6 +149,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### New features
 
+* `jj absorb` now supports `--interactive`/`-i` to let you interactively choose
+  which hunks from the source to consider for absorption. This is useful when
+  you only want to absorb *part* of a commit without first splitting it. Any
+  hunks that are not selected or cannot be absorbed remain in the source commit.
+
 * `jj show` now supports `--reversed` flag.
 
 * `jj` now looks for config files in `/etc/jj`.

--- a/cli/src/commands/absorb.rs
+++ b/cli/src/commands/absorb.rs
@@ -13,10 +13,12 @@
 // limitations under the License.
 
 use clap_complete::ArgValueCompleter;
+use indoc::formatdoc;
 use jj_lib::absorb::AbsorbSource;
 use jj_lib::absorb::absorb_hunks;
 use jj_lib::absorb::split_hunks_to_trees;
 use jj_lib::matchers::EverythingMatcher;
+use jj_lib::merge::Diff;
 use tracing::instrument;
 
 use crate::cli_util::CommandHelper;
@@ -24,6 +26,7 @@ use crate::cli_util::RevisionArg;
 use crate::cli_util::print_unmatched_explicit_paths;
 use crate::cli_util::print_updated_commits;
 use crate::command_error::CommandError;
+use crate::command_error::user_error;
 use crate::complete;
 use crate::diff_util::DiffFormat;
 use crate::ui::Ui;
@@ -34,6 +37,10 @@ use crate::ui::Ui;
 /// the closest mutable ancestor where the corresponding lines were modified
 /// last. If the destination revision cannot be determined unambiguously, the
 /// change will be left in the source revision.
+///
+/// With the `--interactive` option, only the selected changes will be
+/// considered for absorption. This allows picking specific hunks to absorb
+/// (which may then be distributed across multiple ancestors).
 ///
 /// The source revision will be abandoned if all changes are absorbed into the
 /// destination revisions, and if the source revision has no description.
@@ -63,6 +70,10 @@ pub(crate) struct AbsorbArgs {
     #[arg(value_name = "FILESETS", value_hint = clap::ValueHint::AnyPath)]
     #[arg(add = ArgValueCompleter::new(complete::modified_from_files))]
     paths: Vec<String>,
+
+    /// Interactively choose which parts to absorb
+    #[arg(long, short)]
+    interactive: bool,
 }
 
 #[instrument(skip_all)]
@@ -81,16 +92,56 @@ pub(crate) async fn cmd_absorb(
     let fileset_expression = workspace_command.parse_file_patterns(ui, &args.paths)?;
     let matcher = fileset_expression.to_matcher();
 
-    let repo = workspace_command.repo().as_ref();
-    let source = AbsorbSource::from_commit(repo, source_commit.clone()).await?;
-    let selected_trees = split_hunks_to_trees(repo, &source, &destinations, &matcher).await?;
-
     print_unmatched_explicit_paths(
         ui,
         &workspace_command,
         &fileset_expression,
         [&source_commit.tree()],
     )?;
+
+    let diff_selector = workspace_command.diff_selector(ui, None, args.interactive)?;
+    let repo = workspace_command.repo().as_ref();
+    let source = if diff_selector.is_interactive() {
+        let parent_tree = source_commit.parent_tree(repo).await?;
+        let source_tree = source_commit.tree();
+        let format_instructions = || {
+            formatdoc! {"
+                You are selecting changes from: {source} to be considered for
+                absorption into ancestors.
+
+                The left side of the diff shows the parent commit. The right side
+                initially shows the contents of the commit you're absorbing from.
+
+                Adjust the right side until the diff shows the changes you want to
+                absorb. Selected hunks will be considered for assignment to the
+                closest ancestor where the corresponding lines were last modified
+                (using annotation). Any hunks that cannot be absorbed unambiguously
+                remain in the source commit.
+                ",
+                source = workspace_command.format_commit_summary(&source_commit),
+            }
+        };
+        let selected_tree = diff_selector
+            .select(
+                ui,
+                Diff::new(&parent_tree, &source_tree),
+                Diff::new(
+                    source_commit.parents_conflict_label().await?,
+                    source_commit.conflict_label(),
+                ),
+                &matcher,
+                format_instructions,
+            )
+            .await?;
+        if selected_tree.tree_ids() == parent_tree.tree_ids() {
+            return Err(user_error("No changes selected"));
+        }
+        AbsorbSource::from_tree(source_commit.clone(), selected_tree, parent_tree).await?
+    } else {
+        AbsorbSource::from_commit(repo, source_commit.clone()).await?
+    };
+
+    let selected_trees = split_hunks_to_trees(repo, &source, &destinations, &matcher).await?;
 
     let path_converter = workspace_command.path_converter();
     for (path, reason) in selected_trees.skipped_paths {

--- a/cli/src/commands/absorb.rs
+++ b/cli/src/commands/absorb.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use clap_complete::ArgValueCandidates;
 use clap_complete::ArgValueCompleter;
 use indoc::formatdoc;
 use jj_lib::absorb::AbsorbSource;
@@ -40,7 +41,8 @@ use crate::ui::Ui;
 ///
 /// With the `--interactive` option, only the selected changes will be
 /// considered for absorption. This allows picking specific hunks to absorb
-/// (which may then be distributed across multiple ancestors).
+/// (which may then be distributed across multiple ancestors). The `--tool`
+/// option can be used to select a different diff editor.
 ///
 /// The source revision will be abandoned if all changes are absorbed into the
 /// destination revisions, and if the source revision has no description.
@@ -74,6 +76,11 @@ pub(crate) struct AbsorbArgs {
     /// Interactively choose which parts to absorb
     #[arg(long, short)]
     interactive: bool,
+
+    /// Specify diff editor to be used (implies --interactive)
+    #[arg(long, value_name = "NAME")]
+    #[arg(add = ArgValueCandidates::new(complete::diff_editors))]
+    tool: Option<String>,
 }
 
 #[instrument(skip_all)]
@@ -99,7 +106,8 @@ pub(crate) async fn cmd_absorb(
         [&source_commit.tree()],
     )?;
 
-    let diff_selector = workspace_command.diff_selector(ui, None, args.interactive)?;
+    let diff_selector =
+        workspace_command.diff_selector(ui, args.tool.as_deref(), args.interactive)?;
     let repo = workspace_command.repo().as_ref();
     let source = if diff_selector.is_interactive() {
         let parent_tree = source_commit.parent_tree(repo).await?;

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -275,6 +275,8 @@ Move changes from a revision into the stack of mutable revisions
 
 This command splits changes in the source revision and moves each change to the closest mutable ancestor where the corresponding lines were modified last. If the destination revision cannot be determined unambiguously, the change will be left in the source revision.
 
+With the `--interactive` option, only the selected changes will be considered for absorption. This allows picking specific hunks to absorb (which may then be distributed across multiple ancestors).
+
 The source revision will be abandoned if all changes are absorbed into the destination revisions, and if the source revision has no description.
 
 The modification made by `jj absorb` can be reviewed by `jj op show -p`.
@@ -295,6 +297,7 @@ The modification made by `jj absorb` can be reviewed by `jj op show -p`.
    Only ancestors of the source revision will be considered.
 
   Default value: `mutable()`
+* `-i`, `--interactive` — Interactively choose which parts to absorb
 
 
 

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -275,7 +275,7 @@ Move changes from a revision into the stack of mutable revisions
 
 This command splits changes in the source revision and moves each change to the closest mutable ancestor where the corresponding lines were modified last. If the destination revision cannot be determined unambiguously, the change will be left in the source revision.
 
-With the `--interactive` option, only the selected changes will be considered for absorption. This allows picking specific hunks to absorb (which may then be distributed across multiple ancestors).
+With the `--interactive` option, only the selected changes will be considered for absorption. This allows picking specific hunks to absorb (which may then be distributed across multiple ancestors). The `--tool` option can be used to select a different diff editor.
 
 The source revision will be abandoned if all changes are absorbed into the destination revisions, and if the source revision has no description.
 
@@ -298,6 +298,7 @@ The modification made by `jj absorb` can be reviewed by `jj op show -p`.
 
   Default value: `mutable()`
 * `-i`, `--interactive` — Interactively choose which parts to absorb
+* `--tool <NAME>` — Specify diff editor to be used (implies --interactive)
 
 
 

--- a/cli/tests/test_absorb_command.rs
+++ b/cli/tests/test_absorb_command.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use testutils::TestResult;
+
 use crate::common::CommandOutput;
 use crate::common::TestEnvironment;
 use crate::common::TestWorkDir;
@@ -949,6 +951,177 @@ fn test_absorb_immutable() {
        +1b
     [EOF]
     ");
+}
+
+#[test]
+fn test_absorb_interactive() -> TestResult {
+    let mut test_env = TestEnvironment::default();
+    let edit_script = test_env.set_up_fake_diff_editor();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    work_dir.run_jj(["describe", "-m0"]).success();
+    work_dir.write_file("file1", "");
+
+    work_dir.run_jj(["new", "-m1"]).success();
+    work_dir.write_file("file1", "1a\n1b\n");
+
+    work_dir.run_jj(["new", "-m2"]).success();
+    work_dir.write_file("file1", "1a\n1b\n2a\n2b\n");
+
+    // Working copy with changes to lines from both ancestors.
+    work_dir.run_jj(["new"]).success();
+    work_dir.write_file("file1", "1X\n1b\n2Y\n2b\n");
+    // Snapshot the changes so they are part of the source commit when we capture
+    // the op id (otherwise op restore would land on an empty @).
+    work_dir.run_jj(["util", "snapshot"]).success();
+    let setup_opid = work_dir.current_operation_id();
+
+    // If we don't make any changes in the diff-editor, all selected changes are
+    // considered for absorption (and distributed by the usual annotation logic).
+    std::fs::write(&edit_script, "dump JJ-INSTRUCTIONS instrs")?;
+    let output = work_dir.run_jj(["absorb", "-i"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    Absorbed changes into 2 revisions:
+      zsuskuln e1082c87 2
+      kkmpptxz db75688c 1
+    Working copy  (@) now at: yqosqzyt 9959af44 (empty) (no description set)
+    Parent commit (@-)      : zsuskuln e1082c87 2
+    [EOF]
+    ");
+
+    let instrs = std::fs::read_to_string(test_env.env_root().join("instrs"))?;
+    insta::assert_snapshot!(instrs, @"
+    You are selecting changes from: mzvwutvl 97027697 (no description set) to be considered for
+    absorption into ancestors.
+
+    The left side of the diff shows the parent commit. The right side
+    initially shows the contents of the commit you're absorbing from.
+
+    Adjust the right side until the diff shows the changes you want to
+    absorb. Selected hunks will be considered for assignment to the
+    closest ancestor where the corresponding lines were last modified
+    (using annotation). Any hunks that cannot be absorbed unambiguously
+    remain in the source commit.
+    ");
+
+    // Can absorb only some changes in interactive mode (pick hunks that target
+    // only the "1" commit).
+    work_dir.run_jj(["op", "restore", &setup_opid]).success();
+    // The right side written here has only the change to the lines from commit 1.
+    std::fs::write(&edit_script, "write file1\n1X\n1b\n2a\n2b\n")?;
+    let output = work_dir.run_jj(["absorb", "-i"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    Absorbed changes into 1 revisions:
+      kkmpptxz 1478a2b5 1
+    Rebased 2 descendant commits.
+    Working copy  (@) now at: mzvwutvl 1c71fcb1 (no description set)
+    Parent commit (@-)      : zsuskuln f718fb8c 2
+    Remaining changes:
+    M file1
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_diffs(&work_dir, "mutable()"), @"
+    @  mzvwutvl 1c71fcb1 (no description set)
+    │  diff --git a/file1 b/file1
+    │  index 69f126596d..90ee77ff42 100644
+    │  --- a/file1
+    │  +++ b/file1
+    │  @@ -1,4 +1,4 @@
+    │   1X
+    │   1b
+    │  -2a
+    │  +2Y
+    │   2b
+    ○  zsuskuln f718fb8c 2
+    │  diff --git a/file1 b/file1
+    │  index 63451a887b..69f126596d 100644
+    │  --- a/file1
+    │  +++ b/file1
+    │  @@ -1,2 +1,4 @@
+    │   1X
+    │   1b
+    │  +2a
+    │  +2b
+    ○  kkmpptxz 1478a2b5 1
+    │  diff --git a/file1 b/file1
+    │  index e69de29bb2..63451a887b 100644
+    │  --- a/file1
+    │  +++ b/file1
+    │  @@ -0,0 +1,2 @@
+    │  +1X
+    │  +1b
+    ○  qpvuntsm 6a446874 0
+    │  diff --git a/file1 b/file1
+    ~  new file mode 100644
+       index 0000000000..e69de29bb2
+    [EOF]
+    ");
+
+    // Selected hunks that can't be absorbed and unselected changes are left in
+    // the source commit.
+    work_dir.run_jj(["op", "restore", &setup_opid]).success();
+    work_dir.write_file("file1", "1X\n1B\n2A\n2b\n");
+    work_dir.run_jj(["util", "snapshot"]).success();
+    std::fs::write(&edit_script, "write file1\n1a\n1B\n2A\n2b\n")?;
+    let output = work_dir.run_jj(["absorb", "-i"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    Nothing changed.
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_diffs(&work_dir, "mutable()"), @"
+    @  mzvwutvl 8ea686ec (no description set)
+    │  diff --git a/file1 b/file1
+    │  index 3de64a0b0c..c7ae2125d4 100644
+    │  --- a/file1
+    │  +++ b/file1
+    │  @@ -1,4 +1,4 @@
+    │  -1a
+    │  -1b
+    │  -2a
+    │  +1X
+    │  +1B
+    │  +2A
+    │   2b
+    ○  zsuskuln 36fad385 2
+    │  diff --git a/file1 b/file1
+    │  index 8c5268f893..3de64a0b0c 100644
+    │  --- a/file1
+    │  +++ b/file1
+    │  @@ -1,2 +1,4 @@
+    │   1a
+    │   1b
+    │  +2a
+    │  +2b
+    ○  kkmpptxz 1553c5e8 1
+    │  diff --git a/file1 b/file1
+    │  index e69de29bb2..8c5268f893 100644
+    │  --- a/file1
+    │  +++ b/file1
+    │  @@ -0,0 +1,2 @@
+    │  +1a
+    │  +1b
+    ○  qpvuntsm 6a446874 0
+    │  diff --git a/file1 b/file1
+    ~  new file mode 100644
+       index 0000000000..e69de29bb2
+    [EOF]
+    ");
+
+    // Error if no changes selected in interactive mode
+    work_dir.run_jj(["op", "restore", &setup_opid]).success();
+    std::fs::write(&edit_script, "reset file1")?;
+    let output = work_dir.run_jj(["absorb", "-i"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    Error: No changes selected
+    [EOF]
+    [exit status: 1]
+    ");
+    Ok(())
 }
 
 #[must_use]

--- a/docs/git-experts.md
+++ b/docs/git-experts.md
@@ -104,6 +104,10 @@ rebase --autosquash`.
 them incorporated into recent commits. It automatically moves each change in the
 working copy into the previous commit where that line was changed.
 
+Use `jj absorb --interactive` to choose only some hunks to consider for
+absorption. Any hunks that are not selected or cannot be absorbed unambiguously
+remain in the source commit.
+
 It doesn't solve all cases: If multiple commits in the stack modified the same
 line as was changed in the working copy, it will not move that change. But it
 does help the trivial cases, leaving you to decide how to squash the remaining

--- a/lib/src/absorb.rs
+++ b/lib/src/absorb.rs
@@ -55,17 +55,29 @@ pub struct AbsorbSource {
     commit: Commit,
     parents: Vec<Commit>,
     parent_tree: MergedTree,
+    source_tree: MergedTree,
 }
 
 impl AbsorbSource {
     /// Create an absorb source from a single commit.
     pub async fn from_commit(repo: &dyn Repo, commit: Commit) -> BackendResult<Self> {
-        let parents = commit.parents().await?;
         let parent_tree = commit.parent_tree(repo).await?;
+        let source_tree = commit.tree();
+        Self::from_tree(commit, source_tree, parent_tree).await
+    }
+
+    /// Create an absorb source from a commit and a tree derived from it.
+    pub async fn from_tree(
+        commit: Commit,
+        source_tree: MergedTree,
+        parent_tree: MergedTree,
+    ) -> BackendResult<Self> {
+        let parents = commit.parents().await?;
         Ok(Self {
             commit,
             parents,
             parent_tree,
+            source_tree,
         })
     }
 }
@@ -102,10 +114,10 @@ pub async fn split_hunks_to_trees(
     let mut selected_trees = SelectedTrees::default();
 
     let left_tree = &source.parent_tree;
-    let right_tree = source.commit.tree();
+    let right_tree = &source.source_tree;
     // TODO: enable copy tracking if we add support for annotate and merge
     let copy_records = CopyRecords::default();
-    let tree_diff = left_tree.diff_stream_with_copies(&right_tree, matcher, &copy_records);
+    let tree_diff = left_tree.diff_stream_with_copies(right_tree, matcher, &copy_records);
     let mut diff_stream = materialized_diff_stream(
         repo.store(),
         tree_diff,


### PR DESCRIPTION
Users can now interactively select which hunks from the source commit to consider for absorption, just like with `jj squash -i`. The chosen hunks are still routed to the appropriate ancestors using the existing file annotation logic (or left behind in the source if ambiguous or not selected).

This directly addresses the common workflow of only wanting to absorb *part* of a (WIP) commit that touches changes from multiple ancestors, without having to `jj split` + absorb + abandon the rest.

Added `AbsorbSource` accessors and generalized `split_hunks_to_trees` to accept a caller-provided right tree (for the pre-filtered changes). Added tests (including explicit partial-absorb case that leaves changes in the source) and updated the changelog.

Closes https://github.com/jj-vcs/jj/issues/6549.

Thanks!

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [~] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
