### PR TITLE
revset: remove deprecated ui.revsets-use-glob-by-default flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * The deprecated `git_head()` and `git_refs()` functions have been removed from
   revsets and templates.
 
+* The deprecated `ui.revsets-use-glob-by-default` option has been removed.
+
 ### Deprecations
 
 ### New features

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -843,7 +843,6 @@ pub struct WorkspaceCommandEnvironment {
     revset_aliases_map: RevsetAliasesMap,
     template_aliases_map: TemplateAliasesMap,
     default_ignored_remote: Option<&'static RemoteName>,
-    revsets_use_glob_by_default: bool,
     path_converter: RepoPathUiConverter,
     workspace_name: WorkspaceNameBuf,
     immutable_heads_expression: Arc<UserRevsetExpression>,
@@ -870,7 +869,6 @@ impl WorkspaceCommandEnvironment {
             revset_aliases_map,
             template_aliases_map,
             default_ignored_remote,
-            revsets_use_glob_by_default: settings.get("ui.revsets-use-glob-by-default")?,
             path_converter,
             workspace_name: workspace.workspace_name().to_owned(),
             immutable_heads_expression: RevsetExpression::root(),
@@ -930,7 +928,6 @@ impl WorkspaceCommandEnvironment {
             date_pattern_context: now.into(),
             default_ignored_remote: self.default_ignored_remote,
             fileset_aliases_map: &self.fileset_aliases_map,
-            use_glob_by_default: self.revsets_use_glob_by_default,
             extensions: self.command.revset_extensions(),
             workspace: Some(workspace_context),
         }

--- a/cli/src/commit_templater.rs
+++ b/cli/src/commit_templater.rs
@@ -3095,7 +3095,6 @@ mod tests {
                 date_pattern_context: chrono::DateTime::UNIX_EPOCH.fixed_offset().into(),
                 default_ignored_remote: None,
                 fileset_aliases_map: &self.fileset_aliases_map,
-                use_glob_by_default: true,
                 extensions: &self.revset_extensions,
                 workspace: Some(RevsetWorkspaceContext {
                     path_converter: &self.path_converter,

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -235,11 +235,6 @@
                 "conflict-marker-style": {
                     "$ref": "#/properties/ui/definitions/conflict-marker-style"
                 },
-                "revsets-use-glob-by-default": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "Whether to use glob string patterns in revsets by default"
-                },
                 "show-cryptographic-signatures": {
                     "type": "boolean",
                     "default": false,

--- a/cli/src/config/misc.toml
+++ b/cli/src/config/misc.toml
@@ -46,8 +46,6 @@ conflict-marker-style = "diff"
 show-cryptographic-signatures = false
 bookmark-list-sort-keys = ["name"]
 tag-list-sort-keys = ["name"]
-# TODO: delete revsets-use-glob-by-default in jj 0.43+
-revsets-use-glob-by-default = true
 
 [ui.movement]
 edit = false

--- a/cli/tests/test_revset_output.rs
+++ b/cli/tests/test_revset_output.rs
@@ -525,28 +525,6 @@ fn test_default_string_pattern() {
     ~
     [EOF]
     ");
-
-    // with default flipped
-    let output = work_dir.run_jj([
-        "log",
-        "-rauthor('test.user')",
-        "--config=ui.revsets-use-glob-by-default=false",
-    ]);
-    insta::assert_snapshot!(output.normalize_backslash(), @"
-    @  qpvuntsm test.user@example.com 2001-02-03 08:05:07 e8849ae1
-    │  (empty) (no description set)
-    ~
-    [EOF]
-    ------- stderr -------
-    Warning: In revset expression
-     --> 1:8
-      |
-    1 | author('test.user')
-      |        ^---------^
-      |
-      = ui.revsets-use-glob-by-default=false will be removed in a future release
-    [EOF]
-    ");
 }
 
 // TODO: Remove in jj 0.44+

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -1219,13 +1219,9 @@ pub fn expect_fileset_expression(
 pub fn expect_string_expression(
     diagnostics: &mut RevsetDiagnostics,
     node: &ExpressionNode,
-    context: &LoweringContext,
+    _context: &LoweringContext,
 ) -> Result<StringExpression, RevsetParseError> {
-    let default_kind = if context.use_glob_by_default {
-        "glob"
-    } else {
-        "substring"
-    };
+    let default_kind = "glob";
     expect_string_expression_inner(diagnostics, node, default_kind)
 }
 
@@ -1239,12 +1235,6 @@ fn expect_string_expression_inner(
         let expr_error = || RevsetParseError::expression("Invalid string expression", node.span);
         let pattern_error = || RevsetParseError::expression("Invalid string pattern", node.span);
         let default_pattern = |diagnostics: &mut RevsetDiagnostics, value: &str| {
-            if default_kind == "substring" {
-                diagnostics.add_warning(RevsetParseError::expression(
-                    "ui.revsets-use-glob-by-default=false will be removed in a future release",
-                    node.span,
-                ));
-            }
             let pattern = StringPattern::from_str_kind(value, default_kind)
                 .map_err(|err| pattern_error().with_source(err))?;
             Ok(StringExpression::pattern(pattern))
@@ -3498,7 +3488,6 @@ pub struct RevsetParseContext<'a> {
     /// Special remote that should be ignored by default. (e.g. "git")
     pub default_ignored_remote: Option<&'a RemoteName>,
     pub fileset_aliases_map: &'a FilesetAliasesMap,
-    pub use_glob_by_default: bool,
     pub extensions: &'a RevsetExtensions,
     pub workspace: Option<RevsetWorkspaceContext<'a>>,
 }
@@ -3512,7 +3501,6 @@ impl<'a> RevsetParseContext<'a> {
             date_pattern_context,
             default_ignored_remote,
             fileset_aliases_map,
-            use_glob_by_default,
             extensions,
             workspace,
         } = *self;
@@ -3521,7 +3509,6 @@ impl<'a> RevsetParseContext<'a> {
             date_pattern_context,
             default_ignored_remote,
             fileset_aliases_map,
-            use_glob_by_default,
             extensions,
             workspace,
         }
@@ -3535,7 +3522,6 @@ pub struct LoweringContext<'a> {
     date_pattern_context: DatePatternContext,
     default_ignored_remote: Option<&'a RemoteName>,
     fileset_aliases_map: &'a FilesetAliasesMap,
-    use_glob_by_default: bool,
     extensions: &'a RevsetExtensions,
     workspace: Option<RevsetWorkspaceContext<'a>>,
 }
@@ -3632,7 +3618,6 @@ mod tests {
             date_pattern_context: chrono::Utc::now().fixed_offset().into(),
             default_ignored_remote: Some("ignored".as_ref()),
             fileset_aliases_map: &FilesetAliasesMap::new(),
-            use_glob_by_default: true,
             extensions: &RevsetExtensions::default(),
             workspace: None,
         };
@@ -3664,7 +3649,6 @@ mod tests {
             date_pattern_context: chrono::Utc::now().fixed_offset().into(),
             default_ignored_remote: Some("ignored".as_ref()),
             fileset_aliases_map: &FilesetAliasesMap::new(),
-            use_glob_by_default: true,
             extensions: &RevsetExtensions::default(),
             workspace: Some(workspace_ctx),
         };

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -912,10 +912,10 @@ static BUILTIN_FUNCTION_MAP: LazyLock<HashMap<&str, RevsetFunction>> = LazyLock:
         })?;
         Ok(RevsetExpression::commit_id_prefix(prefix))
     });
-    map.insert("bookmarks", |diagnostics, function, context| {
+    map.insert("bookmarks", |diagnostics, function, _context| {
         let ([], [opt_arg]) = function.expect_arguments()?;
         let expr = if let Some(arg) = opt_arg {
-            expect_string_expression(diagnostics, arg, context)?
+            expect_string_expression(diagnostics, arg)?
         } else {
             StringExpression::all()
         };
@@ -942,10 +942,10 @@ static BUILTIN_FUNCTION_MAP: LazyLock<HashMap<&str, RevsetFunction>> = LazyLock:
             Ok(RevsetExpression::remote_bookmarks(symbol, state))
         },
     );
-    map.insert("tags", |diagnostics, function, context| {
+    map.insert("tags", |diagnostics, function, _context| {
         let ([], [opt_arg]) = function.expect_arguments()?;
         let expr = if let Some(arg) = opt_arg {
-            expect_string_expression(diagnostics, arg, context)?
+            expect_string_expression(diagnostics, arg)?
         } else {
             StringExpression::all()
         };
@@ -1000,35 +1000,35 @@ static BUILTIN_FUNCTION_MAP: LazyLock<HashMap<&str, RevsetFunction>> = LazyLock:
             RevsetFilterPredicate::ParentCount(2..u32::MAX),
         ))
     });
-    map.insert("description", |diagnostics, function, context| {
+    map.insert("description", |diagnostics, function, _context| {
         let [arg] = function.expect_exact_arguments()?;
-        let expr = expect_string_expression(diagnostics, arg, context)?;
+        let expr = expect_string_expression(diagnostics, arg)?;
         let predicate = RevsetFilterPredicate::Description(expr);
         Ok(RevsetExpression::filter(predicate))
     });
-    map.insert("subject", |diagnostics, function, context| {
+    map.insert("subject", |diagnostics, function, _context| {
         let [arg] = function.expect_exact_arguments()?;
-        let expr = expect_string_expression(diagnostics, arg, context)?;
+        let expr = expect_string_expression(diagnostics, arg)?;
         let predicate = RevsetFilterPredicate::Subject(expr);
         Ok(RevsetExpression::filter(predicate))
     });
-    map.insert("author", |diagnostics, function, context| {
+    map.insert("author", |diagnostics, function, _context| {
         let [arg] = function.expect_exact_arguments()?;
-        let expr = expect_string_expression(diagnostics, arg, context)?;
+        let expr = expect_string_expression(diagnostics, arg)?;
         let name_predicate = RevsetFilterPredicate::AuthorName(expr.clone());
         let email_predicate = RevsetFilterPredicate::AuthorEmail(expr);
         Ok(RevsetExpression::filter(name_predicate)
             .union(&RevsetExpression::filter(email_predicate)))
     });
-    map.insert("author_name", |diagnostics, function, context| {
+    map.insert("author_name", |diagnostics, function, _context| {
         let [arg] = function.expect_exact_arguments()?;
-        let expr = expect_string_expression(diagnostics, arg, context)?;
+        let expr = expect_string_expression(diagnostics, arg)?;
         let predicate = RevsetFilterPredicate::AuthorName(expr);
         Ok(RevsetExpression::filter(predicate))
     });
-    map.insert("author_email", |diagnostics, function, context| {
+    map.insert("author_email", |diagnostics, function, _context| {
         let [arg] = function.expect_exact_arguments()?;
-        let expr = expect_string_expression(diagnostics, arg, context)?;
+        let expr = expect_string_expression(diagnostics, arg)?;
         let predicate = RevsetFilterPredicate::AuthorEmail(expr);
         Ok(RevsetExpression::filter(predicate))
     });
@@ -1053,23 +1053,23 @@ static BUILTIN_FUNCTION_MAP: LazyLock<HashMap<&str, RevsetFunction>> = LazyLock:
         let predicate = RevsetFilterPredicate::AuthorEmail(StringExpression::pattern(pattern));
         Ok(RevsetExpression::filter(predicate))
     });
-    map.insert("committer", |diagnostics, function, context| {
+    map.insert("committer", |diagnostics, function, _context| {
         let [arg] = function.expect_exact_arguments()?;
-        let expr = expect_string_expression(diagnostics, arg, context)?;
+        let expr = expect_string_expression(diagnostics, arg)?;
         let name_predicate = RevsetFilterPredicate::CommitterName(expr.clone());
         let email_predicate = RevsetFilterPredicate::CommitterEmail(expr);
         Ok(RevsetExpression::filter(name_predicate)
             .union(&RevsetExpression::filter(email_predicate)))
     });
-    map.insert("committer_name", |diagnostics, function, context| {
+    map.insert("committer_name", |diagnostics, function, _context| {
         let [arg] = function.expect_exact_arguments()?;
-        let expr = expect_string_expression(diagnostics, arg, context)?;
+        let expr = expect_string_expression(diagnostics, arg)?;
         let predicate = RevsetFilterPredicate::CommitterName(expr);
         Ok(RevsetExpression::filter(predicate))
     });
-    map.insert("committer_email", |diagnostics, function, context| {
+    map.insert("committer_email", |diagnostics, function, _context| {
         let [arg] = function.expect_exact_arguments()?;
-        let expr = expect_string_expression(diagnostics, arg, context)?;
+        let expr = expect_string_expression(diagnostics, arg)?;
         let predicate = RevsetFilterPredicate::CommitterEmail(expr);
         Ok(RevsetExpression::filter(predicate))
     });
@@ -1104,7 +1104,7 @@ static BUILTIN_FUNCTION_MAP: LazyLock<HashMap<&str, RevsetFunction>> = LazyLock:
             ));
         }
         let ([text_arg], [files_opt_arg]) = function.expect_arguments()?;
-        let text = expect_string_expression(diagnostics, text_arg, context)?;
+        let text = expect_string_expression(diagnostics, text_arg)?;
         let files = expand_optional_files_arg(files_opt_arg, diagnostics, context)?;
         let predicate = RevsetFilterPredicate::DiffLines {
             text,
@@ -1115,7 +1115,7 @@ static BUILTIN_FUNCTION_MAP: LazyLock<HashMap<&str, RevsetFunction>> = LazyLock:
     });
     map.insert("diff_lines_added", |diagnostics, function, context| {
         let ([text_arg], [files_opt_arg]) = function.expect_arguments()?;
-        let text = expect_string_expression(diagnostics, text_arg, context)?;
+        let text = expect_string_expression(diagnostics, text_arg)?;
         let files = expand_optional_files_arg(files_opt_arg, diagnostics, context)?;
         let predicate = RevsetFilterPredicate::DiffLines {
             text,
@@ -1126,7 +1126,7 @@ static BUILTIN_FUNCTION_MAP: LazyLock<HashMap<&str, RevsetFunction>> = LazyLock:
     });
     map.insert("diff_lines_removed", |diagnostics, function, context| {
         let ([text_arg], [files_opt_arg]) = function.expect_arguments()?;
-        let text = expect_string_expression(diagnostics, text_arg, context)?;
+        let text = expect_string_expression(diagnostics, text_arg)?;
         let files = expand_optional_files_arg(files_opt_arg, diagnostics, context)?;
         let predicate = RevsetFilterPredicate::DiffLines {
             text,
@@ -1219,29 +1219,18 @@ pub fn expect_fileset_expression(
 pub fn expect_string_expression(
     diagnostics: &mut RevsetDiagnostics,
     node: &ExpressionNode,
-    _context: &LoweringContext,
-) -> Result<StringExpression, RevsetParseError> {
-    let default_kind = "glob";
-    expect_string_expression_inner(diagnostics, node, default_kind)
-}
-
-fn expect_string_expression_inner(
-    diagnostics: &mut RevsetDiagnostics,
-    node: &ExpressionNode,
-    // TODO: remove this parameter with ui.revsets-use-glob-by-default
-    default_kind: &str,
 ) -> Result<StringExpression, RevsetParseError> {
     revset_parser::catch_aliases(diagnostics, node, |diagnostics, node| {
         let expr_error = || RevsetParseError::expression("Invalid string expression", node.span);
         let pattern_error = || RevsetParseError::expression("Invalid string pattern", node.span);
-        let default_pattern = |diagnostics: &mut RevsetDiagnostics, value: &str| {
-            let pattern = StringPattern::from_str_kind(value, default_kind)
-                .map_err(|err| pattern_error().with_source(err))?;
+        let default_pattern = |value: &str| {
+            let pattern =
+                StringPattern::glob(value).map_err(|err| pattern_error().with_source(err))?;
             Ok(StringExpression::pattern(pattern))
         };
         match &node.kind {
-            ExpressionKind::Identifier(value) => default_pattern(diagnostics, value),
-            ExpressionKind::String(value) => default_pattern(diagnostics, value),
+            ExpressionKind::Identifier(value) => default_pattern(value),
+            ExpressionKind::String(value) => default_pattern(value),
             ExpressionKind::Pattern(pattern) => {
                 let value = revset_parser::expect_string_literal("string", &pattern.value)?;
                 let pattern = StringPattern::from_str_kind(value, pattern.name)
@@ -1254,7 +1243,7 @@ fn expect_string_expression_inner(
             | ExpressionKind::DagRangeAll
             | ExpressionKind::RangeAll => Err(expr_error()),
             ExpressionKind::Unary(op, arg_node) => {
-                let arg = expect_string_expression_inner(diagnostics, arg_node, default_kind)?;
+                let arg = expect_string_expression(diagnostics, arg_node)?;
                 match op {
                     UnaryOp::Negate => Ok(arg.negated()),
                     UnaryOp::DagRangePre
@@ -1266,8 +1255,8 @@ fn expect_string_expression_inner(
                 }
             }
             ExpressionKind::Binary(op, lhs_node, rhs_node) => {
-                let lhs = expect_string_expression_inner(diagnostics, lhs_node, default_kind)?;
-                let rhs = expect_string_expression_inner(diagnostics, rhs_node, default_kind)?;
+                let lhs = expect_string_expression(diagnostics, lhs_node)?;
+                let rhs = expect_string_expression(diagnostics, rhs_node)?;
                 match op {
                     BinaryOp::Intersection => Ok(lhs.intersection(rhs)),
                     BinaryOp::Difference => Ok(lhs.intersection(rhs.negated())),
@@ -1277,7 +1266,7 @@ fn expect_string_expression_inner(
             ExpressionKind::UnionAll(nodes) => {
                 let expressions = nodes
                     .iter()
-                    .map(|node| expect_string_expression_inner(diagnostics, node, default_kind))
+                    .map(|node| expect_string_expression(diagnostics, node))
                     .try_collect()?;
                 Ok(StringExpression::union_all(expressions))
             }
@@ -1310,12 +1299,12 @@ fn parse_remote_refs_arguments(
 ) -> Result<RemoteRefSymbolExpression, RevsetParseError> {
     let ([], [name_opt_arg, remote_opt_arg]) = function.expect_named_arguments(&["", "remote"])?;
     let name = if let Some(name_arg) = name_opt_arg {
-        expect_string_expression(diagnostics, name_arg, context)?
+        expect_string_expression(diagnostics, name_arg)?
     } else {
         StringExpression::all()
     };
     let remote = if let Some(remote_arg) = remote_opt_arg {
-        expect_string_expression(diagnostics, remote_arg, context)?
+        expect_string_expression(diagnostics, remote_arg)?
     } else if let Some(remote) = context.default_ignored_remote {
         StringExpression::exact(remote).negated()
     } else {
@@ -1431,8 +1420,7 @@ pub fn parse_string_expression(
     text: &str,
 ) -> Result<StringExpression, RevsetParseError> {
     let node = parse_program(text)?;
-    let default_kind = "glob";
-    expect_string_expression_inner(diagnostics, &node, default_kind)
+    expect_string_expression(diagnostics, &node)
 }
 
 /// Constructs binary tree from `expressions` list, `unit` node, and associative

--- a/lib/tests/test_revset.rs
+++ b/lib/tests/test_revset.rs
@@ -104,7 +104,6 @@ fn resolve_symbol(repo: &dyn Repo, symbol: &str) -> Result<Vec<CommitId>, Revset
         date_pattern_context: chrono::Local::now().into(),
         default_ignored_remote: Some(git::REMOTE_NAME_FOR_LOCAL_GIT_REPO),
         fileset_aliases_map: &FilesetAliasesMap::new(),
-        use_glob_by_default: true,
         extensions: &RevsetExtensions::default(),
         workspace: None,
     };
@@ -239,7 +238,6 @@ fn test_resolve_symbol_commit_id() -> TestResult {
         date_pattern_context: chrono::Utc::now().fixed_offset().into(),
         default_ignored_remote: Some(git::REMOTE_NAME_FOR_LOCAL_GIT_REPO),
         fileset_aliases_map: &FilesetAliasesMap::new(),
-        use_glob_by_default: true,
         extensions: &RevsetExtensions::default(),
         workspace: None,
     };
@@ -1177,7 +1175,6 @@ fn try_resolve_expression(
         date_pattern_context: chrono::Utc::now().fixed_offset().into(),
         default_ignored_remote: Some(git::REMOTE_NAME_FOR_LOCAL_GIT_REPO),
         fileset_aliases_map: &FilesetAliasesMap::new(),
-        use_glob_by_default: true,
         extensions: &RevsetExtensions::default(),
         workspace: None,
     };
@@ -1230,7 +1227,6 @@ fn resolve_commit_ids_in_workspace(
         date_pattern_context: chrono::Utc::now().fixed_offset().into(),
         default_ignored_remote: Some(git::REMOTE_NAME_FOR_LOCAL_GIT_REPO),
         fileset_aliases_map: &FilesetAliasesMap::new(),
-        use_glob_by_default: true,
         extensions: &RevsetExtensions::default(),
         workspace: Some(workspace_ctx),
     };


### PR DESCRIPTION
# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [x] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [ ] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
