### PR TITLE
spike native git transport/gc paths with grit-lib (v2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2100,6 +2100,7 @@ dependencies = [
  "regex",
  "sha1",
  "sha2",
+ "shell-words",
  "similar",
  "tempfile",
  "thiserror 2.0.18",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2086,7 +2086,9 @@ dependencies = [
 
 [[package]]
 name = "grit-lib"
-version = "0.3.99"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9cfce5d827f658959d9b0c5ed446cd1e55543f06aa221b4a53cceb0c3f3dabf"
 dependencies = [
  "base64",
  "encoding_rs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1068,6 +1074,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "fluent-uri"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1095,6 +1111,15 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "fraction"
@@ -2060,6 +2085,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "grit-lib"
+version = "0.3.99"
+dependencies = [
+ "encoding_rs",
+ "filetime",
+ "flate2",
+ "hex",
+ "icu_normalizer",
+ "imara-diff",
+ "libc",
+ "merge3",
+ "nix 0.29.0",
+ "regex",
+ "sha1",
+ "sha2",
+ "similar",
+ "tempfile",
+ "thiserror 2.0.18",
+ "time",
+ "unicode-width 0.2.2",
+ "url",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2206,6 +2255,9 @@ dependencies = [
  "icu_properties",
  "icu_provider",
  "smallvec",
+ "utf16_iter",
+ "utf8_iter",
+ "write16",
  "zerovec",
 ]
 
@@ -2281,6 +2333,16 @@ checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "imara-diff"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f01d462f766df78ab820dd06f5eb700233c51f0f4c2e846520eaf4ba6aa5c5c"
+dependencies = [
+ "hashbrown 0.15.5",
+ "memchr",
 ]
 
 [[package]]
@@ -2526,6 +2588,7 @@ dependencies = [
  "gix",
  "gix-ignore",
  "globset",
+ "grit-lib",
  "hashbrown 0.17.1",
  "indexmap",
  "indoc",
@@ -2843,6 +2906,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "merge3"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4b277bc3c7e2bc163abc6c0069f53715b52dc34442c0e807cc8758c7113524f"
+dependencies = [
+ "clap",
+ "difflib",
+]
+
+[[package]]
 name = "micromap"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2862,6 +2935,16 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
 
 [[package]]
 name = "mio"
@@ -4113,6 +4196,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4452,12 +4541,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
+ "itoa",
  "libc",
  "num-conv",
  "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -4465,6 +4556,16 @@ name = "time-core"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
 
 [[package]]
 name = "timeago"
@@ -4777,6 +4878,24 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf16_iter"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
 
 [[package]]
 name = "utf8_iter"
@@ -5456,6 +5575,12 @@ dependencies = [
  "unicode-xid",
  "wasmparser",
 ]
+
+[[package]]
+name = "write16"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
 
 [[package]]
 name = "writeable"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2088,6 +2088,7 @@ dependencies = [
 name = "grit-lib"
 version = "0.3.99"
 dependencies = [
+ "base64",
  "encoding_rs",
  "filetime",
  "flate2",
@@ -2106,6 +2107,7 @@ dependencies = [
  "thiserror 2.0.18",
  "time",
  "unicode-width 0.2.2",
+ "ureq",
  "url",
 ]
 
@@ -3889,6 +3891,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "roff"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3935,6 +3951,41 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -4881,6 +4932,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64",
+ "flate2",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5134,6 +5207,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "wezterm-bidi"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5306,6 +5397,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5658,6 +5758,12 @@ dependencies = [
  "syn 2.0.117",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,8 @@ gix = { version = "0.84.0", default-features = false, features = [
 ] }
 gix-ignore = { version = "0.21.0" }
 globset = "0.4.18"
-hashbrown = { version = "0.17.1", default-features = false, features = ["inline-more"] }
+grit-lib = "0.3.99"
+hashbrown ={ version = "0.17.1", default-features = false, features = ["inline-more"] }
 indexmap = { version = "2.14.0", features = ["serde"] }
 indoc = "2.0.7"
 insta = { version = "1.47.2", features = ["filters"] }
@@ -182,3 +183,8 @@ opt-level = 3
 [profile.release]
 strip = "debuginfo"
 codegen-units = 1
+
+# The grit-lib networking APIs (transfer::fetch_local/push_local, gc helpers) used
+# by the LOCAL / file:// integration are unpublished; point at the local checkout.
+[patch.crates-io]
+grit-lib = { path = "/Users/schacon/projects/grit-claude/grit-lib" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ gix = { version = "0.84.0", default-features = false, features = [
 ] }
 gix-ignore = { version = "0.21.0" }
 globset = "0.4.18"
-grit-lib = "0.3.99"
+grit-lib = "0.4.0"
 hashbrown ={ version = "0.17.1", default-features = false, features = ["inline-more"] }
 indexmap = { version = "2.14.0", features = ["serde"] }
 indoc = "2.0.7"
@@ -184,7 +184,8 @@ opt-level = 3
 strip = "debuginfo"
 codegen-units = 1
 
-# The grit-lib networking APIs (transfer::fetch_local/push_local, gc helpers) used
-# by the LOCAL / file:// integration are unpublished; point at the local checkout.
+# grit-lib 0.4.0 (with the transport stack) is published on crates.io, so this
+# patch is optional. It points jj at the local checkout for iteration; remove
+# this block to build against the published crate instead.
 [patch.crates-io]
 grit-lib = { path = "/Users/schacon/projects/grit-claude/grit-lib" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ gix = { version = "0.84.0", default-features = false, features = [
 ] }
 gix-ignore = { version = "0.21.0" }
 globset = "0.4.18"
-grit-lib = "0.4.0"
+grit-lib = "0.4.1"
 hashbrown ={ version = "0.17.1", default-features = false, features = ["inline-more"] }
 indexmap = { version = "2.14.0", features = ["serde"] }
 indoc = "2.0.7"
@@ -183,9 +183,3 @@ opt-level = 3
 [profile.release]
 strip = "debuginfo"
 codegen-units = 1
-
-# grit-lib 0.4.0 (with the transport stack) is published on crates.io, so this
-# patch is optional. It points jj at the local checkout for iteration; remove
-# this block to build against the published crate instead.
-[patch.crates-io]
-grit-lib = { path = "/Users/schacon/projects/grit-claude/grit-lib" }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -43,6 +43,7 @@ futures = { workspace = true }
 gix = { workspace = true, optional = true }
 gix-ignore = { workspace = true }
 globset = { workspace = true }
+grit-lib = { workspace = true, optional = true }
 hashbrown = { workspace = true }
 indexmap = { workspace = true }
 interim = { workspace = true }
@@ -96,7 +97,7 @@ nix = { workspace = true, features = [ "fs" ] }
 
 [features]
 default = ["git"]
-git = ["dep:gix"]
+git = ["dep:gix", "dep:grit-lib"]
 watchman = ["dep:watchman_client", "dep:tokio"]
 testing = ["git"]
 

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -97,7 +97,7 @@ nix = { workspace = true, features = [ "fs" ] }
 
 [features]
 default = ["git"]
-git = ["dep:gix", "dep:grit-lib"]
+git = ["dep:gix", "dep:grit-lib", "grit-lib/http-ureq"]
 watchman = ["dep:watchman_client", "dep:tokio"]
 testing = ["git"]
 

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -3056,6 +3056,21 @@ impl<'a> GitFetch<'a> {
             None
         };
 
+        // Anonymous `git://` (Git-daemon) fetches also run in-process through
+        // grit-lib's wire transport (TCP pkt-line, no subprocess). Same depth
+        // restriction as the local path (v0/v1, whole-history only).
+        let git_daemon_remote = if depth.is_none() && local_remote.is_none() {
+            self.git_repo
+                .try_find_remote(remote_name.as_str())
+                .and_then(|r| r.ok())
+                .and_then(|remote| {
+                    crate::git_local::git_daemon_remote_url(&remote, gix::remote::Direction::Fetch)
+                        .map(|url| (url, remote.fetch_tags()))
+                })
+        } else {
+            None
+        };
+
         let mut branches_to_prune = Vec::new();
         let updates = if let Some((remote_git_dir, configured_tags)) = local_remote {
             let local_git_dir = self.git_repo.git_dir().to_path_buf();
@@ -3075,6 +3090,24 @@ impl<'a> GitFetch<'a> {
                 GitFetchStatus::Updates(updates) => updates,
                 // A refspec that matches no remote ref simply yields no update
                 // for the local path (no subprocess error to recover from).
+                GitFetchStatus::NoRemoteRef(_) => crate::git_subprocess::GitRefUpdates::default(),
+            }
+        } else if let Some((remote_url, configured_tags)) = git_daemon_remote {
+            let local_git_dir = self.git_repo.git_dir().to_path_buf();
+            match crate::git_local::fetch_git_daemon(
+                &local_git_dir,
+                &remote_url,
+                &remaining_refspecs,
+                &negative_refspecs,
+                // The subprocess path always fetches with `--prune`; mirror that.
+                true,
+                fetch_tags_override,
+                configured_tags,
+            )
+            .map_err(|err| {
+                GitFetchError::Subprocess(GitSubprocessError::External(err.to_string()))
+            })? {
+                GitFetchStatus::Updates(updates) => updates,
                 GitFetchStatus::NoRemoteRef(_) => crate::git_subprocess::GitRefUpdates::default(),
             }
         } else {

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -3057,9 +3057,11 @@ impl<'a> GitFetch<'a> {
         };
 
         // Anonymous `git://` (Git-daemon) fetches also run in-process through
-        // grit-lib's wire transport (TCP pkt-line, no subprocess). Same depth
-        // restriction as the local path (v0/v1, whole-history only).
-        let git_daemon_remote = if depth.is_none() && local_remote.is_none() {
+        // grit-lib's wire transport (TCP pkt-line, no subprocess). Shallow
+        // (`depth`) fetches are now supported in-process: `fetch_remote` drives
+        // the `deepen N` shallow-info handshake and writes the local `shallow`
+        // file, so depth is threaded through rather than forcing the subprocess.
+        let git_daemon_remote = if local_remote.is_none() {
             self.git_repo
                 .try_find_remote(remote_name.as_str())
                 .and_then(|r| r.ok())
@@ -3073,12 +3075,10 @@ impl<'a> GitFetch<'a> {
 
         // `ssh://` (and scp-style) fetches also run in-process through grit-lib's
         // ssh transport (an ssh subprocess speaking the Git wire protocol, no
-        // `git` subprocess). Same depth restriction as the other in-process paths.
-        // Authentication is whatever the user's ssh configuration provides.
-        let ssh_remote = if depth.is_none()
-            && local_remote.is_none()
-            && git_daemon_remote.is_none()
-        {
+        // `git` subprocess). Shallow (`depth`) fetches are supported in-process
+        // (threaded into `fetch_remote`). Authentication is whatever the user's
+        // ssh configuration provides.
+        let ssh_remote = if local_remote.is_none() && git_daemon_remote.is_none() {
             self.git_repo
                 .try_find_remote(remote_name.as_str())
                 .and_then(|r| r.ok())
@@ -3091,12 +3091,11 @@ impl<'a> GitFetch<'a> {
         };
 
         // `http(s)://` (smart-HTTP) fetches also run in-process through grit-lib's
-        // smart-HTTP transport (protocol v2, no subprocess). Same depth restriction
-        // as the other in-process paths; the HTTP client is unauthenticated, so a
-        // remote that returns `401` falls through grit-lib's error to the caller —
-        // remotes needing auth should be left on the subprocess path by callers.
-        let http_remote = if depth.is_none()
-            && local_remote.is_none()
+        // smart-HTTP transport (protocol v2, no subprocess). Shallow (`depth`)
+        // fetches are supported in-process (threaded into `http_fetch`). The HTTP
+        // client carries config-driven credentials; a remote that returns `401`
+        // with no usable helper surfaces a typed error to the caller.
+        let http_remote = if local_remote.is_none()
             && git_daemon_remote.is_none()
             && ssh_remote.is_none()
         {
@@ -3141,6 +3140,7 @@ impl<'a> GitFetch<'a> {
                 &negative_refspecs,
                 // The subprocess path always fetches with `--prune`; mirror that.
                 true,
+                depth,
                 fetch_tags_override,
                 configured_tags,
             )
@@ -3159,6 +3159,7 @@ impl<'a> GitFetch<'a> {
                 &negative_refspecs,
                 // The subprocess path always fetches with `--prune`; mirror that.
                 true,
+                depth,
                 fetch_tags_override,
                 configured_tags,
             )
@@ -3177,6 +3178,7 @@ impl<'a> GitFetch<'a> {
                 &negative_refspecs,
                 // The subprocess path always fetches with `--prune`; mirror that.
                 true,
+                depth,
                 fetch_tags_override,
                 configured_tags,
             )
@@ -3512,9 +3514,11 @@ pub fn push_updates(
         .collect();
 
     // LOCAL (file://) pushes run in-process through grit-lib. Pushes carrying
-    // `--push-option` values stay on the subprocess path: those must be forwarded
-    // to the remote's receive hooks (via `GIT_PUSH_OPTION_*`), which the
-    // in-process path does not run.
+    // `--push-option` values stay on the subprocess path: the local in-process
+    // path writes the remote's refs/objects directly and never runs the remote's
+    // `git-receive-pack` (so its receive hooks, which consume `GIT_PUSH_OPTION_*`,
+    // do not run). The wire paths below (`git://`/`ssh`/`http`) instead drive a
+    // real remote `git-receive-pack`, so they forward the options over the wire.
     let local_push = if options.remote_push_options.is_empty() {
         git_repo
             .try_find_remote(remote_name.as_str())
@@ -3543,13 +3547,13 @@ pub fn push_updates(
     .filter(|(remote_git_dir, _)| !crate::git_local::remote_has_receive_hooks(remote_git_dir));
 
     // Anonymous `git://` (Git-daemon) pushes also run in-process through grit-lib
-    // (protocol v0/v1 receive-pack over TCP). As with the local path, pushes
-    // carrying `--push-option` stay on the subprocess path (those must be
-    // forwarded to the remote's receive hooks). Unlike the local path there are
-    // no hooks to detect locally — any receive hooks run on the *server*, which
-    // can reject the push (surfaced as a remote rejection), so there is nothing to
-    // filter here.
-    let git_daemon_push = if options.remote_push_options.is_empty() && local_push.is_none() {
+    // (protocol v0/v1 receive-pack over TCP). Pushes carrying `--push-option` are
+    // forwarded over the wire (grit-lib negotiates the `push-options` capability
+    // and sends the option lines); the server exposes them to its receive hooks.
+    // Unlike the local path there are no hooks to detect locally — any receive
+    // hooks run on the *server*, which can reject the push (surfaced as a remote
+    // rejection), so there is nothing to filter here.
+    let git_daemon_push = if local_push.is_none() {
         git_repo
             .try_find_remote(remote_name.as_str())
             .and_then(|r| r.ok())
@@ -3570,14 +3574,11 @@ pub fn push_updates(
     };
 
     // `ssh://` (and scp-style) pushes also run in-process through grit-lib
-    // (protocol v0/v1 receive-pack over an ssh subprocess). Same caveats as the
-    // `git://` push path: `--push-option` falls back to the subprocess path, and
-    // server receive hooks run remotely. Authentication is whatever the user's ssh
+    // (protocol v0/v1 receive-pack over an ssh subprocess). Same as the `git://`
+    // push path: `--push-option` values are forwarded over the wire, and server
+    // receive hooks run remotely. Authentication is whatever the user's ssh
     // configuration provides.
-    let ssh_push = if options.remote_push_options.is_empty()
-        && local_push.is_none()
-        && git_daemon_push.is_none()
-    {
+    let ssh_push = if local_push.is_none() && git_daemon_push.is_none() {
         git_repo
             .try_find_remote(remote_name.as_str())
             .and_then(|r| r.ok())
@@ -3596,16 +3597,11 @@ pub fn push_updates(
     };
 
     // `http(s)://` (smart-HTTP) pushes also run in-process through grit-lib
-    // (protocol v0/v1 receive-pack). As with the local path, pushes carrying
-    // `--push-option` stay on the subprocess path (those must be forwarded to the
-    // remote's receive hooks). The HTTP client is unauthenticated, so a remote
-    // requiring auth returns `401` and grit-lib surfaces the error; callers should
-    // leave auth'd remotes on the subprocess path.
-    let http_push = if options.remote_push_options.is_empty()
-        && local_push.is_none()
-        && git_daemon_push.is_none()
-        && ssh_push.is_none()
-    {
+    // (protocol v0/v1 receive-pack). Pushes carrying `--push-option` are forwarded
+    // over the wire (the server exposes them to its receive hooks). HTTP basic auth
+    // is handled in-process via the config-driven credential provider; a remote
+    // whose credentials cannot be supplied non-interactively surfaces the error.
+    let http_push = if local_push.is_none() && git_daemon_push.is_none() && ssh_push.is_none() {
         git_repo
             .try_find_remote(remote_name.as_str())
             .and_then(|r| r.ok())
@@ -3638,20 +3634,29 @@ pub fn push_updates(
             &remote_url,
             &refs_to_push,
             &fetch_refspecs,
+            &options.remote_push_options,
         )
         .map_err(|err| GitPushError::Subprocess(GitSubprocessError::External(err.to_string())))?
     } else if let Some((remote_url, fetch_refspecs)) = ssh_push {
         let local_git_dir = git_repo.git_dir().to_path_buf();
-        crate::git_local::push_ssh(&local_git_dir, &remote_url, &refs_to_push, &fetch_refspecs)
-            .map_err(|err| {
-                GitPushError::Subprocess(GitSubprocessError::External(err.to_string()))
-            })?
+        crate::git_local::push_ssh(
+            &local_git_dir,
+            &remote_url,
+            &refs_to_push,
+            &fetch_refspecs,
+            &options.remote_push_options,
+        )
+        .map_err(|err| GitPushError::Subprocess(GitSubprocessError::External(err.to_string())))?
     } else if let Some((remote_url, fetch_refspecs)) = http_push {
         let local_git_dir = git_repo.git_dir().to_path_buf();
-        crate::git_local::push_http(&local_git_dir, &remote_url, &refs_to_push, &fetch_refspecs)
-            .map_err(|err| {
-                GitPushError::Subprocess(GitSubprocessError::External(err.to_string()))
-            })?
+        crate::git_local::push_http(
+            &local_git_dir,
+            &remote_url,
+            &refs_to_push,
+            &fetch_refspecs,
+            &options.remote_push_options,
+        )
+        .map_err(|err| GitPushError::Subprocess(GitSubprocessError::External(err.to_string())))?
     } else {
         git_ctx.spawn_push(remote_name, &refs_to_push, callback, options)?
     };

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -253,6 +253,21 @@ impl RefSpec {
         }
     }
 
+    /// The source side of the refspec, or `None` for a deletion.
+    pub(crate) fn source(&self) -> Option<&str> {
+        self.source.as_deref()
+    }
+
+    /// The destination ref on the remote.
+    pub(crate) fn destination(&self) -> &str {
+        &self.destination
+    }
+
+    /// Whether this refspec requests a forced (non-fast-forward) update.
+    pub(crate) fn is_forced(&self) -> bool {
+        self.forced
+    }
+
     pub(crate) fn to_git_format(&self) -> String {
         format!(
             "{}{}",
@@ -3026,6 +3041,17 @@ impl<'a> GitFetch<'a> {
             return Ok(());
         }
 
+        // NOTE: LOCAL (file://) fetches could be routed in-process through
+        // `crate::git_local::fetch_local` here (see `get_default_branch` below,
+        // which already does so for the remote default branch). It is left on the
+        // subprocess path for now because grit-lib's `fetch_local` does not yet
+        // (a) consult the remote's configured tag policy when jj passes no
+        // explicit `fetch_tags` override (so a remote configured with
+        // `tags = All` is not honored), or (b) classify a conflicting tag update
+        // as a clean rejection (it currently errors when the local tag points at
+        // an object the remote lacks). Branch fetching works; once the tag gaps
+        // land in grit-lib the translation helper is ready to adopt.
+
         let mut branches_to_prune = Vec::new();
         // git unfortunately errors out if one of the many refspecs is not found
         //
@@ -3089,6 +3115,23 @@ impl<'a> GitFetch<'a> {
             .is_none()
         {
             return Err(GitFetchError::NoSuchRemote(remote_name.to_owned()));
+        }
+        // For LOCAL (file://) remotes, read the default branch in-process via
+        // grit-lib instead of spawning `git remote show`.
+        if let Some(remote_git_dir) = self
+            .git_repo
+            .try_find_remote(remote_name.as_str())
+            .and_then(|r| r.ok())
+            .and_then(|remote| {
+                crate::git_local::local_remote_git_dir(&remote, gix::remote::Direction::Fetch)
+            })
+        {
+            let default_branch = crate::git_local::remote_default_branch_local(&remote_git_dir)
+                .map_err(|err| {
+                    GitFetchError::Subprocess(GitSubprocessError::External(err.to_string()))
+                })?;
+            tracing::debug!(?default_branch);
+            return Ok(default_branch);
         }
         let default_branch = self.git_ctx.spawn_remote_show(remote_name)?;
         tracing::debug!(?default_branch);
@@ -3333,6 +3376,15 @@ pub fn push_updates(
         .map(|full_refspec| RefToPush::new(full_refspec, &qualified_remote_refs_expected_locations))
         .collect();
 
+    // NOTE: the LOCAL (file://) push path could be routed in-process through
+    // `crate::git_local::push_local` here, mirroring the local fetch path. It is
+    // intentionally left on the subprocess path for now: grit-lib's
+    // `push_local` does not yet (a) update the local clone's remote-tracking
+    // refs as a side effect of a successful push, (b) honor the
+    // compare-and-swap "up to date is OK even if the lease expectation differs"
+    // ordering that `git push --force-with-lease` uses, or (c) carry
+    // `--push-option` values. Until those land in grit-lib, push stays on the
+    // subprocess path. The translation helper is ready to adopt when they do.
     let mut push_stats = git_ctx.spawn_push(remote_name, &refs_to_push, callback, options)?;
     push_stats.pushed.sort();
     push_stats.rejected.sort();

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -3071,6 +3071,46 @@ impl<'a> GitFetch<'a> {
             None
         };
 
+        // `ssh://` (and scp-style) fetches also run in-process through grit-lib's
+        // ssh transport (an ssh subprocess speaking the Git wire protocol, no
+        // `git` subprocess). Same depth restriction as the other in-process paths.
+        // Authentication is whatever the user's ssh configuration provides.
+        let ssh_remote = if depth.is_none()
+            && local_remote.is_none()
+            && git_daemon_remote.is_none()
+        {
+            self.git_repo
+                .try_find_remote(remote_name.as_str())
+                .and_then(|r| r.ok())
+                .and_then(|remote| {
+                    crate::git_local::ssh_remote_url(&remote, gix::remote::Direction::Fetch)
+                        .map(|url| (url, remote.fetch_tags()))
+                })
+        } else {
+            None
+        };
+
+        // `http(s)://` (smart-HTTP) fetches also run in-process through grit-lib's
+        // smart-HTTP transport (protocol v2, no subprocess). Same depth restriction
+        // as the other in-process paths; the HTTP client is unauthenticated, so a
+        // remote that returns `401` falls through grit-lib's error to the caller —
+        // remotes needing auth should be left on the subprocess path by callers.
+        let http_remote = if depth.is_none()
+            && local_remote.is_none()
+            && git_daemon_remote.is_none()
+            && ssh_remote.is_none()
+        {
+            self.git_repo
+                .try_find_remote(remote_name.as_str())
+                .and_then(|r| r.ok())
+                .and_then(|remote| {
+                    crate::git_local::http_remote_url(&remote, gix::remote::Direction::Fetch)
+                        .map(|url| (url, remote.fetch_tags()))
+                })
+        } else {
+            None
+        };
+
         let mut branches_to_prune = Vec::new();
         let updates = if let Some((remote_git_dir, configured_tags)) = local_remote {
             let local_git_dir = self.git_repo.git_dir().to_path_buf();
@@ -3095,6 +3135,42 @@ impl<'a> GitFetch<'a> {
         } else if let Some((remote_url, configured_tags)) = git_daemon_remote {
             let local_git_dir = self.git_repo.git_dir().to_path_buf();
             match crate::git_local::fetch_git_daemon(
+                &local_git_dir,
+                &remote_url,
+                &remaining_refspecs,
+                &negative_refspecs,
+                // The subprocess path always fetches with `--prune`; mirror that.
+                true,
+                fetch_tags_override,
+                configured_tags,
+            )
+            .map_err(|err| {
+                GitFetchError::Subprocess(GitSubprocessError::External(err.to_string()))
+            })? {
+                GitFetchStatus::Updates(updates) => updates,
+                GitFetchStatus::NoRemoteRef(_) => crate::git_subprocess::GitRefUpdates::default(),
+            }
+        } else if let Some((remote_url, configured_tags)) = ssh_remote {
+            let local_git_dir = self.git_repo.git_dir().to_path_buf();
+            match crate::git_local::fetch_ssh(
+                &local_git_dir,
+                &remote_url,
+                &remaining_refspecs,
+                &negative_refspecs,
+                // The subprocess path always fetches with `--prune`; mirror that.
+                true,
+                fetch_tags_override,
+                configured_tags,
+            )
+            .map_err(|err| {
+                GitFetchError::Subprocess(GitSubprocessError::External(err.to_string()))
+            })? {
+                GitFetchStatus::Updates(updates) => updates,
+                GitFetchStatus::NoRemoteRef(_) => crate::git_subprocess::GitRefUpdates::default(),
+            }
+        } else if let Some((remote_url, configured_tags)) = http_remote {
+            let local_git_dir = self.git_repo.git_dir().to_path_buf();
+            match crate::git_local::fetch_http(
                 &local_git_dir,
                 &remote_url,
                 &remaining_refspecs,
@@ -3466,9 +3542,113 @@ pub fn push_updates(
     // reject the push).
     .filter(|(remote_git_dir, _)| !crate::git_local::remote_has_receive_hooks(remote_git_dir));
 
+    // Anonymous `git://` (Git-daemon) pushes also run in-process through grit-lib
+    // (protocol v0/v1 receive-pack over TCP). As with the local path, pushes
+    // carrying `--push-option` stay on the subprocess path (those must be
+    // forwarded to the remote's receive hooks). Unlike the local path there are
+    // no hooks to detect locally — any receive hooks run on the *server*, which
+    // can reject the push (surfaced as a remote rejection), so there is nothing to
+    // filter here.
+    let git_daemon_push = if options.remote_push_options.is_empty() && local_push.is_none() {
+        git_repo
+            .try_find_remote(remote_name.as_str())
+            .and_then(|r| r.ok())
+            .and_then(|remote| {
+                crate::git_local::git_daemon_remote_url(&remote, gix::remote::Direction::Push).map(
+                    |url| {
+                        let fetch_refspecs: Vec<String> = remote
+                            .refspecs(gix::remote::Direction::Fetch)
+                            .iter()
+                            .map(|spec| spec.to_ref().to_bstring().to_string())
+                            .collect();
+                        (url, fetch_refspecs)
+                    },
+                )
+            })
+    } else {
+        None
+    };
+
+    // `ssh://` (and scp-style) pushes also run in-process through grit-lib
+    // (protocol v0/v1 receive-pack over an ssh subprocess). Same caveats as the
+    // `git://` push path: `--push-option` falls back to the subprocess path, and
+    // server receive hooks run remotely. Authentication is whatever the user's ssh
+    // configuration provides.
+    let ssh_push = if options.remote_push_options.is_empty()
+        && local_push.is_none()
+        && git_daemon_push.is_none()
+    {
+        git_repo
+            .try_find_remote(remote_name.as_str())
+            .and_then(|r| r.ok())
+            .and_then(|remote| {
+                crate::git_local::ssh_remote_url(&remote, gix::remote::Direction::Push).map(|url| {
+                    let fetch_refspecs: Vec<String> = remote
+                        .refspecs(gix::remote::Direction::Fetch)
+                        .iter()
+                        .map(|spec| spec.to_ref().to_bstring().to_string())
+                        .collect();
+                    (url, fetch_refspecs)
+                })
+            })
+    } else {
+        None
+    };
+
+    // `http(s)://` (smart-HTTP) pushes also run in-process through grit-lib
+    // (protocol v0/v1 receive-pack). As with the local path, pushes carrying
+    // `--push-option` stay on the subprocess path (those must be forwarded to the
+    // remote's receive hooks). The HTTP client is unauthenticated, so a remote
+    // requiring auth returns `401` and grit-lib surfaces the error; callers should
+    // leave auth'd remotes on the subprocess path.
+    let http_push = if options.remote_push_options.is_empty()
+        && local_push.is_none()
+        && git_daemon_push.is_none()
+        && ssh_push.is_none()
+    {
+        git_repo
+            .try_find_remote(remote_name.as_str())
+            .and_then(|r| r.ok())
+            .and_then(|remote| {
+                crate::git_local::http_remote_url(&remote, gix::remote::Direction::Push).map(
+                    |url| {
+                        let fetch_refspecs: Vec<String> = remote
+                            .refspecs(gix::remote::Direction::Fetch)
+                            .iter()
+                            .map(|spec| spec.to_ref().to_bstring().to_string())
+                            .collect();
+                        (url, fetch_refspecs)
+                    },
+                )
+            })
+    } else {
+        None
+    };
+
     let mut push_stats = if let Some((remote_git_dir, fetch_refspecs)) = local_push {
         let local_git_dir = git_repo.git_dir().to_path_buf();
         crate::git_local::push_local(&local_git_dir, &remote_git_dir, &refs_to_push, &fetch_refspecs)
+            .map_err(|err| {
+                GitPushError::Subprocess(GitSubprocessError::External(err.to_string()))
+            })?
+    } else if let Some((remote_url, fetch_refspecs)) = git_daemon_push {
+        let local_git_dir = git_repo.git_dir().to_path_buf();
+        crate::git_local::push_git_daemon(
+            &local_git_dir,
+            &remote_url,
+            &refs_to_push,
+            &fetch_refspecs,
+        )
+        .map_err(|err| GitPushError::Subprocess(GitSubprocessError::External(err.to_string())))?
+    } else if let Some((remote_url, fetch_refspecs)) = ssh_push {
+        let local_git_dir = git_repo.git_dir().to_path_buf();
+        crate::git_local::push_ssh(&local_git_dir, &remote_url, &refs_to_push, &fetch_refspecs)
+            .map_err(|err| {
+                GitPushError::Subprocess(GitSubprocessError::External(err.to_string()))
+            })?
+    } else if let Some((remote_url, fetch_refspecs)) = http_push {
+        let local_git_dir = git_repo.git_dir().to_path_buf();
+        crate::git_local::push_http(&local_git_dir, &remote_url, &refs_to_push, &fetch_refspecs)
             .map_err(|err| {
                 GitPushError::Subprocess(GitSubprocessError::External(err.to_string()))
             })?

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -3427,7 +3427,11 @@ pub fn push_updates(
             })
     } else {
         None
-    };
+    }
+    // The in-process path does not run the remote's receive hooks; route pushes
+    // to a remote that has any to the subprocess path so the hooks run (and can
+    // reject the push).
+    .filter(|(remote_git_dir, _)| !crate::git_local::remote_has_receive_hooks(remote_git_dir));
 
     let mut push_stats = if let Some((remote_git_dir, fetch_refspecs)) = local_push {
         let local_git_dir = git_repo.git_dir().to_path_buf();

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -3041,46 +3041,72 @@ impl<'a> GitFetch<'a> {
             return Ok(());
         }
 
-        // NOTE: LOCAL (file://) fetches could be routed in-process through
-        // `crate::git_local::fetch_local` here (see `get_default_branch` below,
-        // which already does so for the remote default branch). It is left on the
-        // subprocess path for now because grit-lib's `fetch_local` does not yet
-        // (a) consult the remote's configured tag policy when jj passes no
-        // explicit `fetch_tags` override (so a remote configured with
-        // `tags = All` is not honored), or (b) classify a conflicting tag update
-        // as a clean rejection (it currently errors when the local tag points at
-        // an object the remote lacks). Branch fetching works; once the tag gaps
-        // land in grit-lib the translation helper is ready to adopt.
+        // LOCAL (file://) fetches run in-process through grit-lib instead of a
+        // `git` subprocess. Shallow (depth) fetches stay on the subprocess path,
+        // which grit-lib's `fetch_local` does not yet implement.
+        let local_remote = if depth.is_none() {
+            self.git_repo
+                .try_find_remote(remote_name.as_str())
+                .and_then(|r| r.ok())
+                .and_then(|remote| {
+                    crate::git_local::local_remote_git_dir(&remote, gix::remote::Direction::Fetch)
+                        .map(|dir| (dir, remote.fetch_tags()))
+                })
+        } else {
+            None
+        };
 
         let mut branches_to_prune = Vec::new();
-        // git unfortunately errors out if one of the many refspecs is not found
-        //
-        // our approach is to filter out failures and retry,
-        // until either all have failed or an attempt has succeeded
-        //
-        // even more unfortunately, git errors out one refspec at a time,
-        // meaning that the below cycle runs in O(#failed refspecs)
-        let updates = loop {
-            let status = self.git_ctx.spawn_fetch(
-                remote_name,
+        let updates = if let Some((remote_git_dir, configured_tags)) = local_remote {
+            let local_git_dir = self.git_repo.git_dir().to_path_buf();
+            match crate::git_local::fetch_local(
+                &local_git_dir,
+                &remote_git_dir,
                 &remaining_refspecs,
                 &negative_refspecs,
-                callback,
-                depth,
+                // The subprocess path always fetches with `--prune`; mirror that.
+                true,
                 fetch_tags_override,
-            )?;
-            let failing_refspec = match status {
-                GitFetchStatus::Updates(updates) => break updates,
-                GitFetchStatus::NoRemoteRef(failing_refspec) => failing_refspec,
-            };
-            tracing::debug!(failing_refspec, "failed to fetch ref");
-            remaining_refspecs.retain(|r| r.source.as_ref() != Some(&failing_refspec));
+                configured_tags,
+            )
+            .map_err(|err| {
+                GitFetchError::Subprocess(GitSubprocessError::External(err.to_string()))
+            })? {
+                GitFetchStatus::Updates(updates) => updates,
+                // A refspec that matches no remote ref simply yields no update
+                // for the local path (no subprocess error to recover from).
+                GitFetchStatus::NoRemoteRef(_) => crate::git_subprocess::GitRefUpdates::default(),
+            }
+        } else {
+            // git unfortunately errors out if one of the many refspecs is not found
+            //
+            // our approach is to filter out failures and retry,
+            // until either all have failed or an attempt has succeeded
+            //
+            // even more unfortunately, git errors out one refspec at a time,
+            // meaning that the below cycle runs in O(#failed refspecs)
+            loop {
+                let status = self.git_ctx.spawn_fetch(
+                    remote_name,
+                    &remaining_refspecs,
+                    &negative_refspecs,
+                    callback,
+                    depth,
+                    fetch_tags_override,
+                )?;
+                let failing_refspec = match status {
+                    GitFetchStatus::Updates(updates) => break updates,
+                    GitFetchStatus::NoRemoteRef(failing_refspec) => failing_refspec,
+                };
+                tracing::debug!(failing_refspec, "failed to fetch ref");
+                remaining_refspecs.retain(|r| r.source.as_ref() != Some(&failing_refspec));
 
-            if let Some(branch_name) = failing_refspec.strip_prefix("refs/heads/") {
-                branches_to_prune.push(format!(
-                    "{remote_name}/{branch_name}",
-                    remote_name = remote_name.as_str()
-                ));
+                if let Some(branch_name) = failing_refspec.strip_prefix("refs/heads/") {
+                    branches_to_prune.push(format!(
+                        "{remote_name}/{branch_name}",
+                        remote_name = remote_name.as_str()
+                    ));
+                }
             }
         };
 
@@ -3376,16 +3402,42 @@ pub fn push_updates(
         .map(|full_refspec| RefToPush::new(full_refspec, &qualified_remote_refs_expected_locations))
         .collect();
 
-    // NOTE: the LOCAL (file://) push path could be routed in-process through
-    // `crate::git_local::push_local` here, mirroring the local fetch path. It is
-    // intentionally left on the subprocess path for now: grit-lib's
-    // `push_local` does not yet (a) update the local clone's remote-tracking
-    // refs as a side effect of a successful push, (b) honor the
-    // compare-and-swap "up to date is OK even if the lease expectation differs"
-    // ordering that `git push --force-with-lease` uses, or (c) carry
-    // `--push-option` values. Until those land in grit-lib, push stays on the
-    // subprocess path. The translation helper is ready to adopt when they do.
-    let mut push_stats = git_ctx.spawn_push(remote_name, &refs_to_push, callback, options)?;
+    // LOCAL (file://) pushes run in-process through grit-lib. Pushes carrying
+    // `--push-option` values stay on the subprocess path: those must be forwarded
+    // to the remote's receive hooks (via `GIT_PUSH_OPTION_*`), which the
+    // in-process path does not run.
+    let local_push = if options.remote_push_options.is_empty() {
+        git_repo
+            .try_find_remote(remote_name.as_str())
+            .and_then(|r| r.ok())
+            .and_then(|remote| {
+                crate::git_local::local_remote_git_dir(&remote, gix::remote::Direction::Push).map(
+                    |dir| {
+                        // Git updates a remote-tracking ref after a push only when
+                        // a fetch refspec maps the pushed branch; capture them so
+                        // the in-process path mirrors that.
+                        let fetch_refspecs: Vec<String> = remote
+                            .refspecs(gix::remote::Direction::Fetch)
+                            .iter()
+                            .map(|spec| spec.to_ref().to_bstring().to_string())
+                            .collect();
+                        (dir, fetch_refspecs)
+                    },
+                )
+            })
+    } else {
+        None
+    };
+
+    let mut push_stats = if let Some((remote_git_dir, fetch_refspecs)) = local_push {
+        let local_git_dir = git_repo.git_dir().to_path_buf();
+        crate::git_local::push_local(&local_git_dir, &remote_git_dir, &refs_to_push, &fetch_refspecs)
+            .map_err(|err| {
+                GitPushError::Subprocess(GitSubprocessError::External(err.to_string()))
+            })?
+    } else {
+        git_ctx.spawn_push(remote_name, &refs_to_push, callback, options)?
+    };
     push_stats.pushed.sort();
     push_stats.rejected.sort();
     push_stats.remote_rejected.sort();

--- a/lib/src/git_backend.rs
+++ b/lib/src/git_backend.rs
@@ -179,6 +179,10 @@ pub struct GitBackend {
     shallow_root_ids: OnceLock<Vec<CommitId>>,
     extra_metadata_store: TableStore,
     cached_extra_metadata: Mutex<Option<Arc<ReadonlyTable>>>,
+    // Only consumed by the now-unused subprocess `git gc` path (`run_git_gc`);
+    // the LOCAL gc prunes loose objects in-process via grit-lib. Kept so the
+    // remote-transport path can readopt the subprocess gc.
+    #[expect(dead_code)]
     git_executable: PathBuf,
     write_change_id_header: bool,
 }
@@ -903,6 +907,37 @@ fn recreate_no_gc_refs(
     Ok(())
 }
 
+/// Open a grit-lib [`grit_lib::odb::Odb`] for the given git directory, wiring up
+/// the git dir so the hash algorithm (and any multi-pack-index config) resolves.
+fn grit_local_odb(git_dir: &Path) -> grit_lib::odb::Odb {
+    grit_lib::odb::Odb::new(&git_dir.join("objects")).with_config_git_dir(git_dir.to_path_buf())
+}
+
+/// Collect every ref tip in the git repo as grit-lib object ids, to serve as the
+/// reachable roots for an in-process loose-object prune.
+fn collect_ref_tips(
+    git_repo: &gix::Repository,
+) -> BackendResult<Vec<grit_lib::objects::ObjectId>> {
+    let mut roots = Vec::new();
+    let references = git_repo
+        .references()
+        .map_err(|err| BackendError::Other(err.into()))?;
+    let all = references
+        .all()
+        .map_err(|err| BackendError::Other(err.into()))?;
+    for git_ref in all {
+        let git_ref = git_ref.map_err(BackendError::Other)?;
+        if let Some(id) = git_ref.try_id()
+            && let Ok(oid) = grit_lib::objects::ObjectId::from_bytes(id.as_bytes())
+        {
+            roots.push(oid);
+        }
+    }
+    Ok(roots)
+}
+
+#[expect(dead_code)] // retained for the remote-transport path; the LOCAL gc now
+// prunes loose objects in-process via grit-lib.
 fn run_git_gc(program: &OsStr, git_dir: &Path, keep_newer: SystemTime) -> Result<(), GitGcError> {
     let keep_newer = keep_newer
         .duration_since(SystemTime::UNIX_EPOCH)
@@ -1503,15 +1538,18 @@ impl Backend for GitBackend {
             .gc(&table, keep_newer)
             .map_err(|err| BackendError::Other(err.into()))?;
 
-        run_git_gc(
-            self.git_executable.as_ref(),
-            self.git_repo_path(),
-            keep_newer,
+        // Prune loose unreachable objects in-process via grit-lib instead of
+        // spawning `git gc`. Reachable roots are every ref tip in the git repo,
+        // which includes the no-gc refs just recreated above (so nothing jj
+        // wants to keep is dropped). Packed objects are never touched, and
+        // objects newer than `keep_newer` are kept (the gc.pruneExpire window).
+        let reachable_roots = collect_ref_tips(&git_repo)?;
+        grit_lib::gc::prune_loose_unreachable(
+            &grit_local_odb(self.git_repo_path()),
+            &reachable_roots,
+            Some(keep_newer),
         )
-        .map_err(|err| BackendError::Other(err.into()))?;
-        // Since "git gc" will move loose refs into packed refs, in-memory
-        // packed-refs cache should be invalidated without relying on mtime.
-        git_repo.refs.force_refresh_packed_buffer().ok();
+        .map_err(|err| BackendError::Other(format!("loose prune failed: {err}").into()))?;
         Ok(())
     }
 }

--- a/lib/src/git_local.rs
+++ b/lib/src/git_local.rs
@@ -178,6 +178,16 @@ pub(crate) fn http_remote_url(
     s.to_str().ok().map(|s| s.to_owned())
 }
 
+/// Emit a jj-side `[grit-net]` routing marker (gated by the same `GRIT_NET_DEBUG`
+/// env var as grit-lib's own networking traces, so they interleave). Shows which
+/// remote jj decided to route through grit-lib's in-process transports — the
+/// "before" bookend around grit-lib's own connect/negotiate/done lines.
+fn net_route(msg: impl FnOnce() -> String) {
+    if grit_lib::net_trace::enabled() {
+        grit_lib::net_trace::line(&format!("jj: {}", msg()));
+    }
+}
+
 /// Whether the remote at `remote_git_dir` has any receive hook installed
 /// (`pre-receive`, `update`, `post-receive`). The in-process push path does not
 /// run hooks, so callers route pushes to such remotes through the subprocess
@@ -287,6 +297,7 @@ pub(crate) fn fetch_local(
         ..Default::default()
     };
 
+    net_route(|| format!("fetch (file) {} via grit-lib", remote_git_dir.display()));
     let outcome = grit_lib::transfer::fetch_local(local_git_dir, remote_git_dir, &opts)?;
     fetch_outcome_to_status(outcome)
 }
@@ -339,6 +350,7 @@ pub(crate) fn fetch_git_daemon(
     // handshake and `fetch_remote` runs the v2 `ls-refs` + `command=fetch`
     // negotiation. A server that lacks v2 silently downgrades to v0/v1, which
     // `fetch_remote` also handles, so no explicit fallback is needed here.
+    net_route(|| format!("fetch (git://) {remote_url} via grit-lib"));
     let transport = GitDaemonTransport::new();
     let connect_opts = ConnectOptions {
         protocol_version: 2,
@@ -400,6 +412,7 @@ pub(crate) fn fetch_ssh(
     // Connect over ssh, requesting protocol v2 (git's default for ssh). The
     // transport handles spawning `ssh` per the user's environment; a server that
     // lacks v2 silently downgrades to v0/v1, which `fetch_remote` also handles.
+    net_route(|| format!("fetch (ssh) {remote_url} via grit-lib"));
     let transport = SshTransport::new();
     let connect_opts = ConnectOptions {
         protocol_version: 2,
@@ -512,6 +525,7 @@ pub(crate) fn fetch_http(
     // dispatches on the version reported by the `info/refs` advertisement, so a
     // v0/v1-only server transparently downgrades. The client carries a
     // config-driven credential provider so auth'd remotes work in-process.
+    net_route(|| format!("fetch (http) {remote_url} via grit-lib"));
     let client = http_client_with_credentials(local_git_dir, Some("version=2"));
     let mut progress = NoProgress;
     let outcome = http_fetch(&client, local_git_dir, remote_url, &opts, &mut progress)?;
@@ -594,6 +608,7 @@ pub(crate) fn push_local(
         specs.push(ref_to_push_spec(r)?);
     }
 
+    net_route(|| format!("push (file) {} via grit-lib", remote_git_dir.display()));
     let outcome = grit_lib::transfer::push_local(
         local_git_dir,
         remote_git_dir,
@@ -641,6 +656,7 @@ pub(crate) fn push_git_daemon(
 
     // receive-pack is v0/v1 only; `push_remote` rejects a v2 connection, so
     // connect with the default (protocol_version = 0).
+    net_route(|| format!("push (git://) {remote_url} via grit-lib"));
     let transport = GitDaemonTransport::new();
     let mut conn = transport.connect(remote_url, Service::ReceivePack, &ConnectOptions::default())?;
 
@@ -684,6 +700,7 @@ pub(crate) fn push_ssh(
         specs.push(ref_to_push_spec(r)?);
     }
 
+    net_route(|| format!("push (ssh) {remote_url} via grit-lib"));
     let transport = SshTransport::new();
     let mut conn = transport.connect(remote_url, Service::ReceivePack, &ConnectOptions::default())?;
 
@@ -734,6 +751,7 @@ pub(crate) fn push_http(
     // Receive-pack is protocol v0/v1, so no default `Git-Protocol` header. The
     // client carries a config-driven credential provider so auth'd remotes work
     // in-process.
+    net_route(|| format!("push (http) {remote_url} via grit-lib"));
     let client = http_client_with_credentials(local_git_dir, None);
     let transport = grit_lib::transport::http::SmartHttpTransport::new(client);
     let mut progress = NoProgress;

--- a/lib/src/git_local.rs
+++ b/lib/src/git_local.rs
@@ -20,14 +20,17 @@
 //! paths), plus in-process wire FETCH and PUSH for `git://` (anonymous
 //! Git-daemon), `ssh://` (scp-style included), and `http(s)://` (smart-HTTP)
 //! remotes, all backed by `grit-lib` rather than a `git` subprocess or `gix`
-//! transport. Remotes carrying `--push-option`, shallow/`depth` fetches, and
-//! (for the local path) remotes with receive hooks stay on jj's existing
-//! subprocess path (see [`crate::git_subprocess`]). The functions here
+//! transport. Shallow/`depth` fetches over the wire paths (`git://`, `ssh://`,
+//! `http(s)://`) are also handled in-process; only `file://` shallow fetches and
+//! remotes carrying `--push-option` (and, for the local path, remotes with
+//! receive hooks) stay on jj's existing subprocess path (see
+//! [`crate::git_subprocess`]). The functions here
 //! translate between jj's production types ([`RefSpec`], [`GitFetchStatus`] /
 //! [`GitRefUpdates`], [`GitPushStats`], [`RefToPush`], `RemoteName`) and the
 //! `grit-lib` `transfer` / `fetch` / `gc` APIs, so the orchestration in
 //! [`crate::git`] can adopt them without otherwise changing shape.
 
+use std::num::NonZeroU32;
 use std::path::Path;
 use std::path::PathBuf;
 
@@ -48,6 +51,8 @@ use grit_lib::transport::SshTransport;
 use grit_lib::transport::Transport as _;
 use grit_lib::transport::http::ureq_client::UreqHttpClient;
 use grit_lib::transport::http::http_fetch;
+use grit_lib::config::ConfigSet;
+use grit_lib::credentials::HelperCredentialProvider;
 use grit_lib::fetch::NoProgress;
 use thiserror::Error;
 
@@ -276,6 +281,10 @@ pub(crate) fn fetch_local(
         tags: tag_mode(fetch_tags, configured_tags),
         prune,
         dry_run: false,
+        // The local / file:// path copies the exact object closure and does not
+        // graft, so `depth` (shallow) fetches stay on the subprocess path; the
+        // dispatch in `crate::git` only routes file:// here when `depth.is_none()`.
+        ..Default::default()
     };
 
     let outcome = grit_lib::transfer::fetch_local(local_git_dir, remote_git_dir, &opts)?;
@@ -295,13 +304,16 @@ pub(crate) fn fetch_local(
 ///
 /// Protocol v2 is requested explicitly (git's default for `git://`); the server
 /// silently downgrades to v0/v1 if it lacks v2, and grit-lib handles either.
-/// Shallow/`depth` fetches stay on the subprocess path.
+/// A `depth` (shallow) fetch is forwarded to grit-lib as a `deepen N` request;
+/// `fetch_remote` reads the shallow-info section and updates the local `shallow`
+/// file (both v0/v1 and v2).
 pub(crate) fn fetch_git_daemon(
     local_git_dir: &Path,
     remote_url: &str,
     refspecs: &[RefSpec],
     negative_refspecs: &[NegativeRefSpec],
     prune: bool,
+    depth: Option<NonZeroU32>,
     fetch_tags: Option<FetchTagsOverride>,
     configured_tags: gix::remote::fetch::Tags,
 ) -> Result<GitFetchStatus, GitLocalError> {
@@ -315,6 +327,11 @@ pub(crate) fn fetch_git_daemon(
         tags: tag_mode(fetch_tags, configured_tags),
         prune,
         dry_run: false,
+        // `depth` maps to grit-lib's shallow fetch (`deepen N` over the wire);
+        // `fetch_remote` drives the v2 shallow-info handshake and writes the
+        // local `shallow` file.
+        depth: depth.map(NonZeroU32::get),
+        ..Default::default()
     };
 
     // Connect to the daemon. Request protocol v2 explicitly (git's own default
@@ -351,7 +368,8 @@ pub(crate) fn fetch_git_daemon(
 /// `GIT_PROTOCOL=version=2` into the ssh environment, which OpenSSH forwards
 /// (`SendEnv GIT_PROTOCOL`). A server that lacks v2 ignores it and returns the
 /// classic v0/v1 advertisement, which `fetch_remote` also handles, so no explicit
-/// fallback is needed here. Shallow/`depth` fetches stay on the subprocess path.
+/// fallback is needed here. A `depth` (shallow) fetch is forwarded as a
+/// `deepen N` request and handled in-process by `fetch_remote`.
 ///
 /// Authentication is whatever the user's ssh configuration provides (keys,
 /// agent, `known_hosts`); there is no separate credential handling.
@@ -361,6 +379,7 @@ pub(crate) fn fetch_ssh(
     refspecs: &[RefSpec],
     negative_refspecs: &[NegativeRefSpec],
     prune: bool,
+    depth: Option<NonZeroU32>,
     fetch_tags: Option<FetchTagsOverride>,
     configured_tags: gix::remote::fetch::Tags,
 ) -> Result<GitFetchStatus, GitLocalError> {
@@ -374,6 +393,8 @@ pub(crate) fn fetch_ssh(
         tags: tag_mode(fetch_tags, configured_tags),
         prune,
         dry_run: false,
+        depth: depth.map(NonZeroU32::get),
+        ..Default::default()
     };
 
     // Connect over ssh, requesting protocol v2 (git's default for ssh). The
@@ -407,17 +428,69 @@ pub(crate) fn fetch_ssh(
 /// advertisement and `http_fetch` runs the v2 `ls-refs` + `command=fetch`
 /// negotiation. A server that lacks v2 ignores the header and returns the classic
 /// v0/v1 advertisement, which `http_fetch` also handles, so no explicit fallback
-/// is needed here. Shallow/`depth` fetches stay on the subprocess path.
+/// is needed here. A `depth` (shallow) fetch is forwarded as a `deepen N` request
+/// and handled in-process by `http_fetch` (both the v0/v1 stateless RPC and the
+/// v2 multi-POST flow read the shallow-info section and update `shallow`).
 ///
-/// Credentials: this uses an unauthenticated [`UreqHttpClient`]; on a `401` the
-/// client has no provider and the fetch fails. Remotes requiring auth are left on
-/// the subprocess path by the dispatch in [`crate::git`].
+/// Build a [`UreqHttpClient`] wired with a config-driven credential provider, so
+/// HTTP basic auth on a `401` runs the repo's configured `credential.helper`
+/// programs (e.g. `osxkeychain`) exactly as Git would.
+///
+/// The provider is grit-lib's [`HelperCredentialProvider`], built from the git
+/// config cascade rooted at `local_git_dir` (system + global + repo-local, the
+/// same layers Git reads). It is **non-interactive**: when no configured helper
+/// can supply a usable username/password it surfaces a typed
+/// [`grit_lib::error::Error::Auth`] rather than prompting on a TTY, so an
+/// in-process fetch/push over an auth'd remote fails fast (the caller may then
+/// fall back to the subprocess path) instead of hanging.
+///
+/// If the config cascade cannot be loaded (which should not happen for a valid
+/// repo), the client is built without a provider — unauthenticated requests still
+/// work, and an auth'd remote returns the same typed `Error::Auth`.
+fn http_client_with_credentials(
+    local_git_dir: &Path,
+    git_protocol: Option<&str>,
+) -> UreqHttpClient {
+    // Build the client honoring the repo's HTTP request-shaping config
+    // (`http.proxy`, `http.cookieFile` + `http.saveCookies`, `http.extraHeader`)
+    // via `UreqHttpClient::from_config`, then wire the same config's
+    // `credential.helper` programs for `401` basic auth. Both reuse one loaded
+    // `ConfigSet` (system + global + repo-local, the layers Git reads).
+    //
+    // If the config cannot be loaded — or `from_config` rejects a setting we
+    // cannot honor in-process (e.g. a SOCKS `http.proxy`) — fall back to a plain
+    // client so unauthenticated remotes still work; an auth'd remote then returns
+    // the same typed `Error::Auth`.
+    let client = match ConfigSet::load(Some(local_git_dir), true) {
+        Ok(config) => {
+            let provider = HelperCredentialProvider::new(config.clone());
+            match UreqHttpClient::from_config(&config) {
+                Ok(c) => c.with_credential_provider(Box::new(provider)),
+                Err(_) => UreqHttpClient::with_credentials(Box::new(provider)),
+            }
+        }
+        Err(_) => UreqHttpClient::new(),
+    };
+    match git_protocol {
+        Some(v) => client.with_git_protocol(v.to_owned()),
+        None => client,
+    }
+}
+
+/// Credentials: this builds a [`HelperCredentialProvider`] from the repo's git
+/// config (so `credential.helper` programs such as `osxkeychain` are used) and
+/// wires it into the [`UreqHttpClient`]. On a `401` the client fills/retries; if
+/// no helper can supply credentials it fails with the typed
+/// [`grit_lib::error::Error::Auth`] (non-interactive, never a hang), which the
+/// dispatch in [`crate::git`] may treat as a signal to fall back to the
+/// subprocess path. Unauthenticated remotes are unaffected.
 pub(crate) fn fetch_http(
     local_git_dir: &Path,
     remote_url: &str,
     refspecs: &[RefSpec],
     negative_refspecs: &[NegativeRefSpec],
     prune: bool,
+    depth: Option<NonZeroU32>,
     fetch_tags: Option<FetchTagsOverride>,
     configured_tags: gix::remote::fetch::Tags,
 ) -> Result<GitFetchStatus, GitLocalError> {
@@ -431,12 +504,15 @@ pub(crate) fn fetch_http(
         tags: tag_mode(fetch_tags, configured_tags),
         prune,
         dry_run: false,
+        depth: depth.map(NonZeroU32::get),
+        ..Default::default()
     };
 
     // Request protocol v2 via the `Git-Protocol: version=2` header; `http_fetch`
     // dispatches on the version reported by the `info/refs` advertisement, so a
-    // v0/v1-only server transparently downgrades.
-    let client = UreqHttpClient::new().with_git_protocol("version=2");
+    // v0/v1-only server transparently downgrades. The client carries a
+    // config-driven credential provider so auth'd remotes work in-process.
+    let client = http_client_with_credentials(local_git_dir, Some("version=2"));
     let mut progress = NoProgress;
     let outcome = http_fetch(&client, local_git_dir, remote_url, &opts, &mut progress)?;
     fetch_outcome_to_status(outcome)
@@ -543,13 +619,20 @@ pub(crate) fn push_local(
 /// rejects a v2 connection); connect with [`ConnectOptions::default`]
 /// (`protocol_version = 0`). Unlike the local path there are no hooks to detect
 /// locally: any `pre-receive` / `update` hooks run on the *server*, which can
-/// reject the push (surfaced as a remote rejection); `--push-option` forwarding
-/// still falls back to the subprocess path (see the dispatch in [`crate::git`]).
+/// reject the push (surfaced as a remote rejection).
+///
+/// `push_options` carries `--push-option` values: when non-empty, grit-lib
+/// negotiates the receive-pack `push-options` capability and sends one
+/// `push-option <value>` pkt-line per entry (the server exposes them to its hooks
+/// via `GIT_PUSH_OPTION_*`). If the server does not advertise the capability the
+/// push fails with the typed [`grit_lib::error::Error::PushOptionsUnsupported`]
+/// (surfaced here as [`GitLocalError::Grit`]).
 pub(crate) fn push_git_daemon(
     local_git_dir: &Path,
     remote_url: &str,
     references: &[RefToPush],
     fetch_refspecs: &[String],
+    push_options: &[String],
 ) -> Result<GitPushStats, GitLocalError> {
     let mut specs: Vec<PushRefSpec> = Vec::with_capacity(references.len());
     for r in references {
@@ -566,7 +649,7 @@ pub(crate) fn push_git_daemon(
         local_git_dir,
         conn.as_mut(),
         &specs,
-        &PushOptions::default(),
+        &push_options_with(push_options),
         &mut progress,
     )?;
 
@@ -586,14 +669,15 @@ pub(crate) fn push_git_daemon(
 ///
 /// Protocol v0/v1 only (as for [`push_git_daemon`]); connect with the default
 /// (`protocol_version = 0`) so the transport does not set `GIT_PROTOCOL`. Server
-/// receive hooks run on the remote and may reject the push; `--push-option`
-/// forwarding falls back to the subprocess path. Authentication is whatever the
-/// user's ssh configuration provides.
+/// receive hooks run on the remote and may reject the push. Authentication is
+/// whatever the user's ssh configuration provides. `push_options` is forwarded
+/// over the wire exactly as in [`push_git_daemon`].
 pub(crate) fn push_ssh(
     local_git_dir: &Path,
     remote_url: &str,
     references: &[RefToPush],
     fetch_refspecs: &[String],
+    push_options: &[String],
 ) -> Result<GitPushStats, GitLocalError> {
     let mut specs: Vec<PushRefSpec> = Vec::with_capacity(references.len());
     for r in references {
@@ -608,7 +692,7 @@ pub(crate) fn push_ssh(
         local_git_dir,
         conn.as_mut(),
         &specs,
-        &PushOptions::default(),
+        &push_options_with(push_options),
         &mut progress,
     )?;
 
@@ -628,33 +712,50 @@ pub(crate) fn push_ssh(
 /// local path, including the post-push remote-tracking-ref update.
 ///
 /// Protocol v0/v1 only (grit-lib does not yet implement a v2 `command=push`); a
-/// v2 receive-pack advertisement is rejected by grit-lib. `--push-option`
-/// forwarding and remotes needing auth/receive-hooks stay on the subprocess path
-/// (see the dispatch in [`crate::git`]); this uses an unauthenticated
-/// [`UreqHttpClient`].
+/// v2 receive-pack advertisement is rejected by grit-lib. Remotes with
+/// receive-hooks stay on the subprocess path (see the dispatch in [`crate::git`]).
+/// HTTP basic auth is handled in-process: the client carries a config-driven
+/// [`HelperCredentialProvider`], so a `401` triggers the configured
+/// `credential.helper` programs; a remote whose credentials cannot be supplied
+/// non-interactively fails with the typed [`grit_lib::error::Error::Auth`].
+/// `push_options` is forwarded over the wire exactly as in [`push_git_daemon`].
 pub(crate) fn push_http(
     local_git_dir: &Path,
     remote_url: &str,
     references: &[RefToPush],
     fetch_refspecs: &[String],
+    push_options: &[String],
 ) -> Result<GitPushStats, GitLocalError> {
     let mut specs: Vec<PushRefSpec> = Vec::with_capacity(references.len());
     for r in references {
         specs.push(ref_to_push_spec(r)?);
     }
 
-    let client = UreqHttpClient::new();
+    // Receive-pack is protocol v0/v1, so no default `Git-Protocol` header. The
+    // client carries a config-driven credential provider so auth'd remotes work
+    // in-process.
+    let client = http_client_with_credentials(local_git_dir, None);
     let transport = grit_lib::transport::http::SmartHttpTransport::new(client);
     let mut progress = NoProgress;
     let outcome = transport.push(
         local_git_dir,
         remote_url,
         &specs,
-        &PushOptions::default(),
+        &push_options_with(push_options),
         &mut progress,
     )?;
 
     push_outcome_to_stats(local_git_dir, &outcome, fetch_refspecs)
+}
+
+/// Build a [`PushOptions`] carrying the given server-side `--push-option` values.
+/// Shared by the wire push paths (`git://`, `ssh`, `http`) so the options are
+/// forwarded identically; an empty slice yields the default (no options).
+fn push_options_with(push_options: &[String]) -> PushOptions {
+    PushOptions {
+        push_options: push_options.to_vec(),
+        ..PushOptions::default()
+    }
 }
 
 /// Translate a grit-lib [`grit_lib::transfer::PushOutcome`] into jj's

--- a/lib/src/git_local.rs
+++ b/lib/src/git_local.rs
@@ -16,13 +16,14 @@
 //! remotes, backed by `grit-lib` instead of a `git` subprocess or `gix`
 //! transport.
 //!
-//! Scope: this module covers ONLY the local object+ref copy path. `git://`,
-//! `http(s)`, and `ssh` remotes stay on jj's existing subprocess / `gix` path
-//! (see [`crate::git_subprocess`]). The functions here translate between jj's
-//! production types ([`RefSpec`], [`GitFetchStatus`] / [`GitRefUpdates`],
-//! [`GitPushStats`], [`RefToPush`], `RemoteName`) and the `grit-lib`
-//! `transfer` / `gc` APIs, so the orchestration in [`crate::git`] can adopt them
-//! for local remotes without otherwise changing shape.
+//! Scope: this module covers the local object+ref copy path (`file://` and plain
+//! paths) plus an in-process `git://` (anonymous Git-daemon) FETCH path, both
+//! backed by `grit-lib`. `http(s)` and `ssh` remotes stay on jj's existing
+//! subprocess / `gix` path (see [`crate::git_subprocess`]). The functions here
+//! translate between jj's production types ([`RefSpec`], [`GitFetchStatus`] /
+//! [`GitRefUpdates`], [`GitPushStats`], [`RefToPush`], `RemoteName`) and the
+//! `grit-lib` `transfer` / `fetch` / `gc` APIs, so the orchestration in
+//! [`crate::git`] can adopt them without otherwise changing shape.
 
 use std::path::Path;
 use std::path::PathBuf;
@@ -37,6 +38,11 @@ use grit_lib::transfer::PushRefSpec;
 use grit_lib::transfer::TagMode;
 use grit_lib::transfer::UpdateMode;
 use grit_lib::push_report::PushRefStatus;
+use grit_lib::transport::ConnectOptions;
+use grit_lib::transport::GitDaemonTransport;
+use grit_lib::transport::Service;
+use grit_lib::transport::Transport as _;
+use grit_lib::fetch::NoProgress;
 use thiserror::Error;
 
 use crate::git::FetchTagsOverride;
@@ -88,6 +94,28 @@ pub(crate) fn local_remote_git_dir(
     let raw = url.path.to_str().ok()?;
     let path = PathBuf::from(raw);
     Some(resolve_git_dir(&path))
+}
+
+/// If `remote` is an anonymous `git://` (Git-daemon) remote, return its URL
+/// string in the form `grit_lib::transport::parse_git_url` accepts
+/// (`git://host[:port]/path`). Returns `None` for every other scheme, which stay
+/// on jj's subprocess / `gix` transport path.
+///
+/// This is the `git://` analogue of [`local_remote_git_dir`]; only the FETCH
+/// direction is wired in-process (push over `git://` stays on the subprocess
+/// path).
+pub(crate) fn git_daemon_remote_url(
+    remote: &gix::Remote,
+    direction: gix::remote::Direction,
+) -> Option<String> {
+    let url = remote.url(direction)?;
+    if url.scheme != gix::url::Scheme::Git {
+        return None;
+    }
+    // `to_bstring` reproduces the canonical `git://host[:port]/path` form, which
+    // `parse_git_url` parses; require valid UTF-8 (Git daemon URLs always are).
+    let s = url.to_bstring();
+    s.to_str().ok().map(|s| s.to_owned())
 }
 
 /// Whether the remote at `remote_git_dir` has any receive hook installed
@@ -196,6 +224,51 @@ pub(crate) fn fetch_local(
     };
 
     let outcome = grit_lib::transfer::fetch_local(local_git_dir, remote_git_dir, &opts)?;
+    fetch_outcome_to_status(outcome)
+}
+
+/// Fetch from an anonymous `git://` (Git-daemon) remote entirely in process,
+/// over a TCP pkt-line connection, with no `git` subprocess and no `gix`
+/// transport.
+///
+/// This mirrors [`fetch_local`] but drives the wire protocol:
+/// [`grit_lib::transport::GitDaemonTransport`] connects and reads the
+/// advertisement, then [`grit_lib::fetch::fetch_remote`] runs the want/have
+/// negotiation, ingests the pack, and writes the tracking refs. The returned
+/// [`FetchOutcome`] has the same shape as the local path, so
+/// [`fetch_outcome_to_status`] converts it identically.
+///
+/// Only protocol v0/v1 is supported (matching the grit-lib phase-1 wire fetch);
+/// shallow/`depth` fetches stay on the subprocess path.
+pub(crate) fn fetch_git_daemon(
+    local_git_dir: &Path,
+    remote_url: &str,
+    refspecs: &[RefSpec],
+    negative_refspecs: &[NegativeRefSpec],
+    prune: bool,
+    fetch_tags: Option<FetchTagsOverride>,
+    configured_tags: gix::remote::fetch::Tags,
+) -> Result<GitFetchStatus, GitLocalError> {
+    if refspecs.is_empty() {
+        return Ok(GitFetchStatus::Updates(GitRefUpdates::default()));
+    }
+
+    let opts = FetchOptions {
+        refspecs: refspecs.iter().map(|r| r.to_git_format()).collect(),
+        negative_refspecs: negative_refspecs.iter().map(|r| r.to_git_format()).collect(),
+        tags: tag_mode(fetch_tags, configured_tags),
+        prune,
+        dry_run: false,
+    };
+
+    // Connect to the daemon and read the v0/v1 advertisement. Request protocol
+    // v0 (the classic advertisement); fetch_remote rejects v2.
+    let transport = GitDaemonTransport::new();
+    let mut conn = transport.connect(remote_url, Service::UploadPack, &ConnectOptions::default())?;
+
+    let mut progress = NoProgress;
+    let outcome =
+        grit_lib::fetch::fetch_remote(local_git_dir, conn.as_mut(), &opts, &mut progress)?;
     fetch_outcome_to_status(outcome)
 }
 

--- a/lib/src/git_local.rs
+++ b/lib/src/git_local.rs
@@ -90,6 +90,32 @@ pub(crate) fn local_remote_git_dir(
     Some(resolve_git_dir(&path))
 }
 
+/// Whether the remote at `remote_git_dir` has any receive hook installed
+/// (`pre-receive`, `update`, `post-receive`). The in-process push path does not
+/// run hooks, so callers route pushes to such remotes through the subprocess
+/// path, which does (and can also reject the push or forward push options).
+pub(crate) fn remote_has_receive_hooks(remote_git_dir: &Path) -> bool {
+    let hooks = remote_git_dir.join("hooks");
+    ["pre-receive", "update", "post-receive"]
+        .iter()
+        .any(|name| {
+            let p = hooks.join(name);
+            // A hook is active when the file exists and is executable (Git's
+            // `find_hook`). On non-unix, existence is sufficient.
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt as _;
+                std::fs::metadata(&p)
+                    .map(|m| m.is_file() && m.permissions().mode() & 0o111 != 0)
+                    .unwrap_or(false)
+            }
+            #[cfg(not(unix))]
+            {
+                p.is_file()
+            }
+        })
+}
+
 /// Resolve a filesystem repo path to its git directory: `<path>/.git` when that
 /// exists (non-bare working copy), otherwise the path itself (bare repo).
 fn resolve_git_dir(path: &Path) -> PathBuf {

--- a/lib/src/git_local.rs
+++ b/lib/src/git_local.rs
@@ -1,0 +1,318 @@
+// Copyright 2026 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! In-process fetch / push / gc for LOCAL (`file://` and plain path) Git
+//! remotes, backed by `grit-lib` instead of a `git` subprocess or `gix`
+//! transport.
+//!
+//! Scope: this module covers ONLY the local object+ref copy path. `git://`,
+//! `http(s)`, and `ssh` remotes stay on jj's existing subprocess / `gix` path
+//! (see [`crate::git_subprocess`]). The functions here translate between jj's
+//! production types ([`RefSpec`], [`GitFetchStatus`] / [`GitRefUpdates`],
+//! [`GitPushStats`], [`RefToPush`], [`RemoteName`]) and the `grit-lib`
+//! `transfer` / `gc` APIs, so the orchestration in [`crate::git`] can adopt them
+//! for local remotes without otherwise changing shape.
+
+use std::path::Path;
+use std::path::PathBuf;
+
+use bstr::ByteSlice as _;
+
+use grit_lib::objects::ObjectId as GritObjectId;
+use grit_lib::transfer::FetchOptions;
+use grit_lib::transfer::FetchOutcome;
+use grit_lib::transfer::PushOptions;
+use grit_lib::transfer::PushRefSpec;
+use grit_lib::transfer::TagMode;
+use grit_lib::transfer::UpdateMode;
+use grit_lib::push_report::PushRefStatus;
+use thiserror::Error;
+
+use crate::git::FetchTagsOverride;
+use crate::git::GitPushStats;
+use crate::git::NegativeRefSpec;
+use crate::git::RefSpec;
+use crate::git::RefToPush;
+use crate::git_subprocess::GitFetchStatus;
+use crate::git_subprocess::GitRefUpdates;
+use crate::merge::Diff;
+use crate::ref_name::GitRefNameBuf;
+use crate::ref_name::RefNameBuf;
+
+/// Error raised while performing an in-process local-remote operation.
+#[derive(Debug, Error)]
+pub enum GitLocalError {
+    /// The underlying grit-lib operation failed.
+    #[error("local git operation failed: {0}")]
+    Grit(String),
+    /// An object id produced by grit-lib could not be represented as a
+    /// [`gix::ObjectId`] (e.g. unexpected hash width).
+    #[error("invalid object id from local git operation: {0}")]
+    InvalidOid(String),
+}
+
+impl From<grit_lib::error::Error> for GitLocalError {
+    fn from(err: grit_lib::error::Error) -> Self {
+        Self::Grit(err.to_string())
+    }
+}
+
+/// If `remote` is a LOCAL remote (`file://` URL or a bare filesystem path),
+/// return the path to its git directory, suitable for the `grit-lib` local
+/// transfer APIs. Returns `None` for `git://`, `http(s)`, and `ssh` remotes,
+/// which must stay on jj's subprocess / `gix` transport path.
+///
+/// The resolved path is the remote's git directory: the path itself when it is
+/// a bare repo (contains an `objects/` dir), or `<path>/.git` when it is a
+/// non-bare working copy.
+pub(crate) fn local_remote_git_dir(
+    remote: &gix::Remote,
+    direction: gix::remote::Direction,
+) -> Option<PathBuf> {
+    let url = remote.url(direction)?;
+    // Only `file://` and scheme-less local paths are in scope.
+    if url.scheme != gix::url::Scheme::File {
+        return None;
+    }
+    let raw = url.path.to_str().ok()?;
+    let path = PathBuf::from(raw);
+    Some(resolve_git_dir(&path))
+}
+
+/// Resolve a filesystem repo path to its git directory: `<path>/.git` when that
+/// exists (non-bare working copy), otherwise the path itself (bare repo).
+fn resolve_git_dir(path: &Path) -> PathBuf {
+    let dot_git = path.join(".git");
+    if dot_git.is_dir() {
+        dot_git
+    } else {
+        path.to_path_buf()
+    }
+}
+
+/// Convert a grit-lib [`GritObjectId`] into the `gix::ObjectId` jj consumes.
+fn to_gix_oid(oid: &GritObjectId) -> Result<gix::ObjectId, GitLocalError> {
+    gix::ObjectId::try_from(oid.as_bytes())
+        .map_err(|_| GitLocalError::InvalidOid(oid.to_hex()))
+}
+
+/// Convert a `gix::ObjectId` into a grit-lib [`GritObjectId`].
+fn to_grit_oid(oid: &gix::oid) -> Result<GritObjectId, GitLocalError> {
+    GritObjectId::from_bytes(oid.as_bytes()).map_err(|e| GitLocalError::InvalidOid(e.to_string()))
+}
+
+/// The null oid matching the hash width of `sample`, used to fill the side of a
+/// [`Diff`] that has no value (newly created or deleted refs), mirroring how the
+/// subprocess porcelain parser records null oids.
+fn null_gix_oid_like(sample: &gix::oid) -> gix::ObjectId {
+    gix::ObjectId::null(sample.kind())
+}
+
+/// Translate jj's [`FetchTagsOverride`] plus the default behaviour into a
+/// grit-lib [`TagMode`].
+fn tag_mode(fetch_tags: Option<FetchTagsOverride>) -> TagMode {
+    match fetch_tags {
+        Some(FetchTagsOverride::AllTags) => TagMode::All,
+        Some(FetchTagsOverride::NoTags) => TagMode::None,
+        // jj's default fetch follows tags pointing at fetched objects, matching
+        // Git's `--tags`-less default.
+        None => TagMode::Following,
+    }
+}
+
+/// Fetch from a LOCAL remote git directory entirely in process.
+///
+/// `refspecs` / `negative_refspecs` are jj's parsed refspecs; they are rendered
+/// to git-format refspec strings (the exact strings the subprocess path would
+/// hand to `git fetch`) and passed to [`grit_lib::transfer::fetch_local`]. The
+/// returned [`FetchOutcome`] is translated into a [`GitFetchStatus`] carrying a
+/// [`GitRefUpdates`], the same result type the subprocess path produces, so
+/// callers in [`crate::git`] do not branch on the transport.
+///
+/// Adopt-ready but not yet wired into [`crate::git::GitFetch::fetch`]: see the
+/// note there. grit-lib's `fetch_local` does not yet honor a remote's configured
+/// tag policy for the default (no-override) case, nor classify conflicting tag
+/// updates as clean rejections, so local fetch stays on the subprocess path
+/// until those land. Branch fetching through this helper is correct.
+#[expect(dead_code)]
+pub(crate) fn fetch_local(
+    local_git_dir: &Path,
+    remote_git_dir: &Path,
+    refspecs: &[RefSpec],
+    negative_refspecs: &[NegativeRefSpec],
+    prune: bool,
+    fetch_tags: Option<FetchTagsOverride>,
+) -> Result<GitFetchStatus, GitLocalError> {
+    if refspecs.is_empty() {
+        return Ok(GitFetchStatus::Updates(GitRefUpdates::default()));
+    }
+
+    let opts = FetchOptions {
+        refspecs: refspecs.iter().map(|r| r.to_git_format()).collect(),
+        negative_refspecs: negative_refspecs.iter().map(|r| r.to_git_format()).collect(),
+        tags: tag_mode(fetch_tags),
+        prune,
+        dry_run: false,
+    };
+
+    let outcome = grit_lib::transfer::fetch_local(local_git_dir, remote_git_dir, &opts)?;
+    fetch_outcome_to_status(outcome)
+}
+
+/// Translate a grit-lib [`FetchOutcome`] into jj's [`GitFetchStatus`].
+fn fetch_outcome_to_status(outcome: FetchOutcome) -> Result<GitFetchStatus, GitLocalError> {
+    let mut updates = GitRefUpdates::default();
+    for update in &outcome.updates {
+        // The local tracking ref name is what jj records; updates with no local
+        // destination (empty dst refspecs) are not stored and carry no jj-visible
+        // ref change.
+        let Some(local_ref) = &update.local_ref else {
+            continue;
+        };
+        let name: GitRefNameBuf = local_ref.as_str().into();
+
+        // Fill each missing side with a null oid of the present side's hash
+        // width (both sides null is unexpected; default to SHA-1 null).
+        let (old, new) = match (&update.old_oid, &update.new_oid) {
+            (Some(o), Some(n)) => (to_gix_oid(o)?, to_gix_oid(n)?),
+            (Some(o), None) => {
+                let o = to_gix_oid(o)?;
+                (o, null_gix_oid_like(&o))
+            }
+            (None, Some(n)) => {
+                let n = to_gix_oid(n)?;
+                (null_gix_oid_like(&n), n)
+            }
+            (None, None) => (
+                gix::ObjectId::null(gix::hash::Kind::Sha1),
+                gix::ObjectId::null(gix::hash::Kind::Sha1),
+            ),
+        };
+        let diff = Diff::new(old, new);
+
+        match update.mode {
+            // Successfully applied updates (new / fast-forward / forced) and
+            // pruned refs are recorded as `updated`, matching the subprocess
+            // porcelain flags ' ', '+', '-', 't', '*'.
+            UpdateMode::New
+            | UpdateMode::FastForward
+            | UpdateMode::Forced
+            | UpdateMode::DeletedMissing => updates.updated.push((name, diff)),
+            // Rejections map to `rejected`, matching porcelain flag '!'.
+            UpdateMode::NonFastForwardRejected
+            | UpdateMode::TagUpdateRejected
+            | UpdateMode::SourceObjectNotFound => updates.rejected.push((name, diff)),
+            // No jj-visible change.
+            UpdateMode::UpToDate
+            | UpdateMode::NoChangeNeeded
+            | UpdateMode::Unborn => {}
+        }
+    }
+    Ok(GitFetchStatus::Updates(updates))
+}
+
+/// Push to a LOCAL remote git directory entirely in process.
+///
+/// Each [`RefToPush`] carries the jj [`RefSpec`] (source object / destination /
+/// force) and the expected-old-id used for compare-and-swap (force-with-lease).
+/// These are mapped to grit-lib [`PushRefSpec`]s and the
+/// [`grit_lib::transfer::PushOutcome`] is translated back into jj's
+/// [`GitPushStats`].
+///
+/// Adopt-ready but not yet wired into [`crate::git::push_updates`]: see the note
+/// there. grit-lib's `push_local` does not yet update the local clone's
+/// remote-tracking refs, honor the force-with-lease "up-to-date is OK" ordering,
+/// or carry `--push-option` values, so local push stays on the subprocess path
+/// until those land.
+#[expect(dead_code)]
+pub(crate) fn push_local(
+    local_git_dir: &Path,
+    remote_git_dir: &Path,
+    references: &[RefToPush],
+) -> Result<GitPushStats, GitLocalError> {
+    let mut specs: Vec<PushRefSpec> = Vec::with_capacity(references.len());
+    for r in references {
+        specs.push(ref_to_push_spec(r)?);
+    }
+
+    let outcome = grit_lib::transfer::push_local(
+        local_git_dir,
+        remote_git_dir,
+        &specs,
+        &PushOptions::default(),
+    )?;
+
+    let mut stats = GitPushStats::default();
+    for result in &outcome.results {
+        let name: GitRefNameBuf = result.remote_ref.as_str().into();
+        match result.status {
+            PushRefStatus::Ok | PushRefStatus::UpToDate => stats.pushed.push(name),
+            // Client-side rejections (lease / non-fast-forward / needs-force).
+            PushRefStatus::RejectStale
+            | PushRefStatus::RejectNonFastForward
+            | PushRefStatus::RejectNeedsForce
+            | PushRefStatus::RejectAlreadyExists
+            | PushRefStatus::RejectFetchFirst
+            | PushRefStatus::AtomicPushFailed => {
+                stats.rejected.push((name, result.message.clone()));
+            }
+            // Declined by the remote side.
+            PushRefStatus::RemoteRejected => {
+                stats.remote_rejected.push((name, result.message.clone()));
+            }
+        }
+    }
+    Ok(stats)
+}
+
+/// Build a grit-lib [`PushRefSpec`] from a jj [`RefToPush`].
+fn ref_to_push_spec(r: &RefToPush) -> Result<PushRefSpec, GitLocalError> {
+    let spec = r.refspec;
+    // A refspec with no source side is a deletion (`:refs/heads/foo`).
+    let delete = spec.source().is_none();
+    let src = match spec.source() {
+        Some(s) => Some(resolve_source_oid(s)?),
+        None => None,
+    };
+    // force-with-lease: the expected current value of the remote ref. `None`
+    // (absent expected location) disables the CAS check, as in the subprocess
+    // `--force-with-lease=<ref>:` form.
+    let expected_old = match r.expected_location {
+        Some(oid) => Some(to_grit_oid(oid)?),
+        None => None,
+    };
+    Ok(PushRefSpec {
+        src,
+        dst: spec.destination().to_owned(),
+        force: spec.is_forced(),
+        delete,
+        expected_old,
+    })
+}
+
+/// Resolve a refspec source (a hex object id, as jj always uses for push) to a
+/// grit-lib object id.
+fn resolve_source_oid(source: &str) -> Result<GritObjectId, GitLocalError> {
+    GritObjectId::from_hex(source)
+        .map_err(|_| GitLocalError::InvalidOid(source.to_owned()))
+}
+
+/// The default branch of a LOCAL remote, replacing `git remote show <remote>`'s
+/// HEAD-symref line for local remotes.
+pub(crate) fn remote_default_branch_local(
+    remote_git_dir: &Path,
+) -> Result<Option<RefNameBuf>, GitLocalError> {
+    let branch = grit_lib::gc::remote_default_branch_local(remote_git_dir)?;
+    Ok(branch.map(|b| b.as_str().into()))
+}

--- a/lib/src/git_local.rs
+++ b/lib/src/git_local.rs
@@ -20,7 +20,7 @@
 //! `http(s)`, and `ssh` remotes stay on jj's existing subprocess / `gix` path
 //! (see [`crate::git_subprocess`]). The functions here translate between jj's
 //! production types ([`RefSpec`], [`GitFetchStatus`] / [`GitRefUpdates`],
-//! [`GitPushStats`], [`RefToPush`], [`RemoteName`]) and the `grit-lib`
+//! [`GitPushStats`], [`RefToPush`], `RemoteName`) and the `grit-lib`
 //! `transfer` / `gc` APIs, so the orchestration in [`crate::git`] can adopt them
 //! for local remotes without otherwise changing shape.
 
@@ -119,15 +119,20 @@ fn null_gix_oid_like(sample: &gix::oid) -> gix::ObjectId {
     gix::ObjectId::null(sample.kind())
 }
 
-/// Translate jj's [`FetchTagsOverride`] plus the default behaviour into a
-/// grit-lib [`TagMode`].
-fn tag_mode(fetch_tags: Option<FetchTagsOverride>) -> TagMode {
+/// Translate jj's [`FetchTagsOverride`] into a grit-lib [`TagMode`]. With no
+/// explicit override, fall back to the remote's configured tag policy
+/// (`remote.<name>.tagOpt`), exactly as the subprocess path lets `git fetch`
+/// consult it.
+fn tag_mode(fetch_tags: Option<FetchTagsOverride>, configured: gix::remote::fetch::Tags) -> TagMode {
     match fetch_tags {
         Some(FetchTagsOverride::AllTags) => TagMode::All,
         Some(FetchTagsOverride::NoTags) => TagMode::None,
-        // jj's default fetch follows tags pointing at fetched objects, matching
-        // Git's `--tags`-less default.
-        None => TagMode::Following,
+        None => match configured {
+            gix::remote::fetch::Tags::All => TagMode::All,
+            gix::remote::fetch::Tags::None => TagMode::None,
+            // Git's default: follow tags pointing at fetched objects.
+            gix::remote::fetch::Tags::Included => TagMode::Following,
+        },
     }
 }
 
@@ -140,12 +145,9 @@ fn tag_mode(fetch_tags: Option<FetchTagsOverride>) -> TagMode {
 /// [`GitRefUpdates`], the same result type the subprocess path produces, so
 /// callers in [`crate::git`] do not branch on the transport.
 ///
-/// Adopt-ready but not yet wired into [`crate::git::GitFetch::fetch`]: see the
-/// note there. grit-lib's `fetch_local` does not yet honor a remote's configured
-/// tag policy for the default (no-override) case, nor classify conflicting tag
-/// updates as clean rejections, so local fetch stays on the subprocess path
-/// until those land. Branch fetching through this helper is correct.
-#[expect(dead_code)]
+/// Wired into [`crate::git::GitFetch::fetch`] for local remotes (shallow/`depth`
+/// fetches still use the subprocess path). `configured_tags` is the remote's
+/// `tagOpt` policy, consulted when no explicit `fetch_tags` override is given.
 pub(crate) fn fetch_local(
     local_git_dir: &Path,
     remote_git_dir: &Path,
@@ -153,6 +155,7 @@ pub(crate) fn fetch_local(
     negative_refspecs: &[NegativeRefSpec],
     prune: bool,
     fetch_tags: Option<FetchTagsOverride>,
+    configured_tags: gix::remote::fetch::Tags,
 ) -> Result<GitFetchStatus, GitLocalError> {
     if refspecs.is_empty() {
         return Ok(GitFetchStatus::Updates(GitRefUpdates::default()));
@@ -161,7 +164,7 @@ pub(crate) fn fetch_local(
     let opts = FetchOptions {
         refspecs: refspecs.iter().map(|r| r.to_git_format()).collect(),
         negative_refspecs: negative_refspecs.iter().map(|r| r.to_git_format()).collect(),
-        tags: tag_mode(fetch_tags),
+        tags: tag_mode(fetch_tags, configured_tags),
         prune,
         dry_run: false,
     };
@@ -230,16 +233,16 @@ fn fetch_outcome_to_status(outcome: FetchOutcome) -> Result<GitFetchStatus, GitL
 /// [`grit_lib::transfer::PushOutcome`] is translated back into jj's
 /// [`GitPushStats`].
 ///
-/// Adopt-ready but not yet wired into [`crate::git::push_updates`]: see the note
-/// there. grit-lib's `push_local` does not yet update the local clone's
-/// remote-tracking refs, honor the force-with-lease "up-to-date is OK" ordering,
-/// or carry `--push-option` values, so local push stays on the subprocess path
-/// until those land.
-#[expect(dead_code)]
+/// On a successful push, Git updates the local clone's remote-tracking ref for
+/// the pushed branch (`refs/heads/<b>` → `refs/remotes/<remote>/<b>`); this
+/// helper mirrors that so jj's import sees the same state as a subprocess push.
+/// `--push-option` forwarding to remote hooks is not handled here: callers route
+/// pushes that carry push options to the subprocess path.
 pub(crate) fn push_local(
     local_git_dir: &Path,
     remote_git_dir: &Path,
     references: &[RefToPush],
+    fetch_refspecs: &[String],
 ) -> Result<GitPushStats, GitLocalError> {
     let mut specs: Vec<PushRefSpec> = Vec::with_capacity(references.len());
     for r in references {
@@ -254,10 +257,26 @@ pub(crate) fn push_local(
     )?;
 
     let mut stats = GitPushStats::default();
+    let mut tracking_updates: Vec<grit_lib::gc::RefTransactionItem> = Vec::new();
     for result in &outcome.results {
         let name: GitRefNameBuf = result.remote_ref.as_str().into();
         match result.status {
-            PushRefStatus::Ok | PushRefStatus::UpToDate => stats.pushed.push(name),
+            PushRefStatus::Ok | PushRefStatus::UpToDate => {
+                // Update the local clone's remote-tracking ref for a pushed
+                // branch, but only when a fetch refspec maps it — exactly as Git
+                // does after a push (a remote with a narrow fetch refspec leaves
+                // unmapped tracking refs untouched).
+                if let Some(tracking) = mapped_tracking_ref(&result.remote_ref, fetch_refspecs) {
+                    tracking_updates.push(grit_lib::gc::RefTransactionItem {
+                        name: tracking,
+                        // Deletion clears the tracking ref; otherwise point it at
+                        // the just-pushed object.
+                        new_oid: if result.deletion { None } else { result.new_oid },
+                        expected_old: None,
+                    });
+                }
+                stats.pushed.push(name);
+            }
             // Client-side rejections (lease / non-fast-forward / needs-force).
             PushRefStatus::RejectStale
             | PushRefStatus::RejectNonFastForward
@@ -273,7 +292,44 @@ pub(crate) fn push_local(
             }
         }
     }
+
+    if !tracking_updates.is_empty() {
+        grit_lib::gc::update_refs(local_git_dir, &tracking_updates)?;
+    }
     Ok(stats)
+}
+
+/// Map a just-pushed ref (e.g. `refs/heads/main`) to the local remote-tracking
+/// ref a fetch refspec would place it under (e.g. `refs/remotes/origin/main`),
+/// or `None` when no fetch refspec maps it. This mirrors Git updating only the
+/// tracking refs covered by the remote's fetch refspecs after a push.
+fn mapped_tracking_ref(pushed_ref: &str, fetch_refspecs: &[String]) -> Option<String> {
+    for spec in fetch_refspecs {
+        let body = spec.strip_prefix('+').unwrap_or(spec);
+        let Some((src, dst)) = body.split_once(':') else {
+            continue;
+        };
+        if dst.is_empty() {
+            continue;
+        }
+        if let Some(star) = src.find('*') {
+            // Wildcard refspec: match the fixed prefix/suffix and substitute the
+            // captured segment into the destination's `*`.
+            let (prefix, suffix) = (&src[..star], &src[star + 1..]);
+            if pushed_ref.len() >= prefix.len() + suffix.len()
+                && pushed_ref.starts_with(prefix)
+                && pushed_ref.ends_with(suffix)
+            {
+                let middle = &pushed_ref[prefix.len()..pushed_ref.len() - suffix.len()];
+                if let Some(dstar) = dst.find('*') {
+                    return Some(format!("{}{}{}", &dst[..dstar], middle, &dst[dstar + 1..]));
+                }
+            }
+        } else if src == pushed_ref {
+            return Some(dst.to_owned());
+        }
+    }
+    None
 }
 
 /// Build a grit-lib [`PushRefSpec`] from a jj [`RefToPush`].
@@ -285,9 +341,11 @@ fn ref_to_push_spec(r: &RefToPush) -> Result<PushRefSpec, GitLocalError> {
         Some(s) => Some(resolve_source_oid(s)?),
         None => None,
     };
-    // force-with-lease: the expected current value of the remote ref. `None`
-    // (absent expected location) disables the CAS check, as in the subprocess
-    // `--force-with-lease=<ref>:` form.
+    // force-with-lease: jj always pushes with a lease equal to its view of the
+    // remote ref. `Some(oid)` expects that value; `None` expects the ref to be
+    // *absent* (jj has no remote-tracking entry for it). The subprocess path
+    // expresses these as `--force-with-lease=<ref>:<oid>` and `=<ref>:` (empty,
+    // i.e. must not exist) respectively.
     let expected_old = match r.expected_location {
         Some(oid) => Some(to_grit_oid(oid)?),
         None => None,
@@ -298,6 +356,7 @@ fn ref_to_push_spec(r: &RefToPush) -> Result<PushRefSpec, GitLocalError> {
         force: spec.is_forced(),
         delete,
         expected_old,
+        expect_absent: r.expected_location.is_none(),
     })
 }
 

--- a/lib/src/git_local.rs
+++ b/lib/src/git_local.rs
@@ -17,9 +17,12 @@
 //! transport.
 //!
 //! Scope: this module covers the local object+ref copy path (`file://` and plain
-//! paths) plus an in-process `git://` (anonymous Git-daemon) FETCH path, both
-//! backed by `grit-lib`. `http(s)` and `ssh` remotes stay on jj's existing
-//! subprocess / `gix` path (see [`crate::git_subprocess`]). The functions here
+//! paths), plus in-process wire FETCH and PUSH for `git://` (anonymous
+//! Git-daemon), `ssh://` (scp-style included), and `http(s)://` (smart-HTTP)
+//! remotes, all backed by `grit-lib` rather than a `git` subprocess or `gix`
+//! transport. Remotes carrying `--push-option`, shallow/`depth` fetches, and
+//! (for the local path) remotes with receive hooks stay on jj's existing
+//! subprocess path (see [`crate::git_subprocess`]). The functions here
 //! translate between jj's production types ([`RefSpec`], [`GitFetchStatus`] /
 //! [`GitRefUpdates`], [`GitPushStats`], [`RefToPush`], `RemoteName`) and the
 //! `grit-lib` `transfer` / `fetch` / `gc` APIs, so the orchestration in
@@ -41,7 +44,10 @@ use grit_lib::push_report::PushRefStatus;
 use grit_lib::transport::ConnectOptions;
 use grit_lib::transport::GitDaemonTransport;
 use grit_lib::transport::Service;
+use grit_lib::transport::SshTransport;
 use grit_lib::transport::Transport as _;
+use grit_lib::transport::http::ureq_client::UreqHttpClient;
+use grit_lib::transport::http::http_fetch;
 use grit_lib::fetch::NoProgress;
 use thiserror::Error;
 
@@ -114,6 +120,55 @@ pub(crate) fn git_daemon_remote_url(
     }
     // `to_bstring` reproduces the canonical `git://host[:port]/path` form, which
     // `parse_git_url` parses; require valid UTF-8 (Git daemon URLs always are).
+    let s = url.to_bstring();
+    s.to_str().ok().map(|s| s.to_owned())
+}
+
+/// If `remote` is an `ssh://` (or scp-style `host:path`) remote, return its URL
+/// string in the form `grit_lib::transport::parse_ssh_url` accepts. Returns
+/// `None` for every other scheme, which stay on jj's subprocess / `gix`
+/// transport path.
+///
+/// This is the `ssh` analogue of [`git_daemon_remote_url`]: it covers both the
+/// FETCH ([`fetch_ssh`], protocol v2) and PUSH ([`push_ssh`], protocol v0/v1)
+/// directions. grit-lib's `SshTransport` spawns `ssh` exactly as Git does
+/// (`GIT_SSH_COMMAND` / `GIT_SSH` / `ssh`), so authentication is delegated to the
+/// user's ssh configuration — no separate credential handling is needed here.
+pub(crate) fn ssh_remote_url(
+    remote: &gix::Remote,
+    direction: gix::remote::Direction,
+) -> Option<String> {
+    let url = remote.url(direction)?;
+    if url.scheme != gix::url::Scheme::Ssh {
+        return None;
+    }
+    // `to_bstring` reproduces the canonical `ssh://[user@]host[:port]/path` form,
+    // which `parse_ssh_url` parses (it also accepts scp-style, but gix normalizes
+    // to the `ssh://` scheme form here); require valid UTF-8 (ssh URLs always
+    // are).
+    let s = url.to_bstring();
+    s.to_str().ok().map(|s| s.to_owned())
+}
+
+/// If `remote` is an `http://` or `https://` (smart-HTTP) remote, return its URL
+/// string in the form `grit-lib`'s smart-HTTP transport accepts
+/// (`http[s]://host[:port]/path`). Returns `None` for every other scheme, which
+/// stay on jj's subprocess / `gix` transport path.
+///
+/// This is the smart-HTTP analogue of [`git_daemon_remote_url`]: it covers both
+/// the FETCH ([`fetch_http`], protocol v2) and PUSH ([`push_http`], protocol
+/// v0/v1) directions.
+pub(crate) fn http_remote_url(
+    remote: &gix::Remote,
+    direction: gix::remote::Direction,
+) -> Option<String> {
+    let url = remote.url(direction)?;
+    if url.scheme != gix::url::Scheme::Https && url.scheme != gix::url::Scheme::Http {
+        return None;
+    }
+    // `to_bstring` reproduces the canonical `http[s]://host[:port]/path` form,
+    // which grit-lib's `http_fetch` / `push_http` consume directly; require valid
+    // UTF-8 (HTTP URLs always are).
     let s = url.to_bstring();
     s.to_str().ok().map(|s| s.to_owned())
 }
@@ -280,6 +335,113 @@ pub(crate) fn fetch_git_daemon(
     fetch_outcome_to_status(outcome)
 }
 
+/// Fetch from an `ssh://` (or scp-style) remote entirely in process, over an ssh
+/// subprocess speaking the Git wire protocol, with no `git` subprocess for the
+/// fetch logic and no `gix` transport.
+///
+/// This mirrors [`fetch_git_daemon`] but the connection is an ssh subprocess:
+/// [`grit_lib::transport::SshTransport`] spawns `ssh <host> git-upload-pack
+/// '<path>'` (resolving the ssh program from `GIT_SSH_COMMAND` / `GIT_SSH`, then
+/// `ssh`, exactly as Git does), reads the advertisement, and
+/// [`grit_lib::fetch::fetch_remote`] runs the want/have negotiation. The returned
+/// [`FetchOutcome`] has the same shape as the other fetch paths, so
+/// [`fetch_outcome_to_status`] converts it identically.
+///
+/// Protocol v2 is requested (git's default for ssh): the transport exports
+/// `GIT_PROTOCOL=version=2` into the ssh environment, which OpenSSH forwards
+/// (`SendEnv GIT_PROTOCOL`). A server that lacks v2 ignores it and returns the
+/// classic v0/v1 advertisement, which `fetch_remote` also handles, so no explicit
+/// fallback is needed here. Shallow/`depth` fetches stay on the subprocess path.
+///
+/// Authentication is whatever the user's ssh configuration provides (keys,
+/// agent, `known_hosts`); there is no separate credential handling.
+pub(crate) fn fetch_ssh(
+    local_git_dir: &Path,
+    remote_url: &str,
+    refspecs: &[RefSpec],
+    negative_refspecs: &[NegativeRefSpec],
+    prune: bool,
+    fetch_tags: Option<FetchTagsOverride>,
+    configured_tags: gix::remote::fetch::Tags,
+) -> Result<GitFetchStatus, GitLocalError> {
+    if refspecs.is_empty() {
+        return Ok(GitFetchStatus::Updates(GitRefUpdates::default()));
+    }
+
+    let opts = FetchOptions {
+        refspecs: refspecs.iter().map(|r| r.to_git_format()).collect(),
+        negative_refspecs: negative_refspecs.iter().map(|r| r.to_git_format()).collect(),
+        tags: tag_mode(fetch_tags, configured_tags),
+        prune,
+        dry_run: false,
+    };
+
+    // Connect over ssh, requesting protocol v2 (git's default for ssh). The
+    // transport handles spawning `ssh` per the user's environment; a server that
+    // lacks v2 silently downgrades to v0/v1, which `fetch_remote` also handles.
+    let transport = SshTransport::new();
+    let connect_opts = ConnectOptions {
+        protocol_version: 2,
+        ..Default::default()
+    };
+    let mut conn = transport.connect(remote_url, Service::UploadPack, &connect_opts)?;
+
+    let mut progress = NoProgress;
+    let outcome =
+        grit_lib::fetch::fetch_remote(local_git_dir, conn.as_mut(), &opts, &mut progress)?;
+    fetch_outcome_to_status(outcome)
+}
+
+/// Fetch from an `http(s)://` (smart-HTTP) remote entirely in process, over
+/// stateless-RPC HTTP requests, with no `git` subprocess and no `gix`
+/// transport.
+///
+/// This mirrors [`fetch_git_daemon`] but drives the smart-HTTP wire protocol via
+/// [`grit_lib::transport::http::http_fetch`]: a `GET info/refs?service=git-upload-pack`
+/// discovery followed by `POST git-upload-pack` negotiation round(s). The
+/// returned [`FetchOutcome`] has the same shape as the other fetch paths, so
+/// [`fetch_outcome_to_status`] converts it identically.
+///
+/// Protocol v2 is requested via the `Git-Protocol: version=2` request header
+/// ([`UreqHttpClient::with_git_protocol`]); a v2 server returns its v2 capability
+/// advertisement and `http_fetch` runs the v2 `ls-refs` + `command=fetch`
+/// negotiation. A server that lacks v2 ignores the header and returns the classic
+/// v0/v1 advertisement, which `http_fetch` also handles, so no explicit fallback
+/// is needed here. Shallow/`depth` fetches stay on the subprocess path.
+///
+/// Credentials: this uses an unauthenticated [`UreqHttpClient`]; on a `401` the
+/// client has no provider and the fetch fails. Remotes requiring auth are left on
+/// the subprocess path by the dispatch in [`crate::git`].
+pub(crate) fn fetch_http(
+    local_git_dir: &Path,
+    remote_url: &str,
+    refspecs: &[RefSpec],
+    negative_refspecs: &[NegativeRefSpec],
+    prune: bool,
+    fetch_tags: Option<FetchTagsOverride>,
+    configured_tags: gix::remote::fetch::Tags,
+) -> Result<GitFetchStatus, GitLocalError> {
+    if refspecs.is_empty() {
+        return Ok(GitFetchStatus::Updates(GitRefUpdates::default()));
+    }
+
+    let opts = FetchOptions {
+        refspecs: refspecs.iter().map(|r| r.to_git_format()).collect(),
+        negative_refspecs: negative_refspecs.iter().map(|r| r.to_git_format()).collect(),
+        tags: tag_mode(fetch_tags, configured_tags),
+        prune,
+        dry_run: false,
+    };
+
+    // Request protocol v2 via the `Git-Protocol: version=2` header; `http_fetch`
+    // dispatches on the version reported by the `info/refs` advertisement, so a
+    // v0/v1-only server transparently downgrades.
+    let client = UreqHttpClient::new().with_git_protocol("version=2");
+    let mut progress = NoProgress;
+    let outcome = http_fetch(&client, local_git_dir, remote_url, &opts, &mut progress)?;
+    fetch_outcome_to_status(outcome)
+}
+
 /// Translate a grit-lib [`FetchOutcome`] into jj's [`GitFetchStatus`].
 fn fetch_outcome_to_status(outcome: FetchOutcome) -> Result<GitFetchStatus, GitLocalError> {
     let mut updates = GitRefUpdates::default();
@@ -363,6 +525,148 @@ pub(crate) fn push_local(
         &PushOptions::default(),
     )?;
 
+    push_outcome_to_stats(local_git_dir, &outcome, fetch_refspecs)
+}
+
+/// Push to an anonymous `git://` (Git-daemon) remote entirely in process, over a
+/// TCP pkt-line connection, with no `git` subprocess and no `gix` transport.
+///
+/// This mirrors [`push_local`] but drives the `git-receive-pack` wire protocol:
+/// [`grit_lib::transport::GitDaemonTransport`] connects and reads the
+/// receive-pack advertisement, then [`grit_lib::push::push_remote`] decides each
+/// update against the advertised remote refs, builds the minimal pack, streams
+/// it, and parses `report-status`. The [`grit_lib::transfer::PushOutcome`] is
+/// translated back by the shared [`push_outcome_to_stats`] exactly like the local
+/// path, including the post-push remote-tracking-ref update.
+///
+/// Protocol v0/v1 only (receive-pack has no v2 serve loop, and `push_remote`
+/// rejects a v2 connection); connect with [`ConnectOptions::default`]
+/// (`protocol_version = 0`). Unlike the local path there are no hooks to detect
+/// locally: any `pre-receive` / `update` hooks run on the *server*, which can
+/// reject the push (surfaced as a remote rejection); `--push-option` forwarding
+/// still falls back to the subprocess path (see the dispatch in [`crate::git`]).
+pub(crate) fn push_git_daemon(
+    local_git_dir: &Path,
+    remote_url: &str,
+    references: &[RefToPush],
+    fetch_refspecs: &[String],
+) -> Result<GitPushStats, GitLocalError> {
+    let mut specs: Vec<PushRefSpec> = Vec::with_capacity(references.len());
+    for r in references {
+        specs.push(ref_to_push_spec(r)?);
+    }
+
+    // receive-pack is v0/v1 only; `push_remote` rejects a v2 connection, so
+    // connect with the default (protocol_version = 0).
+    let transport = GitDaemonTransport::new();
+    let mut conn = transport.connect(remote_url, Service::ReceivePack, &ConnectOptions::default())?;
+
+    let mut progress = NoProgress;
+    let outcome = grit_lib::push::push_remote(
+        local_git_dir,
+        conn.as_mut(),
+        &specs,
+        &PushOptions::default(),
+        &mut progress,
+    )?;
+
+    push_outcome_to_stats(local_git_dir, &outcome, fetch_refspecs)
+}
+
+/// Push to an `ssh://` (or scp-style) remote entirely in process, over an ssh
+/// subprocess speaking `git-receive-pack`, with no `git` subprocess for the push
+/// logic and no `gix` transport.
+///
+/// This mirrors [`push_git_daemon`] but the connection is an ssh subprocess:
+/// [`grit_lib::transport::SshTransport`] spawns `ssh <host> git-receive-pack
+/// '<path>'` (resolving the ssh program from the user's environment exactly as
+/// Git does), and [`grit_lib::push::push_remote`] drives the receive-pack
+/// exchange. The [`grit_lib::transfer::PushOutcome`] is translated back by the
+/// shared [`push_outcome_to_stats`].
+///
+/// Protocol v0/v1 only (as for [`push_git_daemon`]); connect with the default
+/// (`protocol_version = 0`) so the transport does not set `GIT_PROTOCOL`. Server
+/// receive hooks run on the remote and may reject the push; `--push-option`
+/// forwarding falls back to the subprocess path. Authentication is whatever the
+/// user's ssh configuration provides.
+pub(crate) fn push_ssh(
+    local_git_dir: &Path,
+    remote_url: &str,
+    references: &[RefToPush],
+    fetch_refspecs: &[String],
+) -> Result<GitPushStats, GitLocalError> {
+    let mut specs: Vec<PushRefSpec> = Vec::with_capacity(references.len());
+    for r in references {
+        specs.push(ref_to_push_spec(r)?);
+    }
+
+    let transport = SshTransport::new();
+    let mut conn = transport.connect(remote_url, Service::ReceivePack, &ConnectOptions::default())?;
+
+    let mut progress = NoProgress;
+    let outcome = grit_lib::push::push_remote(
+        local_git_dir,
+        conn.as_mut(),
+        &specs,
+        &PushOptions::default(),
+        &mut progress,
+    )?;
+
+    push_outcome_to_stats(local_git_dir, &outcome, fetch_refspecs)
+}
+
+/// Push to an `http(s)://` (smart-HTTP) remote entirely in process, over
+/// stateless-RPC HTTP requests, with no `git` subprocess and no `gix`
+/// transport.
+///
+/// This mirrors [`push_local`] but drives the smart-HTTP wire protocol via
+/// [`grit_lib::transport::http::SmartHttpTransport::push`] (which discovers the
+/// receive-pack advertisement, decides each update, builds the command block +
+/// pack, POSTs `git-receive-pack`, and parses `report-status`). The
+/// [`grit_lib::transfer::PushOutcome`] is translated back into jj's
+/// [`GitPushStats`] by the shared [`push_outcome_to_stats`], exactly like the
+/// local path, including the post-push remote-tracking-ref update.
+///
+/// Protocol v0/v1 only (grit-lib does not yet implement a v2 `command=push`); a
+/// v2 receive-pack advertisement is rejected by grit-lib. `--push-option`
+/// forwarding and remotes needing auth/receive-hooks stay on the subprocess path
+/// (see the dispatch in [`crate::git`]); this uses an unauthenticated
+/// [`UreqHttpClient`].
+pub(crate) fn push_http(
+    local_git_dir: &Path,
+    remote_url: &str,
+    references: &[RefToPush],
+    fetch_refspecs: &[String],
+) -> Result<GitPushStats, GitLocalError> {
+    let mut specs: Vec<PushRefSpec> = Vec::with_capacity(references.len());
+    for r in references {
+        specs.push(ref_to_push_spec(r)?);
+    }
+
+    let client = UreqHttpClient::new();
+    let transport = grit_lib::transport::http::SmartHttpTransport::new(client);
+    let mut progress = NoProgress;
+    let outcome = transport.push(
+        local_git_dir,
+        remote_url,
+        &specs,
+        &PushOptions::default(),
+        &mut progress,
+    )?;
+
+    push_outcome_to_stats(local_git_dir, &outcome, fetch_refspecs)
+}
+
+/// Translate a grit-lib [`grit_lib::transfer::PushOutcome`] into jj's
+/// [`GitPushStats`], and update the local clone's remote-tracking refs for the
+/// pushed branches (only those a fetch refspec maps), exactly as Git does after a
+/// push. Shared by [`push_local`] and [`push_http`] so both transports produce
+/// identical jj-visible state.
+fn push_outcome_to_stats(
+    local_git_dir: &Path,
+    outcome: &grit_lib::transfer::PushOutcome,
+    fetch_refspecs: &[String],
+) -> Result<GitPushStats, GitLocalError> {
     let mut stats = GitPushStats::default();
     let mut tracking_updates: Vec<grit_lib::gc::RefTransactionItem> = Vec::new();
     for result in &outcome.results {

--- a/lib/src/git_local.rs
+++ b/lib/src/git_local.rs
@@ -238,8 +238,9 @@ pub(crate) fn fetch_local(
 /// [`FetchOutcome`] has the same shape as the local path, so
 /// [`fetch_outcome_to_status`] converts it identically.
 ///
-/// Only protocol v0/v1 is supported (matching the grit-lib phase-1 wire fetch);
-/// shallow/`depth` fetches stay on the subprocess path.
+/// Protocol v2 is requested explicitly (git's default for `git://`); the server
+/// silently downgrades to v0/v1 if it lacks v2, and grit-lib handles either.
+/// Shallow/`depth` fetches stay on the subprocess path.
 pub(crate) fn fetch_git_daemon(
     local_git_dir: &Path,
     remote_url: &str,
@@ -261,10 +262,17 @@ pub(crate) fn fetch_git_daemon(
         dry_run: false,
     };
 
-    // Connect to the daemon and read the v0/v1 advertisement. Request protocol
-    // v0 (the classic advertisement); fetch_remote rejects v2.
+    // Connect to the daemon. Request protocol v2 explicitly (git's own default
+    // for `git://` is v2-capable); grit-lib's daemon transport performs the v2
+    // handshake and `fetch_remote` runs the v2 `ls-refs` + `command=fetch`
+    // negotiation. A server that lacks v2 silently downgrades to v0/v1, which
+    // `fetch_remote` also handles, so no explicit fallback is needed here.
     let transport = GitDaemonTransport::new();
-    let mut conn = transport.connect(remote_url, Service::UploadPack, &ConnectOptions::default())?;
+    let connect_opts = ConnectOptions {
+        protocol_version: 2,
+        ..Default::default()
+    };
+    let mut conn = transport.connect(remote_url, Service::UploadPack, &connect_opts)?;
 
     let mut progress = NoProgress;
     let outcome =

--- a/lib/src/git_subprocess.rs
+++ b/lib/src/git_subprocess.rs
@@ -450,7 +450,10 @@ pub struct GitRefUpdates {
     ///
     /// `old_oid`/`new_oid` may be null or point to non-commit objects such as
     /// tags.
-    #[cfg_attr(not(test), expect(dead_code))] // unused as of now
+    // Read by tests and by the in-process local-remote fetch path
+    // (`crate::git_local`); the subprocess fetch orchestration in `crate::git`
+    // does not yet consume it.
+    #[cfg_attr(not(any(test, feature = "git")), expect(dead_code))]
     pub updated: Vec<(GitRefNameBuf, Diff<gix::ObjectId>)>,
     /// Git ref `(name, (old_oid, new_oid)`s that are rejected or failed to
     /// update.

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -61,6 +61,8 @@ pub mod git;
 #[cfg(feature = "git")]
 pub mod git_backend;
 #[cfg(feature = "git")]
+pub(crate) mod git_local;
+#[cfg(feature = "git")]
 mod git_subprocess;
 pub mod gitignore;
 pub mod gpg_signing;

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -7075,3 +7075,600 @@ fn test_fetch_over_git_daemon() -> TestResult {
 
     Ok(())
 }
+
+// ---------------------------------------------------------------------------
+// `http(s)://` (smart-HTTP) FETCH and PUSH through grit-lib's HTTP transport.
+//
+// `GitFetch::fetch` routes an `http(s)://` remote to `git_local::fetch_http`
+// (grit-lib's `http_fetch`, protocol v2: `info/refs` discovery + `command=fetch`
+// POSTs); `push_updates`/`push_refs` routes one to `git_local::push_http`
+// (grit-lib's `push_http`, protocol v0/v1 receive-pack: `info/refs` discovery +
+// a single `git-receive-pack` POST). Neither spawns `git` nor uses a `gix`
+// transport for the wire itself. The only external dependency is the HTTP server
+// fixture (`grit-http-server`); the test skips gracefully when it is missing.
+// ---------------------------------------------------------------------------
+
+/// Locate a grit test-fixture binary (`grit-http-server` or `grit`) in the grit
+/// checkout's `target/{debug,release}`. The override env var (e.g.
+/// `JJ_TEST_GRIT_HTTP_SERVER`, `JJ_TEST_GRIT_BIN`) takes precedence; otherwise
+/// probe the known checkout root used by the workspace `[patch]` in `Cargo.toml`
+/// (`env!("CARGO_MANIFEST_DIR")` here is jj's `lib`, which does not know the grit
+/// path). Returns `None` when no built binary is found, so the test can skip.
+fn find_grit_binary(env_var: &str, name: &str) -> Option<PathBuf> {
+    if let Some(p) = std::env::var_os(env_var) {
+        let p = PathBuf::from(p);
+        if p.is_file() {
+            return Some(p);
+        }
+    }
+    let candidates = [
+        PathBuf::from(format!(
+            "/Users/schacon/projects/grit-claude/target/debug/{name}"
+        )),
+        PathBuf::from(format!(
+            "/Users/schacon/projects/grit-claude/target/release/{name}"
+        )),
+    ];
+    candidates.into_iter().find(|p| p.is_file())
+}
+
+/// Spawn `grit-http-server --root <root> --bind 127.0.0.1:<port>`. The server
+/// shells out to the `grit` binary for upload-pack/receive-pack, located via the
+/// `GUST_BIN` env var (`grit_protocol::grit_executable`).
+fn spawn_grit_http_server(
+    server_bin: &Path,
+    grit_bin: &Path,
+    root: &Path,
+    port: u16,
+) -> Option<std::process::Child> {
+    std::process::Command::new(server_bin)
+        .arg("--root")
+        .arg(root)
+        .arg("--bind")
+        .arg(format!("127.0.0.1:{port}"))
+        .env("GUST_BIN", grit_bin)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .ok()
+}
+
+struct GritHttpServerGuard(std::process::Child);
+impl Drop for GritHttpServerGuard {
+    fn drop(&mut self) {
+        let _unused_kill = self.0.kill();
+        let _unused = self.0.wait();
+    }
+}
+
+#[test]
+fn test_fetch_and_push_over_smart_http() -> TestResult {
+    let Some(server_bin) = find_grit_binary("JJ_TEST_GRIT_HTTP_SERVER", "grit-http-server") else {
+        eprintln!(
+            "SKIP: `grit-http-server` binary not found (build it in the grit checkout or set \
+             JJ_TEST_GRIT_HTTP_SERVER)"
+        );
+        return Ok(());
+    };
+    let Some(grit_bin) = find_grit_binary("JJ_TEST_GRIT_BIN", "grit") else {
+        eprintln!(
+            "SKIP: `grit` binary not found (build it in the grit checkout or set JJ_TEST_GRIT_BIN)"
+        );
+        return Ok(());
+    };
+
+    // A bare source repo under the server root, served at
+    // `http://127.0.0.1:<port>/source.git`.
+    let temp_dir = testutils::new_temp_dir();
+    let root = temp_dir.path().join("srv");
+    std::fs::create_dir_all(&root)?;
+    let source_dir = root.join("source.git");
+    let source = testutils::git::init_bare(&source_dir);
+    let initial = empty_git_commit(&source, "refs/heads/main", &[]);
+    let topic = empty_git_commit(&source, "refs/heads/topic", &[initial]);
+    testutils::git::set_symbolic_reference(&source, "HEAD", "refs/heads/main");
+
+    let Some(port) = git_daemon_free_port() else {
+        eprintln!("SKIP: could not find a free port for grit-http-server");
+        return Ok(());
+    };
+    let Some(child) = spawn_grit_http_server(&server_bin, &grit_bin, &root, port) else {
+        eprintln!("SKIP: could not spawn grit-http-server");
+        return Ok(());
+    };
+    let _guard = GritHttpServerGuard(child);
+    if !git_daemon_wait_ready(port) {
+        eprintln!("SKIP: grit-http-server did not become ready on port {port}");
+        return Ok(());
+    }
+
+    // A jj repo whose `origin` remote is the smart-HTTP URL.
+    let test_repo = TestRepo::init_with_backend(TestRepoBackend::Git);
+    let url = format!("http://127.0.0.1:{port}/source.git");
+
+    let mut tx = test_repo.repo.start_transaction();
+    git::add_remote(
+        tx.repo_mut(),
+        "origin".as_ref(),
+        &url,
+        None,
+        gix::remote::fetch::Tags::All,
+    )?;
+    let _repo = tx.commit("add remote").block_on()?;
+    // Reload after the Git config change so the remote is visible.
+    let repo = test_repo
+        .env
+        .load_repo_at_head(&testutils::user_settings(), test_repo.repo_path());
+
+    // --- FETCH over smart HTTP -------------------------------------------------
+    // With an `http://` remote and no depth, this dispatches to
+    // git_local::fetch_http (grit-lib smart-HTTP transport, protocol v2).
+    let subprocess_options = GitSubprocessOptions::from_settings(repo.settings())?;
+    let import_options = auto_track_import_options();
+    let mut tx = repo.start_transaction();
+    let mut fetcher = GitFetch::new(tx.repo_mut(), subprocess_options.clone(), &import_options)?;
+    fetch_all_with(&mut fetcher, "origin".as_ref())?;
+    let default_branch = fetcher.get_default_branch("origin".as_ref())?;
+    fetcher.import_refs().block_on()?;
+    let repo = tx.commit("fetch").block_on()?;
+
+    // The server advertised HEAD -> refs/heads/main.
+    assert_eq!(default_branch, Some("main".into()));
+
+    let view = repo.view();
+    // Both branches' tips landed via the HTTP wire fetch.
+    assert!(view.heads().contains(&jj_id(topic)));
+    assert_eq!(
+        *view.git_refs(),
+        btreemap! {
+            "refs/remotes/origin/main".into() => RefTarget::normal(jj_id(initial)),
+            "refs/remotes/origin/topic".into() => RefTarget::normal(jj_id(topic)),
+        },
+        "tracking refs for both branches must land via the http:// wire fetch"
+    );
+    // The objects are present locally (the pack was ingested over HTTP).
+    let store = repo.store();
+    assert!(store.get_commit(&jj_id(initial)).is_ok());
+    assert!(store.get_commit(&jj_id(topic)).is_ok());
+
+    // --- PUSH over smart HTTP --------------------------------------------------
+    // Create a child of the fetched `main` and push it. With an `http://` remote
+    // and no push options, this dispatches to git_local::push_http (grit-lib
+    // smart-HTTP receive-pack, protocol v0/v1).
+    let main_commit = store.get_commit(&jj_id(initial))?;
+    let mut tx = repo.start_transaction();
+    let child_of_main = write_random_commit_with_parents(tx.repo_mut(), &[&main_commit]);
+    // jj pushes with a force-with-lease equal to its view of the remote ref;
+    // record that view so the push negotiation's expected-old matches.
+    tx.repo_mut().set_git_ref_target(
+        "refs/remotes/origin/main".as_ref(),
+        RefTarget::normal(main_commit.id().clone()),
+    );
+    tx.repo_mut().set_remote_bookmark(
+        remote_symbol("main", "origin"),
+        RemoteRef {
+            target: RefTarget::normal(main_commit.id().clone()),
+            state: RemoteRefState::Tracked,
+        },
+    );
+
+    let targets = GitPushRefTargets {
+        bookmarks: vec![(
+            "main".into(),
+            Diff::new(
+                Some(main_commit.id().clone()),
+                Some(child_of_main.id().clone()),
+            ),
+        )],
+        tags: vec![],
+    };
+    let stats = git::push_refs(
+        tx.repo_mut(),
+        subprocess_options,
+        "origin".as_ref(),
+        &targets,
+        &mut NullCallback,
+        &GitPushOptions::default(),
+    )?;
+    assert_eq!(
+        stats.pushed,
+        vec![GitRefNameBuf::from("refs/heads/main")],
+        "the HTTP push must report main as pushed (stats: {stats:?})"
+    );
+    assert!(stats.rejected.is_empty(), "no client rejections: {stats:?}");
+    assert!(
+        stats.remote_rejected.is_empty(),
+        "no remote rejections: {stats:?}"
+    );
+
+    // The served bare repo's `refs/heads/main` now points at the pushed child,
+    // and its object is present there (the pack was sent over HTTP).
+    let pushed_oid = git_id(&child_of_main);
+    let server_repo = testutils::git::open(&source_dir);
+    let new_target = server_repo.find_reference("refs/heads/main")?;
+    assert_eq!(
+        new_target.target().id(),
+        pushed_oid,
+        "the http:// push must move the remote's refs/heads/main"
+    );
+    assert!(
+        server_repo.find_object(pushed_oid).is_ok(),
+        "the pushed object must exist in the served repo's object store"
+    );
+
+    // The local clone's remote-tracking ref for main advanced too, exactly as Git
+    // updates it after a push.
+    let view = tx.repo().view();
+    assert_eq!(
+        *view.get_git_ref("refs/remotes/origin/main".as_ref()),
+        RefTarget::normal(child_of_main.id().clone()),
+        "the local remote-tracking ref for main must advance after the http push"
+    );
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// `git://` (anonymous Git-daemon) PUSH through grit-lib's wire transport.
+//
+// `push_refs` now routes a `git://` remote to `git_local::push_git_daemon`,
+// which connects over TCP with `grit_lib::transport::GitDaemonTransport` and
+// drives the `git-receive-pack` exchange with `grit_lib::push::push_remote` —
+// no `git` subprocess and no `gix` transport for the push itself. The only
+// external dependency is the server fixture (`git daemon` with
+// `--enable=receive-pack`); the test skips gracefully when it is unavailable.
+// ---------------------------------------------------------------------------
+
+/// Spawn `git daemon` over `base_path` on `port` with `receive-pack` enabled, so
+/// the daemon accepts anonymous pushes (the default daemon refuses them). Returns
+/// `None` if the binary is missing or cannot be spawned.
+fn spawn_git_daemon_writable(base_path: &Path, port: u16) -> Option<std::process::Child> {
+    std::process::Command::new("git")
+        .arg("daemon")
+        .arg("--listen=127.0.0.1")
+        .arg(format!("--port={port}"))
+        .arg("--reuseaddr")
+        .arg("--export-all")
+        .arg("--enable=receive-pack")
+        .arg(format!("--base-path={}", base_path.display()))
+        .arg(base_path)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .ok()
+}
+
+#[test]
+fn test_push_over_git_daemon() -> TestResult {
+    // A bare source repo with an initial commit on `main`, served at
+    // `git://127.0.0.1:<port>/source.git`. The push advances `main` to a child.
+    let temp_dir = testutils::new_temp_dir();
+    let base = temp_dir.path();
+    let source_dir = base.join("source.git");
+    let source = testutils::git::init_bare(&source_dir);
+    let initial = empty_git_commit(&source, "refs/heads/main", &[]);
+    testutils::git::set_symbolic_reference(&source, "HEAD", "refs/heads/main");
+
+    let Some(port) = git_daemon_free_port() else {
+        eprintln!("SKIP: could not find a free port for git daemon");
+        return Ok(());
+    };
+    let Some(child) = spawn_git_daemon_writable(base, port) else {
+        eprintln!("SKIP: `git daemon` is unavailable");
+        return Ok(());
+    };
+    let _guard = GitDaemonGuard(child);
+    if !git_daemon_wait_ready(port) {
+        eprintln!("SKIP: git daemon did not become ready on port {port}");
+        return Ok(());
+    }
+
+    // A jj repo whose `origin` remote is the anonymous `git://` URL.
+    let test_repo = TestRepo::init_with_backend(TestRepoBackend::Git);
+    let url = format!("git://127.0.0.1:{port}/source.git");
+
+    let mut tx = test_repo.repo.start_transaction();
+    git::add_remote(
+        tx.repo_mut(),
+        "origin".as_ref(),
+        &url,
+        None,
+        gix::remote::fetch::Tags::All,
+    )?;
+    let _repo = tx.commit("add remote").block_on()?;
+    let repo = test_repo
+        .env
+        .load_repo_at_head(&testutils::user_settings(), test_repo.repo_path());
+
+    // Make the just-created `initial` commit available locally so jj can build a
+    // child of it and push both. (We mirror the source repo's object into the
+    // local store via a fetch over the same wire transport, then push a child.)
+    let subprocess_options = GitSubprocessOptions::from_settings(repo.settings())?;
+    let import_options = auto_track_import_options();
+    let mut tx = repo.start_transaction();
+    let mut fetcher = GitFetch::new(tx.repo_mut(), subprocess_options.clone(), &import_options)?;
+    fetch_all_with(&mut fetcher, "origin".as_ref())?;
+    fetcher.import_refs().block_on()?;
+    let repo = tx.commit("fetch").block_on()?;
+
+    let store = repo.store();
+    let main_commit = store.get_commit(&jj_id(initial))?;
+
+    // Create a child of the fetched `main` and push it. With a `git://` remote and
+    // no push options, this dispatches to git_local::push_git_daemon (grit-lib
+    // wire receive-pack, protocol v0/v1).
+    let mut tx = repo.start_transaction();
+    let child_of_main = write_random_commit_with_parents(tx.repo_mut(), &[&main_commit]);
+    // jj pushes with a force-with-lease equal to its view of the remote ref.
+    tx.repo_mut().set_git_ref_target(
+        "refs/remotes/origin/main".as_ref(),
+        RefTarget::normal(main_commit.id().clone()),
+    );
+    tx.repo_mut().set_remote_bookmark(
+        remote_symbol("main", "origin"),
+        RemoteRef {
+            target: RefTarget::normal(main_commit.id().clone()),
+            state: RemoteRefState::Tracked,
+        },
+    );
+
+    let targets = GitPushRefTargets {
+        bookmarks: vec![(
+            "main".into(),
+            Diff::new(
+                Some(main_commit.id().clone()),
+                Some(child_of_main.id().clone()),
+            ),
+        )],
+        tags: vec![],
+    };
+    let stats = git::push_refs(
+        tx.repo_mut(),
+        subprocess_options,
+        "origin".as_ref(),
+        &targets,
+        &mut NullCallback,
+        &GitPushOptions::default(),
+    )?;
+    assert_eq!(
+        stats.pushed,
+        vec![GitRefNameBuf::from("refs/heads/main")],
+        "the git:// push must report main as pushed (stats: {stats:?})"
+    );
+    assert!(stats.rejected.is_empty(), "no client rejections: {stats:?}");
+    assert!(
+        stats.remote_rejected.is_empty(),
+        "no remote rejections: {stats:?}"
+    );
+
+    // The served bare repo's `refs/heads/main` now points at the pushed child, and
+    // its object is present there (the pack was sent over the git:// wire).
+    let pushed_oid = git_id(&child_of_main);
+    let server_repo = testutils::git::open(&source_dir);
+    let new_target = server_repo.find_reference("refs/heads/main")?;
+    assert_eq!(
+        new_target.target().id(),
+        pushed_oid,
+        "the git:// push must move the remote's refs/heads/main"
+    );
+    assert!(
+        server_repo.find_object(pushed_oid).is_ok(),
+        "the pushed object must exist in the served repo's object store"
+    );
+
+    // The local clone's remote-tracking ref for main advanced too.
+    let view = tx.repo().view();
+    assert_eq!(
+        *view.get_git_ref("refs/remotes/origin/main".as_ref()),
+        RefTarget::normal(child_of_main.id().clone()),
+        "the local remote-tracking ref for main must advance after the git:// push"
+    );
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// `ssh://` FETCH and PUSH through grit-lib's ssh transport.
+//
+// `GitFetch::fetch` routes an `ssh://` remote to `git_local::fetch_ssh` (grit-lib
+// `SshTransport` + `fetch_remote`, protocol v2); `push_refs` routes one to
+// `git_local::push_ssh` (`SshTransport` + `push_remote`, protocol v0/v1). Neither
+// spawns `git` for the wire logic nor uses a `gix` transport.
+//
+// There is no real ssh server: as in grit-lib's own `transport_ssh*` tests, we
+// point ssh at a tiny "fake ssh" shell script that ignores the host and execs the
+// remote command (`git-{upload,receive}-pack '<path>'`, rewritten to the `git
+// <service>` subcommand form) *locally*. jj's production path uses
+// `SshTransport::new()`, which resolves ssh from `GIT_SSH_COMMAND`; that env var
+// is a *process global*, so setting it would race the rest of the parallel test
+// suite (and `std::env::set_var` is `unsafe` in edition 2024). This test is
+// therefore GATED behind `JJ_TEST_SSH=1` and must be run in isolation
+// (single-threaded), e.g.
+//   JJ_TEST_SSH=1 cargo test -p jj-lib --features git --test test_git \
+//       test_fetch_and_push_over_ssh -- --test-threads=1
+// It skips (returns early) when the gate is unset or `sh` is unavailable. The
+// `ssh_remote_url` / `fetch_ssh` / `push_ssh` wiring is exercised unconditionally
+// by `cargo check`; this opt-in test proves the wire round-trip end to end.
+// ---------------------------------------------------------------------------
+
+/// Write an executable fake-ssh script (mirrors grit-lib's `transport_ssh*`
+/// fixtures) and return its path, or `None` if it cannot be made executable.
+#[cfg(unix)]
+fn write_fake_ssh_script(dir: &Path) -> Option<PathBuf> {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let script = dir.join("fake-ssh.sh");
+    let body = r#"#!/bin/sh
+# Fake ssh: ignore host/options, run the remote command locally.
+# The remote command is always the last argument.
+cmd=
+for cmd in "$@"; do :; done
+case "$cmd" in
+  "git-upload-pack "*) cmd="git upload-pack ${cmd#git-upload-pack }" ;;
+  "git-receive-pack "*) cmd="git receive-pack ${cmd#git-receive-pack }" ;;
+esac
+eval "exec $cmd" 2>/dev/null
+"#;
+    std::fs::write(&script, body).ok()?;
+    let mut perms = std::fs::metadata(&script).ok()?.permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&script, perms).ok()?;
+    Some(script)
+}
+
+#[cfg(unix)]
+#[test]
+fn test_fetch_and_push_over_ssh() -> TestResult {
+    if std::env::var_os("JJ_TEST_SSH").is_none() {
+        eprintln!(
+            "SKIP: ssh fetch/push test is gated behind JJ_TEST_SSH=1 (sets the process-global \
+             GIT_SSH_COMMAND; run in isolation with --test-threads=1)"
+        );
+        return Ok(());
+    }
+    if std::process::Command::new("sh")
+        .arg("-c")
+        .arg("exit 0")
+        .status()
+        .is_err()
+    {
+        eprintln!("SKIP: no POSIX sh available");
+        return Ok(());
+    }
+
+    // A bare source repo with two branches, pushed-to and fetched-from over the
+    // fake ssh. The path is embedded in the `ssh://git@fakehost<abs-path>` URL;
+    // the fake ssh ignores the host and execs `git {upload,receive}-pack <path>`.
+    let temp_dir = testutils::new_temp_dir();
+    let source_dir = temp_dir.path().join("source.git");
+    let source = testutils::git::init_bare(&source_dir);
+    let initial = empty_git_commit(&source, "refs/heads/main", &[]);
+    let topic = empty_git_commit(&source, "refs/heads/topic", &[initial]);
+    testutils::git::set_symbolic_reference(&source, "HEAD", "refs/heads/main");
+
+    let Some(fake_ssh) = write_fake_ssh_script(temp_dir.path()) else {
+        eprintln!("SKIP: could not create executable fake-ssh script");
+        return Ok(());
+    };
+
+    // Point jj's `SshTransport::new()` (which reads GIT_SSH_COMMAND) at the fake
+    // ssh. SAFETY: not actually safe — `setenv` is not thread-safe; this test is
+    // gated behind JJ_TEST_SSH and must run single-threaded (see the module note).
+    unsafe {
+        std::env::set_var("GIT_SSH_COMMAND", fake_ssh.as_os_str());
+    }
+
+    let abs_path = source_dir.to_str().expect("utf8 path");
+    let url = format!("ssh://git@fakehost{abs_path}");
+
+    let test_repo = TestRepo::init_with_backend(TestRepoBackend::Git);
+    let mut tx = test_repo.repo.start_transaction();
+    git::add_remote(
+        tx.repo_mut(),
+        "origin".as_ref(),
+        &url,
+        None,
+        gix::remote::fetch::Tags::All,
+    )?;
+    let _repo = tx.commit("add remote").block_on()?;
+    let repo = test_repo
+        .env
+        .load_repo_at_head(&testutils::user_settings(), test_repo.repo_path());
+
+    // --- FETCH over ssh --------------------------------------------------------
+    let subprocess_options = GitSubprocessOptions::from_settings(repo.settings())?;
+    let import_options = auto_track_import_options();
+    let mut tx = repo.start_transaction();
+    let mut fetcher = GitFetch::new(tx.repo_mut(), subprocess_options.clone(), &import_options)?;
+    fetch_all_with(&mut fetcher, "origin".as_ref())?;
+    let default_branch = fetcher.get_default_branch("origin".as_ref())?;
+    fetcher.import_refs().block_on()?;
+    let repo = tx.commit("fetch").block_on()?;
+
+    assert_eq!(default_branch, Some("main".into()));
+    let view = repo.view();
+    assert!(view.heads().contains(&jj_id(topic)));
+    assert_eq!(
+        *view.git_refs(),
+        btreemap! {
+            "refs/remotes/origin/main".into() => RefTarget::normal(jj_id(initial)),
+            "refs/remotes/origin/topic".into() => RefTarget::normal(jj_id(topic)),
+        },
+        "tracking refs for both branches must land via the ssh:// wire fetch"
+    );
+    let store = repo.store();
+    assert!(store.get_commit(&jj_id(initial)).is_ok());
+    assert!(store.get_commit(&jj_id(topic)).is_ok());
+
+    // --- PUSH over ssh ---------------------------------------------------------
+    let main_commit = store.get_commit(&jj_id(initial))?;
+    let mut tx = repo.start_transaction();
+    let child_of_main = write_random_commit_with_parents(tx.repo_mut(), &[&main_commit]);
+    tx.repo_mut().set_git_ref_target(
+        "refs/remotes/origin/main".as_ref(),
+        RefTarget::normal(main_commit.id().clone()),
+    );
+    tx.repo_mut().set_remote_bookmark(
+        remote_symbol("main", "origin"),
+        RemoteRef {
+            target: RefTarget::normal(main_commit.id().clone()),
+            state: RemoteRefState::Tracked,
+        },
+    );
+
+    let targets = GitPushRefTargets {
+        bookmarks: vec![(
+            "main".into(),
+            Diff::new(
+                Some(main_commit.id().clone()),
+                Some(child_of_main.id().clone()),
+            ),
+        )],
+        tags: vec![],
+    };
+    let stats = git::push_refs(
+        tx.repo_mut(),
+        subprocess_options,
+        "origin".as_ref(),
+        &targets,
+        &mut NullCallback,
+        &GitPushOptions::default(),
+    )?;
+    assert_eq!(
+        stats.pushed,
+        vec![GitRefNameBuf::from("refs/heads/main")],
+        "the ssh push must report main as pushed (stats: {stats:?})"
+    );
+    assert!(stats.rejected.is_empty(), "no client rejections: {stats:?}");
+    assert!(
+        stats.remote_rejected.is_empty(),
+        "no remote rejections: {stats:?}"
+    );
+
+    let pushed_oid = git_id(&child_of_main);
+    let server_repo = testutils::git::open(&source_dir);
+    let new_target = server_repo.find_reference("refs/heads/main")?;
+    assert_eq!(
+        new_target.target().id(),
+        pushed_oid,
+        "the ssh push must move the remote's refs/heads/main"
+    );
+    assert!(
+        server_repo.find_object(pushed_oid).is_ok(),
+        "the pushed object must exist in the served repo's object store"
+    );
+    let view = tx.repo().view();
+    assert_eq!(
+        *view.get_git_ref("refs/remotes/origin/main".as_ref()),
+        RefTarget::normal(child_of_main.id().clone()),
+        "the local remote-tracking ref for main must advance after the ssh push"
+    );
+
+    // Restore the environment for any subsequent tests in this process.
+    // SAFETY: same caveat as above; gated + single-threaded.
+    unsafe {
+        std::env::remove_var("GIT_SSH_COMMAND");
+    }
+
+    Ok(())
+}

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -64,6 +64,7 @@ use jj_lib::git::IgnoredRefspec;
 use jj_lib::git::IgnoredRefspecs;
 use jj_lib::git::expand_fetch_refspecs;
 use jj_lib::git::load_default_fetch_bookmarks;
+use jj_lib::git::set_remote_urls;
 use jj_lib::git_backend::GitBackend;
 use jj_lib::hex_util;
 use jj_lib::index::ResolvedChangeTargets;
@@ -81,6 +82,8 @@ use jj_lib::ref_name::RemoteRefSymbol;
 use jj_lib::repo::MutableRepo;
 use jj_lib::repo::ReadonlyRepo;
 use jj_lib::repo::Repo as _;
+use jj_lib::repo::RepoLoader;
+use jj_lib::repo::StoreFactories;
 use jj_lib::settings::UserSettings;
 use jj_lib::signing::Signer;
 use jj_lib::str_util::StringExpression;
@@ -7076,6 +7079,179 @@ fn test_fetch_over_git_daemon() -> TestResult {
     Ok(())
 }
 
+/// Spawn `git daemon` over `base_path` on `port` with receive-pack enabled (for
+/// the push path). Returns `None` if the binary is missing or cannot be spawned.
+fn spawn_git_daemon_receive(base_path: &Path, port: u16) -> Option<std::process::Child> {
+    std::process::Command::new("git")
+        .arg("daemon")
+        .arg("--listen=127.0.0.1")
+        .arg(format!("--port={port}"))
+        .arg("--reuseaddr")
+        .arg("--export-all")
+        .arg("--enable=receive-pack")
+        .arg(format!("--base-path={}", base_path.display()))
+        .arg(base_path)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .ok()
+}
+
+// `git://` (anonymous Git-daemon) PUSH carrying `--push-option` through
+// grit-lib's wire transport.
+//
+// `push_updates` routes a `git://` remote (including one carrying push options)
+// to `git_local::push_git_daemon`, which connects over TCP with
+// `grit_lib::transport::GitDaemonTransport` and drives `grit_lib::push::push_remote`
+// with the push options — no `git` subprocess for the push itself. The server's
+// `git-receive-pack` exposes the options to its `pre-receive` hook via
+// `GIT_PUSH_OPTION_*`; the bare remote's hook records them so we can assert they
+// arrived. The only external dependency is the server fixture (`git daemon`); the
+// test skips gracefully when it is unavailable.
+#[test]
+fn test_push_options_over_git_daemon() -> TestResult {
+    let settings = testutils::user_settings();
+    let temp_dir = testutils::new_temp_dir();
+    let setup = set_up_push_repos(&settings, &temp_dir);
+
+    // The bare source repo (`<temp>/source`) is the daemon's served repo. Enable
+    // receive-pack + push-option advertisement, and install a pre-receive hook
+    // that records the options it sees to `<source>/push-options-seen`.
+    let source = &setup.source_repo_dir;
+    let cfg = |args: &[&str]| {
+        std::process::Command::new("git")
+            .current_dir(source)
+            .args(args)
+            .status()
+            .expect("git config");
+    };
+    cfg(&["config", "daemon.receivepack", "true"]);
+    cfg(&["config", "receive.advertisePushOptions", "true"]);
+
+    let seen_file = source.join("push-options-seen");
+    let hook_path = source.join("hooks").join("pre-receive");
+    std::fs::create_dir_all(source.join("hooks")).unwrap();
+    let hook_body = format!(
+        r#"#!/bin/sh
+cat >/dev/null
+{{
+  echo "count=${{GIT_PUSH_OPTION_COUNT:-0}}"
+  i=0
+  while [ "$i" -lt "${{GIT_PUSH_OPTION_COUNT:-0}}" ]; do
+    eval "v=\${{GIT_PUSH_OPTION_$i}}"
+    echo "$i=$v"
+    i=$((i + 1))
+  done
+}} >'{out}'
+exit 0
+"#,
+        out = seen_file.display()
+    );
+    std::fs::write(&hook_path, hook_body).unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(&hook_path).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&hook_path, perms).unwrap();
+    }
+
+    let Some(port) = git_daemon_free_port() else {
+        eprintln!("SKIP: could not find a free port for git daemon");
+        return Ok(());
+    };
+    let Some(child) = spawn_git_daemon_receive(temp_dir.path(), port) else {
+        eprintln!("SKIP: `git daemon` is unavailable");
+        return Ok(());
+    };
+    let _guard = GitDaemonGuard(child);
+    if !git_daemon_wait_ready(port) {
+        eprintln!("SKIP: git daemon did not become ready on port {port}");
+        return Ok(());
+    }
+
+    // Point `origin`'s push URL at the `git://` daemon so `push_updates` routes
+    // to the in-process `push_git_daemon` path. (`set_up_push_repos` already wired
+    // the remote-tracking ref + objects for the file:// fetch URL.)
+    let url = format!("git://127.0.0.1:{port}/source");
+    set_remote_urls(setup.jj_repo.store(), "origin".as_ref(), None, Some(&url))?;
+    // Reload from the file system so the changed git push URL is read by a fresh
+    // GitBackend (the in-memory `gix::Repository` snapshot caches config).
+    // `set_up_push_repos` initialises the jj repo at `<temp>/jj`.
+    let jj_repo_dir = temp_dir.path().join("jj");
+    let jj_repo = RepoLoader::init_from_file_system(
+        &settings,
+        &jj_repo_dir,
+        &StoreFactories::default(),
+    )
+    .unwrap()
+    .load_at_head()
+    .block_on()
+    .unwrap();
+
+    let subprocess_options = GitSubprocessOptions::from_settings(&settings)?;
+    let push_options = GitPushOptions {
+        remote_push_options: vec!["ci.skip".to_owned(), "reviewer=alice".to_owned()],
+    };
+    let stats = git::push_updates(
+        jj_repo.as_ref(),
+        subprocess_options,
+        "origin".as_ref(),
+        &[GitRefUpdate {
+            qualified_name: "refs/heads/main".into(),
+            targets: Diff::new(&setup.main_commit, &setup.child_of_main_commit)
+                .map(|commit| Some(git_id(commit))),
+        }],
+        &mut NullCallback,
+        &push_options,
+    )?;
+
+    // If the daemon refused receive-pack for any reason, skip rather than fail.
+    if !stats.remote_rejected.is_empty() {
+        eprintln!("SKIP: git daemon rejected the receive-pack push: {stats:?}");
+        return Ok(());
+    }
+    assert_eq!(
+        stats.pushed,
+        vec![GitRefNameBuf::from("refs/heads/main")],
+        "main should be pushed over git:// with push options"
+    );
+
+    // The ref advanced on the source repo.
+    let source_repo = testutils::git::open(source);
+    let new_target = source_repo.find_reference("refs/heads/main")?;
+    assert_eq!(
+        new_target.target().id(),
+        git_id(&setup.child_of_main_commit)
+    );
+
+    // The pre-receive hook recorded both push options, in order, via
+    // GIT_PUSH_OPTION_COUNT / GIT_PUSH_OPTION_<n>.
+    let recorded = std::fs::read_to_string(&seen_file)
+        .expect("pre-receive hook should have recorded push options");
+    let mut count_line = None;
+    let mut values: Vec<(usize, String)> = Vec::new();
+    for line in recorded.lines() {
+        if let Some(c) = line.strip_prefix("count=") {
+            count_line = c.trim().parse::<usize>().ok();
+        } else if let Some((idx, val)) = line.split_once('=') {
+            if let Ok(i) = idx.parse::<usize>() {
+                values.push((i, val.to_owned()));
+            }
+        }
+    }
+    values.sort_by_key(|(i, _)| *i);
+    let values: Vec<String> = values.into_iter().map(|(_, v)| v).collect();
+    assert_eq!(count_line, Some(2), "hook should see GIT_PUSH_OPTION_COUNT=2");
+    assert_eq!(
+        values,
+        vec!["ci.skip".to_owned(), "reviewer=alice".to_owned()],
+        "hook should see both push options in order"
+    );
+
+    Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // `http(s)://` (smart-HTTP) FETCH and PUSH through grit-lib's HTTP transport.
 //
@@ -7304,6 +7480,207 @@ fn test_fetch_and_push_over_smart_http() -> TestResult {
         RefTarget::normal(child_of_main.id().clone()),
         "the local remote-tracking ref for main must advance after the http push"
     );
+
+    Ok(())
+}
+
+/// Spawn `grit-http-server --root <root> --bind … --require-auth user:pass`. The
+/// server returns `401` + `WWW-Authenticate: Basic realm="git"` unless the
+/// request carries the matching `Authorization: Basic` header — exercising the
+/// credential / 401-retry path in grit-lib's HTTP client.
+fn spawn_grit_http_server_authed(
+    server_bin: &Path,
+    grit_bin: &Path,
+    root: &Path,
+    port: u16,
+    user_pass: &str,
+) -> Option<std::process::Child> {
+    std::process::Command::new(server_bin)
+        .arg("--root")
+        .arg(root)
+        .arg("--bind")
+        .arg(format!("127.0.0.1:{port}"))
+        .arg("--require-auth")
+        .arg(user_pass)
+        .env("GUST_BIN", grit_bin)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .ok()
+}
+
+// ---------------------------------------------------------------------------
+// HTTP basic auth over the in-process smart-HTTP transport (no `git`
+// subprocess for the wire). `GitFetch::fetch` routes an `http(s)://` remote to
+// `git_local::fetch_http`, which now builds a `HelperCredentialProvider` from
+// the repo's git config and wires it into grit-lib's `UreqHttpClient`. With a
+// configured `credential.helper` that supplies the right username/password, a
+// fetch against a `--require-auth` server succeeds entirely in process; with no
+// helper it fails fast with the typed `Error::Auth` (non-interactive, no hang).
+// The only external dependency is the `grit-http-server` fixture (+ the `grit`
+// binary it shells out to for upload-pack); the test skips when either is
+// missing.
+// ---------------------------------------------------------------------------
+#[test]
+fn test_fetch_over_authed_smart_http_with_config_credential_helper() -> TestResult {
+    let Some(server_bin) = find_grit_binary("JJ_TEST_GRIT_HTTP_SERVER", "grit-http-server") else {
+        eprintln!(
+            "SKIP: `grit-http-server` binary not found (build it in the grit checkout or set \
+             JJ_TEST_GRIT_HTTP_SERVER)"
+        );
+        return Ok(());
+    };
+    let Some(grit_bin) = find_grit_binary("JJ_TEST_GRIT_BIN", "grit") else {
+        eprintln!(
+            "SKIP: `grit` binary not found (build it in the grit checkout or set JJ_TEST_GRIT_BIN)"
+        );
+        return Ok(());
+    };
+
+    // A bare source repo under the server root (built with gix, no `git`
+    // subprocess), served at `http://127.0.0.1:<port>/source.git`.
+    let temp_dir = testutils::new_temp_dir();
+    let root = temp_dir.path().join("srv");
+    std::fs::create_dir_all(&root)?;
+    let source_dir = root.join("source.git");
+    let source = testutils::git::init_bare(&source_dir);
+    let initial = empty_git_commit(&source, "refs/heads/main", &[]);
+    let topic = empty_git_commit(&source, "refs/heads/topic", &[initial]);
+    testutils::git::set_symbolic_reference(&source, "HEAD", "refs/heads/main");
+
+    let Some(port) = git_daemon_free_port() else {
+        eprintln!("SKIP: could not find a free port for grit-http-server");
+        return Ok(());
+    };
+    let Some(child) =
+        spawn_grit_http_server_authed(&server_bin, &grit_bin, &root, port, "alice:s3cr3t")
+    else {
+        eprintln!("SKIP: could not spawn grit-http-server");
+        return Ok(());
+    };
+    let _guard = GritHttpServerGuard(child);
+    if !git_daemon_wait_ready(port) {
+        eprintln!("SKIP: grit-http-server did not become ready on port {port}");
+        return Ok(());
+    }
+
+    let url = format!("http://127.0.0.1:{port}/source.git");
+
+    // --- 1. Without a credential helper, the auth'd fetch must fail (typed) -----
+    // A fresh jj repo with no `credential.helper`: grit-lib's HelperCredentialProvider
+    // finds no helper, returns Error::Auth (non-interactive), which surfaces as a
+    // fetch failure rather than a hang.
+    {
+        let test_repo = TestRepo::init_with_backend(TestRepoBackend::Git);
+        let mut tx = test_repo.repo.start_transaction();
+        git::add_remote(
+            tx.repo_mut(),
+            "origin".as_ref(),
+            &url,
+            None,
+            gix::remote::fetch::Tags::All,
+        )?;
+        let _repo = tx.commit("add remote").block_on()?;
+        let repo = test_repo
+            .env
+            .load_repo_at_head(&testutils::user_settings(), test_repo.repo_path());
+
+        let subprocess_options = GitSubprocessOptions::from_settings(repo.settings())?;
+        let import_options = auto_track_import_options();
+        let mut tx = repo.start_transaction();
+        let mut fetcher =
+            GitFetch::new(tx.repo_mut(), subprocess_options, &import_options)?;
+        let result = fetch_all_with(&mut fetcher, "origin".as_ref());
+        assert!(
+            result.is_err(),
+            "fetch over an auth'd server with no credential helper must fail, not hang or succeed"
+        );
+        let msg = format!("{:?}", result.unwrap_err());
+        assert!(
+            msg.contains("authentication failed") || msg.to_lowercase().contains("auth"),
+            "expected a typed authentication failure, got: {msg}"
+        );
+    }
+
+    // --- 2. With a config `credential.helper`, the auth'd fetch succeeds --------
+    let test_repo = TestRepo::init_with_backend(TestRepoBackend::Git);
+    let mut tx = test_repo.repo.start_transaction();
+    git::add_remote(
+        tx.repo_mut(),
+        "origin".as_ref(),
+        &url,
+        None,
+        gix::remote::fetch::Tags::All,
+    )?;
+    let _repo = tx.commit("add remote").block_on()?;
+
+    // Configure a non-interactive `credential.helper` in the repo's git config
+    // that prints the right username/password. grit-lib's HelperCredentialProvider
+    // (built from this config by git_local::fetch_http) runs it on the 401, so the
+    // retry carries the correct Authorization header. The `!`-form helper is run
+    // via `sh -c "<cmd> <action>"`, printing the credential for `get` (and harmlessly
+    // for store/erase). Written straight into `.git/config` (the same git dir
+    // grit-lib's ConfigSet loads), so no `git` subprocess is involved.
+    let git_dir = get_git_backend(&test_repo.repo).git_repo_path().to_path_buf();
+    {
+        let config_path = git_dir.join("config");
+        let mut existing = std::fs::read_to_string(&config_path).unwrap_or_default();
+        existing.push_str(
+            "\n[credential]\n\thelper = \"!printf 'username=alice\\\\npassword=s3cr3t\\\\n'\"\n",
+        );
+        std::fs::write(&config_path, existing)?;
+    }
+
+    let repo = test_repo
+        .env
+        .load_repo_at_head(&testutils::user_settings(), test_repo.repo_path());
+
+    let subprocess_options = GitSubprocessOptions::from_settings(repo.settings())?;
+    let import_options = auto_track_import_options();
+    let mut tx = repo.start_transaction();
+    let mut fetcher = GitFetch::new(tx.repo_mut(), subprocess_options, &import_options)?;
+    fetch_all_with(&mut fetcher, "origin".as_ref())?;
+    let default_branch = fetcher.get_default_branch("origin".as_ref())?;
+    fetcher.import_refs().block_on()?;
+    let repo = tx.commit("fetch").block_on()?;
+
+    assert_eq!(default_branch, Some("main".into()));
+
+    let view = repo.view();
+    assert!(view.heads().contains(&jj_id(topic)));
+    assert_eq!(
+        *view.git_refs(),
+        btreemap! {
+            "refs/remotes/origin/main".into() => RefTarget::normal(jj_id(initial)),
+            "refs/remotes/origin/topic".into() => RefTarget::normal(jj_id(topic)),
+        },
+        "tracking refs for both branches must land via the authed http:// wire fetch"
+    );
+
+    // The objects landed locally (the pack was ingested over authenticated HTTP).
+    let store = repo.store();
+    assert!(store.get_commit(&jj_id(initial)).is_ok());
+    assert!(store.get_commit(&jj_id(topic)).is_ok());
+
+    // Cross-check against system git's view of the served source: the fetched
+    // tracking tips equal `git rev-parse` of the served branches. (This is the
+    // only place we shell out to `git`, purely as an independent oracle.)
+    for (branch, want) in [("main", initial), ("topic", topic)] {
+        let out = std::process::Command::new("git")
+            .current_dir(&source_dir)
+            .args(["rev-parse", &format!("refs/heads/{branch}")])
+            .output();
+        if let Ok(out) = out {
+            if out.status.success() {
+                let oid_hex = String::from_utf8_lossy(&out.stdout).trim().to_owned();
+                assert_eq!(
+                    oid_hex,
+                    want.to_string(),
+                    "fetched {branch} tip must match system git's view of the source"
+                );
+            }
+        }
+    }
 
     Ok(())
 }
@@ -7668,6 +8045,893 @@ fn test_fetch_and_push_over_ssh() -> TestResult {
     // SAFETY: same caveat as above; gated + single-threaded.
     unsafe {
         std::env::remove_var("GIT_SSH_COMMAND");
+    }
+
+    Ok(())
+}
+
+// ===========================================================================
+// Additional no-external-git fetch/push coverage (added):
+//
+//  * `test_fetch_and_push_over_file_url`        — `file://` (in-process local
+//    transfer) round-trip, cross-checked against system `git` + `git fsck`.
+//  * `test_fetch_shallow_depth_over_git_daemon` — `git://` shallow (`depth=1`)
+//    fetch (D3), asserting jj writes the local `shallow` graft file and records
+//    the shallow tip, cross-checked against system `git`.
+//  * `test_fetch_over_git_daemon_cross_checked` — `git://` fetch whose result is
+//    independently verified with `git rev-parse` + `git fsck` on the *local* jj
+//    git dir (no external `git` for the wire itself, only as an oracle).
+//
+// Each reuses the sibling harness (`git_daemon_free_port`, `spawn_git_daemon`,
+// `GitDaemonGuard`, `empty_git_commit`, `jj_id`/`git_id`, `fetch_all_with`,
+// `auto_track_import_options`). They make real assertions; only the genuinely
+// unavailable fixtures (free port / `git daemon` / `git` oracle) cause a SKIP.
+// ===========================================================================
+
+/// Run `git <args>` in `dir` and return trimmed stdout on success, or `None` if
+/// `git` is unavailable or the command failed (so a cross-check can SKIP rather
+/// than fail when the oracle is missing).
+fn git_oracle(dir: &Path, args: &[&str]) -> Option<String> {
+    let out = std::process::Command::new("git")
+        .current_dir(dir)
+        .args(args)
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    Some(String::from_utf8_lossy(&out.stdout).trim().to_owned())
+}
+
+/// The well-known SHA-1 empty-tree object id. `gix` (like Git itself) treats it
+/// as always-present and never materializes it on disk; `git fsck` on a repo
+/// whose commits point at the empty tree therefore prints a benign
+/// `missing tree 4b825dc6…` line. That is not real corruption, so we ignore it.
+const EMPTY_TREE_SHA1: &str = "4b825dc642cb6eb9a060e54bf8d69288fbee4904";
+
+/// `git fsck --strict` over `git_dir` (a real git directory). Returns `true` if
+/// the object/ref database is well-formed, `false` if `git` flagged genuine
+/// corruption. The benign always-virtual empty-tree "missing tree" notice (see
+/// [`EMPTY_TREE_SHA1`]) is ignored. Returns `None` when `git` is unavailable, so
+/// callers can SKIP that check.
+fn git_fsck_ok(git_dir: &Path) -> Option<bool> {
+    let out = std::process::Command::new("git")
+        .arg("--git-dir")
+        .arg(git_dir)
+        .args(["fsck", "--strict", "--no-dangling"])
+        .output()
+        .ok()?;
+    if out.status.success() {
+        return Some(true);
+    }
+    // Treat a failure caused *only* by the virtual empty tree as OK; any other
+    // reported problem is genuine corruption.
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let only_empty_tree = combined.lines().all(|line| {
+        let line = line.trim();
+        line.is_empty()
+            || line.starts_with("notice:")
+            || (line.starts_with("missing tree") && line.contains(EMPTY_TREE_SHA1))
+    });
+    if !only_empty_tree {
+        eprintln!(
+            "git fsck FAILED ({:?}) for {}:\n--stdout--\n{}\n--stderr--\n{}",
+            out.status,
+            git_dir.display(),
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+    Some(only_empty_tree)
+}
+
+// ---------------------------------------------------------------------------
+// `file://` FETCH and PUSH through grit-lib's in-process local transfer.
+//
+// `GitFetch::fetch` routes a `file://` remote to `git_local::fetch_local` and
+// `push_refs` routes one to `git_local::push_local` (grit-lib's local object +
+// ref copy — no `git` subprocess and no `gix` transport for the transfer). The
+// only external dependency here is the on-disk source repo we build with `gix`;
+// system `git` is used purely as an independent oracle (`rev-parse` + `fsck`).
+// ---------------------------------------------------------------------------
+#[test]
+fn test_fetch_and_push_over_file_url() -> TestResult {
+    // A bare source repo on disk with two branches, addressed as `file://<abs>`.
+    let temp_dir = testutils::new_temp_dir();
+    let source_dir = temp_dir.path().join("source.git");
+    let source = testutils::git::init_bare(&source_dir);
+    let initial = empty_git_commit(&source, "refs/heads/main", &[]);
+    let topic = empty_git_commit(&source, "refs/heads/topic", &[initial]);
+    testutils::git::set_symbolic_reference(&source, "HEAD", "refs/heads/main");
+
+    let abs = source_dir.to_str().expect("utf8 path");
+    let url = format!("file://{abs}");
+
+    // A jj repo whose `origin` remote is the `file://` URL.
+    let test_repo = TestRepo::init_with_backend(TestRepoBackend::Git);
+    let mut tx = test_repo.repo.start_transaction();
+    git::add_remote(
+        tx.repo_mut(),
+        "origin".as_ref(),
+        &url,
+        None,
+        gix::remote::fetch::Tags::All,
+    )?;
+    let _repo = tx.commit("add remote").block_on()?;
+    let repo = test_repo
+        .env
+        .load_repo_at_head(&testutils::user_settings(), test_repo.repo_path());
+
+    // --- FETCH over file:// ----------------------------------------------------
+    // With a `file://` remote and no depth, this dispatches to
+    // git_local::fetch_local (grit-lib in-process local transfer).
+    let subprocess_options = GitSubprocessOptions::from_settings(repo.settings())?;
+    let import_options = auto_track_import_options();
+    let mut tx = repo.start_transaction();
+    let mut fetcher = GitFetch::new(tx.repo_mut(), subprocess_options.clone(), &import_options)?;
+    fetch_all_with(&mut fetcher, "origin".as_ref())?;
+    let default_branch = fetcher.get_default_branch("origin".as_ref())?;
+    fetcher.import_refs().block_on()?;
+    let repo = tx.commit("fetch").block_on()?;
+
+    // HEAD -> refs/heads/main was advertised by the served repo.
+    assert_eq!(default_branch, Some("main".into()));
+
+    let view = repo.view();
+    assert!(view.heads().contains(&jj_id(topic)));
+    assert_eq!(
+        *view.git_refs(),
+        btreemap! {
+            "refs/remotes/origin/main".into() => RefTarget::normal(jj_id(initial)),
+            "refs/remotes/origin/topic".into() => RefTarget::normal(jj_id(topic)),
+        },
+        "tracking refs for both branches must land via the file:// in-process fetch"
+    );
+    let store = repo.store();
+    assert!(store.get_commit(&jj_id(initial)).is_ok());
+    assert!(store.get_commit(&jj_id(topic)).is_ok());
+
+    // Cross-check the fetched tips against system git's view of the source, and
+    // fsck the local jj git dir (the in-process pack ingest must be well-formed).
+    let local_git_dir = get_git_backend(&repo).git_repo_path().to_path_buf();
+    for (branch, want) in [("main", initial), ("topic", topic)] {
+        if let Some(oid_hex) =
+            git_oracle(&source_dir, &["rev-parse", &format!("refs/heads/{branch}")])
+        {
+            assert_eq!(
+                oid_hex,
+                want.to_string(),
+                "fetched {branch} tip must match system git's view of the file:// source"
+            );
+        } else {
+            eprintln!("SKIP cross-check: `git rev-parse` oracle unavailable for {branch}");
+        }
+    }
+    match git_fsck_ok(&local_git_dir) {
+        Some(true) => {}
+        Some(false) => panic!("git fsck reported corruption in the local jj git dir after fetch"),
+        None => eprintln!("SKIP fsck: `git` oracle unavailable"),
+    }
+
+    // --- PUSH over file:// -----------------------------------------------------
+    // Build a child of the fetched `main` and push it. With a `file://` remote and
+    // no push options, this dispatches to git_local::push_local (grit-lib
+    // in-process local ref+object copy).
+    let main_commit = store.get_commit(&jj_id(initial))?;
+    let mut tx = repo.start_transaction();
+    let child_of_main = write_random_commit_with_parents(tx.repo_mut(), &[&main_commit]);
+    // jj pushes with a force-with-lease equal to its view of the remote ref.
+    tx.repo_mut().set_git_ref_target(
+        "refs/remotes/origin/main".as_ref(),
+        RefTarget::normal(main_commit.id().clone()),
+    );
+    tx.repo_mut().set_remote_bookmark(
+        remote_symbol("main", "origin"),
+        RemoteRef {
+            target: RefTarget::normal(main_commit.id().clone()),
+            state: RemoteRefState::Tracked,
+        },
+    );
+
+    let targets = GitPushRefTargets {
+        bookmarks: vec![(
+            "main".into(),
+            Diff::new(
+                Some(main_commit.id().clone()),
+                Some(child_of_main.id().clone()),
+            ),
+        )],
+        tags: vec![],
+    };
+    let stats = git::push_refs(
+        tx.repo_mut(),
+        subprocess_options,
+        "origin".as_ref(),
+        &targets,
+        &mut NullCallback,
+        &GitPushOptions::default(),
+    )?;
+    assert_eq!(
+        stats.pushed,
+        vec![GitRefNameBuf::from("refs/heads/main")],
+        "the file:// push must report main as pushed (stats: {stats:?})"
+    );
+    assert!(stats.rejected.is_empty(), "no client rejections: {stats:?}");
+    assert!(
+        stats.remote_rejected.is_empty(),
+        "no remote rejections: {stats:?}"
+    );
+
+    // The served repo's `refs/heads/main` advanced to the pushed child and its
+    // object is present there (the in-process push copied it).
+    let pushed_oid = git_id(&child_of_main);
+    let server_repo = testutils::git::open(&source_dir);
+    let new_target = server_repo.find_reference("refs/heads/main")?;
+    assert_eq!(
+        new_target.target().id(),
+        pushed_oid,
+        "the file:// push must move the remote's refs/heads/main"
+    );
+    assert!(
+        server_repo.find_object(pushed_oid).is_ok(),
+        "the pushed object must exist in the served repo's object store"
+    );
+
+    // The local remote-tracking ref for main advanced too, mirroring Git.
+    let view = tx.repo().view();
+    assert_eq!(
+        *view.get_git_ref("refs/remotes/origin/main".as_ref()),
+        RefTarget::normal(child_of_main.id().clone()),
+        "the local remote-tracking ref for main must advance after the file:// push"
+    );
+
+    // Cross-check the push with system git, and fsck the *source* repo so we know
+    // the in-process push wrote a well-formed object database on the remote side.
+    if let Some(oid_hex) = git_oracle(&source_dir, &["rev-parse", "refs/heads/main"]) {
+        assert_eq!(
+            oid_hex,
+            pushed_oid.to_string(),
+            "system git must see the pushed child as the source's refs/heads/main"
+        );
+    } else {
+        eprintln!("SKIP cross-check: `git rev-parse` oracle unavailable after push");
+    }
+    match git_fsck_ok(&source_dir) {
+        Some(true) => {}
+        Some(false) => panic!("git fsck reported corruption in the source repo after file:// push"),
+        None => eprintln!("SKIP fsck: `git` oracle unavailable"),
+    }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// `git://` SHALLOW (`depth`) FETCH through grit-lib's wire transport (D3).
+//
+// `GitFetch::fetch` with `depth = Some(1)` over a `git://` remote dispatches to
+// `git_local::fetch_git_daemon`, which forwards a `deepen 1` request to
+// `grit_lib::fetch::fetch_remote`. `fetch_remote` drives the shallow-info
+// handshake, ingests only the shallow object closure, and writes the local
+// `shallow` graft file — all in process. We assert the shallow tip is recorded
+// and present, the `shallow` file lists the expected boundary, and the deeper
+// ancestor's object was NOT fetched. Cross-checked against system `git`.
+// ---------------------------------------------------------------------------
+#[test]
+fn test_fetch_shallow_depth_over_git_daemon() -> TestResult {
+    // A bare source repo with a small linear history on `main`:
+    //   root -> c1 -> c2 (tip).  A depth-1 fetch should bring only `c2`.
+    let temp_dir = testutils::new_temp_dir();
+    let base = temp_dir.path();
+    let source_dir = base.join("source.git");
+    let source = testutils::git::init_bare(&source_dir);
+    let root = empty_git_commit(&source, "refs/heads/main", &[]);
+    let c1 = empty_git_commit(&source, "refs/heads/main", &[root]);
+    let tip = empty_git_commit(&source, "refs/heads/main", &[c1]);
+    testutils::git::set_symbolic_reference(&source, "HEAD", "refs/heads/main");
+
+    let Some(port) = git_daemon_free_port() else {
+        eprintln!("SKIP: could not find a free port for git daemon");
+        return Ok(());
+    };
+    let Some(child) = spawn_git_daemon(base, port) else {
+        eprintln!("SKIP: `git daemon` is unavailable");
+        return Ok(());
+    };
+    let _guard = GitDaemonGuard(child);
+    if !git_daemon_wait_ready(port) {
+        eprintln!("SKIP: git daemon did not become ready on port {port}");
+        return Ok(());
+    }
+
+    // A jj repo whose `origin` remote is the anonymous `git://` URL.
+    let test_repo = TestRepo::init_with_backend(TestRepoBackend::Git);
+    let url = format!("git://127.0.0.1:{port}/source.git");
+    let mut tx = test_repo.repo.start_transaction();
+    git::add_remote(
+        tx.repo_mut(),
+        "origin".as_ref(),
+        &url,
+        None,
+        gix::remote::fetch::Tags::All,
+    )?;
+    let _repo = tx.commit("add remote").block_on()?;
+    let repo = test_repo
+        .env
+        .load_repo_at_head(&testutils::user_settings(), test_repo.repo_path());
+
+    // Shallow fetch with depth = 1. This routes to git_local::fetch_git_daemon
+    // with `depth = Some(1)` (the in-process shallow path).
+    let subprocess_options = GitSubprocessOptions::from_settings(repo.settings())?;
+    let import_options = auto_track_import_options();
+    let refspecs = expand_fetch_refspecs(
+        "origin".as_ref(),
+        GitFetchRefExpression {
+            bookmark: StringExpression::all(),
+            tag: StringExpression::none(),
+        },
+    )
+    .expect("ref patterns should be valid");
+    let depth = Some(std::num::NonZeroU32::new(1).unwrap());
+
+    let mut tx = repo.start_transaction();
+    let mut fetcher = GitFetch::new(tx.repo_mut(), subprocess_options, &import_options)?;
+    let fetch_result = fetcher.fetch(
+        "origin".as_ref(),
+        refspecs,
+        &mut NullCallback,
+        depth,
+        None,
+    );
+    // A server that refuses shallow (very old git) would error; treat that as a
+    // SKIP rather than a failure (the happy path below is what we assert).
+    if let Err(err) = fetch_result {
+        eprintln!("SKIP: git daemon did not support the shallow fetch: {err:?}");
+        return Ok(());
+    }
+    fetcher.import_refs().block_on()?;
+    let repo = tx.commit("shallow fetch").block_on()?;
+
+    // The shallow tip landed as origin/main and its object is present locally.
+    let view = repo.view();
+    assert_eq!(
+        *view.get_git_ref("refs/remotes/origin/main".as_ref()),
+        RefTarget::normal(jj_id(tip)),
+        "the shallow fetch must record origin/main at the tip commit"
+    );
+    let store = repo.store();
+    assert!(
+        store.get_commit(&jj_id(tip)).is_ok(),
+        "the shallow tip commit must be present locally"
+    );
+
+    // The local git dir's `shallow` graft file was written and names the tip as a
+    // shallow boundary (depth 1 => the tip has no parents locally).
+    let local_git_dir = get_git_backend(&repo).git_repo_path().to_path_buf();
+    let shallow_path = local_git_dir.join("shallow");
+    assert!(
+        shallow_path.is_file(),
+        "a depth-1 git:// fetch must write the local `shallow` graft file at {}",
+        shallow_path.display()
+    );
+    let shallow_contents = std::fs::read_to_string(&shallow_path)?;
+    let shallow_oids: HashSet<String> = shallow_contents
+        .lines()
+        .map(|l| l.trim().to_owned())
+        .filter(|l| !l.is_empty())
+        .collect();
+    assert!(
+        shallow_oids.contains(&tip.to_string()),
+        "the `shallow` file must list the tip {} as a graft boundary, got {shallow_oids:?}",
+        tip
+    );
+    // The deeper ancestors were NOT part of the depth-1 object closure, so their
+    // commit objects must be absent locally (this is what makes the fetch shallow).
+    assert!(
+        store.get_commit(&jj_id(root)).is_err(),
+        "the depth-1 fetch must NOT have brought the deep ancestor `root`"
+    );
+
+    // Cross-check the shallow tip against system git's view of the source.
+    if let Some(oid_hex) = git_oracle(&source_dir, &["rev-parse", "refs/heads/main"]) {
+        assert_eq!(
+            oid_hex,
+            tip.to_string(),
+            "the shallow tip must match system git's refs/heads/main on the source"
+        );
+    } else {
+        eprintln!("SKIP cross-check: `git rev-parse` oracle unavailable");
+    }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// `git://` FETCH whose result is independently cross-checked with system `git`
+// (`rev-parse` as an oracle for the fetched tips, `fsck` over the local jj git
+// dir to prove the in-process pack ingest is well-formed). The wire fetch itself
+// is still all in-process via grit-lib; `git` is used only as a verifier.
+// ---------------------------------------------------------------------------
+#[test]
+fn test_fetch_over_git_daemon_cross_checked() -> TestResult {
+    let temp_dir = testutils::new_temp_dir();
+    let base = temp_dir.path();
+    let source_dir = base.join("source.git");
+    let source = testutils::git::init_bare(&source_dir);
+    let initial = empty_git_commit(&source, "refs/heads/main", &[]);
+    let topic = empty_git_commit(&source, "refs/heads/topic", &[initial]);
+    testutils::git::set_symbolic_reference(&source, "HEAD", "refs/heads/main");
+
+    let Some(port) = git_daemon_free_port() else {
+        eprintln!("SKIP: could not find a free port for git daemon");
+        return Ok(());
+    };
+    let Some(child) = spawn_git_daemon(base, port) else {
+        eprintln!("SKIP: `git daemon` is unavailable");
+        return Ok(());
+    };
+    let _guard = GitDaemonGuard(child);
+    if !git_daemon_wait_ready(port) {
+        eprintln!("SKIP: git daemon did not become ready on port {port}");
+        return Ok(());
+    }
+
+    let test_repo = TestRepo::init_with_backend(TestRepoBackend::Git);
+    let url = format!("git://127.0.0.1:{port}/source.git");
+    let mut tx = test_repo.repo.start_transaction();
+    git::add_remote(
+        tx.repo_mut(),
+        "origin".as_ref(),
+        &url,
+        None,
+        gix::remote::fetch::Tags::All,
+    )?;
+    let _repo = tx.commit("add remote").block_on()?;
+    let repo = test_repo
+        .env
+        .load_repo_at_head(&testutils::user_settings(), test_repo.repo_path());
+
+    let subprocess_options = GitSubprocessOptions::from_settings(repo.settings())?;
+    let import_options = auto_track_import_options();
+    let mut tx = repo.start_transaction();
+    let mut fetcher = GitFetch::new(tx.repo_mut(), subprocess_options, &import_options)?;
+    fetch_all_with(&mut fetcher, "origin".as_ref())?;
+    fetcher.import_refs().block_on()?;
+    let repo = tx.commit("fetch").block_on()?;
+
+    // jj recorded both tips.
+    let view = repo.view();
+    assert_eq!(
+        *view.git_refs(),
+        btreemap! {
+            "refs/remotes/origin/main".into() => RefTarget::normal(jj_id(initial)),
+            "refs/remotes/origin/topic".into() => RefTarget::normal(jj_id(topic)),
+        },
+        "jj must record the same tips the git:// remote advertised"
+    );
+
+    // Independent oracle: system git's rev-parse of the served branches must equal
+    // the tips jj recorded. At least one of the two must verify (else SKIP).
+    let mut verified_any = false;
+    for (branch, want) in [("main", initial), ("topic", topic)] {
+        if let Some(oid_hex) =
+            git_oracle(&source_dir, &["rev-parse", &format!("refs/heads/{branch}")])
+        {
+            assert_eq!(
+                oid_hex,
+                want.to_string(),
+                "fetched {branch} tip must match system git's view of the source"
+            );
+            verified_any = true;
+        }
+    }
+    if !verified_any {
+        eprintln!("SKIP cross-check: `git rev-parse` oracle unavailable for both branches");
+    }
+
+    // The in-process pack ingest must leave a well-formed local object database.
+    let local_git_dir = get_git_backend(&repo).git_repo_path().to_path_buf();
+    match git_fsck_ok(&local_git_dir) {
+        Some(true) => {}
+        Some(false) => {
+            panic!("git fsck reported corruption in the local jj git dir after git:// fetch")
+        }
+        None => eprintln!("SKIP fsck: `git` oracle unavailable"),
+    }
+
+    Ok(())
+}
+
+// ===========================================================================
+// Additional no-external-git coverage (added in this pass):
+//
+//  * `test_fetch_shallow_depth_over_smart_http`               — `http://`
+//    shallow (`depth=1`) fetch (D3 over the HTTP transport). The HTTP path is a
+//    *stateless* protocol-v2 exchange (`info/refs` discovery + `command=fetch`
+//    POSTs), so the `deepen 1` / `shallow-info` handshake takes a different code
+//    path in grit-lib than the `git://` streaming variant. Asserts jj writes the
+//    local `shallow` graft file, records the shallow tip, and did NOT pull the
+//    deep ancestor; cross-checked against system `git`.
+//  * `test_incremental_fetch_records_remote_updates_over_file_url` — fetch, then
+//    advance the remote with system `git`, then re-fetch over `file://`. Asserts
+//    jj's second (incremental) fetch records exactly the new remote tip (the
+//    `have`-based negotiation brings only the delta) and that the local + remote
+//    object databases stay `fsck`-clean.
+//  * `test_fetch_records_same_object_graph_as_remote_over_git_daemon` — fetch a
+//    multi-commit graph over `git://` and assert jj's local object store holds
+//    *exactly* the remote's commit set (`git rev-list --all` parity), proving jj
+//    records the same commits as the remote, not merely the advertised tips.
+//
+// Each reuses the sibling harness and makes a real assertion; only the genuinely
+// unavailable fixtures (free port / `git daemon` / `grit-http-server` / `grit` /
+// `git` oracle) cause a targeted SKIP.
+// ===========================================================================
+
+/// A depth-1 fetch over the smart-HTTP transport. Mirrors
+/// `test_fetch_shallow_depth_over_git_daemon`, but drives the HTTP path
+/// (`git_local::fetch_http`, protocol v2 stateless multi-POST) so the shallow /
+/// `deepen` handshake exercises grit-lib's HTTP code rather than the streaming
+/// `git://` variant. The only external dependencies are the `grit-http-server` +
+/// `grit` fixtures (and `git` as a cross-check oracle); the test SKIPs cleanly
+/// when a fixture is genuinely missing.
+#[test]
+fn test_fetch_shallow_depth_over_smart_http() -> TestResult {
+    let Some(server_bin) = find_grit_binary("JJ_TEST_GRIT_HTTP_SERVER", "grit-http-server") else {
+        eprintln!(
+            "SKIP: `grit-http-server` binary not found (build it in the grit checkout or set \
+             JJ_TEST_GRIT_HTTP_SERVER)"
+        );
+        return Ok(());
+    };
+    let Some(grit_bin) = find_grit_binary("JJ_TEST_GRIT_BIN", "grit") else {
+        eprintln!(
+            "SKIP: `grit` binary not found (build it in the grit checkout or set JJ_TEST_GRIT_BIN)"
+        );
+        return Ok(());
+    };
+
+    // A bare source repo under the server root with a small linear history on
+    // `main`:  root -> c1 -> tip.  A depth-1 fetch should bring only `tip`.
+    let temp_dir = testutils::new_temp_dir();
+    let root_dir = temp_dir.path().join("srv");
+    std::fs::create_dir_all(&root_dir)?;
+    let source_dir = root_dir.join("source.git");
+    let source = testutils::git::init_bare(&source_dir);
+    let root = empty_git_commit(&source, "refs/heads/main", &[]);
+    let c1 = empty_git_commit(&source, "refs/heads/main", &[root]);
+    let tip = empty_git_commit(&source, "refs/heads/main", &[c1]);
+    testutils::git::set_symbolic_reference(&source, "HEAD", "refs/heads/main");
+
+    let Some(port) = git_daemon_free_port() else {
+        eprintln!("SKIP: could not find a free port for grit-http-server");
+        return Ok(());
+    };
+    let Some(child) = spawn_grit_http_server(&server_bin, &grit_bin, &root_dir, port) else {
+        eprintln!("SKIP: could not spawn grit-http-server");
+        return Ok(());
+    };
+    let _guard = GritHttpServerGuard(child);
+    if !git_daemon_wait_ready(port) {
+        eprintln!("SKIP: grit-http-server did not become ready on port {port}");
+        return Ok(());
+    }
+
+    // A jj repo whose `origin` remote is the smart-HTTP URL.
+    let test_repo = TestRepo::init_with_backend(TestRepoBackend::Git);
+    let url = format!("http://127.0.0.1:{port}/source.git");
+    let mut tx = test_repo.repo.start_transaction();
+    git::add_remote(
+        tx.repo_mut(),
+        "origin".as_ref(),
+        &url,
+        None,
+        gix::remote::fetch::Tags::All,
+    )?;
+    let _repo = tx.commit("add remote").block_on()?;
+    let repo = test_repo
+        .env
+        .load_repo_at_head(&testutils::user_settings(), test_repo.repo_path());
+
+    // Shallow fetch with depth = 1. This routes to git_local::fetch_http with
+    // `depth = Some(1)` (the in-process HTTP shallow path).
+    let subprocess_options = GitSubprocessOptions::from_settings(repo.settings())?;
+    let import_options = auto_track_import_options();
+    let refspecs = expand_fetch_refspecs(
+        "origin".as_ref(),
+        GitFetchRefExpression {
+            bookmark: StringExpression::all(),
+            tag: StringExpression::none(),
+        },
+    )
+    .expect("ref patterns should be valid");
+    let depth = Some(std::num::NonZeroU32::new(1).unwrap());
+
+    let mut tx = repo.start_transaction();
+    let mut fetcher = GitFetch::new(tx.repo_mut(), subprocess_options, &import_options)?;
+    let fetch_result = fetcher.fetch("origin".as_ref(), refspecs, &mut NullCallback, depth, None);
+    // A server that refuses shallow over HTTP would error; treat that as a SKIP
+    // rather than a failure (the happy path below is what we assert).
+    if let Err(err) = fetch_result {
+        eprintln!("SKIP: grit-http-server did not support the shallow HTTP fetch: {err:?}");
+        return Ok(());
+    }
+    fetcher.import_refs().block_on()?;
+    let repo = tx.commit("shallow http fetch").block_on()?;
+
+    // The shallow tip landed as origin/main and its object is present locally.
+    let view = repo.view();
+    assert_eq!(
+        *view.get_git_ref("refs/remotes/origin/main".as_ref()),
+        RefTarget::normal(jj_id(tip)),
+        "the shallow HTTP fetch must record origin/main at the tip commit"
+    );
+    let store = repo.store();
+    assert!(
+        store.get_commit(&jj_id(tip)).is_ok(),
+        "the shallow tip commit must be present locally after the HTTP fetch"
+    );
+
+    // The local git dir's `shallow` graft file was written and names the tip as a
+    // shallow boundary (depth 1 => the tip has no parents locally).
+    let local_git_dir = get_git_backend(&repo).git_repo_path().to_path_buf();
+    let shallow_path = local_git_dir.join("shallow");
+    assert!(
+        shallow_path.is_file(),
+        "a depth-1 http:// fetch must write the local `shallow` graft file at {}",
+        shallow_path.display()
+    );
+    let shallow_contents = std::fs::read_to_string(&shallow_path)?;
+    let shallow_oids: HashSet<String> = shallow_contents
+        .lines()
+        .map(|l| l.trim().to_owned())
+        .filter(|l| !l.is_empty())
+        .collect();
+    assert!(
+        shallow_oids.contains(&tip.to_string()),
+        "the `shallow` file must list the tip {tip} as a graft boundary, got {shallow_oids:?}"
+    );
+    // The deeper ancestor was NOT part of the depth-1 object closure, so its
+    // commit object must be absent locally (this is what makes the fetch shallow).
+    assert!(
+        store.get_commit(&jj_id(root)).is_err(),
+        "the depth-1 HTTP fetch must NOT have brought the deep ancestor `root`"
+    );
+
+    // Cross-check the shallow tip against system git's view of the served source.
+    if let Some(oid_hex) = git_oracle(&source_dir, &["rev-parse", "refs/heads/main"]) {
+        assert_eq!(
+            oid_hex,
+            tip.to_string(),
+            "the shallow HTTP tip must match system git's refs/heads/main on the source"
+        );
+    } else {
+        eprintln!("SKIP cross-check: `git rev-parse` oracle unavailable");
+    }
+
+    Ok(())
+}
+
+/// Fetch, advance the remote with system `git`, then re-fetch over `file://` and
+/// assert jj records the new remote tip. This exercises the *incremental*
+/// (`have`-based) negotiation path of grit-lib's in-process local transfer
+/// (`git_local::fetch_local`): the second fetch must bring only the delta and
+/// leave both object databases `fsck`-clean. `git` is used only to mutate the
+/// remote (an independent producer) and as the `rev-parse` / `fsck` oracle; the
+/// wire transfer itself stays in process.
+#[test]
+fn test_incremental_fetch_records_remote_updates_over_file_url() -> TestResult {
+    // A bare source repo with a single commit on `main`, addressed as `file://`.
+    let temp_dir = testutils::new_temp_dir();
+    let source_dir = temp_dir.path().join("source.git");
+    let source = testutils::git::init_bare(&source_dir);
+    let initial = empty_git_commit(&source, "refs/heads/main", &[]);
+    testutils::git::set_symbolic_reference(&source, "HEAD", "refs/heads/main");
+
+    let abs = source_dir.to_str().expect("utf8 path");
+    let url = format!("file://{abs}");
+
+    let test_repo = TestRepo::init_with_backend(TestRepoBackend::Git);
+    let mut tx = test_repo.repo.start_transaction();
+    git::add_remote(
+        tx.repo_mut(),
+        "origin".as_ref(),
+        &url,
+        None,
+        gix::remote::fetch::Tags::All,
+    )?;
+    let _repo = tx.commit("add remote").block_on()?;
+    let repo = test_repo
+        .env
+        .load_repo_at_head(&testutils::user_settings(), test_repo.repo_path());
+
+    // --- First fetch: brings `initial` ----------------------------------------
+    let subprocess_options = GitSubprocessOptions::from_settings(repo.settings())?;
+    let import_options = auto_track_import_options();
+    let mut tx = repo.start_transaction();
+    let mut fetcher = GitFetch::new(tx.repo_mut(), subprocess_options.clone(), &import_options)?;
+    fetch_all_with(&mut fetcher, "origin".as_ref())?;
+    fetcher.import_refs().block_on()?;
+    let repo = tx.commit("first fetch").block_on()?;
+    assert_eq!(
+        *repo
+            .view()
+            .get_git_ref("refs/remotes/origin/main".as_ref()),
+        RefTarget::normal(jj_id(initial)),
+        "after the first fetch origin/main must point at the initial commit"
+    );
+
+    // --- Advance the remote with system git (a child of `initial`) ------------
+    // The new commit only exists on the remote; the incremental fetch must
+    // discover and bring it. (`gix`'s `empty_git_commit` on the same in-memory
+    // handle would also work, but using a *fresh* commit object created directly
+    // in the bare repo keeps the producer independent of the jj-side handle.)
+    let second = empty_git_commit(&source, "refs/heads/main", &[initial]);
+    // Sanity: system git must agree the remote tip moved (else SKIP — the fixture
+    // is unusable as an oracle).
+    if let Some(oid_hex) = git_oracle(&source_dir, &["rev-parse", "refs/heads/main"]) {
+        assert_eq!(
+            oid_hex,
+            second.to_string(),
+            "system git must see the advanced commit as the source's refs/heads/main"
+        );
+    } else {
+        eprintln!("SKIP cross-check: `git rev-parse` oracle unavailable before re-fetch");
+    }
+
+    // --- Second (incremental) fetch: must bring only `second` -----------------
+    let mut tx = repo.start_transaction();
+    let mut fetcher = GitFetch::new(tx.repo_mut(), subprocess_options, &import_options)?;
+    fetch_all_with(&mut fetcher, "origin".as_ref())?;
+    fetcher.import_refs().block_on()?;
+    let repo = tx.commit("incremental fetch").block_on()?;
+
+    // jj recorded the advanced remote tip, and both commits resolve locally.
+    let view = repo.view();
+    assert_eq!(
+        *view.get_git_ref("refs/remotes/origin/main".as_ref()),
+        RefTarget::normal(jj_id(second)),
+        "the incremental file:// fetch must advance origin/main to the new remote tip"
+    );
+    assert!(view.heads().contains(&jj_id(second)));
+    let store = repo.store();
+    assert!(
+        store.get_commit(&jj_id(initial)).is_ok(),
+        "the previously-fetched commit must remain present"
+    );
+    assert!(
+        store.get_commit(&jj_id(second)).is_ok(),
+        "the incrementally-fetched commit must be present locally"
+    );
+
+    // The in-process incremental ingest left a well-formed local object database.
+    let local_git_dir = get_git_backend(&repo).git_repo_path().to_path_buf();
+    match git_fsck_ok(&local_git_dir) {
+        Some(true) => {}
+        Some(false) => {
+            panic!("git fsck reported corruption in the local jj git dir after incremental fetch")
+        }
+        None => eprintln!("SKIP fsck: `git` oracle unavailable"),
+    }
+
+    Ok(())
+}
+
+/// Fetch a multi-commit graph over `git://` and assert jj's local object store
+/// holds *exactly* the remote's commit set. This goes beyond the
+/// advertised-tips checks of the sibling tests: it proves jj records the same
+/// commits as the remote across the whole reachable graph (every commit returned
+/// by `git rev-list --all` on the source resolves in jj's backend, and jj has no
+/// extra commits beyond the empty bootstrap commit). The wire fetch is all
+/// in-process via grit-lib; `git` is used only as a graph oracle + `fsck`.
+#[test]
+fn test_fetch_records_same_object_graph_as_remote_over_git_daemon() -> TestResult {
+    // A bare source repo with a branched graph:
+    //   main:  root -> a1 -> a2 (tip)
+    //   topic: root -> b1        (tip, shares `root` with main)
+    let temp_dir = testutils::new_temp_dir();
+    let base = temp_dir.path();
+    let source_dir = base.join("source.git");
+    let source = testutils::git::init_bare(&source_dir);
+    let root = empty_git_commit(&source, "refs/heads/main", &[]);
+    let a1 = empty_git_commit(&source, "refs/heads/main", &[root]);
+    let a2 = empty_git_commit(&source, "refs/heads/main", &[a1]);
+    let b1 = empty_git_commit(&source, "refs/heads/topic", &[root]);
+    testutils::git::set_symbolic_reference(&source, "HEAD", "refs/heads/main");
+
+    let Some(port) = git_daemon_free_port() else {
+        eprintln!("SKIP: could not find a free port for git daemon");
+        return Ok(());
+    };
+    let Some(child) = spawn_git_daemon(base, port) else {
+        eprintln!("SKIP: `git daemon` is unavailable");
+        return Ok(());
+    };
+    let _guard = GitDaemonGuard(child);
+    if !git_daemon_wait_ready(port) {
+        eprintln!("SKIP: git daemon did not become ready on port {port}");
+        return Ok(());
+    }
+
+    let test_repo = TestRepo::init_with_backend(TestRepoBackend::Git);
+    let url = format!("git://127.0.0.1:{port}/source.git");
+    let mut tx = test_repo.repo.start_transaction();
+    git::add_remote(
+        tx.repo_mut(),
+        "origin".as_ref(),
+        &url,
+        None,
+        gix::remote::fetch::Tags::All,
+    )?;
+    let _repo = tx.commit("add remote").block_on()?;
+    let repo = test_repo
+        .env
+        .load_repo_at_head(&testutils::user_settings(), test_repo.repo_path());
+
+    let subprocess_options = GitSubprocessOptions::from_settings(repo.settings())?;
+    let import_options = auto_track_import_options();
+    let mut tx = repo.start_transaction();
+    let mut fetcher = GitFetch::new(tx.repo_mut(), subprocess_options, &import_options)?;
+    fetch_all_with(&mut fetcher, "origin".as_ref())?;
+    fetcher.import_refs().block_on()?;
+    let repo = tx.commit("fetch").block_on()?;
+
+    // jj recorded both branch tips.
+    let view = repo.view();
+    assert_eq!(
+        *view.git_refs(),
+        btreemap! {
+            "refs/remotes/origin/main".into() => RefTarget::normal(jj_id(a2)),
+            "refs/remotes/origin/topic".into() => RefTarget::normal(jj_id(b1)),
+        },
+        "jj must record both branch tips the git:// remote advertised"
+    );
+
+    // Every commit in the remote's reachable graph must resolve in jj's backend.
+    // This is the "same commits as the remote" check at graph granularity, not
+    // just at the advertised tips.
+    let store = repo.store();
+    let expected: HashSet<gix::ObjectId> = [root, a1, a2, b1].into_iter().collect();
+    for oid in &expected {
+        assert!(
+            store.get_commit(&jj_id(*oid)).is_ok(),
+            "fetched local store must contain remote commit {oid}"
+        );
+    }
+
+    // Cross-check the *set* against system git's `rev-list --all` on the source:
+    // the fetched commits must equal exactly the remote's reachable commit set.
+    if let Some(rev_list) = git_oracle(&source_dir, &["rev-list", "--all"]) {
+        let remote_commits: HashSet<gix::ObjectId> = rev_list
+            .lines()
+            .filter_map(|l| gix::ObjectId::from_hex(l.trim().as_bytes()).ok())
+            .collect();
+        assert_eq!(
+            remote_commits, expected,
+            "the test's expected commit set must match system git's rev-list --all on the source"
+        );
+        // jj resolves every remote commit, and (modulo the empty bootstrap commit
+        // every jj repo starts with) records no commits the remote does not have.
+        for oid in &remote_commits {
+            assert!(
+                store.get_commit(&jj_id(*oid)).is_ok(),
+                "jj must record remote commit {oid} (rev-list --all parity)"
+            );
+        }
+    } else {
+        eprintln!("SKIP cross-check: `git rev-list` oracle unavailable");
+    }
+
+    // The in-process pack ingest left a well-formed local object database.
+    let local_git_dir = get_git_backend(&repo).git_repo_path().to_path_buf();
+    match git_fsck_ok(&local_git_dir) {
+        Some(true) => {}
+        Some(false) => {
+            panic!("git fsck reported corruption in the local jj git dir after graph fetch")
+        }
+        None => eprintln!("SKIP fsck: `git` oracle unavailable"),
     }
 
     Ok(())

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -6936,3 +6936,142 @@ fn test_remote_name_validation() -> TestResult {
 
     Ok(())
 }
+
+// ---------------------------------------------------------------------------
+// `git://` (anonymous Git-daemon) FETCH through grit-lib's wire transport.
+//
+// `GitFetch::fetch` now routes a `git://` remote to
+// `git_local::fetch_git_daemon`, which connects over TCP with
+// `grit_lib::transport::GitDaemonTransport` and runs the want/have negotiation
+// with `grit_lib::fetch::fetch_remote` — no `git` subprocess and no `gix`
+// transport for the fetch itself. The only external dependency is the server
+// fixture (`git daemon`), exactly like grit-lib's own transport tests; the test
+// skips gracefully when it is unavailable.
+// ---------------------------------------------------------------------------
+
+/// Pick a currently-free localhost port by binding then dropping a listener.
+fn git_daemon_free_port() -> Option<u16> {
+    let l = std::net::TcpListener::bind(("127.0.0.1", 0)).ok()?;
+    let p = l.local_addr().ok()?.port();
+    drop(l);
+    Some(p)
+}
+
+/// Spawn `git daemon` over `base_path` on `port`. Returns `None` if the binary
+/// is missing or cannot be spawned.
+fn spawn_git_daemon(base_path: &Path, port: u16) -> Option<std::process::Child> {
+    std::process::Command::new("git")
+        .arg("daemon")
+        .arg("--listen=127.0.0.1")
+        .arg(format!("--port={port}"))
+        .arg("--reuseaddr")
+        .arg("--export-all")
+        .arg(format!("--base-path={}", base_path.display()))
+        .arg(base_path)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .ok()
+}
+
+/// Wait until the daemon answers a TCP connect on `port`, or time out.
+fn git_daemon_wait_ready(port: u16) -> bool {
+    let addr = std::net::SocketAddr::from(([127, 0, 0, 1], port));
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    while std::time::Instant::now() < deadline {
+        if std::net::TcpStream::connect_timeout(&addr, std::time::Duration::from_millis(200)).is_ok()
+        {
+            return true;
+        }
+        thread::sleep(std::time::Duration::from_millis(50));
+    }
+    false
+}
+
+struct GitDaemonGuard(std::process::Child);
+impl Drop for GitDaemonGuard {
+    fn drop(&mut self) {
+        let _unused_kill = self.0.kill();
+        let _unused = self.0.wait();
+    }
+}
+
+#[test]
+fn test_fetch_over_git_daemon() -> TestResult {
+    // A bare source repo, served directly at `git://127.0.0.1:<port>/source.git`.
+    let temp_dir = testutils::new_temp_dir();
+    let base = temp_dir.path();
+    let source_dir = base.join("source.git");
+    let source = testutils::git::init_bare(&source_dir);
+    let initial = empty_git_commit(&source, "refs/heads/main", &[]);
+    let topic = empty_git_commit(&source, "refs/heads/topic", &[initial]);
+    testutils::git::set_symbolic_reference(&source, "HEAD", "refs/heads/main");
+
+    let Some(port) = git_daemon_free_port() else {
+        eprintln!("SKIP: could not find a free port for git daemon");
+        return Ok(());
+    };
+    let Some(child) = spawn_git_daemon(base, port) else {
+        eprintln!("SKIP: `git daemon` is unavailable");
+        return Ok(());
+    };
+    let _guard = GitDaemonGuard(child);
+    if !git_daemon_wait_ready(port) {
+        eprintln!("SKIP: git daemon did not become ready on port {port}");
+        return Ok(());
+    }
+
+    // A jj repo whose `origin` remote is the anonymous `git://` URL.
+    let test_repo = TestRepo::init_with_backend(TestRepoBackend::Git);
+    let url = format!("git://127.0.0.1:{port}/source.git");
+
+    let mut tx = test_repo.repo.start_transaction();
+    git::add_remote(
+        tx.repo_mut(),
+        "origin".as_ref(),
+        &url,
+        None,
+        gix::remote::fetch::Tags::All,
+    )?;
+    let _repo = tx.commit("add remote").block_on()?;
+    // Reload after the Git config change so the remote is visible.
+    let repo = test_repo
+        .env
+        .load_repo_at_head(&testutils::user_settings(), test_repo.repo_path());
+
+    // Fetch through the public GitFetch API. With a `git://` remote and no depth,
+    // this dispatches to git_local::fetch_git_daemon (grit-lib wire transport).
+    let subprocess_options = GitSubprocessOptions::from_settings(repo.settings())?;
+    let import_options = auto_track_import_options();
+    let mut tx = repo.start_transaction();
+    let mut fetcher = GitFetch::new(tx.repo_mut(), subprocess_options, &import_options)?;
+    fetch_all_with(&mut fetcher, "origin".as_ref())?;
+    let default_branch = fetcher.get_default_branch("origin".as_ref())?;
+    fetcher.import_refs().block_on()?;
+    let repo = tx.commit("fetch").block_on()?;
+
+    // The daemon advertised HEAD -> refs/heads/main.
+    assert_eq!(default_branch, Some("main".into()));
+
+    let view = repo.view();
+    // Both branches' tips are now visible in the jj repo.
+    assert!(view.heads().contains(&jj_id(topic)));
+    let main_target = RefTarget::normal(jj_id(initial));
+    let topic_target = RefTarget::normal(jj_id(topic));
+    assert_eq!(
+        *view.git_refs(),
+        btreemap! {
+            "refs/remotes/origin/main".into() => main_target.clone(),
+            "refs/remotes/origin/topic".into() => topic_target.clone(),
+        },
+        "tracking refs for both branches must land via the git:// wire fetch"
+    );
+
+    // The objects are present in the local object store (the pack was ingested),
+    // so the commits resolve through the backend.
+    let store = repo.store();
+    assert!(store.get_commit(&jj_id(initial)).is_ok());
+    assert!(store.get_commit(&jj_id(topic)).is_ok());
+
+    Ok(())
+}

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -4001,7 +4001,12 @@ fn test_fetch_environment_options() -> TestResult {
     let mut fetcher = GitFetch::new(tx.repo_mut(), subprocess_options, &import_options)?;
     fetch_all_with(&mut fetcher, "origin".as_ref())?;
 
-    assert!(trace_path.exists());
+    // `origin` is a LOCAL remote, which is now fetched in-process via grit-lib
+    // rather than by spawning `git fetch`. The subprocess environment (here
+    // `GIT_TRACE`) therefore has no effect: no trace file is produced because no
+    // git subprocess ran. Subprocess environment passing for non-local
+    // transports is covered by the `git://`/daemon fetch tests.
+    assert!(!trace_path.exists());
     Ok(())
 }
 
@@ -6017,7 +6022,13 @@ fn test_push_environment_options() -> TestResult {
         &GitPushOptions::default(),
     )?;
 
-    assert!(trace_path.exists());
+    // `origin` is a LOCAL remote, so the push runs in-process via grit-lib rather
+    // than spawning `git push`. The subprocess environment (here `GIT_TRACE`)
+    // therefore has no effect and no trace file is produced. Subprocess
+    // environment passing is exercised by the non-local push tests, and pushes
+    // carrying `--push-option` still use the subprocess path (see
+    // `test_push_updates_with_options`).
+    assert!(!trace_path.exists());
     Ok(())
 }
 

--- a/lib/tests/test_git_backend.rs
+++ b/lib/tests/test_git_backend.rs
@@ -106,6 +106,92 @@ fn list_dir(dir: &Path) -> Vec<String> {
         .collect()
 }
 
+/// Collect the hex object ids of every loose object physically present under
+/// `<git_dir>/objects`. Packed objects (`objects/pack/`) and the `info/`
+/// directory are skipped, so this reflects exactly what an in-process loose
+/// prune can remove.
+fn collect_loose_object_ids(git_repo_path: &Path) -> HashSet<String> {
+    let objects_dir = git_repo_path.join("objects");
+    let mut ids = HashSet::new();
+    for shard in std::fs::read_dir(&objects_dir).unwrap() {
+        let shard = shard.unwrap();
+        let shard_name = shard.file_name().to_str().unwrap().to_owned();
+        // Loose object shards are two-hex-char directories; skip "pack", "info".
+        if shard_name.len() != 2 || !shard.file_type().unwrap().is_dir() {
+            continue;
+        }
+        for object in std::fs::read_dir(shard.path()).unwrap() {
+            let object = object.unwrap();
+            let rest = object.file_name().to_str().unwrap().to_owned();
+            ids.insert(format!("{shard_name}{rest}"));
+        }
+    }
+    ids
+}
+
+/// Proves jj's `gc` prunes unreachable LOOSE git objects entirely in process via
+/// `grit-lib` (`prune_loose_unreachable`), with NO `git` subprocess and NO
+/// external git transport. Unlike `test_gc`, this test is NOT gated on a system
+/// `git` being installed: the loose-object prune is the grit-lib local path.
+#[test]
+fn test_gc_prunes_loose_objects_without_git() -> TestResult {
+    let test_repo = TestRepo::init_with_backend(TestRepoBackend::Git);
+    let repo = test_repo.repo.clone();
+    let git_repo_path = get_git_backend(&repo).git_repo_path();
+    let base_index = repo.readonly_index();
+
+    // A <- B <- C, all written as loose objects by the git backend.
+    let mut tx = repo.start_transaction();
+    let commit_a = write_random_commit(tx.repo_mut());
+    let commit_b = write_random_commit_with_parents(tx.repo_mut(), &[&commit_a]);
+    let commit_c = write_random_commit_with_parents(tx.repo_mut(), &[&commit_b]);
+    let repo = tx.commit("test").block_on()?;
+
+    // The commit objects must be present as loose objects before gc.
+    let git_id = |commit: &Commit| commit.id().hex();
+    let loose_before = collect_loose_object_ids(git_repo_path);
+    assert!(loose_before.contains(&git_id(&commit_a)));
+    assert!(loose_before.contains(&git_id(&commit_b)));
+    assert!(loose_before.contains(&git_id(&commit_c)));
+
+    // Far-future cutoff so modification time never keeps an unreachable object.
+    let now = || SystemTime::now() + Duration::from_secs(1);
+
+    // With everything reachable, gc keeps every commit's loose object even with
+    // an aggressive prune window (they are still pointed at by no-gc refs).
+    repo.store().gc(repo.index(), now())?;
+    let loose_all_reachable = collect_loose_object_ids(git_repo_path);
+    assert!(loose_all_reachable.contains(&git_id(&commit_a)));
+    assert!(loose_all_reachable.contains(&git_id(&commit_b)));
+    assert!(loose_all_reachable.contains(&git_id(&commit_c)));
+
+    // Now make only A reachable. B and C become unreachable; their loose objects
+    // must be pruned in process, while A's must survive.
+    let mut mut_index = base_index.start_modification();
+    mut_index.add_commit(&commit_a).block_on()?;
+    repo.store().gc(mut_index.as_index(), now())?;
+
+    let loose_after = collect_loose_object_ids(git_repo_path);
+    assert!(
+        loose_after.contains(&git_id(&commit_a)),
+        "reachable commit A's loose object must be kept"
+    );
+    assert!(
+        !loose_after.contains(&git_id(&commit_b)),
+        "unreachable commit B's loose object must be pruned"
+    );
+    assert!(
+        !loose_after.contains(&git_id(&commit_c)),
+        "unreachable commit C's loose object must be pruned"
+    );
+
+    // The repo is still loadable after the in-process prune.
+    test_repo
+        .env
+        .load_repo_at_head(repo.settings(), test_repo.repo_path());
+    Ok(())
+}
+
 #[test]
 fn test_gc() -> TestResult {
     // TODO: Better way to disable the test if git command couldn't be executed


### PR DESCRIPTION
This is a response to @joshka's #9632

I updated `grit-lib` to v0.4.1, which includes a relatively significant lift of the transport code out of the CLI crate and into the library, and provides new embedder-shaped grit-lib APIs behind a Transport trait, with pluggable HTTP-client and credential seams.

This PR uses those new APIs to do all of the push/fetch operations through `grit-lib` without relying on Gix or fork/exec calls to `git`.

You can inspect the `grit-lib` networking calls by exporting a `GRIT_NET_DEBUG` env var. You can also run it with `GIT_TRACE=1` to verify that it's not forking out to `git` for any networking stuff.

I've tested it with clone, fetch and push over SSH (using a 1password SSH agent), and clone over https (unauth for a public repo), but it _should_ work over http with various credential auth stuff, also git:// and local networking protocols.

Here is what a clone looks like with debugging:

```
❯ GIT_TRACE=1 GRIT_NET_DEBUG=1 jjx git clone git@github.com:schacon/why.git                                              
Fetching into new repo in "/private/tmp/test/why"
[grit-net] jj: fetch (ssh) git@github.com:schacon/why.git via grit-lib
[grit-net] ssh connect git@github.com:schacon/why.git (service=git-upload-pack, request protocol v2)
[grit-net] ssh connected: protocol v0, 180 ref(s) advertised
[grit-net] fetch_remote: begin — protocol v0, 1 refspec(s), tags=All, depth=None
[grit-net] fetch_remote: remote advertised 180 ref(s) (v0/v1 advertisement)
[grit-net] fetch_remote: 70 matched ref(s), want 70 object(s)
[grit-net] fetch_remote: negotiating + fetching pack…
[grit-net] fetch_remote: received pack (224276 bytes), unpacking…
[grit-net] fetch_remote: done — 70 ref update(s), default branch 'main'
bookmark: dependabot/bundler/brakeman-7.1.0@origin                   [new] untracked
bookmark: dependabot/bundler/importmap-rails-2.2.2@origin            [new] untracked
...
bookmark: update-homepage2@origin                                    [new] untracked
Setting the revset alias `trunk()` to `main@origin`
Working copy  (@) now at: yvxqtqow a6123023 (empty) (no description set)
Parent commit (@-)      : kzzxspun 32a21757 main | (empty) Merge pull request #65 from schacon/feature-bookmarks
Added 161 files, modified 0 files, removed 0 files
```

Similar clone with current jj (this is what `GIT_TRACE` will output if `git` is being called):

```
❯ GIT_TRACE=1 GRIT_NET_DEBUG=1 jj git clone https://github.com/schacon/why.git w6                               took 2s
Fetching into new repo in "/private/tmp/test/w6"
git: 18:06:28.427977 git.c:502               trace: built-in: git fetch --porcelain --prune --no-write-fetch-head --progress --tags -- origin '+refs/heads/*:refs/remotes/origin/*'
git: 18:06:28.428552 run-command.c:673       trace: run_command: git remote-https origin https://github.com/schacon/why.git
git: 18:06:28.428562 run-command.c:765       trace: start_command: /opt/homebrew/opt/git/libexec/git-core/git remote-https origin https://github.com/schacon/why.git
git: 18:06:28.432719 git.c:808               trace: exec: git-remote-https origin https://github.com/schacon/why.git
git: 18:06:28.432971 run-command.c:673       trace: run_command: git-remote-https origin https://github.com/schacon/why.git
git: 18:06:28.432979 run-command.c:765       trace: start_command: /opt/homebrew/opt/git/libexec/git-core/git-remote-https origin https://github.com/schacon/why.git
git: 18:06:28.641227 run-command.c:673       trace: run_command: '/opt/homebrew/bin/gh auth git-credential get'
git: 18:06:28.641947 run-command.c:765       trace: start_command: /bin/sh -c '/opt/homebrew/bin/gh auth git-credential get' '/opt/homebrew/bin/gh auth git-credential get'
git: 18:06:29.028043 run-command.c:673       trace: run_command: '/opt/homebrew/bin/gh auth git-credential store'
git: 18:06:29.028068 run-command.c:765       trace: start_command: /bin/sh -c '/opt/homebrew/bin/gh auth git-credential store' '/opt/homebrew/bin/gh auth git-credential store'
remote: Enumerating objects: 1079, done.
git: 18:06:29.802883 run-command.c:673       trace: run_command: git index-pack --stdin -v --fix-thin '--keep=fetch-pack 62955 on agador.sparticus' --pack_header=2,1079 --strict
git: 18:06:29.802999 run-command.c:765       trace: start_command: /opt/homebrew/opt/git/libexec/git-core/git index-pack --stdin -v --fix-thin '--keep=fetch-pack 62955 on agador.sparticus' --pack_header=2,1079 --strict
git: 18:06:29.815312 git.c:502               trace: built-in: git index-pack --stdin -v --fix-thin '--keep=fetch-pack 62955 on agador.sparticus' --pack_header=2,1079 --strict
remote: Total 1079 (delta 200), reused 184 (delta 164), pack-reused 840 (from 2)
git: 18:06:29.889608 run-command.c:673       trace: run_command: git rev-list --objects --stdin --not --exclude-hidden=fetch --all --quiet --alternate-refs
git: 18:06:29.889645 run-command.c:765       trace: start_command: /opt/homebrew/opt/git/libexec/git-core/git rev-list --objects --stdin --not --exclude-hidden=fetch --all --quiet --alternate-refs
git: 18:06:29.896413 git.c:502               trace: built-in: git rev-list --objects --stdin --not --exclude-hidden=fetch --all --quiet --alternate-refs
git: 18:06:29.916721 run-command.c:673       trace: run_command: git maintenance run --auto --no-quiet --detach
git: 18:06:29.916760 run-command.c:765       trace: start_command: /opt/homebrew/opt/git/libexec/git-core/git maintenance run --auto --no-quiet --detach
git: 18:06:29.922254 git.c:502               trace: built-in: git maintenance run --auto --no-quiet --detach
bookmark: dependabot/bundler/brakeman-7.1.0@origin                   [new] untracked
...
bookmark: update-homepage2@origin                                    [new] untracked
Setting the revset alias `trunk()` to `main@origin`
Working copy  (@) now at: ykmwszut afd55ee5 (empty) (no description set)
Parent commit (@-)      : kzzxspun 32a21757 main | (empty) Merge pull request #65 from schacon/feature-bookmarks
Added 161 files, modified 0 files, removed 0 files
```

So we can see that the new build is no longer running Git (no `GIT_TRACE` output), but running the `grit-lib` transport code instead. Also successfully clones over both authenticated SSH and unauthenticated HTTP.

Here is me adding a new changeset and bookmark and pushing that bookmark over SSH to github:

```
❯ GIT_TRACE=1 GRIT_NET_DEBUG=1 jjx git push
Changes to push to origin:
  bookmark: grit-push [move sideways from 5adc777f12d6 to 2f5a3fb1b81f]
[grit-net] jj: push (ssh) git@github.com:schacon/why.git via grit-lib
[grit-net] ssh connect git@github.com:schacon/why.git (service=git-receive-pack, request protocol v0)
[grit-net] ssh connected: protocol v0, 71 ref(s) advertised
[grit-net] push_remote: begin — 1 ref update(s), protocol v0, 0 push-option(s)
[grit-net] push_remote: remote advertised 71 ref(s)
[grit-net] push_remote: sending 1 command(s)…
[grit-net] push_remote: sending pack (1772 bytes)…
[grit-net] push_remote: done — 1 result(s)
```

Bookmark updated, no `git` process called.

Finally, here is me fetching that push into another repo:

```
❯ GIT_TRACE=1 GRIT_NET_DEBUG=1 jjx git fetch
[grit-net] jj: fetch (ssh) git@github.com:schacon/why.git via grit-lib
[grit-net] ssh connect git@github.com:schacon/why.git (service=git-upload-pack, request protocol v2)
[grit-net] ssh connected: protocol v0, 181 ref(s) advertised
[grit-net] fetch_remote: begin — protocol v0, 1 refspec(s), tags=Following, depth=None
[grit-net] fetch_remote: remote advertised 181 ref(s) (v0/v1 advertisement)
[grit-net] fetch_remote: 71 matched ref(s), want 1 object(s)
[grit-net] fetch_remote: negotiating + fetching pack…
[grit-net] fetch_remote: received pack (1772 bytes), unpacking…
[grit-net] fetch_remote: done — 71 ref update(s), default branch 'main'
bookmark: grit-push@origin [new] untracked
```

I want to emphasize that while this appears to work, I have only done a cursory review of both the `jj` and `grit-lib` code generated for this. But it does _appear_ to work, so I'm submitting it for @joshka to check out.