### PR TITLE
rewrite: follow file renames when rebasing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   changes/conflicts are propagated accordingly, e.g., `jj run -- cargo check
   --all-features` or `jj run -- cargo fix` behaves as one might expect.
 
+* Rebasing across file renames now moves changes to the new name.
+
 ### Fixed bugs
 
 * `jj` now creates a new working-copy revision during snapshotting if the

--- a/cli/tests/test_rebase_command.rs
+++ b/cli/tests/test_rebase_command.rs
@@ -3088,3 +3088,63 @@ fn get_long_log_output(work_dir: &TestWorkDir) -> CommandOutput {
                     ++ surround(':  ', '', parents.map(|c| c.bookmarks()))";
     work_dir.run_jj(["log", "-T", template])
 }
+
+#[test]
+fn test_rebase_follows_file_rename() {
+    // BASE has foo.txt. A modifies foo.txt. B renames foo.txt → bar.txt (the
+    // git backend detects this as a rename via similarity). Rebasing A onto B
+    // should produce a commit where bar.txt carries A's modification and
+    // foo.txt is absent with no conflicts.
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    // BASE: write a long body so gix similarity detection treats the
+    // foo→bar change as a rename (well above 50% similarity threshold).
+    let body = "line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10\n";
+    create_commit_with_files(&work_dir, "base", &[], &[("foo.txt", body)]);
+
+    // A: modify the first line of foo.txt (small diff, high similarity kept)
+    let a_body = format!("MODIFIED\n{body}");
+    create_commit_with_files(&work_dir, "a", &["base"], &[("foo.txt", &a_body)]);
+
+    // B: rename foo.txt → bar.txt (delete foo, write bar with same content)
+    work_dir
+        .run_jj_with(|cmd| cmd.args(["new", "-m", "b", "base"]))
+        .success();
+    work_dir.remove_file("foo.txt");
+    work_dir.write_file("bar.txt", body);
+    work_dir
+        .run_jj(["bookmark", "create", "-r@", "b"])
+        .success();
+
+    // Rebase a onto b
+    let output = work_dir.run_jj(["rebase", "-r", "a", "-d", "b"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    Rebased 1 commits to destination
+    [EOF]
+    ");
+
+    // After the rebase, "a" should have bar.txt carrying A's modification
+    // and foo.txt should be absent (no conflict).
+    insta::assert_snapshot!(work_dir.run_jj(["diff", "-r", "a", "--summary"]), @"
+    M bar.txt
+    [EOF]
+    ");
+    // The content at bar.txt should be A's version (MODIFIED prepended).
+    insta::assert_snapshot!(work_dir.run_jj(["file", "show", "-r", "a", "bar.txt"]), @"
+    MODIFIED
+    line1
+    line2
+    line3
+    line4
+    line5
+    line6
+    line7
+    line8
+    line9
+    line10
+    [EOF]
+    ");
+}

--- a/lib/src/rewrite.rs
+++ b/lib/src/rewrite.rs
@@ -31,6 +31,7 @@ use tracing::instrument;
 use crate::backend::BackendError;
 use crate::backend::BackendResult;
 use crate::backend::CommitId;
+use crate::backend::CopyRecord;
 use crate::commit::Commit;
 use crate::commit::CommitIteratorExt as _;
 use crate::commit::conflict_label_for_commits;
@@ -50,9 +51,59 @@ use crate::merged_tree_builder::MergedTreeBuilder;
 use crate::repo::MutableRepo;
 use crate::repo::Repo;
 use crate::repo_path::RepoPath;
+use crate::repo_path::RepoPathBuf;
 use crate::revset::RevsetExpression;
 use crate::revset::RevsetStreamExt as _;
 use crate::store::Store;
+
+/// Given a set of `CopyRecord`s and the target tree, returns the subset that
+/// are renames (source path absent in target) as a map from old to new path.
+///
+/// Uses the same source-absence rule as
+/// `CopiesTreeDiffStream::resolve_copy_source`.
+async fn renames_from_records(
+    target_tree: &MergedTree,
+    records: impl IntoIterator<Item = CopyRecord>,
+) -> BackendResult<HashMap<RepoPathBuf, RepoPathBuf>> {
+    let mut renames = HashMap::new();
+    for record in records {
+        let at_source = target_tree.path_value(&record.source).await?;
+        if at_source.is_absent() {
+            renames.insert(record.source, record.target);
+        }
+    }
+    Ok(renames)
+}
+
+/// Fetches copy records between `old_base_commit` and `new_base_commit` from
+/// the backend and returns those that are renames (source deleted in
+/// `new_base_tree`). Returns an empty map for backends without copy support.
+async fn detect_renames(
+    store: &Arc<Store>,
+    old_base_commit: &CommitId,
+    new_base_commit: &CommitId,
+    new_base_tree: &MergedTree,
+) -> BackendResult<HashMap<RepoPathBuf, RepoPathBuf>> {
+    let records: Vec<CopyRecord> = store
+        .get_copy_records(None, old_base_commit, new_base_commit)?
+        .try_collect()
+        .await?;
+    renames_from_records(new_base_tree, records).await
+}
+
+/// Returns a copy of `tree` with file values moved from old paths to new paths.
+async fn remap_tree_paths(
+    tree: &MergedTree,
+    renames: &HashMap<RepoPathBuf, RepoPathBuf>,
+) -> BackendResult<MergedTree> {
+    let mut builder = MergedTreeBuilder::new(tree.clone());
+    for (old_path, new_path) in renames {
+        let value = tree.path_value(old_path).await?;
+        builder.set_or_remove(old_path.clone(), Merge::absent());
+        builder.set_or_remove(new_path.clone(), value);
+    }
+    builder.write_tree().await
+}
 
 /// Merges `commits` and tries to resolve any conflicts recursively.
 #[instrument(skip(repo))]
@@ -345,8 +396,48 @@ impl<'repo> CommitRewriter<'repo> {
             let new_base_tree_fut = merge_commit_trees(self.mut_repo, &new_parents);
             let old_tree = self.old_commit.tree();
             let (old_base_tree, new_base_tree) = try_join!(old_base_tree_fut, new_base_tree_fut)?;
+            let was_empty = old_base_tree.tree_ids() == self.old_commit.tree_ids();
+
+            // For single-parent → single-parent rebases, detect renames introduced
+            // by the destination and pre-shift both old_base_tree and old_tree so
+            // the per-path 3-way merge sees the content at the correct new path.
+            let (old_base_tree, old_tree) = if let ([old_parent], [new_parent]) =
+                (old_parents.as_slice(), new_parents.as_slice())
+            {
+                let renames = detect_renames(
+                    self.mut_repo.store(),
+                    old_parent.id(),
+                    new_parent.id(),
+                    &new_base_tree,
+                )
+                .await?;
+                if renames.is_empty() {
+                    (old_base_tree, old_tree)
+                } else {
+                    let mut relevant = HashMap::new();
+                    for (old_path, new_path) in &renames {
+                        let at_old = old_tree.path_value(old_path).await?;
+                        let at_new = old_tree.path_value(new_path).await?;
+                        // Skip if the rebased commit already occupies the new path —
+                        // let the regular 3-way merge produce its conflict.
+                        if !at_old.is_absent() && at_new.is_absent() {
+                            relevant.insert(old_path.clone(), new_path.clone());
+                        }
+                    }
+                    if relevant.is_empty() {
+                        (old_base_tree, old_tree)
+                    } else {
+                        let adj_base = remap_tree_paths(&old_base_tree, &relevant).await?;
+                        let adj_tree = remap_tree_paths(&old_tree, &relevant).await?;
+                        (adj_base, adj_tree)
+                    }
+                }
+            } else {
+                (old_base_tree, old_tree)
+            };
+
             (
-                old_base_tree.tree_ids() == self.old_commit.tree_ids(),
+                was_empty,
                 MergedTree::merge(Merge::from_vec(vec![
                     (
                         new_base_tree,

--- a/lib/tests/test_rewrite.rs
+++ b/lib/tests/test_rewrite.rs
@@ -39,6 +39,7 @@ use jj_lib::rewrite::find_duplicate_divergent_commits;
 use jj_lib::rewrite::find_recursive_merge_commits;
 use jj_lib::rewrite::merge_commit_trees;
 use jj_lib::rewrite::merge_commit_trees_no_resolve;
+use jj_lib::rewrite::rebase_commit;
 use jj_lib::rewrite::rebase_commit_with_options;
 use jj_lib::rewrite::restore_tree;
 use maplit::hashmap;
@@ -47,6 +48,7 @@ use pollster::FutureExt as _;
 use test_case::test_case;
 use testutils::CommitBuilderExt as _;
 use testutils::TestRepo;
+use testutils::TestRepoBackend;
 use testutils::TestResult;
 use testutils::assert_abandoned_with_parent;
 use testutils::assert_rebased_onto;
@@ -2379,5 +2381,162 @@ fn test_find_duplicate_divergent_commits() -> TestResult {
     .block_on()?;
     // Commit c2 is a duplicate
     assert_eq!(duplicate_commits, std::slice::from_ref(&commit_c2));
+    Ok(())
+}
+
+// The body needs enough lines so that adding one more keeps similarity above
+// gix's 50% rename-detection threshold.
+const RENAME_TEST_BODY: &str =
+    "line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10\n";
+
+#[test]
+fn test_rebase_follows_file_rename() -> TestResult {
+    // BASE has foo.txt. A modifies foo.txt. B renames foo.txt → bar.txt
+    // (pure rename, same content). Rebasing A onto B should produce a commit
+    // where bar.txt carries A's modification and foo.txt is absent.
+    let test_repo = TestRepo::init_with_backend(TestRepoBackend::Git);
+    let repo = &test_repo.repo;
+
+    let foo = repo_path("foo.txt");
+    let bar = repo_path("bar.txt");
+    let modified = format!("MODIFIED\n{RENAME_TEST_BODY}");
+
+    let tree_base = create_tree(repo, &[(foo, RENAME_TEST_BODY)]);
+    let tree_a = create_tree(repo, &[(foo, &modified)]);
+    let tree_b = create_tree(repo, &[(bar, RENAME_TEST_BODY)]); // same content → rename
+
+    let mut tx = repo.start_transaction();
+    let commit_base = tx
+        .repo_mut()
+        .new_commit(vec![repo.store().root_commit_id().clone()], tree_base)
+        .write_unwrap();
+    let commit_a = tx
+        .repo_mut()
+        .new_commit(vec![commit_base.id().clone()], tree_a)
+        .write_unwrap();
+    let commit_b = tx
+        .repo_mut()
+        .new_commit(vec![commit_base.id().clone()], tree_b)
+        .write_unwrap();
+
+    let rebased =
+        rebase_commit(tx.repo_mut(), commit_a.clone(), vec![commit_b.id().clone()]).block_on()?;
+
+    let rebased_tree = rebased.tree();
+    assert_eq!(
+        rebased_tree.path_value(foo).block_on()?,
+        Merge::absent(),
+        "foo.txt should be absent after rename-following rebase"
+    );
+    assert_eq!(
+        rebased_tree.path_value(bar).block_on()?,
+        commit_a.tree().path_value(foo).block_on()?,
+        "bar.txt should carry A's modification"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_rebase_follows_renamed_and_edited_file() -> TestResult {
+    // Like test_rebase_follows_file_rename, but B also edits the file while
+    // renaming it (content-changed rename). The rebase should produce a
+    // 3-way merge of A's change and B's change at bar.txt with no conflict.
+    let test_repo = TestRepo::init_with_backend(TestRepoBackend::Git);
+    let repo = &test_repo.repo;
+
+    let foo = repo_path("foo.txt");
+    let bar = repo_path("bar.txt");
+
+    let a_body = format!("MODIFIED_BY_A\n{RENAME_TEST_BODY}");
+    let b_body = format!("{RENAME_TEST_BODY}line11\n"); // extra line kept within similarity
+
+    let tree_base = create_tree(repo, &[(foo, RENAME_TEST_BODY)]);
+    let tree_a = create_tree(repo, &[(foo, &a_body)]);
+    let tree_b = create_tree(repo, &[(bar, &b_body)]); // renamed + edited
+
+    let mut tx = repo.start_transaction();
+    let commit_base = tx
+        .repo_mut()
+        .new_commit(vec![repo.store().root_commit_id().clone()], tree_base)
+        .write_unwrap();
+    let commit_a = tx
+        .repo_mut()
+        .new_commit(vec![commit_base.id().clone()], tree_a)
+        .write_unwrap();
+    let commit_b = tx
+        .repo_mut()
+        .new_commit(vec![commit_base.id().clone()], tree_b)
+        .write_unwrap();
+
+    let rebased =
+        rebase_commit(tx.repo_mut(), commit_a.clone(), vec![commit_b.id().clone()]).block_on()?;
+
+    let rebased_tree = rebased.tree();
+    assert_eq!(
+        rebased_tree.path_value(foo).block_on()?,
+        Merge::absent(),
+        "foo.txt should be absent"
+    );
+    // The result should be a conflict-free 3-way merge: both A and B made
+    // edits to non-overlapping regions.
+    assert!(
+        !rebased.has_conflict(),
+        "rename-following rebase should produce no conflict"
+    );
+    // bar.txt must be present in the result.
+    assert!(
+        !rebased_tree.path_value(bar).block_on()?.is_absent(),
+        "bar.txt must exist in rebased commit"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_rebase_does_not_follow_file_copy() -> TestResult {
+    // B copies foo.txt → bar.txt but keeps foo.txt (a copy, not a rename).
+    // A modifies foo.txt. Rebasing A onto B should apply A's change at
+    // foo.txt — not at bar.txt — because it is a copy, not a rename.
+    let test_repo = TestRepo::init_with_backend(TestRepoBackend::Git);
+    let repo = &test_repo.repo;
+
+    let foo = repo_path("foo.txt");
+    let bar = repo_path("bar.txt");
+    let modified = format!("MODIFIED\n{RENAME_TEST_BODY}");
+
+    let tree_base = create_tree(repo, &[(foo, RENAME_TEST_BODY)]);
+    let tree_a = create_tree(repo, &[(foo, &modified)]);
+    // B keeps both foo and bar (copy, not rename)
+    let tree_b = create_tree(repo, &[(foo, RENAME_TEST_BODY), (bar, RENAME_TEST_BODY)]);
+
+    let mut tx = repo.start_transaction();
+    let commit_base = tx
+        .repo_mut()
+        .new_commit(vec![repo.store().root_commit_id().clone()], tree_base)
+        .write_unwrap();
+    let commit_a = tx
+        .repo_mut()
+        .new_commit(vec![commit_base.id().clone()], tree_a)
+        .write_unwrap();
+    let commit_b = tx
+        .repo_mut()
+        .new_commit(vec![commit_base.id().clone()], tree_b)
+        .write_unwrap();
+
+    let rebased =
+        rebase_commit(tx.repo_mut(), commit_a.clone(), vec![commit_b.id().clone()]).block_on()?;
+
+    let rebased_tree = rebased.tree();
+    // foo.txt should have A's modification (the copy source is still present).
+    assert_eq!(
+        rebased_tree.path_value(foo).block_on()?,
+        commit_a.tree().path_value(foo).block_on()?,
+        "A's modification should be at foo.txt (the original path)"
+    );
+    // bar.txt should have B's content unchanged (A didn't touch bar.txt).
+    assert_eq!(
+        rebased_tree.path_value(bar).block_on()?,
+        commit_b.tree().path_value(bar).block_on()?,
+        "bar.txt should remain as B left it (the copy target)"
+    );
     Ok(())
 }


### PR DESCRIPTION
This implementation works, sort of. The problem is that it detects copies (renames) between the trees of the original base and the new base. That means the file in the original base needs to still be similar to the file in the new base, it can't have changed too much since the rename.

I'm currently considering walking the whole DAG between `original_base` and `new_base` and building up a map of all the renames, but that seems like it will be prohibitively expensive in large repos. I'm not really sure how to gauge that.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [ ] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
