### PR TITLE
`run`: fix a bug, report when blocked on concurrent execution

### DIFF
--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -475,7 +475,14 @@ pub async fn cmd_run(
     // still held, and on Windows a directory can't be removed while it contains
     // an open file handle. A sibling lock file avoids that and lets us hold the
     // lock across the deletion, so no other process can race in between.
-    let lock = FileLock::lock(base_path.with_extension("lock")).map_err(RunError::from)?;
+    let lock_path = base_path.with_extension("lock");
+    let lock = match FileLock::try_lock(lock_path.clone()).map_err(RunError::from)? {
+        Some(lock) => lock,
+        None => {
+            writeln!(ui.status(), "Waiting for another `jj run` to finish...")?;
+            FileLock::lock(lock_path).map_err(RunError::from)?
+        }
+    };
     let base_path = Arc::new(base_path);
     let stored_len = resolved_commits.len();
 

--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -408,8 +408,27 @@ pub async fn cmd_run(
     command: &CommandHelper,
     args: &RunArgs,
 ) -> Result<(), CommandError> {
+    let repo_path = command.workspace_loader()?.repo_path().to_path_buf();
+    // TODO: should be stored in a backend and not hardcoded.
+    let base_path = repo_path.parent().unwrap().join("run").join("default");
+
+    // NOTE: we have to take the lock as early as possible before resolving
+    // revsets, so that if we block on an existing process to finish, we
+    // properly resolve the given set of commits if they were rewritten
+    let lock_dir = base_path
+        .parent()
+        .expect("run directory should have a parent");
+    fs::create_dir_all(lock_dir)?;
+    let lock_path = base_path.with_extension("lock");
+    let lock = match FileLock::try_lock(lock_path.clone()).map_err(RunError::from)? {
+        Some(lock) => lock,
+        None => {
+            writeln!(ui.status(), "Waiting for another `jj run` to finish...")?;
+            FileLock::lock(lock_path).map_err(RunError::from)?
+        }
+    };
+
     let mut workspace_command = command.workspace_helper(ui).await?;
-    // The commits are already returned in reverse topological order.
     let resolved_commits: Vec<_> = if args.revisions.is_empty() {
         let revs = workspace_command.settings().get_string("revsets.run")?;
         workspace_command
@@ -457,32 +476,11 @@ pub async fn cmd_run(
 
     let store = workspace_command.repo().store().clone();
     let mut tx = workspace_command.start_transaction();
-    let repo_path = tx.base_workspace_helper().repo_path();
 
-    // Per-commit working copies are now created on demand inside
-    // `rewrite_commit`; we just need the parent directory to exist.
-    // The lock is held for the duration of the run, including the cleanup that
-    // removes the run directory, and released on drop.
-    // TODO: should be stored in a backend and not hardcoded.
-    // The parent() call is needed to not write under `.jj/repo/`.
-    let base_path = repo_path.parent().unwrap().join("run").join("default");
-    if !base_path.exists() {
-        tracing::debug!(?base_path, "does not exist, so creating it");
-        fs::create_dir_all(&base_path)?;
-    }
-    // Keep the lock file *beside* `base_path` (e.g. `run/default.lock`) rather
-    // than inside it. The directory is removed during cleanup while the lock is
-    // still held, and on Windows a directory can't be removed while it contains
-    // an open file handle. A sibling lock file avoids that and lets us hold the
-    // lock across the deletion, so no other process can race in between.
-    let lock_path = base_path.with_extension("lock");
-    let lock = match FileLock::try_lock(lock_path.clone()).map_err(RunError::from)? {
-        Some(lock) => lock,
-        None => {
-            writeln!(ui.status(), "Waiting for another `jj run` to finish...")?;
-            FileLock::lock(lock_path).map_err(RunError::from)?
-        }
-    };
+    // A previous run's cleanup (that may have finished while we waited for the
+    // lock) may have removed the base path directory, it, so (re)create it now
+    // that we hold the lock.
+    fs::create_dir_all(&base_path)?;
     let base_path = Arc::new(base_path);
     let stored_len = resolved_commits.len();
 

--- a/lib/src/lock/mod.rs
+++ b/lib/src/lock/mod.rs
@@ -83,4 +83,28 @@ mod tests {
         let value = u32::from_le_bytes(data.try_into().unwrap());
         assert_eq!(value, num_threads as u32);
     }
+
+    #[test]
+    fn try_lock_succeeds_when_unlocked() {
+        let temp_dir = new_temp_dir();
+        let lock_path = temp_dir.path().join("test.lock");
+        assert!(!lock_path.exists());
+        {
+            let lock = FileLock::try_lock(lock_path.clone()).unwrap();
+            assert!(lock.is_some());
+            assert!(lock_path.exists());
+        }
+        assert!(!lock_path.exists());
+    }
+
+    #[test]
+    fn try_lock_gives_up_when_locked() {
+        let temp_dir = new_temp_dir();
+        let lock_path = temp_dir.path().join("test.lock");
+        let _held = FileLock::lock(lock_path.clone()).unwrap();
+        // The lock is already held, so a non-blocking attempt returns `None`
+        // instead of blocking. The two lock handles are independent even within
+        // a single process, so the second attempt is denied.
+        assert!(FileLock::try_lock(lock_path).unwrap().is_none());
+    }
 }

--- a/lib/src/lock/unix.rs
+++ b/lib/src/lock/unix.rs
@@ -28,8 +28,25 @@ pub struct FileLock {
 }
 
 impl FileLock {
+    /// Acquire an exclusive lock on `path`, blocking until it's available.
     pub fn lock(path: PathBuf) -> Result<Self, FileLockError> {
+        // In blocking mode, `lock_inner` never returns `Ok(None)`.
+        Ok(Self::lock_inner(path, true)?.expect("blocking lock should return a lock"))
+    }
+
+    /// Try to acquire an exclusive lock on `path` without blocking. Returns
+    /// `Ok(None)` if the lock is currently held by another process.
+    pub fn try_lock(path: PathBuf) -> Result<Option<Self>, FileLockError> {
+        Self::lock_inner(path, false)
+    }
+
+    fn lock_inner(path: PathBuf, blocking: bool) -> Result<Option<Self>, FileLockError> {
         tracing::info!("Attempting to lock {path:?}");
+        let operation = if blocking {
+            FlockOperation::LockExclusive
+        } else {
+            FlockOperation::NonBlockingLockExclusive
+        };
         loop {
             // Create lockfile, or open pre-existing one
             let file = File::create(&path).map_err(|err| FileLockError {
@@ -37,14 +54,19 @@ impl FileLock {
                 path: path.clone(),
                 err,
             })?;
-            // If the lock was already held, wait for it to be released
-            rustix::fs::flock(&file, FlockOperation::LockExclusive).map_err(|errno| {
-                FileLockError {
-                    message: "Failed to lock lock file",
-                    path: path.clone(),
-                    err: errno.into(),
+            // If the lock was already held, block until it's released, or (in
+            // non-blocking mode) report that it's currently unavailable.
+            match rustix::fs::flock(&file, operation) {
+                Ok(()) => {}
+                Err(rustix::io::Errno::WOULDBLOCK) if !blocking => return Ok(None),
+                Err(errno) => {
+                    return Err(FileLockError {
+                        message: "Failed to lock lock file",
+                        path: path.clone(),
+                        err: errno.into(),
+                    });
                 }
-            })?;
+            }
 
             match rustix::fs::fstat(&file) {
                 Ok(stat) => {
@@ -74,7 +96,7 @@ impl FileLock {
             }
 
             tracing::info!("Locked {path:?}");
-            return Ok(Self { path, file });
+            return Ok(Some(Self { path, file }));
         }
     }
 }

--- a/lib/src/lock/windows.rs
+++ b/lib/src/lock/windows.rs
@@ -17,6 +17,7 @@
 
 use std::fs::File;
 use std::fs::OpenOptions;
+use std::fs::TryLockError;
 use std::io;
 use std::os::windows::fs::OpenOptionsExt as _;
 use std::path::Path;
@@ -39,7 +40,19 @@ pub struct FileLock {
 }
 
 impl FileLock {
+    /// Acquire an exclusive lock on `path`, blocking until it's available.
     pub fn lock(path: PathBuf) -> Result<Self, FileLockError> {
+        // In blocking mode, `lock_inner` never returns `Ok(None)`.
+        Ok(Self::lock_inner(path, true)?.expect("blocking lock should return a lock"))
+    }
+
+    /// Try to acquire an exclusive lock on `path` without blocking. Returns
+    /// `Ok(None)` if the lock is currently held by another process.
+    pub fn try_lock(path: PathBuf) -> Result<Option<Self>, FileLockError> {
+        Self::lock_inner(path, false)
+    }
+
+    fn lock_inner(path: PathBuf, blocking: bool) -> Result<Option<Self>, FileLockError> {
         tracing::info!("Attempting to lock {path:?}");
 
         let file = try_create_file(&path).map_err(|err| FileLockError {
@@ -48,18 +61,33 @@ impl FileLock {
             err,
         })?;
 
-        // Acquire exclusive lock (blocks until available)
-        file.lock().map_err(|err| FileLockError {
-            message: "Failed to lock lock file",
-            path: path.clone(),
-            err,
-        })?;
+        if blocking {
+            // Acquire exclusive lock (blocks until available)
+            file.lock().map_err(|err| FileLockError {
+                message: "Failed to lock lock file",
+                path: path.clone(),
+                err,
+            })?;
+        } else {
+            // Acquire the lock, or report that another process holds it.
+            match file.try_lock() {
+                Ok(()) => {}
+                Err(TryLockError::WouldBlock) => return Ok(None),
+                Err(TryLockError::Error(err)) => {
+                    return Err(FileLockError {
+                        message: "Failed to lock lock file",
+                        path,
+                        err,
+                    });
+                }
+            }
+        }
 
         tracing::info!("Locked {path:?}");
-        Ok(Self {
+        Ok(Some(Self {
             path,
             file: Some(file),
-        })
+        }))
     }
 }
 


### PR DESCRIPTION
From my own testing and usage. Claude diagnosed the concurrency bug mentioned and wrote the patch; I reviewed it for correctness.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [ ] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
