### PR TITLE
git: bump zlib-rs to 0.6.4 for loose object fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   remote's fetch URL or effective push URL.
   [#413](https://github.com/jj-vcs/jj/issues/413)
 
+* Fixed corrupt loose Git objects written through zlib-rs. Previously, jj could
+  report a successful commit even though `git fsck` later failed with
+  `incorrect data check`, `corrupt loose object`, or `missing blob`, and later
+  jj operations could fail with `corrupt deflate stream`.
+
 ## [0.42.0] - 2026-06-04
 
 ### Release highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5569,9 +5569,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
+checksum = "977347db8caa080403f6b6b7c1cda9479a8e869316f7e13a59b19076a40f94e3"
 
 [[package]]
 name = "zmij"


### PR DESCRIPTION
Original description (before 2026-06-22):

> deps: pin unreleased zlib-rs fixes
> 
> zlib-rs 0.6.3 is currently the latest release but it is missing fixes for bad compression output. jj writes loose Git objects through the gix zlib-rs backend, so these bugs can leave commits that succeed but fail later when Git or jj inflate the object.
> 
> I have a repository where I can reliably reproduce jj (version prior to
> this patch) corrupting Git state because of one of these issues.
> 
> Pin the current upstream revision until a crates.io release contains
> the fixes.
>
> In case it's not desired to depend on a not-yet-released zlib-rs version I asked for a release: https://github.com/trifectatechfoundation/zlib-rs/issues/526.

---
This zlib-rs release fixes bugs that could make zlib output written by
gix's zlib-rs backend unreadable later[1][2]. jj uses that path when
writing loose Git objects, so an affected commit could appear to succeed
even though the object later failed to inflate or failed its zlib checksum.

[1] https://github.com/trifectatechfoundation/zlib-rs/pull/504
[2] https://github.com/trifectatechfoundation/zlib-rs/pull/520

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
