### PR TITLE
`jj run`: Reuse a pool of workspaces between invocations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,7 +117,7 @@ test-case = "3.3.1"
 textwrap = "0.16.2"
 thiserror = "2.0.17"
 timeago = { version = "0.6.0", default-features = false }
-tokio = { version = "1.52.3", features = ["fs", "io-util", "process", "rt-multi-thread", "sync"] }
+tokio = { version = "1.52.3", features = ["fs", "io-util", "process", "rt-multi-thread", "sync", "time"] }
 toml = "1.1.0"
 toml_edit = { version = "0.25.12", features = ["serde"] }
 tracing = "0.1.44"

--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -167,6 +167,9 @@ struct WorkspacePool {
     /// rewritten commit. Loaded once from `snapshot.auto-track`; essentially
     /// the user's `.gitignore` story for what counts as a build artifact.
     auto_tracking_matcher: Box<dyn Matcher>,
+    /// When true, wipe each slot's working copy on acquisition so every commit
+    /// starts from a freshly checked-out tree (no artifact reuse).
+    clean: bool,
 }
 
 impl WorkspacePool {
@@ -174,6 +177,7 @@ impl WorkspacePool {
         repo_path: &Path,
         size: NonZeroUsize,
         auto_tracking_matcher: Box<dyn Matcher>,
+        clean: bool,
     ) -> Result<Self, RunError> {
         // The parent() call is needed to not write under `.jj/repo/`.
         let base_path = repo_path.parent().unwrap().join("run").join("default");
@@ -182,6 +186,7 @@ impl WorkspacePool {
             base_path,
             size,
             auto_tracking_matcher,
+            clean,
         })
     }
 
@@ -209,7 +214,7 @@ impl WorkspacePool {
 
         let is_reused_workspace = tree_state_path.exists();
         let settings = default_tree_state_settings();
-        let mut tree_state = if is_reused_workspace {
+        let mut tree_state = if !self.clean && is_reused_workspace {
             // Load the persisted tree state so `check_out` below can diff
             // against it, only touching files that changed and removing files
             // no longer present in the new tree.
@@ -227,10 +232,15 @@ impl WorkspacePool {
             fs::remove_file(&tree_state_path)?;
             ts
         } else {
-            // First use, or the previous job crashed before saving. Wipe any
-            // leftover working copy so we start from a clean slate, then use
-            // an in-memory empty tree state. `tree_state` stays absent on disk
-            // until a job writes it via `persist()`.
+            // This is the first use of the workspace, the previous job crashed,
+            // or --clean was passed. Wipe any leftover working copy so we start
+            // from a clean slate, then use an in-memory empty tree state.
+            // `tree_state` stays absent on disk until a successful job writes
+            // it via `persist()`.
+            fs::remove_file(&tree_state_path).or_else(|e| match e {
+                e if e.kind() == io::ErrorKind::NotFound => Ok(()),
+                e => Err(RunError::PathDeletionFailure(tree_state_path.clone(), e)),
+            })?;
             fs::remove_dir_all(&working_copy_dir).or_else(|e| match e {
                 e if e.kind() == io::ErrorKind::NotFound => Ok(()),
                 e => Err(RunError::PathDeletionFailure(working_copy_dir.clone(), e)),
@@ -586,6 +596,14 @@ pub struct RunArgs {
     /// from the subdirectory `jj run` was invoked from.
     #[arg(long)]
     root: bool,
+
+    /// Delete each working copy before running the command
+    ///
+    /// By default `jj run` reuses working copies between invocations so build
+    /// artifacts are preserved. With `--clean`, every commit starts from a
+    /// freshly checked-out tree.
+    #[arg(long)]
+    clean: bool,
 }
 
 /// Precedence: `--jobs`, `run.jobs` config, 1.
@@ -680,7 +698,12 @@ pub async fn cmd_run(
     let mut done_commits = HashSet::new();
     let (sender_tx, mut receiver) = mpsc::channel(jobs.get());
 
-    let pool = Arc::new(WorkspacePool::new(&repo_path, jobs, auto_tracking_matcher)?);
+    let pool = Arc::new(WorkspacePool::new(
+        &repo_path,
+        jobs,
+        auto_tracking_matcher,
+        args.clean,
+    )?);
     let stored_len = resolved_commits.len();
 
     let spec = Arc::new(CommandSpec {

--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -14,18 +14,22 @@
 
 //! This file contains the internal implementation of `run`.
 
+use std::cmp::min;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::fmt;
 use std::fs;
 use std::io;
 use std::io::Write as _;
+use std::num::NonZeroUsize;
 use std::path::Path;
 use std::path::PathBuf;
 use std::process::ExitStatus;
 use std::process::Stdio;
 use std::sync::Arc;
+use std::time::Duration;
 
+use futures::StreamExt as _;
 use futures::TryStreamExt as _;
 use itertools::Itertools as _;
 use jj_lib::backend::BackendError;
@@ -43,6 +47,7 @@ use jj_lib::local_working_copy::TreeStateSettings;
 use jj_lib::lock::FileLock;
 use jj_lib::lock::FileLockError;
 use jj_lib::matchers::EverythingMatcher;
+use jj_lib::matchers::Matcher;
 use jj_lib::matchers::NothingMatcher;
 use jj_lib::merge::Merge;
 use jj_lib::merged_tree::MergedTree;
@@ -58,9 +63,11 @@ use tokio::sync::mpsc;
 use tokio::sync::mpsc::Sender;
 use tokio::task::JoinError;
 use tokio::task::JoinSet;
+use tokio::time::sleep;
 
 use crate::cli_util::CommandHelper;
 use crate::cli_util::RevisionArg;
+use crate::cli_util::WorkspaceCommandHelper;
 use crate::cli_util::WorkspaceCommandTransaction;
 use crate::command_error::CommandError;
 use crate::command_error::CommandErrorKind;
@@ -74,16 +81,20 @@ enum RunError {
     CommandFailure(String, ExitStatus, CommitId),
     #[error(transparent)]
     IoError(#[from] io::Error),
-    #[error("failed to create path {} with {}", .0.to_string_lossy(), .1)]
+    #[error("failed to create path {}: {}", .0.to_string_lossy(), .1)]
     PathCreationFailure(PathBuf, io::Error),
-    #[error("failed to load a commits tree")]
+    #[error("failed to delete path {}: {}", .0.to_string_lossy(), .1)]
+    PathDeletionFailure(PathBuf, io::Error),
+    #[error("failed to load a commit's tree")]
     TreeState(#[from] TreeStateError),
     #[error(transparent)]
     Backend(#[from] BackendError),
     #[error(transparent)]
     JobFailure(#[from] JoinError),
     #[error(transparent)]
-    LockError(#[from] FileLockError),
+    FileLock(#[from] FileLockError),
+    #[error("invalid value for `run.jobs`: {0} (must be a positive integer)")]
+    InvalidJobCount(i64),
 }
 
 impl From<RunError> for CommandError {
@@ -92,61 +103,33 @@ impl From<RunError> for CommandError {
     }
 }
 
-/// Provision an isolated per-commit working copy under `base_path` and check
-/// out `commit`'s tree into it. Returns the working-copy directory and its
-/// initialized `TreeState`, ready for the caller to spawn a command in and
-/// later snapshot.
-async fn create_working_copy(
-    base_path: &Path,
-    commit: &Commit,
-) -> Result<(PathBuf, TreeState), RunError> {
-    // Per-commit working-copy directory, keyed by commit id so concurrent jobs
-    // don't collide and so the working copy is reproducible across runs.
-    let commit_path = base_path.join(commit.id().hex());
-    // A previous `jj run` that failed before cleanup may have left this
-    // directory behind. Clear it so the working_copy/state subdirs below
-    // start from a clean slate.
-    if commit_path.exists() {
-        tracing::debug!(
-            dir = ?commit_path,
-            commit = commit.id().hex(),
-            "removing leftover directory from a previous run"
-        );
-        fs::remove_dir_all(&commit_path)
-            .map_err(|e| RunError::PathCreationFailure(commit_path.clone(), e))?;
-    }
-    tracing::debug!(
-        dir = ?commit_path,
-        commit = commit.id().hex(),
-        "creating directory for commit"
-    );
-    fs::create_dir(&commit_path)
-        .map_err(|e| RunError::PathCreationFailure(commit_path.clone(), e))?;
-
-    tracing::debug!(?commit_path, "creating working copy paths for path");
-    let working_copy_dir = commit_path.join("working_copy");
-    let state_dir = commit_path.join("state");
-    tracing::debug!(?working_copy_dir, ?state_dir, "creating paths for a commit");
-    fs::create_dir(&working_copy_dir)
-        .map_err(|e| RunError::PathCreationFailure(working_copy_dir.clone(), e))?;
-    fs::create_dir(&state_dir).map_err(|e| RunError::PathCreationFailure(state_dir.clone(), e))?;
-    let tree_state_settings = TreeStateSettings {
+fn default_tree_state_settings() -> TreeStateSettings {
+    TreeStateSettings {
         conflict_marker_style: ConflictMarkerStyle::Snapshot,
         eol_conversion_mode: EolConversionMode::None,
         exec_change_setting: ExecChangeSetting::Auto,
         fsmonitor_settings: FsmonitorSettings::None,
-    };
-    let mut tree_state = TreeState::init(
-        commit.store().clone(),
-        working_copy_dir.clone(),
-        state_dir,
-        &tree_state_settings,
-    )?;
-    tree_state
-        .check_out(&commit.tree())
-        .map_err(|_| RunError::FailedCheckout(commit.id().clone()))?;
+    }
+}
 
-    Ok((working_copy_dir, tree_state))
+/// A workspace that's ready for a single job to run against.
+///
+/// Dropping the workspace releases its interprocess lock, freeing the slot for
+/// the next worker.
+struct RunWorkspace {
+    working_copy_dir: PathBuf,
+    tree_state: TreeState,
+    /// Holds the slot's interprocess lock for the duration of the job.
+    _lock: FileLock,
+}
+
+impl RunWorkspace {
+    /// Persist the post-snapshot tree state to disk so the next slot
+    /// acquisition can diff against it and only touch changed files.
+    fn persist(&mut self) -> Result<(), RunError> {
+        self.tree_state.save()?;
+        Ok(())
+    }
 }
 
 /// A command, its arguments, and the workspace-relative directory it should
@@ -167,6 +150,196 @@ impl fmt::Display for CommandSpec {
             f.write_str(arg)?;
         }
         Ok(())
+    }
+}
+
+/// Manages a fixed-size pool of workspaces under `.jj/run/default/`.
+///
+/// Each workspace lives at `.jj/run/default/N/` with subdirs `working_copy/`
+/// and `state/`. Its lockfile is the sibling `.jj/run/default/N.lock`.
+/// Workspaces persist between `jj run` invocations so build artifacts can be
+/// reused. Acquisition picks the first free workspace, so multiple concurrent
+/// `jj run` processes cooperatively share the pool.
+struct WorkspacePool {
+    base_path: PathBuf,
+    size: NonZeroUsize,
+    /// Determines which untracked files left in a slot get pulled into the
+    /// rewritten commit. Loaded once from `snapshot.auto-track`; essentially
+    /// the user's `.gitignore` story for what counts as a build artifact.
+    auto_tracking_matcher: Box<dyn Matcher>,
+}
+
+impl WorkspacePool {
+    fn new(
+        repo_path: &Path,
+        size: NonZeroUsize,
+        auto_tracking_matcher: Box<dyn Matcher>,
+    ) -> Result<Self, RunError> {
+        // The parent() call is needed to not write under `.jj/repo/`.
+        let base_path = repo_path.parent().unwrap().join("run").join("default");
+        fs::create_dir_all(&base_path)?;
+        Ok(Self {
+            base_path,
+            size,
+            auto_tracking_matcher,
+        })
+    }
+
+    async fn acquire(
+        &self,
+        commit: &Commit,
+        base_ignores: Arc<GitIgnoreFile>,
+    ) -> Result<RunWorkspace, RunError> {
+        // Find a free slot. The first iteration may fail if another worker
+        // (this process or another) holds every slot; sleep and retry.
+        let mut cur_sleep = Duration::from_millis(10);
+        let max_sleep = Duration::from_millis(250);
+        let (slot_index, lock) = loop {
+            if let Some(found) = self.try_acquire_any_slot()? {
+                break found;
+            }
+            sleep(cur_sleep).await;
+            cur_sleep = min(cur_sleep.saturating_mul(2), max_sleep);
+        };
+
+        let slot_path = self.slot_path(slot_index);
+        let working_copy_dir = slot_path.join("working_copy");
+        let state_dir = slot_path.join("state");
+        let tree_state_path = state_dir.join("tree_state");
+
+        let is_reused_workspace = tree_state_path.exists();
+        let settings = default_tree_state_settings();
+        let mut tree_state = if is_reused_workspace {
+            // Load the persisted tree state so `check_out` below can diff
+            // against it, only touching files that changed and removing files
+            // no longer present in the new tree.
+            //
+            // Delete `tree_state` from disk before checkout to act as a dirty
+            // marker. If we crash between here and the save at the end of the
+            // job, the next acquisition will see the file absent and wipe the
+            // slot rather than trusting inconsistent state.
+            let ts = TreeState::load(
+                commit.store().clone(),
+                working_copy_dir.clone(),
+                state_dir.clone(),
+                &settings,
+            )?;
+            fs::remove_file(&tree_state_path)?;
+            ts
+        } else {
+            // First use, or the previous job crashed before saving. Wipe any
+            // leftover working copy so we start from a clean slate, then use
+            // an in-memory empty tree state. `tree_state` stays absent on disk
+            // until a job writes it via `persist()`.
+            fs::remove_dir_all(&working_copy_dir).or_else(|e| match e {
+                e if e.kind() == io::ErrorKind::NotFound => Ok(()),
+                e => Err(RunError::PathDeletionFailure(working_copy_dir.clone(), e)),
+            })?;
+            fs::remove_dir_all(&state_dir).or_else(|e| match e {
+                e if e.kind() == io::ErrorKind::NotFound => Ok(()),
+                e => Err(RunError::PathDeletionFailure(state_dir.clone(), e)),
+            })?;
+            fs::create_dir_all(&working_copy_dir)
+                .map_err(|e| RunError::PathCreationFailure(working_copy_dir.clone(), e))?;
+            fs::create_dir_all(&state_dir)
+                .map_err(|e| RunError::PathCreationFailure(state_dir.clone(), e))?;
+            TreeState::init_without_saving(
+                commit.store().clone(),
+                working_copy_dir.clone(),
+                state_dir,
+                &settings,
+            )
+        };
+
+        tree_state
+            .check_out(&commit.tree())
+            .map_err(|_| RunError::FailedCheckout(commit.id().clone()))?;
+
+        // If we checked out a revision with a completely empty tree,
+        // TreeState::check_out() deletes the working_copy directory because it
+        // recursively deletes empty directories until it reaches an error. In
+        // normal workspaces, the .jj directory prevents the root directory from
+        // being deleted, but our slots don't have that. It might be better to
+        // make check_out explicitly avoid deleting the root directory, but that
+        // needs to be a carefully considered change.
+        fs::create_dir_all(&working_copy_dir)
+            .map_err(|e| RunError::PathCreationFailure(working_copy_dir.clone(), e))?;
+
+        // Remove files from a previous run that were ignored in the previous
+        // revision but are not ignored in the new commit:
+        // - Check out the new revsision
+        // - Snapshot to discover any new files in the working copy
+        // - Delete any new files
+        // - Check out again to reset tree state
+        if is_reused_workspace {
+            let options = self.snapshot_options(base_ignores);
+            tree_state.snapshot(&options).await.unwrap();
+            let post_snapshot_tree = tree_state.current_tree().clone();
+            let original_tree = commit.tree();
+            let mut diff = original_tree.diff_stream(&post_snapshot_tree, &EverythingMatcher);
+            let mut added_paths = Vec::new();
+            while let Some(entry) = diff.next().await {
+                let values = entry.values?;
+                if values.before.is_absent() && values.after.is_present() {
+                    added_paths.push(entry.path);
+                }
+            }
+            drop(diff);
+            for path in &added_paths {
+                let abs = path.to_fs_path_unchecked(&working_copy_dir);
+                if let Err(err) = fs::remove_file(&abs)
+                    && err.kind() != io::ErrorKind::NotFound
+                {
+                    return Err(err.into());
+                }
+            }
+            if !added_paths.is_empty() {
+                tree_state
+                    .check_out(&original_tree)
+                    .map_err(|_| RunError::FailedCheckout(commit.id().clone()))?;
+            }
+        }
+
+        Ok(RunWorkspace {
+            working_copy_dir,
+            tree_state,
+            _lock: lock,
+        })
+    }
+
+    fn snapshot_options(&self, base_ignores: Arc<GitIgnoreFile>) -> SnapshotOptions<'_> {
+        SnapshotOptions {
+            base_ignores,
+            start_tracking_matcher: self.auto_tracking_matcher.as_ref(),
+            progress: None,
+            // TODO: read from current wc/settings
+            max_new_file_size: 64_000_u64, // 64 MB for now
+            force_tracking_matcher: &NothingMatcher,
+        }
+    }
+
+    fn slot_path(&self, index: usize) -> PathBuf {
+        self.base_path.join(index.to_string())
+    }
+
+    fn slot_lock_path(&self, index: usize) -> PathBuf {
+        self.base_path.join(format!("{index}.lock"))
+    }
+
+    /// Try to acquire any slot's lock without blocking. Returns the slot
+    /// index and the held lock if one was available, `Ok(None)` if every
+    /// slot was contended.
+    fn try_acquire_any_slot(&self) -> Result<Option<(usize, FileLock)>, RunError> {
+        for slot in 1..=self.size.get() {
+            let slot_path = self.slot_path(slot);
+            fs::create_dir_all(&slot_path)
+                .map_err(|e| RunError::PathCreationFailure(slot_path.clone(), e))?;
+            if let Some(lock) = FileLock::try_lock(self.slot_lock_path(slot))? {
+                tracing::debug!(slot, "acquired pool slot");
+                return Ok(Some((slot, lock)));
+            }
+        }
+        Ok(None)
     }
 }
 
@@ -199,7 +372,7 @@ async fn run_inner(
     sender: Sender<RunJob>,
     handle: &tokio::runtime::Handle,
     spec: Arc<CommandSpec>,
-    base_path: Arc<PathBuf>,
+    pool: Arc<WorkspacePool>,
     commits: Arc<Vec<Commit>>,
     jobs: usize,
 ) -> Result<(), RunError> {
@@ -209,7 +382,7 @@ async fn run_inner(
     for commit in commits.iter() {
         let permit_future = semaphore.clone().acquire_owned();
         let base_ignores = base_ignores.clone();
-        let base_path = base_path.clone();
+        let pool = pool.clone();
         let commit = commit.clone();
         let spec = spec.clone();
         command_futures.spawn_on(
@@ -217,7 +390,7 @@ async fn run_inner(
                 let _permit: OwnedSemaphorePermit =
                     permit_future.await.expect("semaphore not closed");
                 // TODO: handle/propagate error here
-                rewrite_commit(base_ignores, base_path, commit, spec).await
+                rewrite_commit(base_ignores, pool, commit, spec).await
             },
             handle,
         );
@@ -242,20 +415,16 @@ async fn run_inner(
 
 /// Run `spec` against `commit`. The caller is responsible for committing any
 /// returned new tree to the repo.
-///
-/// Each invocation provisions its own per-commit working copy under
-/// `base_path` so multiple `rewrite_commit` futures can do their work in
-/// parallel without contending on shared state.
 async fn rewrite_commit(
     base_ignores: Arc<GitIgnoreFile>,
-    base_path: Arc<PathBuf>,
+    pool: Arc<WorkspacePool>,
     commit: Commit,
     spec: Arc<CommandSpec>,
 ) -> Result<RunJob, RunError> {
+    let mut workspace = pool.acquire(&commit, base_ignores.clone()).await?;
+    let working_copy_dir = workspace.working_copy_dir.clone();
     let old_id = commit.id().clone();
     let old_tree = commit.tree();
-
-    let (working_copy_dir, mut tree_state) = create_working_copy(&base_path, &commit).await?;
 
     // Resolve where the command should run. If the subdir doesn't exist in this
     // commit's checked-out tree, skip the commit entirely.
@@ -267,6 +436,9 @@ async fn rewrite_commit(
                 commit = old_id.hex(),
                 "subdirectory does not exist in commit; skipping"
             );
+            // Persist the post-checkout state so the next pool acquisition
+            // can diff from this tree even though no command ran.
+            workspace.persist()?;
             return Ok(RunJob {
                 old_id,
                 old_tree,
@@ -309,30 +481,9 @@ async fn rewrite_commit(
 
     let output = command.wait_with_output().await?;
 
-    if !output.status.success() {
-        return Ok(RunJob {
-            old_id,
-            old_tree,
-            new_tree: None,
-            dirty: false,
-            stdout: output.stdout,
-            stderr: output.stderr,
-            skipped: false,
-            status: Some(output.status),
-        });
-    }
-
-    let options = SnapshotOptions {
-        base_ignores,
-        // TODO: read from current wc/settings
-        start_tracking_matcher: &EverythingMatcher,
-        progress: None,
-        // TODO: read from current wc/settings
-        max_new_file_size: 64_000_u64, // 64 MB for now,
-        force_tracking_matcher: &NothingMatcher,
-    };
+    let options = pool.snapshot_options(base_ignores);
     tracing::debug!("trying to snapshot the new tree");
-    let (dirty, _) = tree_state.snapshot(&options).await.unwrap();
+    let (dirty, stats) = workspace.tree_state.snapshot(&options).await.unwrap();
     if !dirty {
         tracing::debug!(
             "commit {} was not modified as the passed command did not modify any tracked files",
@@ -340,18 +491,42 @@ async fn rewrite_commit(
         );
     }
 
-    let rewritten_id = tree_state.current_tree().tree_ids();
-    let new_id = rewritten_id.as_resolved().unwrap();
+    if !output.status.success() {
+        // Remove non-ignored untracked files left by the command. Ignored paths
+        // are absent from `untracked_paths` and survive for build-artifact reuse.
+        // This keeps the slot free of stale files that would cause silent
+        // `skipped_files` collisions in the next `check_out`.
+        for path in stats.untracked_paths.keys() {
+            let abs = path.to_fs_path_unchecked(&working_copy_dir);
+            if let Err(err) = fs::remove_file(&abs)
+                && err.kind() != io::ErrorKind::NotFound
+            {
+                return Err(err.into());
+            }
+        }
+    }
 
-    let new_tree = commit.store().get_tree(RepoPathBuf::root(), new_id).await?;
+    // Persist the post-snapshot tree state so the next pool acquisition can
+    // diff against it and only touch files that changed. Done unconditionally
+    // so the slot is reusable even when the command failed.
+    workspace.persist()?;
 
-    // TODO: Serialize the new tree into /output/{id-tree} for a cache lookup
-    // TODO: supersede with a custom workspace implementation
+    let new_tree = if output.status.success() {
+        let rewritten_id = workspace.tree_state.current_tree().tree_ids();
+        let new_id = rewritten_id.as_resolved().unwrap();
+
+        Some(commit.store().get_tree(RepoPathBuf::root(), new_id).await?)
+
+        // TODO: Serialize the new tree into /output/{id-tree} for a cache
+        // lookup TODO: supersede with a custom workspace implementation
+    } else {
+        None
+    };
 
     Ok(RunJob {
         old_id,
         old_tree,
-        new_tree: Some(new_tree),
+        new_tree,
         dirty,
         stdout: output.stdout,
         stderr: output.stderr,
@@ -401,13 +576,45 @@ pub struct RunArgs {
     exec: bool,
 
     /// How many processes should run in parallel
-    #[arg(long, short, default_value_t = 1)]
-    jobs: usize,
+    ///
+    /// Overrides the `run.jobs` config setting. Defaults to 1 if neither is
+    /// set.
+    #[arg(long, short)]
+    jobs: Option<usize>,
 
     /// Run the command from the working-copy root in each commit instead of
     /// from the subdirectory `jj run` was invoked from.
     #[arg(long)]
     root: bool,
+}
+
+/// Precedence: `--jobs`, `run.jobs` config, 1.
+fn resolve_jobs(
+    workspace_command: &WorkspaceCommandHelper,
+    jobs: Option<usize>,
+) -> Result<NonZeroUsize, CommandError> {
+    if let Some(j) = jobs {
+        return NonZeroUsize::new(j).ok_or_else(|| {
+            CommandError::new(
+                CommandErrorKind::Cli,
+                Box::new(RunError::InvalidJobCount(
+                    i64::try_from(j).unwrap_or(i64::MAX),
+                )),
+            )
+        });
+    }
+    if let Ok(size) = workspace_command.settings().get_int("run.jobs") {
+        let size: usize = size
+            .try_into()
+            .map_err(|_| RunError::InvalidJobCount(size))?;
+        return NonZeroUsize::new(size).ok_or_else(|| {
+            CommandError::new(
+                CommandErrorKind::Config,
+                Box::new(RunError::InvalidJobCount(0)),
+            )
+        });
+    }
+    Ok(NonZeroUsize::MIN)
 }
 
 pub async fn cmd_run(
@@ -418,22 +625,7 @@ pub async fn cmd_run(
     let repo_path = command.workspace_loader()?.repo_path().to_path_buf();
     // TODO: should be stored in a backend and not hardcoded.
     let base_path = repo_path.parent().unwrap().join("run").join("default");
-
-    // NOTE: we have to take the lock as early as possible before resolving
-    // revsets, so that if we block on an existing process to finish, we
-    // properly resolve the given set of commits if they were rewritten
-    let lock_dir = base_path
-        .parent()
-        .expect("run directory should have a parent");
-    fs::create_dir_all(lock_dir)?;
-    let lock_path = base_path.with_extension("lock");
-    let lock = match FileLock::try_lock(lock_path.clone()).map_err(RunError::from)? {
-        Some(lock) => lock,
-        None => {
-            writeln!(ui.status(), "Waiting for another `jj run` to finish...")?;
-            FileLock::lock(lock_path).map_err(RunError::from)?
-        }
-    };
+    fs::create_dir_all(&base_path)?;
 
     let mut workspace_command = command.workspace_helper(ui).await?;
     let resolved_commits: Vec<_> = if args.revisions.is_empty() {
@@ -455,16 +647,9 @@ pub async fn cmd_run(
         .check_rewritable(resolved_commits.iter().ids())
         .await?;
 
-    tracing::debug!(?args.jobs, "starting with `jj run` with available threads");
+    let jobs = resolve_jobs(&workspace_command, args.jobs)?;
 
-    let rt = {
-        let mut builder = Builder::new_multi_thread();
-        builder.enable_io();
-        builder.build().unwrap()
-    };
-    // TODO: Add a extension point for custom output/status aggregation.
-    let mut done_commits = HashSet::new();
-    let (sender_tx, mut receiver) = mpsc::channel(args.jobs);
+    tracing::debug!(?jobs, "starting `jj run`");
 
     // Run each command from the subdirectory the user invoked `jj run` from,
     // unless `--root` overrides that. The subdir is relative to the workspace
@@ -482,13 +667,20 @@ pub async fn cmd_run(
     };
 
     let store = workspace_command.repo().store().clone();
+    let auto_tracking_matcher = workspace_command.auto_tracking_matcher(ui)?;
+
     let mut tx = workspace_command.start_transaction();
 
-    // A previous run's cleanup (that may have finished while we waited for the
-    // lock) may have removed the base path directory, it, so (re)create it now
-    // that we hold the lock.
-    fs::create_dir_all(&base_path)?;
-    let base_path = Arc::new(base_path);
+    let rt = {
+        let mut builder = Builder::new_multi_thread();
+        builder.enable_io();
+        builder.enable_time();
+        builder.build().unwrap()
+    };
+    let mut done_commits = HashSet::new();
+    let (sender_tx, mut receiver) = mpsc::channel(jobs.get());
+
+    let pool = Arc::new(WorkspacePool::new(&repo_path, jobs, auto_tracking_matcher)?);
     let stored_len = resolved_commits.len();
 
     let spec = Arc::new(CommandSpec {
@@ -508,9 +700,9 @@ pub async fn cmd_run(
                 sender_tx,
                 rt.handle(),
                 spec.clone(),
-                base_path,
+                pool.clone(),
                 Arc::new(resolved_commits.clone()),
-                args.jobs,
+                jobs.get(),
             )
             .await
             .map_err(CommandError::from)
@@ -564,12 +756,8 @@ pub async fn cmd_run(
         },
     )?;
 
-    let run_path = repo_path.parent().unwrap().join("run").join("default");
     // The operation was a no-op, bail.
     if rewritten_commits.is_empty() {
-        // Yeet everything, caching is better implemented in a follow-up.
-        fs::remove_dir_all(&run_path)?;
-
         writeln!(
             ui.stderr(),
             "No commits were rewritten as the command did not modify any tracked files"
@@ -616,13 +804,8 @@ pub async fn cmd_run(
         )
         .await?;
     writeln!(ui.stderr(), "Rewrote {count} commits with {spec}")?;
-
-    // Yeet everything, caching is implemented in a follow-up.
-    fs::remove_dir_all(&run_path)?;
-
     tx.finish(ui, format!("run: rewrite {count} commits with {spec}"))
         .await?;
 
-    drop(lock);
     Ok(())
 }

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -836,6 +836,17 @@
                 ]
             }
         },
+        "run": {
+            "type": "object",
+            "description": "Settings for the `jj run` command, which runs a shell command across a set of revisions.",
+            "properties": {
+                "jobs": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Maximum number of working copies (and parallel jobs) `jj run` uses. Defaults to 1. Overridden by `--jobs`."
+                }
+            }
+        },
         "snapshot": {
             "type": "object",
             "description": "Parameters governing automatic capture of files into the working copy commit",

--- a/cli/testing/fake-formatter.rs
+++ b/cli/testing/fake-formatter.rs
@@ -70,7 +70,7 @@ struct Args {
 
     /// Duplicate stdout into this file.
     #[arg(long)]
-    tee: Option<PathBuf>,
+    tee: Vec<PathBuf>,
 
     /// Read one byte at a time, and send one byte to the stdout before reading
     /// the next byte.
@@ -229,7 +229,7 @@ fn main() -> ExitCode {
         print!("{stdout}");
         stdout
     };
-    if let Some(path) = args.tee {
+    for path in args.tee {
         let mut file = OpenOptions::new()
             .create(true)
             .append(true)

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -2995,6 +2995,9 @@ $ jj run -j 4 -- pre-commit run .github/pre-commit.yaml
 
    Overrides the `run.jobs` config setting. Defaults to 1 if neither is set.
 * `--root` — Run the command from the working-copy root in each commit instead of from the subdirectory `jj run` was invoked from
+* `--clean` — Delete each working copy before running the command
+
+   By default `jj run` reuses working copies between invocations so build artifacts are preserved. With `--clean`, every commit starts from a freshly checked-out tree.
 
 
 

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -2993,7 +2993,7 @@ $ jj run -j 4 -- pre-commit run .github/pre-commit.yaml
 * `-r`, `--revision <REVSETS>` — The revisions to change
 * `-j`, `--jobs <JOBS>` — How many processes should run in parallel
 
-  Default value: `1`
+   Overrides the `run.jobs` config setting. Defaults to 1 if neither is set.
 * `--root` — Run the command from the working-copy root in each commit instead of from the subdirectory `jj run` was invoked from
 
 

--- a/cli/tests/test_run_command.rs
+++ b/cli/tests/test_run_command.rs
@@ -13,6 +13,8 @@
 // limitations under the License.
 //
 
+use std::fs;
+
 use insta::assert_snapshot;
 
 use crate::common::TestEnvironment;
@@ -464,13 +466,13 @@ fn test_run_recovers_after_failure() {
     work_dir.write_file("b.txt", "b");
     work_dir.run_jj(&["commit", "-m", "B"]).success();
 
-    // First run fails outright on every commit, leaving the per-commit
-    // working copies in `.jj/run/default/` behind.
+    // First run fails; snapshot+persist still runs, leaving each slot with a
+    // valid tree_state on disk.
     let first = work_dir.run_jj(&["run", "-r", "..@", "--", &fake_formatter_path, "--fail"]);
     assert!(!first.status.success(), "expected first `jj run` to fail");
 
-    // A second run with a working command must succeed despite those leftover
-    // directories — `jj run` clears each per-commit dir before reusing it.
+    // A second run with a working command must succeed: the persisted
+    // tree_state lets each slot be reused without a wipe-and-reinit.
     work_dir
         .run_jj(&[
             "run",
@@ -610,17 +612,563 @@ fn test_run_sets_workspace_root_env_var() {
             + "\n"
     };
     // $TEST_ENV is the normalized placeholder for the test environment's temp
-    // root directory. JJ_WORKSPACE_ROOT should point to the per-commit
-    // isolated working copy under .jj/run/default/<commit-id>/working_copy,
-    // not to the original workspace.
+    // root directory. JJ_WORKSPACE_ROOT should point to the slot working copy
+    // under .jj/run/default/1/working_copy, not to the original workspace.
     insta::assert_snapshot!(
         work_dir
             .run_jj(&["file", "show", "-r", "@-", "workspace_root.txt"])
             .normalize_stdout_with(normalize_whitespace),
         @r"
-    $TEST_ENV/repo/.jj/run/default/5fbe90560fed1c39d46a46a672ba98abd53bdc6d/working_copy
+    $TEST_ENV/repo/.jj/run/default/1/working_copy
     [EOF]
     "
+    );
+}
+
+/// After a failed `jj run`, the pool slot must be reusable: ignored files
+/// (build artifacts) survive and non-ignored stray files are cleaned up.
+#[test]
+fn test_run_pool_reuses_slot_after_failure() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let fake_formatter = assert_cmd::cargo::cargo_bin("fake-formatter");
+    assert!(fake_formatter.is_file());
+    let fake_formatter_path = fake_formatter.to_string_lossy().into_owned();
+    let work_dir = test_env.work_dir("repo");
+
+    work_dir.write_file(".gitignore", "cache/\n");
+    work_dir.write_file("seed.txt", "seed");
+    work_dir.run_jj(&["commit", "-m", "seed"]).success();
+
+    // Failing command writes an ignored artifact and a non-ignored stray file.
+    let first = work_dir.run_jj(&[
+        "run",
+        "--config",
+        "run.jobs=1",
+        "-r",
+        "@-",
+        "--",
+        "sh",
+        "-c",
+        &format!(
+            "mkdir -p cache && echo artifact > cache/artifact.txt && touch stray.txt && \
+             {fake_formatter_path} --fail"
+        ),
+    ]);
+    assert!(!first.status.success(), "expected first run to fail");
+
+    let slot_state = work_dir.root().join(".jj/run/default/1/state/tree_state");
+    assert!(
+        slot_state.exists(),
+        "tree_state must be persisted even after failure"
+    );
+
+    // Succeeding second run: ignored artifact must still be present on disk;
+    // the non-ignored stray.txt must have been cleaned up (not leaked into
+    // the new commit).
+    work_dir
+        .run_jj(&[
+            "run",
+            "--config",
+            "run.jobs=1",
+            "-r",
+            "@-",
+            "--",
+            "sh",
+            "-c",
+            "if [ -f cache/artifact.txt ]; then cp cache/artifact.txt result.txt; else echo \
+             MISSING > result.txt; fi",
+        ])
+        .success();
+
+    assert_snapshot!(
+        work_dir.run_jj(&["file", "show", "-r", "@-", "result.txt"]),@r"
+    artifact
+    [EOF]
+    "
+    );
+    assert_snapshot!(
+        work_dir
+        .run_jj(&["file", "list", "-r", "@-"]),
+        @r"
+    .gitignore
+    result.txt
+    seed.txt
+    [EOF]
+    "
+    );
+}
+
+#[test]
+fn test_run_pool_persists_between_runs() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+    work_dir.write_file("seed.txt", "seed");
+    work_dir.run_jj(&["commit", "-m", "seed"]).success();
+
+    work_dir
+        .run_jj(&[
+            "run",
+            "--config",
+            "run.jobs=1",
+            "-r",
+            "@-",
+            "--",
+            "touch",
+            "ran.txt",
+        ])
+        .success();
+
+    // The pool slot directory survives the run.
+    let pool_slot = work_dir.root().join(".jj/run/default/1");
+    assert!(
+        pool_slot.exists(),
+        "expected pool slot 1 to persist between runs at {pool_slot:?}",
+    );
+    assert!(pool_slot.join("working_copy").exists());
+    assert!(pool_slot.join("state").exists());
+
+    // A second run reuses the existing slot rather than recreating it from
+    // scratch.
+    work_dir
+        .run_jj(&[
+            "run",
+            "--config",
+            "run.jobs=1",
+            "-r",
+            "@-",
+            "--",
+            "touch",
+            "ran2.txt",
+        ])
+        .success();
+    assert!(pool_slot.join("working_copy").exists());
+}
+
+#[test]
+fn test_run_pool_size_from_config() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+    work_dir.write_file("a.txt", "a");
+    work_dir.run_jj(&["commit", "-m", "A"]).success();
+    work_dir.write_file("b.txt", "b");
+    work_dir.run_jj(&["commit", "-m", "B"]).success();
+    work_dir.write_file("c.txt", "c");
+    work_dir.run_jj(&["commit", "-m", "C"]).success();
+
+    // `run.jobs = 1` forces all three commits to share a single slot
+    // and be processed sequentially.
+    work_dir
+        .run_jj(&[
+            "run",
+            "--config",
+            "run.jobs=2",
+            "-r",
+            "..@",
+            "--",
+            "sh",
+            "-c",
+            "touch ran-$JJ_CHANGE_ID.txt",
+        ])
+        .success();
+
+    let pool_dir = work_dir.root().join(".jj/run/default");
+    assert!(pool_dir.join("1").exists(), "pool/1 should exist");
+    assert!(pool_dir.join("2").exists(), "pool/2 should exist");
+    assert!(
+        !pool_dir.join("3").exists(),
+        "pool/3 should NOT exist with size=2",
+    );
+
+    // All three commits picked up `ran.txt`.
+    assert_snapshot!(work_dir.run_jj(&["file", "list", "-r", "@---"]), @r"
+        a.txt
+        ran-qpvuntsmwlqtpsluzzsnyyzlmlwvmlnu.txt
+        [EOF]
+        ");
+    assert_snapshot!(work_dir.run_jj(&["file", "list", "-r", "@--"]), @r"
+        a.txt
+        b.txt
+        ran-qpvuntsmwlqtpsluzzsnyyzlmlwvmlnu.txt
+        ran-rlvkpnrzqnoowoytxnquwvuryrwnrmlp.txt
+        [EOF]
+        ");
+    assert_snapshot!(work_dir.run_jj(&["file", "list", "-r", "@-"]), @r"
+        a.txt
+        b.txt
+        c.txt
+        ran-kkmpptxzrspxrzommnulwmwkkqwworpl.txt
+        ran-qpvuntsmwlqtpsluzzsnyyzlmlwvmlnu.txt
+        ran-rlvkpnrzqnoowoytxnquwvuryrwnrmlp.txt
+        [EOF]
+        ");
+}
+
+/// `--jobs N` controls pool size when `run.jobs` is not set.
+#[test]
+fn test_run_pool_size_from_jobs_flag() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+    work_dir.write_file("a.txt", "a");
+    work_dir.run_jj(&["commit", "-m", "A"]).success();
+    work_dir.write_file("b.txt", "b");
+    work_dir.run_jj(&["commit", "-m", "B"]).success();
+    work_dir.write_file("c.txt", "c");
+    work_dir.run_jj(&["commit", "-m", "C"]).success();
+
+    // `--jobs 2` with pool: expect exactly 2 slots, no more.
+    work_dir
+        .run_jj(&["run", "--jobs", "2", "-r", "..@", "--", "touch", "ran.txt"])
+        .success();
+
+    let pool_dir = work_dir.root().join(".jj/run/default");
+    assert!(pool_dir.join("1").exists(), "pool/1 should exist");
+    assert!(pool_dir.join("2").exists(), "pool/2 should exist");
+    assert!(
+        !pool_dir.join("3").exists(),
+        "pool/3 must NOT exist with --jobs 2",
+    );
+}
+
+#[test]
+fn test_run_pool_preserves_untracked_artifacts() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    // The .gitignore keeps `cache/` out of the snapshot's tracking set, so
+    // files there persist on disk between jobs without being committed.
+    work_dir.write_file(".gitignore", "cache/\n");
+    work_dir.write_file("seed.txt", "seed");
+    work_dir.run_jj(&["commit", "-m", "seed"]).success();
+
+    // Run 1: drop a marker into the gitignored cache directory.
+    work_dir
+        .run_jj(&[
+            "run",
+            "--config",
+            "run.jobs=1",
+            "-r",
+            "@-",
+            "--",
+            "sh",
+            "-c",
+            "mkdir -p cache && echo run1 > cache/marker && touch ran1.txt",
+        ])
+        .success();
+
+    // Run 2: assert the marker is still there, write its contents into a
+    // tracked file so we can verify from outside.
+    work_dir
+        .run_jj(&[
+            "run",
+            "--config",
+            "run.jobs=1",
+            "-r",
+            "@-",
+            "--",
+            "sh",
+            "-c",
+            "if [ -f cache/marker ]; then cp cache/marker result.txt; else echo MISSING > \
+             result.txt; fi",
+        ])
+        .success();
+
+    assert_snapshot!(
+        work_dir
+        .run_jj(&["file", "show", "-r", "@-", "result.txt"])
+        .success()
+        .stdout,
+        @r"
+        run1
+        [EOF]
+        ",
+    );
+}
+
+/// Pool correctly removes a file that is present in one commit's tree but
+/// absent in the next commit processed by the same slot.
+#[test]
+fn test_run_pool_removes_file_absent_in_next_commit() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    // Commit A has only_in_a.txt.
+    work_dir.write_file("only_in_a.txt", "a");
+    work_dir.run_jj(&["commit", "-m", "A"]).success();
+    // After commit -m A the WC inherits A's files. Delete the file so that
+    // commit B's tree is empty (no only_in_a.txt).
+    std::fs::remove_file(work_dir.root().join("only_in_a.txt")).unwrap();
+    work_dir.run_jj(&["commit", "-m", "B"]).success();
+    // Stack: root → A (only_in_a.txt) → B ({}) → @
+
+    // Pool size 1 forces both commits through the same slot sequentially.
+    // @-- = A, @- = B (WC is above B).
+    work_dir
+        .run_jj(&[
+            "run",
+            "--config",
+            "run.jobs=1",
+            "-r",
+            "@--::@-",
+            "--",
+            "touch",
+            "ran.txt",
+        ])
+        .success();
+
+    // A's rewrite (@--) keeps only_in_a.txt (and gains ran.txt).
+    assert_snapshot!(
+        work_dir
+        .run_jj(&["file", "list", "-r", "@--"])
+        .success()
+        .stdout,
+        @r"
+        only_in_a.txt
+        ran.txt
+        [EOF]
+        ",
+    );
+
+    // B's rewrite (@-) must NOT have only_in_a.txt leaked from A's slot.
+    assert_snapshot!(
+        work_dir
+        .run_jj(&["file", "list", "-r", "@-"])
+        .success()
+        .stdout,
+        @r"
+        ran.txt
+        [EOF]
+        ",
+    );
+}
+
+/// Files tracked into a commit by run 1 must not reappear in a different
+/// commit processed by the same pool slot in run 2.
+///
+/// Run 1 rewrites commit2 (adding artifact.txt). The slot's saved tree_state
+/// therefore records {seed.txt, artifact.txt}. Run 2 targets commit1 whose
+/// tree is {seed.txt}; the checkout diff removes artifact.txt from the slot,
+/// so commit1's rewrite must not contain it.
+#[test]
+fn test_run_pool_no_file_leak_between_invocations() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    // commit1: seed.txt only.
+    work_dir.write_file("seed.txt", "seed");
+    work_dir.run_jj(&["commit", "-m", "commit1"]).success();
+    // commit2: descends from commit1, no extra files (same tree).
+    work_dir.run_jj(&["commit", "-m", "commit2"]).success();
+    // Stack: root → commit1 (seed.txt) → commit2 (seed.txt) → @
+
+    // Run 1: produce artifact.txt in commit2 (@-) so the slot's saved
+    // tree_state records {seed.txt, artifact.txt}.
+    // Stack before run 1: root → commit1 (@--) → commit2 (@-) → @
+    work_dir
+        .run_jj(&[
+            "run",
+            "--config",
+            "run.jobs=1",
+            "-r",
+            "@-",
+            "--",
+            "touch",
+            "artifact.txt",
+        ])
+        .success();
+    // After run 1: root → commit1 (@--) → commit2' (@-) → @ (rebased).
+    // commit2' now has {seed.txt, artifact.txt}.
+
+    // Run 2: no-op on commit1 (@--). Pool reuses the slot whose tree_state
+    // says {seed.txt, artifact.txt}. The checkout diff removes artifact.txt,
+    // so commit1's rewrite must not contain it.
+    work_dir
+        .run_jj(&["run", "--config", "run.jobs=1", "-r", "@--", "--", "true"])
+        .success();
+    // After run 2: root → commit1' (@--) → commit2'' (@-) → @ (rebased).
+
+    assert_snapshot!(
+        work_dir.run_jj(&["file", "list", "-r", "@--"]).success().stdout,
+        @r"
+        seed.txt
+        [EOF]
+        ",
+    );
+}
+
+/// When a pool slot is reused, files left on disk that the previous commit's
+/// .gitignore excluded must be removed before the next commit runs. Otherwise
+/// the next commit (which may not ignore the same paths) would pick them up at
+/// snapshot time and incorrectly add them to its rewritten tree.
+#[test]
+fn test_run_pool_removes_previously_ignored_files() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let fake_formatter = assert_cmd::cargo::cargo_bin("fake-formatter");
+    assert!(fake_formatter.is_file());
+    let fake_formatter_path = fake_formatter.to_string_lossy().into_owned();
+    let work_dir = test_env.work_dir("repo");
+
+    // Commit a: no .gitignore.
+    work_dir.write_file("seed.txt", "seed");
+    work_dir.write_file(".gitignore", "always_ignored.txt\n");
+    work_dir
+        .run_jj(&["bookmark", "create", "-r@", "a"])
+        .success();
+    work_dir.run_jj(&["commit", "-m", "a"]).success();
+    // Commit b: adds a .gitignore that excludes `ignored.txt`.
+    work_dir.write_file(".gitignore", "always_ignored.txt\nignored.txt\n");
+    work_dir
+        .run_jj(&["bookmark", "create", "-r@", "b"])
+        .success();
+    work_dir.run_jj(&["commit", "-m", "b"]).success();
+
+    let run_wc = work_dir.root().join(".jj/run/default/1/working_copy");
+
+    // Leave two ignored files in the run workspace
+    work_dir
+        .run_jj(&[
+            "run",
+            "-r=b",
+            "--",
+            &fake_formatter_path,
+            "--tee=always_ignored.txt",
+            "--tee=ignored.txt",
+        ])
+        .success();
+    assert_snapshot!(
+        work_dir.run_jj(&["file", "list", "-r", "b"]),
+        @r"
+    .gitignore
+    seed.txt
+    [EOF]
+    "
+    );
+    assert!(fs::exists(run_wc.join("always_ignored.txt")).unwrap());
+    assert!(fs::exists(run_wc.join("ignored.txt")).unwrap());
+
+    // Run against a version that only ignores always_ignored.txt, ensure that
+    // ignored.txt is removed, not amended into 'a'.
+    work_dir
+        .run_jj(&[
+            "run",
+            "-r=a",
+            "--",
+            &fake_formatter_path,
+            "--stdout",
+            "done",
+        ])
+        .success();
+    assert_snapshot!(
+        work_dir.run_jj(&["file", "list", "-r", "a"]),
+        @r"
+    .gitignore
+    seed.txt
+    [EOF]
+    "
+    );
+    // Remove files that are no longer ignored in the new revision, but don't
+    // unnecessarily remove files that are still ignored
+    assert!(fs::exists(run_wc.join("always_ignored.txt")).unwrap());
+    assert!(!fs::exists(run_wc.join("ignored.txt")).unwrap());
+}
+
+/// A slot whose tree_state is absent (simulating a crash mid-job) should be
+/// wiped and reinitialized on the next acquisition, not produce garbage.
+#[test]
+fn test_run_pool_recovers_from_missing_tree_state() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    work_dir.write_file("seed.txt", "seed");
+    work_dir.run_jj(&["commit", "-m", "seed"]).success();
+
+    // Prime the slot so working_copy/ exists.
+    work_dir
+        .run_jj(&["run", "--config", "run.jobs=1", "-r", "@-", "--", "true"])
+        .success();
+
+    // Simulate a crash: plant a stale file in the slot and delete tree_state.
+    let slot = work_dir.root().join(".jj/run/default/1");
+    std::fs::write(slot.join("working_copy/stale.txt"), "crash leftovers").unwrap();
+    std::fs::remove_file(slot.join("state/tree_state")).unwrap();
+
+    // A second run should wipe the stale state and produce a clean rewrite.
+    work_dir
+        .run_jj(&[
+            "run",
+            "--config",
+            "run.jobs=1",
+            "-r",
+            "@-",
+            "--",
+            "touch",
+            "ran.txt",
+        ])
+        .success();
+
+    assert_snapshot!(
+        work_dir.run_jj(&["file", "list", "-r", "@-"]).success().stdout,
+        @r"
+        ran.txt
+        seed.txt
+        [EOF]
+        ",
+    );
+}
+
+/// A failed command (non-zero exit) must not poison the pool slot for the
+/// next `jj run` invocation.
+#[test]
+fn test_run_pool_failed_command_does_not_poison_slot() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    work_dir.write_file("seed.txt", "seed");
+    work_dir.run_jj(&["commit", "-m", "seed"]).success();
+
+    // Run 1: command fails, but writes a file first.
+    drop(work_dir.run_jj(&[
+        "run",
+        "--config",
+        "run.jobs=1",
+        "-r",
+        "@-",
+        "--",
+        "sh",
+        "-c",
+        "touch poison.txt; exit 1",
+    ]));
+
+    // Run 2: a clean command. poison.txt must not appear in the rewrite.
+    work_dir
+        .run_jj(&[
+            "run",
+            "--config",
+            "run.jobs=1",
+            "-r",
+            "@-",
+            "--",
+            "touch",
+            "ran.txt",
+        ])
+        .success();
+
+    assert_snapshot!(
+        work_dir.run_jj(&["file", "list", "-r", "@-"]).success().stdout,
+        @r"
+        ran.txt
+        seed.txt
+        [EOF]
+        ",
     );
 }
 

--- a/cli/tests/test_run_command.rs
+++ b/cli/tests/test_run_command.rs
@@ -947,61 +947,6 @@ fn test_run_pool_removes_file_absent_in_next_commit() {
     );
 }
 
-/// Files tracked into a commit by run 1 must not reappear in a different
-/// commit processed by the same pool slot in run 2.
-///
-/// Run 1 rewrites commit2 (adding artifact.txt). The slot's saved tree_state
-/// therefore records {seed.txt, artifact.txt}. Run 2 targets commit1 whose
-/// tree is {seed.txt}; the checkout diff removes artifact.txt from the slot,
-/// so commit1's rewrite must not contain it.
-#[test]
-fn test_run_pool_no_file_leak_between_invocations() {
-    let test_env = TestEnvironment::default();
-    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
-    let work_dir = test_env.work_dir("repo");
-
-    // commit1: seed.txt only.
-    work_dir.write_file("seed.txt", "seed");
-    work_dir.run_jj(&["commit", "-m", "commit1"]).success();
-    // commit2: descends from commit1, no extra files (same tree).
-    work_dir.run_jj(&["commit", "-m", "commit2"]).success();
-    // Stack: root → commit1 (seed.txt) → commit2 (seed.txt) → @
-
-    // Run 1: produce artifact.txt in commit2 (@-) so the slot's saved
-    // tree_state records {seed.txt, artifact.txt}.
-    // Stack before run 1: root → commit1 (@--) → commit2 (@-) → @
-    work_dir
-        .run_jj(&[
-            "run",
-            "--config",
-            "run.jobs=1",
-            "-r",
-            "@-",
-            "--",
-            "touch",
-            "artifact.txt",
-        ])
-        .success();
-    // After run 1: root → commit1 (@--) → commit2' (@-) → @ (rebased).
-    // commit2' now has {seed.txt, artifact.txt}.
-
-    // Run 2: no-op on commit1 (@--). Pool reuses the slot whose tree_state
-    // says {seed.txt, artifact.txt}. The checkout diff removes artifact.txt,
-    // so commit1's rewrite must not contain it.
-    work_dir
-        .run_jj(&["run", "--config", "run.jobs=1", "-r", "@--", "--", "true"])
-        .success();
-    // After run 2: root → commit1' (@--) → commit2'' (@-) → @ (rebased).
-
-    assert_snapshot!(
-        work_dir.run_jj(&["file", "list", "-r", "@--"]).success().stdout,
-        @r"
-        seed.txt
-        [EOF]
-        ",
-    );
-}
-
 /// When a pool slot is reused, files left on disk that the previous commit's
 /// .gitignore excluded must be removed before the next commit runs. Otherwise
 /// the next commit (which may not ignore the same paths) would pick them up at
@@ -1076,6 +1021,29 @@ fn test_run_pool_removes_previously_ignored_files() {
     // Remove files that are no longer ignored in the new revision, but don't
     // unnecessarily remove files that are still ignored
     assert!(fs::exists(run_wc.join("always_ignored.txt")).unwrap());
+    assert!(!fs::exists(run_wc.join("ignored.txt")).unwrap());
+
+    // Passing --clean removes even always-ignored files
+    work_dir
+        .run_jj(&[
+            "run",
+            "-r=a",
+            "--clean",
+            "--",
+            &fake_formatter_path,
+            "--stdout",
+            "done",
+        ])
+        .success();
+    assert_snapshot!(
+        work_dir.run_jj(&["file", "list", "-r", "a"]),
+        @r"
+    .gitignore
+    seed.txt
+    [EOF]
+    "
+    );
+    assert!(!fs::exists(run_wc.join("always_ignored.txt")).unwrap());
     assert!(!fs::exists(run_wc.join("ignored.txt")).unwrap());
 }
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -1561,6 +1561,29 @@ Then to use the tool in a specific repository, set the `enabled` config:
 $ jj config set --repo fix.tools.rustfmt.enabled true
 ```
 
+## `run`: Running commands across revisions {: #run }
+
+The `jj run` command executes a command against each revision in a set,
+checking out each one into an isolated working copy, running the command, and
+amending the revision with any resulting changes.
+
+### `run.jobs`: Default parallelism {: #run.jobs }
+
+By default `jj run` processes one revision at a time. You can increase
+parallelism with the `run.jobs` setting:
+
+```toml
+[run]
+jobs = 8
+```
+
+The value must be a positive integer. The `--jobs` / `-j` CLI flag overrides
+this setting for a single invocation:
+
+```shell
+jj run -j 4 -- cargo fmt
+```
+
 ## Commit Signing
 
 `jj` can be configured to sign and verify the commits it creates using either

--- a/lib/src/local_working_copy.rs
+++ b/lib/src/local_working_copy.rs
@@ -1058,6 +1058,19 @@ impl TreeState {
         Ok(wc)
     }
 
+    /// Like `init` but does not persist the initial empty tree state to
+    /// disk. Use when the caller will save state itself only after a
+    /// successful operation (e.g. to use `tree_state` file absence as a
+    /// dirty marker).
+    pub fn init_without_saving(
+        store: Arc<Store>,
+        working_copy_path: PathBuf,
+        state_path: PathBuf,
+        tree_state_settings: &TreeStateSettings,
+    ) -> Self {
+        Self::empty(store, working_copy_path, state_path, tree_state_settings)
+    }
+
     fn empty(
         store: Arc<Store>,
         working_copy_path: PathBuf,


### PR DESCRIPTION
I had a `try_lock` implementation, but Austin's is better, so I rebased on top of his branch.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [X] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [X] I have updated the config schema (`cli/src/config-schema.json`)
- [X] I have added/updated tests to cover my changes
- [X] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [X] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
