### PR TITLE
run: 3-way merge changes instead of replacing trees

### DIFF
--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -44,6 +44,7 @@ use jj_lib::lock::FileLock;
 use jj_lib::lock::FileLockError;
 use jj_lib::matchers::EverythingMatcher;
 use jj_lib::matchers::NothingMatcher;
+use jj_lib::merge::Merge;
 use jj_lib::merged_tree::MergedTree;
 use jj_lib::object_id::ObjectId as _;
 use jj_lib::repo::Repo as _;
@@ -173,6 +174,8 @@ impl fmt::Display for CommandSpec {
 struct RunJob {
     /// The old `CommitId` of the commit.
     old_id: CommitId,
+    /// The original tree of the commit before the command ran.
+    old_tree: MergedTree,
     /// The new tree generated from the commit. `None` when the command wasn't
     /// run (i.e. the commit was skipped).
     new_tree: Option<Tree>,
@@ -250,6 +253,7 @@ async fn rewrite_commit(
     spec: Arc<CommandSpec>,
 ) -> Result<RunJob, RunError> {
     let old_id = commit.id().clone();
+    let old_tree = commit.tree();
 
     let (working_copy_dir, mut tree_state) = create_working_copy(&base_path, &commit).await?;
 
@@ -265,6 +269,7 @@ async fn rewrite_commit(
             );
             return Ok(RunJob {
                 old_id,
+                old_tree,
                 new_tree: None,
                 dirty: false,
                 stdout: Vec::new(),
@@ -307,6 +312,7 @@ async fn rewrite_commit(
     if !output.status.success() {
         return Ok(RunJob {
             old_id,
+            old_tree,
             new_tree: None,
             dirty: false,
             stdout: output.stdout,
@@ -344,6 +350,7 @@ async fn rewrite_commit(
 
     Ok(RunJob {
         old_id,
+        old_tree,
         new_tree: Some(new_tree),
         dirty,
         stdout: output.stdout,
@@ -540,7 +547,7 @@ pub async fn cmd_run(
                         && let Some(new_tree) = res.new_tree
                     {
                         done_commits.insert(res.old_id.clone());
-                        rewritten_commits.insert(res.old_id.clone(), new_tree);
+                        rewritten_commits.insert(res.old_id.clone(), (res.old_tree, new_tree));
                     }
                 }
                 visited += 1;
@@ -579,13 +586,23 @@ pub async fn cmd_run(
                 // Only rewrite the tree if the command changed it. Descendants
                 // that weren't part of the input set still need to be rebased
                 // but keep their original tree.
-                if let Some(new_tree) = rewritten_commits.get(&old_id) {
-                    let new_tree_id = new_tree.id().clone();
+                if let Some((old_tree, new_tree)) = rewritten_commits.get(&old_id) {
+                    // Apply only the diff the command introduced (new_tree -
+                    // old_tree) on top of the rebased tree. This propagates
+                    // changes into descendants via the normal rebase merge
+                    // rather than being replaced.
+                    let rebased_tree = builder.tree();
+                    let merged = MergedTree::merge(Merge::from_vec(vec![
+                        (
+                            MergedTree::resolved(store.clone(), new_tree.id().clone()),
+                            "command result".to_owned(),
+                        ),
+                        (old_tree.clone(), "original commit".to_owned()),
+                        (rebased_tree, "rebased".to_owned()),
+                    ]))
+                    .await?;
                     count += 1;
-                    builder
-                        .set_tree(MergedTree::resolved(store.clone(), new_tree_id))
-                        .write()
-                        .await?;
+                    builder.set_tree(merged).write().await?;
                 } else {
                     builder.write().await?;
                 }

--- a/cli/tests/test_run_command.rs
+++ b/cli/tests/test_run_command.rs
@@ -13,6 +13,8 @@
 // limitations under the License.
 //
 
+use insta::assert_snapshot;
+
 use crate::common::TestEnvironment;
 use crate::common::TestWorkDir;
 
@@ -663,6 +665,56 @@ fn test_run_failure_shows_output() {
         [exit status: 1]
         ");
     });
+}
+
+/// Changes made to an ancestor commit must still propagate into descendant
+/// commits after rebasing.
+#[test]
+fn test_run_parallel_changes_propagate_to_descendants() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+    work_dir.write_file("a.txt", "a");
+    work_dir.run_jj(&["commit", "-m", "A"]).success();
+    work_dir.write_file("b.txt", "b");
+    work_dir.run_jj(&["commit", "-m", "B"]).success();
+    work_dir.write_file("c.txt", "c");
+    work_dir.run_jj(&["commit", "-m", "C"]).success();
+
+    // Add a unique file to each change
+    work_dir
+        .run_jj(&[
+            "run",
+            "--jobs=3",
+            "-r=..@",
+            "--",
+            "sh",
+            "-c",
+            "touch newfile-$JJ_CHANGE_ID.txt",
+        ])
+        .success();
+
+    assert_snapshot!(work_dir.run_jj(&["file", "list", "-r=@---"]).success().stdout,@r"
+    a.txt
+    newfile-qpvuntsmwlqtpsluzzsnyyzlmlwvmlnu.txt
+    [EOF]
+    ");
+    assert_snapshot!(work_dir.run_jj(&["file", "list", "-r=@--"]).success().stdout,@r"
+    a.txt
+    b.txt
+    newfile-qpvuntsmwlqtpsluzzsnyyzlmlwvmlnu.txt
+    newfile-rlvkpnrzqnoowoytxnquwvuryrwnrmlp.txt
+    [EOF]
+    ");
+    assert_snapshot!(work_dir.run_jj(&["file", "list", "-r=@-"]).success().stdout,@r"
+    a.txt
+    b.txt
+    c.txt
+    newfile-kkmpptxzrspxrzommnulwmwkkqwworpl.txt
+    newfile-qpvuntsmwlqtpsluzzsnyyzlmlwvmlnu.txt
+    newfile-rlvkpnrzqnoowoytxnquwvuryrwnrmlp.txt
+    [EOF]
+    ");
 }
 
 fn get_log_output(work_dir: &TestWorkDir) -> String {


### PR DESCRIPTION
When a command passed to `jj run` modifies the working copy, these changes are supposed to be merged into the working copy.

However, we were simply _replacing_ the old tree with the new tree, which gave us behavior like `--restore-descendants`. Instead, we need to do a 3-way merge so the changes accumulate.

A future enhancement will add `jj run --restore-descendants`.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [X] I have added/updated tests to cover my changes
- [X] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [X] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
