### PR TITLE
docs: Add warning about changing revsets.log.

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -647,6 +647,13 @@ log = "main@origin.."
 The default value for `revsets.log` is
 `'present(@) | ancestors(immutable_heads().., 2) | trunk()'`.
 
+!!! warning
+
+    When `revsets.short-prefixes` is not specified, it defaults to the value of `revsets.log`. This
+    affects how change and commit id references are resolved when multiple commits share a common
+    prefix. Changing `revsets.log` without also setting `revsets.short-prefixes` might increase the
+    length of prefixes needed on the command-line, especially in large repositories.
+
 ### Default revisions for operation diffs
 
 You can configure the set of revisions that are considered "interesting" when


### PR DESCRIPTION
Changing `revsets.log`, which the docs reassured me only

> configure[s] the revisions jj log would show when neither -r nor any paths are specified

resulted in changes suddenly needing very long ids to disambiguate. Ultimately this seems to be related to undocumented behavior of `revsets.short-prefixes`.

The simplest fix here is this documentation change. You could instead consider changing this behavior; while I can see the logic, by the time a repo is large enough for `revsets.short-prefixes` to matter (i.e. to hide conflicts with high probability), it's probably also large enough that `revsets.short-prefixes` should remain at the default `"present(@) | ancestors(immutable_heads().., 2) | trunk()"` rather than tracking `revsets.log`.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ yes ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ N/A ] I have updated the config schema (`cli/src/config-schema.json`)
- [ N/A ] I have added/updated tests to cover my changes
- [ N/A ] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ N/A ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
