### PR TITLE
revset: implement "filtered range" optimization for `latest()`

### DIFF
--- a/lib/src/default_index/revset_engine.rs
+++ b/lib/src/default_index/revset_engine.rs
@@ -1063,14 +1063,48 @@ impl EvaluationContext<'_> {
                 }
                 let max_depth = u32::try_from(count - 1).unwrap_or(u32::MAX);
 
-                let candidates: Vec<_> = self
-                    .evaluate(candidates)?
-                    .positions()
-                    .attach(self.index)
-                    .try_collect()?;
+                let (subgraph, heads) = match candidates {
+                    ExpressionOrFilteredRange::Expression(candidates) => {
+                        let candidates: Vec<_> = self
+                            .evaluate(candidates)?
+                            .positions()
+                            .attach(self.index)
+                            .try_collect()?;
 
-                let (subgraph, heads) =
-                    subgraph_and_heads_from_positions(index, &candidates, max_depth);
+                        subgraph_and_heads_from_positions(index, &candidates, max_depth)
+                    }
+                    ExpressionOrFilteredRange::FilteredRange(filtered_range) => {
+                        let root_set = self.evaluate(&filtered_range.roots)?;
+                        let root_positions: Vec<_> =
+                            root_set.positions().attach(index).try_collect()?;
+                        // Pre-filter heads so queries like 'immutable_heads()..' can
+                        // terminate early. immutable_heads() usually includes some
+                        // visible heads, which can be trivially rejected.
+                        let head_set = self.evaluate(&filtered_range.heads)?;
+                        let head_positions: Vec<_> = difference_by(
+                            head_set.positions(),
+                            EagerRevWalk::new(root_positions.iter().copied().map(Ok)),
+                            |pos1, pos2| pos1.cmp(pos2).reverse(),
+                        )
+                        .attach(index)
+                        .try_collect()?;
+
+                        let mut filter: BoxedPredicateFn =
+                            if let Some(filter) = &filtered_range.filter {
+                                self.evaluate_predicate(filter)?.to_predicate_fn()
+                            } else {
+                                Box::new(|_, _| Ok(true))
+                            };
+                        subgraph_and_heads_from_range_and_filter(
+                            index,
+                            root_positions,
+                            head_positions,
+                            &filtered_range.parents_range,
+                            |pos| filter(index, pos),
+                            max_depth,
+                        )?
+                    }
+                };
 
                 Ok(Box::new(self.take_latest_revset(subgraph, &heads, *count)?))
             }
@@ -1700,6 +1734,134 @@ fn subgraph_and_heads_from_positions(
         }
     }
     (Subgraph { commits }, heads)
+}
+
+fn subgraph_and_heads_from_range_and_filter<E>(
+    index: &CompositeIndex,
+    roots: Vec<GlobalCommitPosition>,
+    heads: Vec<GlobalCommitPosition>,
+    parents_range: &Range<u32>,
+    mut filter: impl FnMut(GlobalCommitPosition) -> Result<bool, E>,
+    max_depth: u32,
+) -> Result<(Subgraph, Vec<GlobalCommitPosition>), E> {
+    let commit_index = index.commits();
+
+    #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+    struct WantedItem {
+        // We need to walk backward through all parent edges, but we need to handle `parents_range`
+        // as well. Therefore, we keep track of whether this commit was reachable from the child
+        // using only edges in `parents_range`. Since this field is considered first for ordering,
+        // if there was no path to the current position through edges in `parents_range`, then the
+        // first value in the `RevWalkQueue` max-heap will be `false`, so we can efficiently skip
+        // these commits.
+        is_in_parents_range: bool,
+        // The child which we are currently walking backwards from (if any).
+        child_pos: GlobalCommitPosition,
+        // If true, this is a head, so the child position should be ignored. It might be cleaner to
+        // use `Option<GlobalCommitPosition>` for `child_pos` instead, but that makes the struct
+        // 50% larger due to alignment.
+        is_head: bool,
+    }
+
+    let mut wanted_queue: RevWalkQueue<GlobalCommitPosition, WantedItem> =
+        RevWalkQueue::with_min_pos(GlobalCommitPosition::MIN);
+    let mut unwanted_queue: RevWalkQueue<GlobalCommitPosition, ()> =
+        RevWalkQueue::with_min_pos(GlobalCommitPosition::MIN);
+    unwanted_queue.extend(roots, ());
+
+    for head in heads {
+        wanted_queue.push(
+            head,
+            WantedItem {
+                is_in_parents_range: true,
+                child_pos: GlobalCommitPosition::MIN,
+                is_head: true,
+            },
+        );
+    }
+
+    let mut found_heads = Vec::new();
+    let mut depths: BTreeMap<GlobalCommitPosition, u32> = BTreeMap::new();
+    let mut commits: BTreeMap<GlobalCommitPosition, SubgraphCommitData> = BTreeMap::new();
+
+    while let Some(peeked_item) = wanted_queue.peek() {
+        let pos = peeked_item.pos;
+
+        if flush_queue_until(&mut unwanted_queue, index, pos).is_some() {
+            wanted_queue.skip_while_eq(&pos);
+            continue;
+        }
+
+        // If `is_in_parents_range` is `false` for the first entry with this position,
+        // it will be false for all of the entries with the same position.
+        if !peeked_item.value.is_in_parents_range || !filter(pos)? {
+            let parent_positions = commit_index.entry_by_pos(pos).parent_positions();
+
+            while let Some(item) = wanted_queue.pop_eq(&pos) {
+                for (i, &parent_pos) in (0u32..).zip(&parent_positions) {
+                    let mut value = item.value;
+                    value.is_in_parents_range =
+                        value.is_in_parents_range && parents_range.contains(&i);
+                    wanted_queue.push(parent_pos, value);
+                }
+
+                wanted_queue.skip_while(|x| *x == item);
+            }
+
+            continue;
+        }
+
+        let mut num_children = 0;
+        let mut depth = 0;
+        while let Some(item) = wanted_queue.pop_eq(&pos) {
+            if item.value.is_head {
+                continue;
+            }
+
+            let child_pos = item.value.child_pos;
+            let child_data = commits
+                .get_mut(&child_pos)
+                .expect("child commit should be in subgraph");
+            if child_data.parents.last() == Some(&pos) {
+                continue;
+            }
+
+            child_data.parents.push(pos);
+            num_children += 1;
+            depth = depth.max(depths[&child_pos] + 1);
+        }
+
+        depths.insert(pos, depth);
+        commits.insert(
+            pos,
+            SubgraphCommitData {
+                parents: SmallGlobalCommitPositionsVec::new(),
+                num_children,
+            },
+        );
+
+        if num_children == 0 {
+            found_heads.push(pos);
+        }
+
+        let parent_positions = commit_index.entry_by_pos(pos).parent_positions();
+        if depth >= max_depth {
+            unwanted_queue.extend(parent_positions, ());
+            continue;
+        }
+
+        for (i, parent_pos) in (0u32..).zip(parent_positions) {
+            wanted_queue.push(
+                parent_pos,
+                WantedItem {
+                    is_in_parents_range: parents_range.contains(&i),
+                    child_pos: pos,
+                    is_head: false,
+                },
+            );
+        }
+    }
+    Ok((Subgraph { commits }, found_heads))
 }
 
 #[cfg(test)]

--- a/lib/src/default_index/revset_engine.rs
+++ b/lib/src/default_index/revset_engine.rs
@@ -65,6 +65,7 @@ use crate::object_id::ObjectId as _;
 use crate::object_id::PrefixResolution;
 use crate::repo_path::RepoPath;
 use crate::revset::DiffMatchSide;
+use crate::revset::ExpressionOrFilteredRange;
 use crate::revset::GENERATION_RANGE_FULL;
 use crate::revset::ResolvedExpression;
 use crate::revset::ResolvedPredicateExpression;
@@ -910,25 +911,20 @@ impl EvaluationContext<'_> {
                     .collect_vec();
                 Ok(Box::new(EagerRevset { positions }))
             }
-            ResolvedExpression::Heads(candidates) => {
+            ResolvedExpression::Heads(ExpressionOrFilteredRange::Expression(candidates)) => {
                 let candidate_set = self.evaluate(candidates)?;
                 let positions = index
                     .commits()
                     .heads_pos(candidate_set.positions().attach(index).try_collect()?);
                 Ok(Box::new(EagerRevset { positions }))
             }
-            ResolvedExpression::HeadsRange {
-                roots,
-                heads,
-                parents_range,
-                filter,
-            } => {
-                let root_set = self.evaluate(roots)?;
+            ResolvedExpression::Heads(ExpressionOrFilteredRange::FilteredRange(filtered_range)) => {
+                let root_set = self.evaluate(&filtered_range.roots)?;
                 let root_positions: Vec<_> = root_set.positions().attach(index).try_collect()?;
                 // Pre-filter heads so queries like 'immutable_heads()..' can
                 // terminate early. immutable_heads() usually includes some
                 // visible heads, which can be trivially rejected.
-                let head_set = self.evaluate(heads)?;
+                let head_set = self.evaluate(&filtered_range.heads)?;
                 let head_positions = difference_by(
                     head_set.positions(),
                     EagerRevWalk::new(root_positions.iter().copied().map(Ok)),
@@ -936,19 +932,19 @@ impl EvaluationContext<'_> {
                 )
                 .attach(index)
                 .try_collect()?;
-                let positions = if let Some(filter) = filter {
+                let positions = if let Some(filter) = &filtered_range.filter {
                     let mut filter = self.evaluate_predicate(filter)?.to_predicate_fn();
                     index.commits().heads_from_range_and_filter(
                         root_positions,
                         head_positions,
-                        parents_range,
+                        &filtered_range.parents_range,
                         |pos| filter(index, pos),
                     )?
                 } else {
                     let Ok(positions) = index.commits().heads_from_range_and_filter::<Infallible>(
                         root_positions,
                         head_positions,
-                        parents_range,
+                        &filtered_range.parents_range,
                         |_| Ok(true),
                     );
                     positions

--- a/lib/src/default_index/revset_engine.rs
+++ b/lib/src/default_index/revset_engine.rs
@@ -66,6 +66,7 @@ use crate::object_id::ObjectId as _;
 use crate::object_id::PrefixResolution;
 use crate::repo_path::RepoPath;
 use crate::revset::DiffMatchSide;
+use crate::revset::ExpressionOrFilteredRange;
 use crate::revset::GENERATION_RANGE_FULL;
 use crate::revset::ResolvedExpression;
 use crate::revset::ResolvedPredicateExpression;
@@ -914,25 +915,20 @@ impl EvaluationContext<'_> {
                     .collect_vec();
                 Ok(Box::new(EagerRevset { positions }))
             }
-            ResolvedExpression::Heads(candidates) => {
+            ResolvedExpression::Heads(ExpressionOrFilteredRange::Expression(candidates)) => {
                 let candidate_set = self.evaluate(candidates)?;
                 let positions = index
                     .commits()
                     .heads_pos(candidate_set.positions().attach(index).try_collect()?);
                 Ok(Box::new(EagerRevset { positions }))
             }
-            ResolvedExpression::HeadsRange {
-                roots,
-                heads,
-                parents_range,
-                filter,
-            } => {
-                let root_set = self.evaluate(roots)?;
+            ResolvedExpression::Heads(ExpressionOrFilteredRange::FilteredRange(filtered_range)) => {
+                let root_set = self.evaluate(&filtered_range.roots)?;
                 let root_positions: Vec<_> = root_set.positions().attach(index).try_collect()?;
                 // Pre-filter heads so queries like 'immutable_heads()..' can
                 // terminate early. immutable_heads() usually includes some
                 // visible heads, which can be trivially rejected.
-                let head_set = self.evaluate(heads)?;
+                let head_set = self.evaluate(&filtered_range.heads)?;
                 let head_positions = difference_by(
                     head_set.positions(),
                     EagerRevWalk::new(root_positions.iter().copied().map(Ok)),
@@ -940,19 +936,19 @@ impl EvaluationContext<'_> {
                 )
                 .attach(index)
                 .try_collect()?;
-                let positions = if let Some(filter) = filter {
+                let positions = if let Some(filter) = &filtered_range.filter {
                     let mut filter = self.evaluate_predicate(filter)?.to_predicate_fn();
                     index.commits().heads_from_range_and_filter(
                         root_positions,
                         head_positions,
-                        parents_range,
+                        &filtered_range.parents_range,
                         |pos| filter(index, pos),
                     )?
                 } else {
                     let Ok(positions) = index.commits().heads_from_range_and_filter::<Infallible>(
                         root_positions,
                         head_positions,
-                        parents_range,
+                        &filtered_range.parents_range,
                         |_| Ok(true),
                     );
                     positions

--- a/lib/src/default_index/revset_engine.rs
+++ b/lib/src/default_index/revset_engine.rs
@@ -1067,14 +1067,48 @@ impl EvaluationContext<'_> {
                 }
                 let max_depth = u32::try_from(count - 1).unwrap_or(u32::MAX);
 
-                let candidates: Vec<_> = self
-                    .evaluate(candidates)?
-                    .positions()
-                    .attach(self.index)
-                    .try_collect()?;
+                let (subgraph, heads) = match candidates {
+                    ExpressionOrFilteredRange::Expression(candidates) => {
+                        let candidates: Vec<_> = self
+                            .evaluate(candidates)?
+                            .positions()
+                            .attach(self.index)
+                            .try_collect()?;
 
-                let (subgraph, heads) =
-                    subgraph_and_heads_from_positions(index, &candidates, max_depth);
+                        subgraph_and_heads_from_positions(index, &candidates, max_depth)
+                    }
+                    ExpressionOrFilteredRange::FilteredRange(filtered_range) => {
+                        let root_set = self.evaluate(&filtered_range.roots)?;
+                        let root_positions: Vec<_> =
+                            root_set.positions().attach(index).try_collect()?;
+                        // Pre-filter heads so queries like 'immutable_heads()..' can
+                        // terminate early. immutable_heads() usually includes some
+                        // visible heads, which can be trivially rejected.
+                        let head_set = self.evaluate(&filtered_range.heads)?;
+                        let head_positions: Vec<_> = difference_by(
+                            head_set.positions(),
+                            EagerRevWalk::new(root_positions.iter().copied().map(Ok)),
+                            |pos1, pos2| pos1.cmp(pos2).reverse(),
+                        )
+                        .attach(index)
+                        .try_collect()?;
+
+                        let mut filter: BoxedPredicateFn =
+                            if let Some(filter) = &filtered_range.filter {
+                                self.evaluate_predicate(filter)?.to_predicate_fn()
+                            } else {
+                                Box::new(|_, _| Ok(true))
+                            };
+                        subgraph_and_heads_from_range_and_filter(
+                            index,
+                            root_positions,
+                            head_positions,
+                            &filtered_range.parents_range,
+                            |pos| filter(index, pos),
+                            max_depth,
+                        )?
+                    }
+                };
 
                 Ok(Box::new(self.take_latest_revset(subgraph, &heads, *count)?))
             }
@@ -1704,6 +1738,134 @@ fn subgraph_and_heads_from_positions(
         }
     }
     (Subgraph { commits }, heads)
+}
+
+fn subgraph_and_heads_from_range_and_filter<E>(
+    index: &CompositeIndex,
+    roots: Vec<GlobalCommitPosition>,
+    heads: Vec<GlobalCommitPosition>,
+    parents_range: &Range<u32>,
+    mut filter: impl FnMut(GlobalCommitPosition) -> Result<bool, E>,
+    max_depth: u32,
+) -> Result<(Subgraph, Vec<GlobalCommitPosition>), E> {
+    let commit_index = index.commits();
+
+    #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+    struct WantedItem {
+        // We need to walk backward through all parent edges, but we need to handle `parents_range`
+        // as well. Therefore, we keep track of whether this commit was reachable from the child
+        // using only edges in `parents_range`. Since this field is considered first for ordering,
+        // if there was no path to the current position through edges in `parents_range`, then the
+        // first value in the `RevWalkQueue` max-heap will be `false`, so we can efficiently skip
+        // these commits.
+        is_in_parents_range: bool,
+        // The child which we are currently walking backwards from (if any).
+        child_pos: GlobalCommitPosition,
+        // If true, this is a head, so the child position should be ignored. It might be cleaner to
+        // use `Option<GlobalCommitPosition>` for `child_pos` instead, but that makes the struct
+        // 50% larger due to alignment.
+        is_head: bool,
+    }
+
+    let mut wanted_queue: RevWalkQueue<GlobalCommitPosition, WantedItem> =
+        RevWalkQueue::with_min_pos(GlobalCommitPosition::MIN);
+    let mut unwanted_queue: RevWalkQueue<GlobalCommitPosition, ()> =
+        RevWalkQueue::with_min_pos(GlobalCommitPosition::MIN);
+    unwanted_queue.extend(roots, ());
+
+    for head in heads {
+        wanted_queue.push(
+            head,
+            WantedItem {
+                is_in_parents_range: true,
+                child_pos: GlobalCommitPosition::MIN,
+                is_head: true,
+            },
+        );
+    }
+
+    let mut found_heads = Vec::new();
+    let mut depths: BTreeMap<GlobalCommitPosition, u32> = BTreeMap::new();
+    let mut commits: BTreeMap<GlobalCommitPosition, SubgraphCommitData> = BTreeMap::new();
+
+    while let Some(peeked_item) = wanted_queue.peek() {
+        let pos = peeked_item.pos;
+
+        if flush_queue_until(&mut unwanted_queue, index, pos).is_some() {
+            wanted_queue.skip_while_eq(&pos);
+            continue;
+        }
+
+        // If `is_in_parents_range` is `false` for the first entry with this position,
+        // it will be false for all of the entries with the same position.
+        if !peeked_item.value.is_in_parents_range || !filter(pos)? {
+            let parent_positions = commit_index.entry_by_pos(pos).parent_positions();
+
+            while let Some(item) = wanted_queue.pop_eq(&pos) {
+                for (i, &parent_pos) in (0u32..).zip(&parent_positions) {
+                    let mut value = item.value;
+                    value.is_in_parents_range =
+                        value.is_in_parents_range && parents_range.contains(&i);
+                    wanted_queue.push(parent_pos, value);
+                }
+
+                wanted_queue.skip_while(|x| *x == item);
+            }
+
+            continue;
+        }
+
+        let mut num_children = 0;
+        let mut depth = 0;
+        while let Some(item) = wanted_queue.pop_eq(&pos) {
+            if item.value.is_head {
+                continue;
+            }
+
+            let child_pos = item.value.child_pos;
+            let child_data = commits
+                .get_mut(&child_pos)
+                .expect("child commit should be in subgraph");
+            if child_data.parents.last() == Some(&pos) {
+                continue;
+            }
+
+            child_data.parents.push(pos);
+            num_children += 1;
+            depth = depth.max(depths[&child_pos] + 1);
+        }
+
+        depths.insert(pos, depth);
+        commits.insert(
+            pos,
+            SubgraphCommitData {
+                parents: SmallGlobalCommitPositionsVec::new(),
+                num_children,
+            },
+        );
+
+        if num_children == 0 {
+            found_heads.push(pos);
+        }
+
+        let parent_positions = commit_index.entry_by_pos(pos).parent_positions();
+        if depth >= max_depth {
+            unwanted_queue.extend(parent_positions, ());
+            continue;
+        }
+
+        for (i, parent_pos) in (0u32..).zip(parent_positions) {
+            wanted_queue.push(
+                parent_pos,
+                WantedItem {
+                    is_in_parents_range: parents_range.contains(&i),
+                    child_pos: pos,
+                    is_head: false,
+                },
+            );
+        }
+    }
+    Ok((Subgraph { commits }, found_heads))
 }
 
 #[cfg(test)]

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -226,6 +226,26 @@ pub enum RevsetFilterPredicate {
     Extension(Arc<dyn RevsetFilterExtension>),
 }
 
+#[derive(Clone, Debug)]
+pub struct FilteredRange<E, Filter = E> {
+    pub roots: E,
+    pub heads: E,
+    pub parents_range: Range<u32>,
+    pub filter: Filter,
+}
+
+#[derive(Clone, Debug)]
+pub enum ExpressionOrFilteredRange<E, Filter = E> {
+    Expression(E),
+    FilteredRange(FilteredRange<E, Filter>),
+}
+
+impl<E, F> From<E> for ExpressionOrFilteredRange<E, F> {
+    fn from(value: E) -> Self {
+        Self::Expression(value)
+    }
+}
+
 mod private {
     /// Defines [`RevsetExpression`] variants depending on resolution state.
     pub trait ExpressionState {
@@ -302,15 +322,7 @@ pub enum RevsetExpression<St: ExpressionState> {
         sources: Arc<Self>,
         domain: Arc<Self>,
     },
-    Heads(Arc<Self>),
-    /// Heads of the set of commits which are ancestors of `heads` but are not
-    /// ancestors of `roots`, and which also are contained in `filter`.
-    HeadsRange {
-        roots: Arc<Self>,
-        heads: Arc<Self>,
-        parents_range: Range<u32>,
-        filter: Arc<Self>,
-    },
+    Heads(ExpressionOrFilteredRange<Arc<Self>>),
     Roots(Arc<Self>),
     Forks,
     ForkPoint(Arc<Self>),
@@ -474,7 +486,7 @@ impl<St: ExpressionState> RevsetExpression<St> {
 
     /// Commits in `self` that don't have descendants in `self`.
     pub fn heads(self: &Arc<Self>) -> Arc<Self> {
-        Arc::new(Self::Heads(self.clone()))
+        Arc::new(Self::Heads(self.clone().into()))
     }
 
     /// Commits in `self` that don't have ancestors in `self`.
@@ -759,15 +771,7 @@ pub enum ResolvedExpression {
         sources: Box<Self>,
         domain: Box<Self>,
     },
-    Heads(Box<Self>),
-    /// Heads of the set of commits which are ancestors of `heads` but are not
-    /// ancestors of `roots`, and which also are contained in `filter`.
-    HeadsRange {
-        roots: Box<Self>,
-        heads: Box<Self>,
-        parents_range: Range<u32>,
-        filter: Option<ResolvedPredicateExpression>,
-    },
+    Heads(ExpressionOrFilteredRange<Box<Self>, Option<ResolvedPredicateExpression>>),
     Roots(Box<Self>),
     Forks {
         heads: Box<Self>,
@@ -1562,26 +1566,7 @@ fn try_transform_expression<St: ExpressionState, E>(
                     .map(|(sources, domain)| RevsetExpression::Reachable { sources, domain })
             }
             RevsetExpression::Heads(candidates) => {
-                transform_rec(candidates, pre, post)?.map(RevsetExpression::Heads)
-            }
-            RevsetExpression::HeadsRange {
-                roots,
-                heads,
-                parents_range,
-                filter,
-            } => {
-                let transformed_roots = transform_rec(roots, pre, post)?;
-                let transformed_heads = transform_rec(heads, pre, post)?;
-                let transformed_filter = transform_rec(filter, pre, post)?;
-                (transformed_roots.is_some()
-                    || transformed_heads.is_some()
-                    || transformed_filter.is_some())
-                .then(|| RevsetExpression::HeadsRange {
-                    roots: transformed_roots.unwrap_or_else(|| roots.clone()),
-                    heads: transformed_heads.unwrap_or_else(|| heads.clone()),
-                    parents_range: parents_range.clone(),
-                    filter: transformed_filter.unwrap_or_else(|| filter.clone()),
-                })
+                transform_rec_filtered_range(candidates, pre, post)?.map(RevsetExpression::Heads)
             }
             RevsetExpression::Roots(candidates) => {
                 transform_rec(candidates, pre, post)?.map(RevsetExpression::Roots)
@@ -1693,6 +1678,39 @@ fn try_transform_expression<St: ExpressionState, E>(
         }
     }
 
+    fn transform_rec_filtered_range<St: ExpressionState, E>(
+        expression_or_filtered_range: &ExpressionOrFilteredRange<Arc<RevsetExpression<St>>>,
+        pre: &mut impl FnMut(&Arc<RevsetExpression<St>>) -> Result<PreTransformedExpression<St>, E>,
+        post: &mut impl FnMut(&Arc<RevsetExpression<St>>) -> Result<TransformedExpression<St>, E>,
+    ) -> Result<Option<ExpressionOrFilteredRange<Arc<RevsetExpression<St>>>>, E> {
+        Ok(match expression_or_filtered_range {
+            ExpressionOrFilteredRange::Expression(expression) => {
+                transform_rec(expression, pre, post)?.map(ExpressionOrFilteredRange::Expression)
+            }
+            ExpressionOrFilteredRange::FilteredRange(FilteredRange {
+                roots,
+                heads,
+                parents_range,
+                filter,
+            }) => {
+                let transformed_roots = transform_rec(roots, pre, post)?;
+                let transformed_heads = transform_rec(heads, pre, post)?;
+                let transformed_filter = transform_rec(filter, pre, post)?;
+                (transformed_roots.is_some()
+                    || transformed_heads.is_some()
+                    || transformed_filter.is_some())
+                .then(|| {
+                    ExpressionOrFilteredRange::FilteredRange(FilteredRange {
+                        roots: transformed_roots.unwrap_or_else(|| roots.clone()),
+                        heads: transformed_heads.unwrap_or_else(|| heads.clone()),
+                        parents_range: parents_range.clone(),
+                        filter: transformed_filter.unwrap_or_else(|| filter.clone()),
+                    })
+                })
+            }
+        })
+    }
+
     fn transform_rec<St: ExpressionState, E>(
         expression: &Arc<RevsetExpression<St>>,
         pre: &mut impl FnMut(&Arc<RevsetExpression<St>>) -> Result<PreTransformedExpression<St>, E>,
@@ -1752,6 +1770,32 @@ where
     OutSt: ExpressionState,
     F: ExpressionStateFolder<InSt, OutSt> + ?Sized,
 {
+    let fold_filtered_range = |folder: &mut F,
+                               expression_or_filtered_range: &ExpressionOrFilteredRange<
+        Arc<RevsetExpression<InSt>>,
+    >| {
+        match expression_or_filtered_range {
+            ExpressionOrFilteredRange::Expression(expression) => folder
+                .fold_expression(expression)
+                .map(ExpressionOrFilteredRange::Expression),
+            ExpressionOrFilteredRange::FilteredRange(FilteredRange {
+                roots,
+                heads,
+                parents_range,
+                filter,
+            }) => {
+                let roots = folder.fold_expression(roots)?;
+                let heads = folder.fold_expression(heads)?;
+                let filter = folder.fold_expression(filter)?;
+                Ok(ExpressionOrFilteredRange::FilteredRange(FilteredRange {
+                    roots,
+                    heads,
+                    parents_range: parents_range.clone(),
+                    filter,
+                }))
+            }
+        }
+    };
     let expression: Arc<_> = match expression {
         RevsetExpression::None => RevsetExpression::None.into(),
         RevsetExpression::All => RevsetExpression::All.into(),
@@ -1811,26 +1855,8 @@ where
             RevsetExpression::Reachable { sources, domain }.into()
         }
         RevsetExpression::Heads(heads) => {
-            let heads = folder.fold_expression(heads)?;
+            let heads = fold_filtered_range(folder, heads)?;
             RevsetExpression::Heads(heads).into()
-        }
-        RevsetExpression::HeadsRange {
-            roots,
-            heads,
-            parents_range,
-            filter,
-        } => {
-            let roots = folder.fold_expression(roots)?;
-            let heads = folder.fold_expression(heads)?;
-            let parents_range = parents_range.clone();
-            let filter = folder.fold_expression(filter)?;
-            RevsetExpression::HeadsRange {
-                roots,
-                heads,
-                parents_range,
-                filter,
-            }
-            .into()
         }
         RevsetExpression::Roots(roots) => {
             let roots = folder.fold_expression(roots)?;
@@ -2278,17 +2304,17 @@ fn fold_ancestors_union<St: ExpressionState>(
 ///
 /// Ancestors and negated ancestors should have already been moved to the left
 /// in intersections, and negated ancestors should have been combined already.
-fn fold_heads_range<St: ExpressionState>(
+fn fold_filtered_range<St: ExpressionState>(
     expression: &Arc<RevsetExpression<St>>,
 ) -> TransformedExpression<St> {
     // Represents `roots..heads & filter`
-    struct FilteredRange<St: ExpressionState> {
+    struct FilteredRangeBuilder<St: ExpressionState> {
         roots: Arc<RevsetExpression<St>>,
         heads_and_parents_range: Option<(Arc<RevsetExpression<St>>, Range<u32>)>,
         filter: Arc<RevsetExpression<St>>,
     }
 
-    impl<St: ExpressionState> FilteredRange<St> {
+    impl<St: ExpressionState> FilteredRangeBuilder<St> {
         fn new(roots: Arc<RevsetExpression<St>>) -> Self {
             // roots.. & all()
             Self {
@@ -2320,16 +2346,31 @@ fn fold_heads_range<St: ExpressionState>(
             };
             self
         }
+
+        fn build(self) -> FilteredRange<Arc<RevsetExpression<St>>> {
+            let (heads, parents_range) = self.heads_and_parents_range.unwrap_or_else(|| {
+                (
+                    RevsetExpression::visible_heads_or_referenced(),
+                    PARENTS_RANGE_FULL,
+                )
+            });
+            FilteredRange {
+                roots: self.roots,
+                heads,
+                parents_range,
+                filter: self.filter,
+            }
+        }
     }
 
-    fn to_filtered_range<St: ExpressionState>(
+    fn build_filtered_range<St: ExpressionState>(
         expression: &Arc<RevsetExpression<St>>,
-    ) -> Option<FilteredRange<St>> {
+    ) -> Option<FilteredRangeBuilder<St>> {
         // If the first expression is `ancestors(x)`, then we already know the range
         // must be `none()..x`, since any roots would've been moved to the left by an
         // earlier pass.
         if let Ok(heads_and_parents_range) = ancestors_to_heads_and_parents_range(expression) {
-            return Some(FilteredRange {
+            return Some(FilteredRangeBuilder {
                 roots: RevsetExpression::none(),
                 heads_and_parents_range: Some(heads_and_parents_range),
                 filter: RevsetExpression::all(),
@@ -2340,60 +2381,52 @@ fn fold_heads_range<St: ExpressionState>(
             // so we can set the roots based on the first expression in the intersection.
             RevsetExpression::NotIn(complement) => {
                 if let Ok(roots) = ancestors_to_heads(complement) {
-                    Some(FilteredRange::new(roots))
+                    Some(FilteredRangeBuilder::new(roots))
                 } else {
                     // If the first expression is a non-ancestors negation, we still want to use
-                    // `HeadsRange` since `~x` is equivalent to `::visible_heads() ~ x`.
-                    Some(FilteredRange::new(RevsetExpression::none()).add_filter(expression))
+                    // `FilteredRange` since `~x` is equivalent to `::visible_heads() ~ x`.
+                    Some(FilteredRangeBuilder::new(RevsetExpression::none()).add_filter(expression))
                 }
             }
             // We also want to optimize `heads()` if the first expression is `all()` or a filter.
             RevsetExpression::All | RevsetExpression::Filter(_) | RevsetExpression::AsFilter(_) => {
-                Some(FilteredRange::new(RevsetExpression::none()).add_filter(expression))
+                Some(FilteredRangeBuilder::new(RevsetExpression::none()).add_filter(expression))
             }
             // We only need to handle intersections recursively. Differences will have been
             // unfolded already.
             RevsetExpression::Intersection(expression1, expression2) => {
-                to_filtered_range(expression1).map(|filtered_range| filtered_range.add(expression2))
+                build_filtered_range(expression1)
+                    .map(|filtered_range| filtered_range.add(expression2))
             }
             _ => None,
         }
     }
 
-    fn to_heads_range<St: ExpressionState>(
+    fn to_filtered_range<St: ExpressionState>(
         candidates: &Arc<RevsetExpression<St>>,
-    ) -> Option<Arc<RevsetExpression<St>>> {
-        to_filtered_range(candidates).map(|filtered_range| {
-            let (heads, parents_range) =
-                filtered_range.heads_and_parents_range.unwrap_or_else(|| {
-                    (
-                        RevsetExpression::visible_heads_or_referenced(),
-                        PARENTS_RANGE_FULL,
-                    )
-                });
-            RevsetExpression::HeadsRange {
-                roots: filtered_range.roots,
-                heads,
-                parents_range,
-                filter: filtered_range.filter,
-            }
-            .into()
-        })
+    ) -> Option<ExpressionOrFilteredRange<Arc<RevsetExpression<St>>>> {
+        build_filtered_range(candidates)
+            .map(FilteredRangeBuilder::build)
+            .map(ExpressionOrFilteredRange::FilteredRange)
     }
 
     transform_expression_bottom_up(expression, |expression| match expression.as_ref() {
-        // ::(x..y & filter) -> ::heads_range(x, y, filter)
-        // ::filter -> ::heads_range(none(), visible_heads_or_referenced(), filter)
+        // ::(x..y & filter) -> ::heads(filtered_range(x, y, filter))
+        // ::filter -> ::heads(filtered_range(none(), visible_heads_or_referenced(), filter))
         RevsetExpression::Ancestors {
             heads,
             // This optimization is only valid for full generation and parents ranges, since
             // otherwise adding `heads()` would change the result.
             generation: GENERATION_RANGE_FULL,
             parents_range: PARENTS_RANGE_FULL,
-        } => to_heads_range(heads).map(|heads| heads.ancestors()),
-        // heads(x..y & filter) -> heads_range(x, y, filter)
-        // heads(filter) -> heads_range(none(), visible_heads_or_referenced(), filter)
-        RevsetExpression::Heads(candidates) => to_heads_range(candidates),
+        } => to_filtered_range(heads)
+            .map(|heads| RevsetExpression::ancestors(&RevsetExpression::Heads(heads).into())),
+        // heads(x..y & filter) -> heads(filtered_range(x, y, filter))
+        // heads(filter) -> heads(filtered_range(none(), visible_heads_or_referenced(), filter))
+        RevsetExpression::Heads(ExpressionOrFilteredRange::Expression(candidates)) => {
+            to_filtered_range(candidates)
+                .map(|candidates| RevsetExpression::Heads(candidates).into())
+        }
         _ => None,
     })
 }
@@ -2578,7 +2611,7 @@ pub fn optimize<St: ExpressionState>(
     let expression = sort_negations_and_ancestors(&expression).unwrap_or(expression);
     let expression = fold_ancestors_union(&expression).unwrap_or(expression);
     let expression = internalize_filter(&expression).unwrap_or(expression);
-    let expression = fold_heads_range(&expression).unwrap_or(expression);
+    let expression = fold_filtered_range(&expression).unwrap_or(expression);
     let expression = fold_difference(&expression).unwrap_or(expression);
     fold_not_in_ancestors(&expression).unwrap_or(expression)
 }
@@ -3173,20 +3206,8 @@ impl VisibilityResolutionContext<'_> {
                 domain: self.resolve(domain).into(),
             },
             RevsetExpression::Heads(candidates) => {
-                ResolvedExpression::Heads(self.resolve(candidates).into())
+                ResolvedExpression::Heads(self.resolve_filtered_range(candidates))
             }
-            RevsetExpression::HeadsRange {
-                roots,
-                heads,
-                parents_range,
-                filter,
-            } => ResolvedExpression::HeadsRange {
-                roots: self.resolve(roots).into(),
-                heads: self.resolve(heads).into(),
-                parents_range: parents_range.clone(),
-                filter: (!matches!(filter.as_ref(), RevsetExpression::All))
-                    .then(|| self.resolve_predicate(filter)),
-            },
             RevsetExpression::Roots(candidates) => {
                 ResolvedExpression::Roots(self.resolve(candidates).into())
             }
@@ -3312,6 +3333,27 @@ impl VisibilityResolutionContext<'_> {
         ResolvedExpression::Commits(vec![self.root.to_owned()])
     }
 
+    fn resolve_filtered_range(
+        &self,
+        expression_or_filtered_range: &ExpressionOrFilteredRange<Arc<ResolvedRevsetExpression>>,
+    ) -> ExpressionOrFilteredRange<Box<ResolvedExpression>, Option<ResolvedPredicateExpression>>
+    {
+        match expression_or_filtered_range {
+            ExpressionOrFilteredRange::Expression(expression) => {
+                ExpressionOrFilteredRange::Expression(self.resolve(expression.as_ref()).into())
+            }
+            ExpressionOrFilteredRange::FilteredRange(filtered_range) => {
+                ExpressionOrFilteredRange::FilteredRange(FilteredRange {
+                    roots: self.resolve(&filtered_range.roots).into(),
+                    heads: self.resolve(&filtered_range.heads).into(),
+                    parents_range: filtered_range.parents_range.clone(),
+                    filter: (!matches!(&filtered_range.filter.as_ref(), RevsetExpression::All))
+                        .then(|| self.resolve_predicate(&filtered_range.filter)),
+                })
+            }
+        }
+    }
+
     /// Resolves expression tree as filter predicate.
     ///
     /// For filter expression, this never inserts a hidden `all()` since a
@@ -3334,7 +3376,6 @@ impl VisibilityResolutionContext<'_> {
             | RevsetExpression::DagRange { .. }
             | RevsetExpression::Reachable { .. }
             | RevsetExpression::Heads(_)
-            | RevsetExpression::HeadsRange { .. }
             | RevsetExpression::Roots(_)
             | RevsetExpression::Forks
             | RevsetExpression::ForkPoint(_)
@@ -3699,7 +3740,11 @@ mod tests {
             @r#"CommitRef(WorkingCopy(WorkspaceNameBuf("default")))"#);
         insta::assert_debug_snapshot!(
             current_wc.heads(),
-            @r#"Heads(CommitRef(WorkingCopy(WorkspaceNameBuf("default"))))"#);
+            @r#"
+        Heads(
+            Expression(CommitRef(WorkingCopy(WorkspaceNameBuf("default")))),
+        )
+        "#);
         insta::assert_debug_snapshot!(
             current_wc.roots(),
             @r#"Roots(CommitRef(WorkingCopy(WorkspaceNameBuf("default"))))"#);
@@ -4514,21 +4559,21 @@ mod tests {
         // Continue without pre transformation, do transform child
         insta::assert_debug_snapshot!(
             transform_expression(
-                &ResolvedRevsetExpression::root().heads(),
+                &ResolvedRevsetExpression::root().negated(),
                 |_| ControlFlow::Continue(()),
                 |x| match x.as_ref() {
                     RevsetExpression::Root => Some(RevsetExpression::none()),
                     _ => None,
                 },
-            ), @"Some(Heads(None))");
+            ), @"Some(NotIn(None))");
 
         // Continue without pre transformation, do transform self
         insta::assert_debug_snapshot!(
             transform_expression(
-                &ResolvedRevsetExpression::root().heads(),
+                &ResolvedRevsetExpression::root().negated(),
                 |_| ControlFlow::Continue(()),
                 |x| match x.as_ref() {
-                    RevsetExpression::Heads(y) => Some(y.clone()),
+                    RevsetExpression::NotIn(y) => Some(y.clone()),
                     _ => None,
                 },
             ), @"Some(Root)");
@@ -4825,7 +4870,9 @@ mod tests {
             optimize(parse("heads(bookmarks() & all())")?),
             @r#"
         Heads(
-            CommitRef(Bookmarks(Pattern(Substring("")))),
+            Expression(
+                CommitRef(Bookmarks(Pattern(Substring("")))),
+            ),
         )
         "#);
         insta::assert_debug_snapshot!(
@@ -5691,17 +5738,21 @@ mod tests {
         // Filters can be merged after ancestor unions are folded.
         insta::assert_debug_snapshot!(optimize(parse("::foo | ::author_name(bar)")?), @r#"
         Ancestors {
-            heads: HeadsRange {
-                roots: None,
-                heads: VisibleHeadsOrReferenced,
-                parents_range: 0..4294967295,
-                filter: AsFilter(
-                    Union(
-                        CommitRef(Symbol("foo")),
-                        Filter(AuthorName(Pattern(Exact("bar")))),
-                    ),
+            heads: Heads(
+                FilteredRange(
+                    FilteredRange {
+                        roots: None,
+                        heads: VisibleHeadsOrReferenced,
+                        parents_range: 0..4294967295,
+                        filter: AsFilter(
+                            Union(
+                                CommitRef(Symbol("foo")),
+                                Filter(AuthorName(Pattern(Exact("bar")))),
+                            ),
+                        ),
+                    },
                 ),
-            },
+            ),
             generation: 0..18446744073709551615,
             parents_range: 0..4294967295,
         }
@@ -5805,12 +5856,16 @@ mod tests {
         insta::assert_debug_snapshot!(optimize(parse("foo..(bar..baz)")?), @r#"
         Range {
             roots: CommitRef(Symbol("foo")),
-            heads: HeadsRange {
-                roots: CommitRef(Symbol("bar")),
-                heads: CommitRef(Symbol("baz")),
-                parents_range: 0..4294967295,
-                filter: All,
-            },
+            heads: Heads(
+                FilteredRange(
+                    FilteredRange {
+                        roots: CommitRef(Symbol("bar")),
+                        heads: CommitRef(Symbol("baz")),
+                        parents_range: 0..4294967295,
+                        filter: All,
+                    },
+                ),
+            ),
             generation: 0..18446744073709551615,
             parents_range: 0..4294967295,
         }
@@ -6100,224 +6155,304 @@ mod tests {
 
         // Heads of basic range operators can be folded.
         insta::assert_debug_snapshot!(optimize(parse("heads(::)")?), @"
-        HeadsRange {
-            roots: None,
-            heads: VisibleHeadsOrReferenced,
-            parents_range: 0..4294967295,
-            filter: All,
-        }
+        Heads(
+            FilteredRange(
+                FilteredRange {
+                    roots: None,
+                    heads: VisibleHeadsOrReferenced,
+                    parents_range: 0..4294967295,
+                    filter: All,
+                },
+            ),
+        )
         ");
         insta::assert_debug_snapshot!(optimize(parse("heads(::foo)")?), @r#"
-        HeadsRange {
-            roots: None,
-            heads: CommitRef(Symbol("foo")),
-            parents_range: 0..4294967295,
-            filter: All,
-        }
+        Heads(
+            FilteredRange(
+                FilteredRange {
+                    roots: None,
+                    heads: CommitRef(Symbol("foo")),
+                    parents_range: 0..4294967295,
+                    filter: All,
+                },
+            ),
+        )
         "#);
         // It might be better to use `roots: Root`, but it would require adding a
         // special case for `~root()`, and this should be similar in performance.
         insta::assert_debug_snapshot!(optimize(parse("heads(..)")?), @"
-        HeadsRange {
-            roots: None,
-            heads: VisibleHeadsOrReferenced,
-            parents_range: 0..4294967295,
-            filter: NotIn(Root),
-        }
+        Heads(
+            FilteredRange(
+                FilteredRange {
+                    roots: None,
+                    heads: VisibleHeadsOrReferenced,
+                    parents_range: 0..4294967295,
+                    filter: NotIn(Root),
+                },
+            ),
+        )
         ");
         insta::assert_debug_snapshot!(optimize(parse("heads(foo..)")?), @r#"
-        HeadsRange {
-            roots: CommitRef(Symbol("foo")),
-            heads: VisibleHeadsOrReferenced,
-            parents_range: 0..4294967295,
-            filter: All,
-        }
+        Heads(
+            FilteredRange(
+                FilteredRange {
+                    roots: CommitRef(Symbol("foo")),
+                    heads: VisibleHeadsOrReferenced,
+                    parents_range: 0..4294967295,
+                    filter: All,
+                },
+            ),
+        )
         "#);
         insta::assert_debug_snapshot!(optimize(parse("heads(..bar)")?), @r#"
-        HeadsRange {
-            roots: Root,
-            heads: CommitRef(Symbol("bar")),
-            parents_range: 0..4294967295,
-            filter: All,
-        }
+        Heads(
+            FilteredRange(
+                FilteredRange {
+                    roots: Root,
+                    heads: CommitRef(Symbol("bar")),
+                    parents_range: 0..4294967295,
+                    filter: All,
+                },
+            ),
+        )
         "#);
         insta::assert_debug_snapshot!(optimize(parse("heads(foo..bar)")?), @r#"
-        HeadsRange {
-            roots: CommitRef(Symbol("foo")),
-            heads: CommitRef(Symbol("bar")),
-            parents_range: 0..4294967295,
-            filter: All,
-        }
+        Heads(
+            FilteredRange(
+                FilteredRange {
+                    roots: CommitRef(Symbol("foo")),
+                    heads: CommitRef(Symbol("bar")),
+                    parents_range: 0..4294967295,
+                    filter: All,
+                },
+            ),
+        )
         "#);
         insta::assert_debug_snapshot!(optimize(parse("heads(~::foo & ::bar)")?), @r#"
-        HeadsRange {
-            roots: CommitRef(Symbol("foo")),
-            heads: CommitRef(Symbol("bar")),
-            parents_range: 0..4294967295,
-            filter: All,
-        }
+        Heads(
+            FilteredRange(
+                FilteredRange {
+                    roots: CommitRef(Symbol("foo")),
+                    heads: CommitRef(Symbol("bar")),
+                    parents_range: 0..4294967295,
+                    filter: All,
+                },
+            ),
+        )
         "#);
         insta::assert_debug_snapshot!(optimize(parse("heads(~::foo)")?), @r#"
-        HeadsRange {
-            roots: CommitRef(Symbol("foo")),
-            heads: VisibleHeadsOrReferenced,
-            parents_range: 0..4294967295,
-            filter: All,
-        }
+        Heads(
+            FilteredRange(
+                FilteredRange {
+                    roots: CommitRef(Symbol("foo")),
+                    heads: VisibleHeadsOrReferenced,
+                    parents_range: 0..4294967295,
+                    filter: All,
+                },
+            ),
+        )
         "#);
         insta::assert_debug_snapshot!(optimize(parse("heads(a..b & c..d)")?), @r#"
-        HeadsRange {
-            roots: Union(
-                CommitRef(Symbol("a")),
-                CommitRef(Symbol("c")),
+        Heads(
+            FilteredRange(
+                FilteredRange {
+                    roots: Union(
+                        CommitRef(Symbol("a")),
+                        CommitRef(Symbol("c")),
+                    ),
+                    heads: CommitRef(Symbol("b")),
+                    parents_range: 0..4294967295,
+                    filter: Ancestors {
+                        heads: CommitRef(Symbol("d")),
+                        generation: 0..18446744073709551615,
+                        parents_range: 0..4294967295,
+                    },
+                },
             ),
-            heads: CommitRef(Symbol("b")),
-            parents_range: 0..4294967295,
-            filter: Ancestors {
-                heads: CommitRef(Symbol("d")),
-                generation: 0..18446744073709551615,
-                parents_range: 0..4294967295,
-            },
-        }
+        )
         "#);
 
         // Heads of first-parent ancestors can also be folded.
         insta::assert_debug_snapshot!(optimize(parse("heads(first_ancestors(foo))")?), @r#"
-        HeadsRange {
-            roots: None,
-            heads: CommitRef(Symbol("foo")),
-            parents_range: 0..1,
-            filter: All,
-        }
+        Heads(
+            FilteredRange(
+                FilteredRange {
+                    roots: None,
+                    heads: CommitRef(Symbol("foo")),
+                    parents_range: 0..1,
+                    filter: All,
+                },
+            ),
+        )
         "#);
         insta::assert_debug_snapshot!(optimize(parse("heads(first_ancestors(foo) & bar..)")?), @r#"
-        HeadsRange {
-            roots: CommitRef(Symbol("bar")),
-            heads: CommitRef(Symbol("foo")),
-            parents_range: 0..1,
-            filter: All,
-        }
+        Heads(
+            FilteredRange(
+                FilteredRange {
+                    roots: CommitRef(Symbol("bar")),
+                    heads: CommitRef(Symbol("foo")),
+                    parents_range: 0..1,
+                    filter: All,
+                },
+            ),
+        )
         "#);
         insta::assert_debug_snapshot!(optimize(parse("heads(foo.. & first_ancestors(bar) & ::baz)")?), @r#"
-        HeadsRange {
-            roots: CommitRef(Symbol("foo")),
-            heads: CommitRef(Symbol("bar")),
-            parents_range: 0..1,
-            filter: Ancestors {
-                heads: CommitRef(Symbol("baz")),
-                generation: 0..18446744073709551615,
-                parents_range: 0..4294967295,
-            },
-        }
+        Heads(
+            FilteredRange(
+                FilteredRange {
+                    roots: CommitRef(Symbol("foo")),
+                    heads: CommitRef(Symbol("bar")),
+                    parents_range: 0..1,
+                    filter: Ancestors {
+                        heads: CommitRef(Symbol("baz")),
+                        generation: 0..18446744073709551615,
+                        parents_range: 0..4294967295,
+                    },
+                },
+            ),
+        )
         "#);
 
         // Ancestors with a limited depth should not be optimized.
         insta::assert_debug_snapshot!(optimize(parse("heads(ancestors(foo, 2))")?), @r#"
         Heads(
-            Ancestors {
-                heads: CommitRef(Symbol("foo")),
-                generation: 0..2,
-                parents_range: 0..4294967295,
-            },
+            Expression(
+                Ancestors {
+                    heads: CommitRef(Symbol("foo")),
+                    generation: 0..2,
+                    parents_range: 0..4294967295,
+                },
+            ),
         )
         "#);
         insta::assert_debug_snapshot!(optimize(parse("heads(first_ancestors(foo, 2))")?), @r#"
         Heads(
-            Ancestors {
-                heads: CommitRef(Symbol("foo")),
-                generation: 0..2,
-                parents_range: 0..1,
-            },
+            Expression(
+                Ancestors {
+                    heads: CommitRef(Symbol("foo")),
+                    generation: 0..2,
+                    parents_range: 0..1,
+                },
+            ),
         )
         "#);
 
         // Generation folding should not prevent optimizing heads.
         insta::assert_debug_snapshot!(optimize(parse("heads(ancestors(foo--))")?), @r#"
-        HeadsRange {
-            roots: None,
-            heads: Ancestors {
-                heads: CommitRef(Symbol("foo")),
-                generation: 2..3,
-                parents_range: 0..4294967295,
-            },
-            parents_range: 0..4294967295,
-            filter: All,
-        }
+        Heads(
+            FilteredRange(
+                FilteredRange {
+                    roots: None,
+                    heads: Ancestors {
+                        heads: CommitRef(Symbol("foo")),
+                        generation: 2..3,
+                        parents_range: 0..4294967295,
+                    },
+                    parents_range: 0..4294967295,
+                    filter: All,
+                },
+            ),
+        )
         "#);
         insta::assert_debug_snapshot!(optimize(parse("heads(first_ancestors(first_parent(foo, 2)))")?), @r#"
-        HeadsRange {
-            roots: None,
-            heads: Ancestors {
-                heads: CommitRef(Symbol("foo")),
-                generation: 2..3,
-                parents_range: 0..1,
-            },
-            parents_range: 0..1,
-            filter: All,
-        }
+        Heads(
+            FilteredRange(
+                FilteredRange {
+                    roots: None,
+                    heads: Ancestors {
+                        heads: CommitRef(Symbol("foo")),
+                        generation: 2..3,
+                        parents_range: 0..1,
+                    },
+                    parents_range: 0..1,
+                    filter: All,
+                },
+            ),
+        )
         "#);
 
         // Heads of filters and negations can be folded.
         insta::assert_debug_snapshot!(optimize(parse("heads(author_name(A) | author_name(B))")?), @r#"
-        HeadsRange {
-            roots: None,
-            heads: VisibleHeadsOrReferenced,
-            parents_range: 0..4294967295,
-            filter: AsFilter(
-                Union(
-                    Filter(AuthorName(Pattern(Exact("A")))),
-                    Filter(AuthorName(Pattern(Exact("B")))),
-                ),
+        Heads(
+            FilteredRange(
+                FilteredRange {
+                    roots: None,
+                    heads: VisibleHeadsOrReferenced,
+                    parents_range: 0..4294967295,
+                    filter: AsFilter(
+                        Union(
+                            Filter(AuthorName(Pattern(Exact("A")))),
+                            Filter(AuthorName(Pattern(Exact("B")))),
+                        ),
+                    ),
+                },
             ),
-        }
+        )
         "#);
         insta::assert_debug_snapshot!(optimize(parse("heads(~author_name(A))")?), @r#"
-        HeadsRange {
-            roots: None,
-            heads: VisibleHeadsOrReferenced,
-            parents_range: 0..4294967295,
-            filter: AsFilter(
-                NotIn(
-                    Filter(AuthorName(Pattern(Exact("A")))),
-                ),
+        Heads(
+            FilteredRange(
+                FilteredRange {
+                    roots: None,
+                    heads: VisibleHeadsOrReferenced,
+                    parents_range: 0..4294967295,
+                    filter: AsFilter(
+                        NotIn(
+                            Filter(AuthorName(Pattern(Exact("A")))),
+                        ),
+                    ),
+                },
             ),
-        }
+        )
         "#);
         insta::assert_debug_snapshot!(optimize(parse("heads(~foo)")?), @r#"
-        HeadsRange {
-            roots: None,
-            heads: VisibleHeadsOrReferenced,
-            parents_range: 0..4294967295,
-            filter: NotIn(CommitRef(Symbol("foo"))),
-        }
+        Heads(
+            FilteredRange(
+                FilteredRange {
+                    roots: None,
+                    heads: VisibleHeadsOrReferenced,
+                    parents_range: 0..4294967295,
+                    filter: NotIn(CommitRef(Symbol("foo"))),
+                },
+            ),
+        )
         "#);
 
         // Heads of intersections with filters can be folded.
         insta::assert_debug_snapshot!(optimize(parse("heads(author_name(A) & ::foo ~ author_name(B))")?), @r#"
-        HeadsRange {
-            roots: None,
-            heads: CommitRef(Symbol("foo")),
-            parents_range: 0..4294967295,
-            filter: AsFilter(
-                Difference(
-                    Filter(AuthorName(Pattern(Exact("A")))),
-                    Filter(AuthorName(Pattern(Exact("B")))),
-                ),
+        Heads(
+            FilteredRange(
+                FilteredRange {
+                    roots: None,
+                    heads: CommitRef(Symbol("foo")),
+                    parents_range: 0..4294967295,
+                    filter: AsFilter(
+                        Difference(
+                            Filter(AuthorName(Pattern(Exact("A")))),
+                            Filter(AuthorName(Pattern(Exact("B")))),
+                        ),
+                    ),
+                },
             ),
-        }
+        )
         "#);
 
         // Heads of intersections with negations can be folded.
         insta::assert_debug_snapshot!(optimize(parse("heads(~foo & ~roots(bar) & ::baz)")?), @r#"
-        HeadsRange {
-            roots: None,
-            heads: CommitRef(Symbol("baz")),
-            parents_range: 0..4294967295,
-            filter: Difference(
-                NotIn(CommitRef(Symbol("foo"))),
-                Roots(CommitRef(Symbol("bar"))),
+        Heads(
+            FilteredRange(
+                FilteredRange {
+                    roots: None,
+                    heads: CommitRef(Symbol("baz")),
+                    parents_range: 0..4294967295,
+                    filter: Difference(
+                        NotIn(CommitRef(Symbol("foo"))),
+                        Roots(CommitRef(Symbol("bar"))),
+                    ),
+                },
             ),
-        }
+        )
         "#);
         Ok(())
     }
@@ -6327,40 +6462,48 @@ mod tests {
         // Can use heads range to optimize ancestors of filter.
         insta::assert_debug_snapshot!(optimize(parse("::description(bar)")?), @r#"
         Ancestors {
-            heads: HeadsRange {
-                roots: None,
-                heads: VisibleHeadsOrReferenced,
-                parents_range: 0..4294967295,
-                filter: Filter(
-                    Description(
-                        Pattern(
-                            Exact(
-                                "bar",
+            heads: Heads(
+                FilteredRange(
+                    FilteredRange {
+                        roots: None,
+                        heads: VisibleHeadsOrReferenced,
+                        parents_range: 0..4294967295,
+                        filter: Filter(
+                            Description(
+                                Pattern(
+                                    Exact(
+                                        "bar",
+                                    ),
+                                ),
                             ),
                         ),
-                    ),
+                    },
                 ),
-            },
+            ),
             generation: 0..18446744073709551615,
             parents_range: 0..4294967295,
         }
         "#);
         insta::assert_debug_snapshot!(optimize(parse("author_name(foo)..")?), @r#"
         Range {
-            roots: HeadsRange {
-                roots: None,
-                heads: VisibleHeadsOrReferenced,
-                parents_range: 0..4294967295,
-                filter: Filter(
-                    AuthorName(
-                        Pattern(
-                            Exact(
-                                "foo",
+            roots: Heads(
+                FilteredRange(
+                    FilteredRange {
+                        roots: None,
+                        heads: VisibleHeadsOrReferenced,
+                        parents_range: 0..4294967295,
+                        filter: Filter(
+                            AuthorName(
+                                Pattern(
+                                    Exact(
+                                        "foo",
+                                    ),
+                                ),
                             ),
                         ),
-                    ),
+                    },
                 ),
-            },
+            ),
             heads: VisibleHeadsOrReferenced,
             generation: 0..18446744073709551615,
             parents_range: 0..4294967295,
@@ -6370,20 +6513,24 @@ mod tests {
         // Can use heads range to optimize ancestors of range.
         insta::assert_debug_snapshot!(optimize(parse("::(foo..bar)")?), @r#"
         Ancestors {
-            heads: HeadsRange {
-                roots: CommitRef(
-                    Symbol(
-                        "foo",
-                    ),
+            heads: Heads(
+                FilteredRange(
+                    FilteredRange {
+                        roots: CommitRef(
+                            Symbol(
+                                "foo",
+                            ),
+                        ),
+                        heads: CommitRef(
+                            Symbol(
+                                "bar",
+                            ),
+                        ),
+                        parents_range: 0..4294967295,
+                        filter: All,
+                    },
                 ),
-                heads: CommitRef(
-                    Symbol(
-                        "bar",
-                    ),
-                ),
-                parents_range: 0..4294967295,
-                filter: All,
-            },
+            ),
             generation: 0..18446744073709551615,
             parents_range: 0..4294967295,
         }

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -333,7 +333,7 @@ pub enum RevsetExpression<St: ExpressionState> {
         count: usize,
     },
     Latest {
-        candidates: Arc<Self>,
+        candidates: ExpressionOrFilteredRange<Arc<Self>>,
         count: usize,
     },
     Filter(RevsetFilterPredicate),
@@ -479,7 +479,7 @@ impl<St: ExpressionState<CommitRef = RevsetCommitRef>> RevsetExpression<St> {
 impl<St: ExpressionState> RevsetExpression<St> {
     pub fn latest(self: &Arc<Self>, count: usize) -> Arc<Self> {
         Arc::new(Self::Latest {
-            candidates: self.clone(),
+            candidates: self.clone().into(),
             count,
         })
     }
@@ -787,7 +787,7 @@ pub enum ResolvedExpression {
         count: usize,
     },
     Latest {
-        candidates: Box<Self>,
+        candidates: ExpressionOrFilteredRange<Box<Self>, Option<ResolvedPredicateExpression>>,
         count: usize,
     },
     Coalesce(Box<Self>, Box<Self>),
@@ -1587,11 +1587,14 @@ fn try_transform_expression<St: ExpressionState, E>(
                     count: *count,
                 })
             }
-            RevsetExpression::Latest { candidates, count } => transform_rec(candidates, pre, post)?
-                .map(|candidates| RevsetExpression::Latest {
-                    candidates,
-                    count: *count,
-                }),
+            RevsetExpression::Latest { candidates, count } => {
+                transform_rec_filtered_range(candidates, pre, post)?.map(|candidates| {
+                    RevsetExpression::Latest {
+                        candidates,
+                        count: *count,
+                    }
+                })
+            }
             RevsetExpression::Filter(_) => None,
             RevsetExpression::AsFilter(candidates) => {
                 transform_rec(candidates, pre, post)?.map(RevsetExpression::AsFilter)
@@ -1881,7 +1884,7 @@ where
             RevsetExpression::HasSize { candidates, count }.into()
         }
         RevsetExpression::Latest { candidates, count } => {
-            let candidates = folder.fold_expression(candidates)?;
+            let candidates = fold_filtered_range(folder, candidates)?;
             let count = *count;
             RevsetExpression::Latest { candidates, count }.into()
         }
@@ -2427,6 +2430,18 @@ fn fold_filtered_range<St: ExpressionState>(
             to_filtered_range(candidates)
                 .map(|candidates| RevsetExpression::Heads(candidates).into())
         }
+        // latest(x..y & filter, n) -> latest(filtered_range(x, y, filter), n)
+        // latest(filter) -> latest(filtered_range(none(), visible_heads_or_referenced(), filter))
+        RevsetExpression::Latest {
+            candidates: ExpressionOrFilteredRange::Expression(candidates),
+            count,
+        } => to_filtered_range(candidates).map(|candidates| {
+            RevsetExpression::Latest {
+                candidates,
+                count: *count,
+            }
+            .into()
+        }),
         _ => None,
     })
 }
@@ -3225,7 +3240,7 @@ impl VisibilityResolutionContext<'_> {
                 ResolvedExpression::Bisect(self.resolve(expression).into())
             }
             RevsetExpression::Latest { candidates, count } => ResolvedExpression::Latest {
-                candidates: self.resolve(candidates).into(),
+                candidates: self.resolve_filtered_range(candidates),
                 count: *count,
             },
             RevsetExpression::HasSize { candidates, count } => ResolvedExpression::HasSize {
@@ -4886,7 +4901,9 @@ mod tests {
         insta::assert_debug_snapshot!(
             optimize(parse("latest(bookmarks() & all(), 2)")?), @r#"
         Latest {
-            candidates: CommitRef(Bookmarks(Pattern(Substring("")))),
+            candidates: Expression(
+                CommitRef(Bookmarks(Pattern(Substring("")))),
+            ),
             count: 2,
         }
         "#);

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -227,6 +227,26 @@ pub enum RevsetFilterPredicate {
     Extension(Arc<dyn RevsetFilterExtension>),
 }
 
+#[derive(Clone, Debug)]
+pub struct FilteredRange<E, Filter = E> {
+    pub roots: E,
+    pub heads: E,
+    pub parents_range: Range<u32>,
+    pub filter: Filter,
+}
+
+#[derive(Clone, Debug)]
+pub enum ExpressionOrFilteredRange<E, Filter = E> {
+    Expression(E),
+    FilteredRange(FilteredRange<E, Filter>),
+}
+
+impl<E, F> From<E> for ExpressionOrFilteredRange<E, F> {
+    fn from(value: E) -> Self {
+        Self::Expression(value)
+    }
+}
+
 mod private {
     /// Defines [`RevsetExpression`] variants depending on resolution state.
     pub trait ExpressionState {
@@ -303,15 +323,7 @@ pub enum RevsetExpression<St: ExpressionState> {
         sources: Arc<Self>,
         domain: Arc<Self>,
     },
-    Heads(Arc<Self>),
-    /// Heads of the set of commits which are ancestors of `heads` but are not
-    /// ancestors of `roots`, and which also are contained in `filter`.
-    HeadsRange {
-        roots: Arc<Self>,
-        heads: Arc<Self>,
-        parents_range: Range<u32>,
-        filter: Arc<Self>,
-    },
+    Heads(ExpressionOrFilteredRange<Arc<Self>>),
     Roots(Arc<Self>),
     Forks,
     ForkPoint(Arc<Self>),
@@ -477,7 +489,7 @@ impl<St: ExpressionState> RevsetExpression<St> {
 
     /// Commits in `self` that don't have descendants in `self`.
     pub fn heads(self: &Arc<Self>) -> Arc<Self> {
-        Arc::new(Self::Heads(self.clone()))
+        Arc::new(Self::Heads(self.clone().into()))
     }
 
     /// Commits in `self` that don't have ancestors in `self`.
@@ -774,15 +786,7 @@ pub enum ResolvedExpression {
         sources: Box<Self>,
         domain: Box<Self>,
     },
-    Heads(Box<Self>),
-    /// Heads of the set of commits which are ancestors of `heads` but are not
-    /// ancestors of `roots`, and which also are contained in `filter`.
-    HeadsRange {
-        roots: Box<Self>,
-        heads: Box<Self>,
-        parents_range: Range<u32>,
-        filter: Option<ResolvedPredicateExpression>,
-    },
+    Heads(ExpressionOrFilteredRange<Box<Self>, Option<ResolvedPredicateExpression>>),
     Roots(Box<Self>),
     Forks {
         heads: Box<Self>,
@@ -1577,26 +1581,7 @@ fn try_transform_expression<St: ExpressionState, E>(
                     .map(|(sources, domain)| RevsetExpression::Reachable { sources, domain })
             }
             RevsetExpression::Heads(candidates) => {
-                transform_rec(candidates, pre, post)?.map(RevsetExpression::Heads)
-            }
-            RevsetExpression::HeadsRange {
-                roots,
-                heads,
-                parents_range,
-                filter,
-            } => {
-                let transformed_roots = transform_rec(roots, pre, post)?;
-                let transformed_heads = transform_rec(heads, pre, post)?;
-                let transformed_filter = transform_rec(filter, pre, post)?;
-                (transformed_roots.is_some()
-                    || transformed_heads.is_some()
-                    || transformed_filter.is_some())
-                .then(|| RevsetExpression::HeadsRange {
-                    roots: transformed_roots.unwrap_or_else(|| roots.clone()),
-                    heads: transformed_heads.unwrap_or_else(|| heads.clone()),
-                    parents_range: parents_range.clone(),
-                    filter: transformed_filter.unwrap_or_else(|| filter.clone()),
-                })
+                transform_rec_filtered_range(candidates, pre, post)?.map(RevsetExpression::Heads)
             }
             RevsetExpression::Roots(candidates) => {
                 transform_rec(candidates, pre, post)?.map(RevsetExpression::Roots)
@@ -1708,6 +1693,39 @@ fn try_transform_expression<St: ExpressionState, E>(
         }
     }
 
+    fn transform_rec_filtered_range<St: ExpressionState, E>(
+        expression_or_filtered_range: &ExpressionOrFilteredRange<Arc<RevsetExpression<St>>>,
+        pre: &mut impl FnMut(&Arc<RevsetExpression<St>>) -> Result<PreTransformedExpression<St>, E>,
+        post: &mut impl FnMut(&Arc<RevsetExpression<St>>) -> Result<TransformedExpression<St>, E>,
+    ) -> Result<Option<ExpressionOrFilteredRange<Arc<RevsetExpression<St>>>>, E> {
+        Ok(match expression_or_filtered_range {
+            ExpressionOrFilteredRange::Expression(expression) => {
+                transform_rec(expression, pre, post)?.map(ExpressionOrFilteredRange::Expression)
+            }
+            ExpressionOrFilteredRange::FilteredRange(FilteredRange {
+                roots,
+                heads,
+                parents_range,
+                filter,
+            }) => {
+                let transformed_roots = transform_rec(roots, pre, post)?;
+                let transformed_heads = transform_rec(heads, pre, post)?;
+                let transformed_filter = transform_rec(filter, pre, post)?;
+                (transformed_roots.is_some()
+                    || transformed_heads.is_some()
+                    || transformed_filter.is_some())
+                .then(|| {
+                    ExpressionOrFilteredRange::FilteredRange(FilteredRange {
+                        roots: transformed_roots.unwrap_or_else(|| roots.clone()),
+                        heads: transformed_heads.unwrap_or_else(|| heads.clone()),
+                        parents_range: parents_range.clone(),
+                        filter: transformed_filter.unwrap_or_else(|| filter.clone()),
+                    })
+                })
+            }
+        })
+    }
+
     fn transform_rec<St: ExpressionState, E>(
         expression: &Arc<RevsetExpression<St>>,
         pre: &mut impl FnMut(&Arc<RevsetExpression<St>>) -> Result<PreTransformedExpression<St>, E>,
@@ -1767,6 +1785,32 @@ where
     OutSt: ExpressionState,
     F: ExpressionStateFolder<InSt, OutSt> + ?Sized,
 {
+    let fold_filtered_range = |folder: &mut F,
+                               expression_or_filtered_range: &ExpressionOrFilteredRange<
+        Arc<RevsetExpression<InSt>>,
+    >| {
+        match expression_or_filtered_range {
+            ExpressionOrFilteredRange::Expression(expression) => folder
+                .fold_expression(expression)
+                .map(ExpressionOrFilteredRange::Expression),
+            ExpressionOrFilteredRange::FilteredRange(FilteredRange {
+                roots,
+                heads,
+                parents_range,
+                filter,
+            }) => {
+                let roots = folder.fold_expression(roots)?;
+                let heads = folder.fold_expression(heads)?;
+                let filter = folder.fold_expression(filter)?;
+                Ok(ExpressionOrFilteredRange::FilteredRange(FilteredRange {
+                    roots,
+                    heads,
+                    parents_range: parents_range.clone(),
+                    filter,
+                }))
+            }
+        }
+    };
     let expression: Arc<_> = match expression {
         RevsetExpression::None => RevsetExpression::None.into(),
         RevsetExpression::All => RevsetExpression::All.into(),
@@ -1826,26 +1870,8 @@ where
             RevsetExpression::Reachable { sources, domain }.into()
         }
         RevsetExpression::Heads(heads) => {
-            let heads = folder.fold_expression(heads)?;
+            let heads = fold_filtered_range(folder, heads)?;
             RevsetExpression::Heads(heads).into()
-        }
-        RevsetExpression::HeadsRange {
-            roots,
-            heads,
-            parents_range,
-            filter,
-        } => {
-            let roots = folder.fold_expression(roots)?;
-            let heads = folder.fold_expression(heads)?;
-            let parents_range = parents_range.clone();
-            let filter = folder.fold_expression(filter)?;
-            RevsetExpression::HeadsRange {
-                roots,
-                heads,
-                parents_range,
-                filter,
-            }
-            .into()
         }
         RevsetExpression::Roots(roots) => {
             let roots = folder.fold_expression(roots)?;
@@ -2304,17 +2330,17 @@ fn fold_ancestors_union<St: ExpressionState>(
 ///
 /// Ancestors and negated ancestors should have already been moved to the left
 /// in intersections, and negated ancestors should have been combined already.
-fn fold_heads_range<St: ExpressionState>(
+fn fold_filtered_range<St: ExpressionState>(
     expression: &Arc<RevsetExpression<St>>,
 ) -> TransformedExpression<St> {
     // Represents `roots..heads & filter`
-    struct FilteredRange<St: ExpressionState> {
+    struct FilteredRangeBuilder<St: ExpressionState> {
         roots: Arc<RevsetExpression<St>>,
         heads_and_parents_range: Option<(Arc<RevsetExpression<St>>, Range<u32>)>,
         filter: Arc<RevsetExpression<St>>,
     }
 
-    impl<St: ExpressionState> FilteredRange<St> {
+    impl<St: ExpressionState> FilteredRangeBuilder<St> {
         fn new(roots: Arc<RevsetExpression<St>>) -> Self {
             // roots.. & all()
             Self {
@@ -2346,16 +2372,31 @@ fn fold_heads_range<St: ExpressionState>(
             };
             self
         }
+
+        fn build(self) -> FilteredRange<Arc<RevsetExpression<St>>> {
+            let (heads, parents_range) = self.heads_and_parents_range.unwrap_or_else(|| {
+                (
+                    RevsetExpression::visible_heads_or_referenced(),
+                    PARENTS_RANGE_FULL,
+                )
+            });
+            FilteredRange {
+                roots: self.roots,
+                heads,
+                parents_range,
+                filter: self.filter,
+            }
+        }
     }
 
-    fn to_filtered_range<St: ExpressionState>(
+    fn build_filtered_range<St: ExpressionState>(
         expression: &Arc<RevsetExpression<St>>,
-    ) -> Option<FilteredRange<St>> {
+    ) -> Option<FilteredRangeBuilder<St>> {
         // If the first expression is `ancestors(x)`, then we already know the range
         // must be `none()..x`, since any roots would've been moved to the left by an
         // earlier pass.
         if let Ok(heads_and_parents_range) = ancestors_to_heads_and_parents_range(expression) {
-            return Some(FilteredRange {
+            return Some(FilteredRangeBuilder {
                 roots: RevsetExpression::none(),
                 heads_and_parents_range: Some(heads_and_parents_range),
                 filter: RevsetExpression::all(),
@@ -2366,60 +2407,52 @@ fn fold_heads_range<St: ExpressionState>(
             // so we can set the roots based on the first expression in the intersection.
             RevsetExpression::NotIn(complement) => {
                 if let Ok(roots) = ancestors_to_heads(complement) {
-                    Some(FilteredRange::new(roots))
+                    Some(FilteredRangeBuilder::new(roots))
                 } else {
                     // If the first expression is a non-ancestors negation, we still want to use
-                    // `HeadsRange` since `~x` is equivalent to `::visible_heads() ~ x`.
-                    Some(FilteredRange::new(RevsetExpression::none()).add_filter(expression))
+                    // `FilteredRange` since `~x` is equivalent to `::visible_heads() ~ x`.
+                    Some(FilteredRangeBuilder::new(RevsetExpression::none()).add_filter(expression))
                 }
             }
             // We also want to optimize `heads()` if the first expression is `all()` or a filter.
             RevsetExpression::All | RevsetExpression::Filter(_) | RevsetExpression::AsFilter(_) => {
-                Some(FilteredRange::new(RevsetExpression::none()).add_filter(expression))
+                Some(FilteredRangeBuilder::new(RevsetExpression::none()).add_filter(expression))
             }
             // We only need to handle intersections recursively. Differences will have been
             // unfolded already.
             RevsetExpression::Intersection(expression1, expression2) => {
-                to_filtered_range(expression1).map(|filtered_range| filtered_range.add(expression2))
+                build_filtered_range(expression1)
+                    .map(|filtered_range| filtered_range.add(expression2))
             }
             _ => None,
         }
     }
 
-    fn to_heads_range<St: ExpressionState>(
+    fn to_filtered_range<St: ExpressionState>(
         candidates: &Arc<RevsetExpression<St>>,
-    ) -> Option<Arc<RevsetExpression<St>>> {
-        to_filtered_range(candidates).map(|filtered_range| {
-            let (heads, parents_range) =
-                filtered_range.heads_and_parents_range.unwrap_or_else(|| {
-                    (
-                        RevsetExpression::visible_heads_or_referenced(),
-                        PARENTS_RANGE_FULL,
-                    )
-                });
-            RevsetExpression::HeadsRange {
-                roots: filtered_range.roots,
-                heads,
-                parents_range,
-                filter: filtered_range.filter,
-            }
-            .into()
-        })
+    ) -> Option<ExpressionOrFilteredRange<Arc<RevsetExpression<St>>>> {
+        build_filtered_range(candidates)
+            .map(FilteredRangeBuilder::build)
+            .map(ExpressionOrFilteredRange::FilteredRange)
     }
 
     transform_expression_bottom_up(expression, |expression| match expression.as_ref() {
-        // ::(x..y & filter) -> ::heads_range(x, y, filter)
-        // ::filter -> ::heads_range(none(), visible_heads_or_referenced(), filter)
+        // ::(x..y & filter) -> ::heads(filtered_range(x, y, filter))
+        // ::filter -> ::heads(filtered_range(none(), visible_heads_or_referenced(), filter))
         RevsetExpression::Ancestors {
             heads,
             // This optimization is only valid for full generation and parents ranges, since
             // otherwise adding `heads()` would change the result.
             generation: GENERATION_RANGE_FULL,
             parents_range: PARENTS_RANGE_FULL,
-        } => to_heads_range(heads).map(|heads| heads.ancestors()),
-        // heads(x..y & filter) -> heads_range(x, y, filter)
-        // heads(filter) -> heads_range(none(), visible_heads_or_referenced(), filter)
-        RevsetExpression::Heads(candidates) => to_heads_range(candidates),
+        } => to_filtered_range(heads)
+            .map(|heads| RevsetExpression::ancestors(&RevsetExpression::Heads(heads).into())),
+        // heads(x..y & filter) -> heads(filtered_range(x, y, filter))
+        // heads(filter) -> heads(filtered_range(none(), visible_heads_or_referenced(), filter))
+        RevsetExpression::Heads(ExpressionOrFilteredRange::Expression(candidates)) => {
+            to_filtered_range(candidates)
+                .map(|candidates| RevsetExpression::Heads(candidates).into())
+        }
         _ => None,
     })
 }
@@ -2604,7 +2637,7 @@ pub fn optimize<St: ExpressionState>(
     let expression = sort_negations_and_ancestors(&expression).unwrap_or(expression);
     let expression = fold_ancestors_union(&expression).unwrap_or(expression);
     let expression = internalize_filter(&expression).unwrap_or(expression);
-    let expression = fold_heads_range(&expression).unwrap_or(expression);
+    let expression = fold_filtered_range(&expression).unwrap_or(expression);
     let expression = fold_difference(&expression).unwrap_or(expression);
     fold_not_in_ancestors(&expression).unwrap_or(expression)
 }
@@ -3199,20 +3232,8 @@ impl VisibilityResolutionContext<'_> {
                 domain: self.resolve(domain).into(),
             },
             RevsetExpression::Heads(candidates) => {
-                ResolvedExpression::Heads(self.resolve(candidates).into())
+                ResolvedExpression::Heads(self.resolve_filtered_range(candidates))
             }
-            RevsetExpression::HeadsRange {
-                roots,
-                heads,
-                parents_range,
-                filter,
-            } => ResolvedExpression::HeadsRange {
-                roots: self.resolve(roots).into(),
-                heads: self.resolve(heads).into(),
-                parents_range: parents_range.clone(),
-                filter: (!matches!(filter.as_ref(), RevsetExpression::All))
-                    .then(|| self.resolve_predicate(filter)),
-            },
             RevsetExpression::Roots(candidates) => {
                 ResolvedExpression::Roots(self.resolve(candidates).into())
             }
@@ -3326,7 +3347,7 @@ impl VisibilityResolutionContext<'_> {
         if self.is_heads_normalized {
             visible_heads
         } else {
-            ResolvedExpression::Heads(visible_heads.into())
+            ResolvedExpression::Heads(Box::new(visible_heads).into())
         }
     }
 
@@ -3343,6 +3364,27 @@ impl VisibilityResolutionContext<'_> {
 
     fn resolve_root(&self) -> ResolvedExpression {
         ResolvedExpression::Commits(vec![self.root.to_owned()])
+    }
+
+    fn resolve_filtered_range(
+        &self,
+        expression_or_filtered_range: &ExpressionOrFilteredRange<Arc<ResolvedRevsetExpression>>,
+    ) -> ExpressionOrFilteredRange<Box<ResolvedExpression>, Option<ResolvedPredicateExpression>>
+    {
+        match expression_or_filtered_range {
+            ExpressionOrFilteredRange::Expression(expression) => {
+                ExpressionOrFilteredRange::Expression(self.resolve(expression.as_ref()).into())
+            }
+            ExpressionOrFilteredRange::FilteredRange(filtered_range) => {
+                ExpressionOrFilteredRange::FilteredRange(FilteredRange {
+                    roots: self.resolve(&filtered_range.roots).into(),
+                    heads: self.resolve(&filtered_range.heads).into(),
+                    parents_range: filtered_range.parents_range.clone(),
+                    filter: (!matches!(&filtered_range.filter.as_ref(), RevsetExpression::All))
+                        .then(|| self.resolve_predicate(&filtered_range.filter)),
+                })
+            }
+        }
     }
 
     /// Resolves expression tree as filter predicate.
@@ -3367,7 +3409,6 @@ impl VisibilityResolutionContext<'_> {
             | RevsetExpression::DagRange { .. }
             | RevsetExpression::Reachable { .. }
             | RevsetExpression::Heads(_)
-            | RevsetExpression::HeadsRange { .. }
             | RevsetExpression::Roots(_)
             | RevsetExpression::Forks
             | RevsetExpression::ForkPoint(_)
@@ -3733,7 +3774,11 @@ mod tests {
             @r#"CommitRef(WorkingCopy(WorkspaceNameBuf("default")))"#);
         insta::assert_debug_snapshot!(
             current_wc.heads(),
-            @r#"Heads(CommitRef(WorkingCopy(WorkspaceNameBuf("default"))))"#);
+            @r#"
+        Heads(
+            Expression(CommitRef(WorkingCopy(WorkspaceNameBuf("default")))),
+        )
+        "#);
         insta::assert_debug_snapshot!(
             current_wc.roots(),
             @r#"Roots(CommitRef(WorkingCopy(WorkspaceNameBuf("default"))))"#);
@@ -4548,21 +4593,21 @@ mod tests {
         // Continue without pre transformation, do transform child
         insta::assert_debug_snapshot!(
             transform_expression(
-                &ResolvedRevsetExpression::root().heads(),
+                &ResolvedRevsetExpression::root().negated(),
                 |_| ControlFlow::Continue(()),
                 |x| match x.as_ref() {
                     RevsetExpression::Root => Some(RevsetExpression::none()),
                     _ => None,
                 },
-            ), @"Some(Heads(None))");
+            ), @"Some(NotIn(None))");
 
         // Continue without pre transformation, do transform self
         insta::assert_debug_snapshot!(
             transform_expression(
-                &ResolvedRevsetExpression::root().heads(),
+                &ResolvedRevsetExpression::root().negated(),
                 |_| ControlFlow::Continue(()),
                 |x| match x.as_ref() {
-                    RevsetExpression::Heads(y) => Some(y.clone()),
+                    RevsetExpression::NotIn(y) => Some(y.clone()),
                     _ => None,
                 },
             ), @"Some(Root)");
@@ -4867,7 +4912,9 @@ mod tests {
             optimize(parse("heads(bookmarks() & all())")?),
             @r#"
         Heads(
-            CommitRef(Bookmarks(Pattern(Substring("")))),
+            Expression(
+                CommitRef(Bookmarks(Pattern(Substring("")))),
+            ),
         )
         "#);
         insta::assert_debug_snapshot!(
@@ -5736,17 +5783,21 @@ mod tests {
         // Filters can be merged after ancestor unions are folded.
         insta::assert_debug_snapshot!(optimize(parse("::foo | ::author_name(bar)")?), @r#"
         Ancestors {
-            heads: HeadsRange {
-                roots: None,
-                heads: VisibleHeadsOrReferenced,
-                parents_range: 0..4294967295,
-                filter: AsFilter(
-                    Union(
-                        CommitRef(Symbol("foo")),
-                        Filter(AuthorName(Pattern(Exact("bar")))),
-                    ),
+            heads: Heads(
+                FilteredRange(
+                    FilteredRange {
+                        roots: None,
+                        heads: VisibleHeadsOrReferenced,
+                        parents_range: 0..4294967295,
+                        filter: AsFilter(
+                            Union(
+                                CommitRef(Symbol("foo")),
+                                Filter(AuthorName(Pattern(Exact("bar")))),
+                            ),
+                        ),
+                    },
                 ),
-            },
+            ),
             generation: 0..18446744073709551615,
             parents_range: 0..4294967295,
         }
@@ -5850,12 +5901,16 @@ mod tests {
         insta::assert_debug_snapshot!(optimize(parse("foo..(bar..baz)")?), @r#"
         Range {
             roots: CommitRef(Symbol("foo")),
-            heads: HeadsRange {
-                roots: CommitRef(Symbol("bar")),
-                heads: CommitRef(Symbol("baz")),
-                parents_range: 0..4294967295,
-                filter: All,
-            },
+            heads: Heads(
+                FilteredRange(
+                    FilteredRange {
+                        roots: CommitRef(Symbol("bar")),
+                        heads: CommitRef(Symbol("baz")),
+                        parents_range: 0..4294967295,
+                        filter: All,
+                    },
+                ),
+            ),
             generation: 0..18446744073709551615,
             parents_range: 0..4294967295,
         }
@@ -6145,224 +6200,304 @@ mod tests {
 
         // Heads of basic range operators can be folded.
         insta::assert_debug_snapshot!(optimize(parse("heads(::)")?), @"
-        HeadsRange {
-            roots: None,
-            heads: VisibleHeadsOrReferenced,
-            parents_range: 0..4294967295,
-            filter: All,
-        }
+        Heads(
+            FilteredRange(
+                FilteredRange {
+                    roots: None,
+                    heads: VisibleHeadsOrReferenced,
+                    parents_range: 0..4294967295,
+                    filter: All,
+                },
+            ),
+        )
         ");
         insta::assert_debug_snapshot!(optimize(parse("heads(::foo)")?), @r#"
-        HeadsRange {
-            roots: None,
-            heads: CommitRef(Symbol("foo")),
-            parents_range: 0..4294967295,
-            filter: All,
-        }
+        Heads(
+            FilteredRange(
+                FilteredRange {
+                    roots: None,
+                    heads: CommitRef(Symbol("foo")),
+                    parents_range: 0..4294967295,
+                    filter: All,
+                },
+            ),
+        )
         "#);
         // It might be better to use `roots: Root`, but it would require adding a
         // special case for `~root()`, and this should be similar in performance.
         insta::assert_debug_snapshot!(optimize(parse("heads(..)")?), @"
-        HeadsRange {
-            roots: None,
-            heads: VisibleHeadsOrReferenced,
-            parents_range: 0..4294967295,
-            filter: NotIn(Root),
-        }
+        Heads(
+            FilteredRange(
+                FilteredRange {
+                    roots: None,
+                    heads: VisibleHeadsOrReferenced,
+                    parents_range: 0..4294967295,
+                    filter: NotIn(Root),
+                },
+            ),
+        )
         ");
         insta::assert_debug_snapshot!(optimize(parse("heads(foo..)")?), @r#"
-        HeadsRange {
-            roots: CommitRef(Symbol("foo")),
-            heads: VisibleHeadsOrReferenced,
-            parents_range: 0..4294967295,
-            filter: All,
-        }
+        Heads(
+            FilteredRange(
+                FilteredRange {
+                    roots: CommitRef(Symbol("foo")),
+                    heads: VisibleHeadsOrReferenced,
+                    parents_range: 0..4294967295,
+                    filter: All,
+                },
+            ),
+        )
         "#);
         insta::assert_debug_snapshot!(optimize(parse("heads(..bar)")?), @r#"
-        HeadsRange {
-            roots: Root,
-            heads: CommitRef(Symbol("bar")),
-            parents_range: 0..4294967295,
-            filter: All,
-        }
+        Heads(
+            FilteredRange(
+                FilteredRange {
+                    roots: Root,
+                    heads: CommitRef(Symbol("bar")),
+                    parents_range: 0..4294967295,
+                    filter: All,
+                },
+            ),
+        )
         "#);
         insta::assert_debug_snapshot!(optimize(parse("heads(foo..bar)")?), @r#"
-        HeadsRange {
-            roots: CommitRef(Symbol("foo")),
-            heads: CommitRef(Symbol("bar")),
-            parents_range: 0..4294967295,
-            filter: All,
-        }
+        Heads(
+            FilteredRange(
+                FilteredRange {
+                    roots: CommitRef(Symbol("foo")),
+                    heads: CommitRef(Symbol("bar")),
+                    parents_range: 0..4294967295,
+                    filter: All,
+                },
+            ),
+        )
         "#);
         insta::assert_debug_snapshot!(optimize(parse("heads(~::foo & ::bar)")?), @r#"
-        HeadsRange {
-            roots: CommitRef(Symbol("foo")),
-            heads: CommitRef(Symbol("bar")),
-            parents_range: 0..4294967295,
-            filter: All,
-        }
+        Heads(
+            FilteredRange(
+                FilteredRange {
+                    roots: CommitRef(Symbol("foo")),
+                    heads: CommitRef(Symbol("bar")),
+                    parents_range: 0..4294967295,
+                    filter: All,
+                },
+            ),
+        )
         "#);
         insta::assert_debug_snapshot!(optimize(parse("heads(~::foo)")?), @r#"
-        HeadsRange {
-            roots: CommitRef(Symbol("foo")),
-            heads: VisibleHeadsOrReferenced,
-            parents_range: 0..4294967295,
-            filter: All,
-        }
+        Heads(
+            FilteredRange(
+                FilteredRange {
+                    roots: CommitRef(Symbol("foo")),
+                    heads: VisibleHeadsOrReferenced,
+                    parents_range: 0..4294967295,
+                    filter: All,
+                },
+            ),
+        )
         "#);
         insta::assert_debug_snapshot!(optimize(parse("heads(a..b & c..d)")?), @r#"
-        HeadsRange {
-            roots: Union(
-                CommitRef(Symbol("a")),
-                CommitRef(Symbol("c")),
+        Heads(
+            FilteredRange(
+                FilteredRange {
+                    roots: Union(
+                        CommitRef(Symbol("a")),
+                        CommitRef(Symbol("c")),
+                    ),
+                    heads: CommitRef(Symbol("b")),
+                    parents_range: 0..4294967295,
+                    filter: Ancestors {
+                        heads: CommitRef(Symbol("d")),
+                        generation: 0..18446744073709551615,
+                        parents_range: 0..4294967295,
+                    },
+                },
             ),
-            heads: CommitRef(Symbol("b")),
-            parents_range: 0..4294967295,
-            filter: Ancestors {
-                heads: CommitRef(Symbol("d")),
-                generation: 0..18446744073709551615,
-                parents_range: 0..4294967295,
-            },
-        }
+        )
         "#);
 
         // Heads of first-parent ancestors can also be folded.
         insta::assert_debug_snapshot!(optimize(parse("heads(first_ancestors(foo))")?), @r#"
-        HeadsRange {
-            roots: None,
-            heads: CommitRef(Symbol("foo")),
-            parents_range: 0..1,
-            filter: All,
-        }
+        Heads(
+            FilteredRange(
+                FilteredRange {
+                    roots: None,
+                    heads: CommitRef(Symbol("foo")),
+                    parents_range: 0..1,
+                    filter: All,
+                },
+            ),
+        )
         "#);
         insta::assert_debug_snapshot!(optimize(parse("heads(first_ancestors(foo) & bar..)")?), @r#"
-        HeadsRange {
-            roots: CommitRef(Symbol("bar")),
-            heads: CommitRef(Symbol("foo")),
-            parents_range: 0..1,
-            filter: All,
-        }
+        Heads(
+            FilteredRange(
+                FilteredRange {
+                    roots: CommitRef(Symbol("bar")),
+                    heads: CommitRef(Symbol("foo")),
+                    parents_range: 0..1,
+                    filter: All,
+                },
+            ),
+        )
         "#);
         insta::assert_debug_snapshot!(optimize(parse("heads(foo.. & first_ancestors(bar) & ::baz)")?), @r#"
-        HeadsRange {
-            roots: CommitRef(Symbol("foo")),
-            heads: CommitRef(Symbol("bar")),
-            parents_range: 0..1,
-            filter: Ancestors {
-                heads: CommitRef(Symbol("baz")),
-                generation: 0..18446744073709551615,
-                parents_range: 0..4294967295,
-            },
-        }
+        Heads(
+            FilteredRange(
+                FilteredRange {
+                    roots: CommitRef(Symbol("foo")),
+                    heads: CommitRef(Symbol("bar")),
+                    parents_range: 0..1,
+                    filter: Ancestors {
+                        heads: CommitRef(Symbol("baz")),
+                        generation: 0..18446744073709551615,
+                        parents_range: 0..4294967295,
+                    },
+                },
+            ),
+        )
         "#);
 
         // Ancestors with a limited depth should not be optimized.
         insta::assert_debug_snapshot!(optimize(parse("heads(ancestors(foo, 2))")?), @r#"
         Heads(
-            Ancestors {
-                heads: CommitRef(Symbol("foo")),
-                generation: 0..2,
-                parents_range: 0..4294967295,
-            },
+            Expression(
+                Ancestors {
+                    heads: CommitRef(Symbol("foo")),
+                    generation: 0..2,
+                    parents_range: 0..4294967295,
+                },
+            ),
         )
         "#);
         insta::assert_debug_snapshot!(optimize(parse("heads(first_ancestors(foo, 2))")?), @r#"
         Heads(
-            Ancestors {
-                heads: CommitRef(Symbol("foo")),
-                generation: 0..2,
-                parents_range: 0..1,
-            },
+            Expression(
+                Ancestors {
+                    heads: CommitRef(Symbol("foo")),
+                    generation: 0..2,
+                    parents_range: 0..1,
+                },
+            ),
         )
         "#);
 
         // Generation folding should not prevent optimizing heads.
         insta::assert_debug_snapshot!(optimize(parse("heads(ancestors(foo--))")?), @r#"
-        HeadsRange {
-            roots: None,
-            heads: Ancestors {
-                heads: CommitRef(Symbol("foo")),
-                generation: 2..3,
-                parents_range: 0..4294967295,
-            },
-            parents_range: 0..4294967295,
-            filter: All,
-        }
+        Heads(
+            FilteredRange(
+                FilteredRange {
+                    roots: None,
+                    heads: Ancestors {
+                        heads: CommitRef(Symbol("foo")),
+                        generation: 2..3,
+                        parents_range: 0..4294967295,
+                    },
+                    parents_range: 0..4294967295,
+                    filter: All,
+                },
+            ),
+        )
         "#);
         insta::assert_debug_snapshot!(optimize(parse("heads(first_ancestors(first_parent(foo, 2)))")?), @r#"
-        HeadsRange {
-            roots: None,
-            heads: Ancestors {
-                heads: CommitRef(Symbol("foo")),
-                generation: 2..3,
-                parents_range: 0..1,
-            },
-            parents_range: 0..1,
-            filter: All,
-        }
+        Heads(
+            FilteredRange(
+                FilteredRange {
+                    roots: None,
+                    heads: Ancestors {
+                        heads: CommitRef(Symbol("foo")),
+                        generation: 2..3,
+                        parents_range: 0..1,
+                    },
+                    parents_range: 0..1,
+                    filter: All,
+                },
+            ),
+        )
         "#);
 
         // Heads of filters and negations can be folded.
         insta::assert_debug_snapshot!(optimize(parse("heads(author_name(A) | author_name(B))")?), @r#"
-        HeadsRange {
-            roots: None,
-            heads: VisibleHeadsOrReferenced,
-            parents_range: 0..4294967295,
-            filter: AsFilter(
-                Union(
-                    Filter(AuthorName(Pattern(Exact("A")))),
-                    Filter(AuthorName(Pattern(Exact("B")))),
-                ),
+        Heads(
+            FilteredRange(
+                FilteredRange {
+                    roots: None,
+                    heads: VisibleHeadsOrReferenced,
+                    parents_range: 0..4294967295,
+                    filter: AsFilter(
+                        Union(
+                            Filter(AuthorName(Pattern(Exact("A")))),
+                            Filter(AuthorName(Pattern(Exact("B")))),
+                        ),
+                    ),
+                },
             ),
-        }
+        )
         "#);
         insta::assert_debug_snapshot!(optimize(parse("heads(~author_name(A))")?), @r#"
-        HeadsRange {
-            roots: None,
-            heads: VisibleHeadsOrReferenced,
-            parents_range: 0..4294967295,
-            filter: AsFilter(
-                NotIn(
-                    Filter(AuthorName(Pattern(Exact("A")))),
-                ),
+        Heads(
+            FilteredRange(
+                FilteredRange {
+                    roots: None,
+                    heads: VisibleHeadsOrReferenced,
+                    parents_range: 0..4294967295,
+                    filter: AsFilter(
+                        NotIn(
+                            Filter(AuthorName(Pattern(Exact("A")))),
+                        ),
+                    ),
+                },
             ),
-        }
+        )
         "#);
         insta::assert_debug_snapshot!(optimize(parse("heads(~foo)")?), @r#"
-        HeadsRange {
-            roots: None,
-            heads: VisibleHeadsOrReferenced,
-            parents_range: 0..4294967295,
-            filter: NotIn(CommitRef(Symbol("foo"))),
-        }
+        Heads(
+            FilteredRange(
+                FilteredRange {
+                    roots: None,
+                    heads: VisibleHeadsOrReferenced,
+                    parents_range: 0..4294967295,
+                    filter: NotIn(CommitRef(Symbol("foo"))),
+                },
+            ),
+        )
         "#);
 
         // Heads of intersections with filters can be folded.
         insta::assert_debug_snapshot!(optimize(parse("heads(author_name(A) & ::foo ~ author_name(B))")?), @r#"
-        HeadsRange {
-            roots: None,
-            heads: CommitRef(Symbol("foo")),
-            parents_range: 0..4294967295,
-            filter: AsFilter(
-                Difference(
-                    Filter(AuthorName(Pattern(Exact("A")))),
-                    Filter(AuthorName(Pattern(Exact("B")))),
-                ),
+        Heads(
+            FilteredRange(
+                FilteredRange {
+                    roots: None,
+                    heads: CommitRef(Symbol("foo")),
+                    parents_range: 0..4294967295,
+                    filter: AsFilter(
+                        Difference(
+                            Filter(AuthorName(Pattern(Exact("A")))),
+                            Filter(AuthorName(Pattern(Exact("B")))),
+                        ),
+                    ),
+                },
             ),
-        }
+        )
         "#);
 
         // Heads of intersections with negations can be folded.
         insta::assert_debug_snapshot!(optimize(parse("heads(~foo & ~roots(bar) & ::baz)")?), @r#"
-        HeadsRange {
-            roots: None,
-            heads: CommitRef(Symbol("baz")),
-            parents_range: 0..4294967295,
-            filter: Difference(
-                NotIn(CommitRef(Symbol("foo"))),
-                Roots(CommitRef(Symbol("bar"))),
+        Heads(
+            FilteredRange(
+                FilteredRange {
+                    roots: None,
+                    heads: CommitRef(Symbol("baz")),
+                    parents_range: 0..4294967295,
+                    filter: Difference(
+                        NotIn(CommitRef(Symbol("foo"))),
+                        Roots(CommitRef(Symbol("bar"))),
+                    ),
+                },
             ),
-        }
+        )
         "#);
         Ok(())
     }
@@ -6372,40 +6507,48 @@ mod tests {
         // Can use heads range to optimize ancestors of filter.
         insta::assert_debug_snapshot!(optimize(parse("::description(bar)")?), @r#"
         Ancestors {
-            heads: HeadsRange {
-                roots: None,
-                heads: VisibleHeadsOrReferenced,
-                parents_range: 0..4294967295,
-                filter: Filter(
-                    Description(
-                        Pattern(
-                            Exact(
-                                "bar",
+            heads: Heads(
+                FilteredRange(
+                    FilteredRange {
+                        roots: None,
+                        heads: VisibleHeadsOrReferenced,
+                        parents_range: 0..4294967295,
+                        filter: Filter(
+                            Description(
+                                Pattern(
+                                    Exact(
+                                        "bar",
+                                    ),
+                                ),
                             ),
                         ),
-                    ),
+                    },
                 ),
-            },
+            ),
             generation: 0..18446744073709551615,
             parents_range: 0..4294967295,
         }
         "#);
         insta::assert_debug_snapshot!(optimize(parse("author_name(foo)..")?), @r#"
         Range {
-            roots: HeadsRange {
-                roots: None,
-                heads: VisibleHeadsOrReferenced,
-                parents_range: 0..4294967295,
-                filter: Filter(
-                    AuthorName(
-                        Pattern(
-                            Exact(
-                                "foo",
+            roots: Heads(
+                FilteredRange(
+                    FilteredRange {
+                        roots: None,
+                        heads: VisibleHeadsOrReferenced,
+                        parents_range: 0..4294967295,
+                        filter: Filter(
+                            AuthorName(
+                                Pattern(
+                                    Exact(
+                                        "foo",
+                                    ),
+                                ),
                             ),
                         ),
-                    ),
+                    },
                 ),
-            },
+            ),
             heads: VisibleHeadsOrReferenced,
             generation: 0..18446744073709551615,
             parents_range: 0..4294967295,
@@ -6415,20 +6558,24 @@ mod tests {
         // Can use heads range to optimize ancestors of range.
         insta::assert_debug_snapshot!(optimize(parse("::(foo..bar)")?), @r#"
         Ancestors {
-            heads: HeadsRange {
-                roots: CommitRef(
-                    Symbol(
-                        "foo",
-                    ),
+            heads: Heads(
+                FilteredRange(
+                    FilteredRange {
+                        roots: CommitRef(
+                            Symbol(
+                                "foo",
+                            ),
+                        ),
+                        heads: CommitRef(
+                            Symbol(
+                                "bar",
+                            ),
+                        ),
+                        parents_range: 0..4294967295,
+                        filter: All,
+                    },
                 ),
-                heads: CommitRef(
-                    Symbol(
-                        "bar",
-                    ),
-                ),
-                parents_range: 0..4294967295,
-                filter: All,
-            },
+            ),
             generation: 0..18446744073709551615,
             parents_range: 0..4294967295,
         }

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -334,7 +334,7 @@ pub enum RevsetExpression<St: ExpressionState> {
         count: usize,
     },
     Latest {
-        candidates: Arc<Self>,
+        candidates: ExpressionOrFilteredRange<Arc<Self>>,
         count: usize,
     },
     Filter(RevsetFilterPredicate),
@@ -482,7 +482,7 @@ impl<St: ExpressionState<CommitRef = RevsetCommitRef>> RevsetExpression<St> {
 impl<St: ExpressionState> RevsetExpression<St> {
     pub fn latest(self: &Arc<Self>, count: usize) -> Arc<Self> {
         Arc::new(Self::Latest {
-            candidates: self.clone(),
+            candidates: self.clone().into(),
             count,
         })
     }
@@ -802,7 +802,7 @@ pub enum ResolvedExpression {
         count: usize,
     },
     Latest {
-        candidates: Box<Self>,
+        candidates: ExpressionOrFilteredRange<Box<Self>, Option<ResolvedPredicateExpression>>,
         count: usize,
     },
     Coalesce(Box<Self>, Box<Self>),
@@ -1602,11 +1602,14 @@ fn try_transform_expression<St: ExpressionState, E>(
                     count: *count,
                 })
             }
-            RevsetExpression::Latest { candidates, count } => transform_rec(candidates, pre, post)?
-                .map(|candidates| RevsetExpression::Latest {
-                    candidates,
-                    count: *count,
-                }),
+            RevsetExpression::Latest { candidates, count } => {
+                transform_rec_filtered_range(candidates, pre, post)?.map(|candidates| {
+                    RevsetExpression::Latest {
+                        candidates,
+                        count: *count,
+                    }
+                })
+            }
             RevsetExpression::Filter(_) => None,
             RevsetExpression::AsFilter(candidates) => {
                 transform_rec(candidates, pre, post)?.map(RevsetExpression::AsFilter)
@@ -1896,7 +1899,7 @@ where
             RevsetExpression::HasSize { candidates, count }.into()
         }
         RevsetExpression::Latest { candidates, count } => {
-            let candidates = folder.fold_expression(candidates)?;
+            let candidates = fold_filtered_range(folder, candidates)?;
             let count = *count;
             RevsetExpression::Latest { candidates, count }.into()
         }
@@ -2453,6 +2456,18 @@ fn fold_filtered_range<St: ExpressionState>(
             to_filtered_range(candidates)
                 .map(|candidates| RevsetExpression::Heads(candidates).into())
         }
+        // latest(x..y & filter, n) -> latest(filtered_range(x, y, filter), n)
+        // latest(filter) -> latest(filtered_range(none(), visible_heads_or_referenced(), filter))
+        RevsetExpression::Latest {
+            candidates: ExpressionOrFilteredRange::Expression(candidates),
+            count,
+        } => to_filtered_range(candidates).map(|candidates| {
+            RevsetExpression::Latest {
+                candidates,
+                count: *count,
+            }
+            .into()
+        }),
         _ => None,
     })
 }
@@ -3251,7 +3266,7 @@ impl VisibilityResolutionContext<'_> {
                 ResolvedExpression::Bisect(self.resolve(expression).into())
             }
             RevsetExpression::Latest { candidates, count } => ResolvedExpression::Latest {
-                candidates: self.resolve(candidates).into(),
+                candidates: self.resolve_filtered_range(candidates),
                 count: *count,
             },
             RevsetExpression::HasSize { candidates, count } => ResolvedExpression::HasSize {
@@ -4928,7 +4943,9 @@ mod tests {
         insta::assert_debug_snapshot!(
             optimize(parse("latest(bookmarks() & all(), 2)")?), @r#"
         Latest {
-            candidates: CommitRef(Bookmarks(Pattern(Substring("")))),
+            candidates: Expression(
+                CommitRef(Bookmarks(Pattern(Substring("")))),
+            ),
             count: 2,
         }
         "#);

--- a/lib/tests/test_revset.rs
+++ b/lib/tests/test_revset.rs
@@ -3098,12 +3098,19 @@ fn test_evaluate_expression_latest() {
         root_commit_id.clone(),
     ];
 
+    // Using `all()` triggers the filtered range optimization, so we also test using
+    // an explicit union of commit IDs.
+    let explicit_commit_ids = resolve_commit_ids(mut_repo, "all()").into_iter().join("|");
+
     for count in 1..=expected_order.len() {
         let result = resolve_commit_ids(mut_repo, &format!("latest(all(), {count})"));
         assert_eq!(result.len(), count);
         for expected_item in &expected_order[0..count] {
             assert!(result.contains(expected_item));
         }
+        let result_explicit_commit_ids =
+            resolve_commit_ids(mut_repo, &format!("latest({explicit_commit_ids}, {count})"));
+        assert_eq!(result_explicit_commit_ids, result);
     }
 
     // Since only the commit with timestamp 1 is out of order, if we exclude it from

--- a/lib/tests/test_revset.rs
+++ b/lib/tests/test_revset.rs
@@ -3106,12 +3106,19 @@ fn test_evaluate_expression_latest() {
         root_commit_id.clone(),
     ];
 
+    // Using `all()` triggers the filtered range optimization, so we also test using
+    // an explicit union of commit IDs.
+    let explicit_commit_ids = resolve_commit_ids(mut_repo, "all()").into_iter().join("|");
+
     for count in 1..=expected_order.len() {
         let result = resolve_commit_ids(mut_repo, &format!("latest(all(), {count})"));
         assert_eq!(result.len(), count);
         for expected_item in &expected_order[0..count] {
             assert!(result.contains(expected_item));
         }
+        let result_explicit_commit_ids =
+            resolve_commit_ids(mut_repo, &format!("latest({explicit_commit_ids}, {count})"));
+        assert_eq!(result_explicit_commit_ids, result);
     }
 
     // Since only the commit with timestamp 1 is out of order, if we exclude it from


### PR DESCRIPTION
Further optimization based on #9617

Ideally, it would be nice to only have to evaluate the filter on candidate heads, but this is difficult because we have to apply the filter in index order, and information from later commits could affect whether a commit becomes a candidate head. Instead, we just build a subgraph up to the required maximum depth. This also allows us to take advantage of the existing `take_latest_revset()` method.

Benchmark results on git repo:

```
latest(all(), 5)                 1.5x faster
latest(author(peff*), 5)        14.2x faster
latest(merges() ~ empty(), 5)   85.6x faster
```

Benchmark results on nixpkgs repo:

```
latest(all(), 5)                 1.4x faster
latest(subject(*jujutsu*), 5)    7.1x faster
latest(26.05.. ~ empty(), 5)    32.0x faster
```

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [X] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [X] ~~For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.~~
