### PR TITLE
squash: make `--revision` take multiple changes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * New `builtin_workspace_list` and `builtin_workspace_list_with_root` template
   aliases are available for `jj workspace list`, and `WorkspaceRef.root()` now
   returns an optional `FsPath` value.
+  
+* `squash -r` now take multiple changes. The destination to squash into is 
+  `roots(REVSETS)-`. Note: when a single commit is supplied, the behavior 
+  remains unchanged.
 
 ### Fixed bugs
 

--- a/cli/src/commands/squash.rs
+++ b/cli/src/commands/squash.rs
@@ -26,6 +26,7 @@ use jj_lib::matchers::Matcher;
 use jj_lib::merge::Diff;
 use jj_lib::object_id::ObjectId as _;
 use jj_lib::repo::Repo as _;
+use jj_lib::revset::RevsetExpression;
 use jj_lib::rewrite;
 use jj_lib::rewrite::CommitWithSelection;
 use jj_lib::rewrite::merge_commit_trees;
@@ -54,8 +55,8 @@ use crate::ui::Ui;
 /// parent revision.
 ///
 /// With the `-r` option, moves the changes from the specified revision to the
-/// parent revision. Fails if there are several parent revisions (i.e., the
-/// given revision is a merge).
+/// parent revision, or more specifically, `-r REVSET` squashes into
+/// `roots(REVSET)-`. Fails if there are more than one parent revisions.
 ///
 /// With the `--from` and/or `--into` options, moves changes from/to the given
 /// revisions. If either is left out, it defaults to the working-copy commit.
@@ -84,11 +85,11 @@ use crate::ui::Ui;
 /// `--from @` is assumed).
 #[derive(clap::Args, Clone, Debug)]
 pub(crate) struct SquashArgs {
-    /// Revision to squash into its parent (default: @). Incompatible with the
-    /// experimental `-o`/`-A`/`-B` options.
-    #[arg(long, short, value_name = "REVSET")]
+    /// Revision(s) to squash into their parent (default: @). Incompatible with
+    /// the experimental `-o`/`-A`/`-B` options.
+    #[arg(long, short, value_name = "REVSETS")]
     #[arg(add = ArgValueCompleter::new(complete::revset_expression_mutable))]
-    revision: Option<RevisionArg>,
+    revision: Vec<RevisionArg>,
 
     /// Revision(s) to squash from (default: @)
     #[arg(long, short, conflicts_with = "revision", value_name = "REVSETS")]
@@ -216,17 +217,28 @@ pub(crate) async fn cmd_squash(
         // a little faster.
         sources.reverse();
     } else {
-        let source = workspace_command
-            .resolve_single_rev(ui, args.revision.as_ref().unwrap_or(&RevisionArg::AT))
+        let sources_evaluator = if args.revision.is_empty() {
+            workspace_command.parse_revset(ui, &RevisionArg::AT)?
+        } else {
+            workspace_command.parse_union_revsets(ui, &args.revision)?
+        };
+        let parents_expr =
+            RevsetExpression::parents(&RevsetExpression::roots(sources_evaluator.expression()));
+        let mut parents: Vec<Commit> = workspace_command
+            .attach_revset_evaluator(parents_expr)
+            .evaluate_to_commits()?
+            .try_collect()
             .await?;
-        let mut parents = source.parents().await?;
         if parents.len() != 1 {
             return Err(
                 user_error("Cannot squash merge commits without a specified destination")
-                    .hinted("Use `--into` to specify which parent to squash into"),
+                    .hinted("Use `--from` with `--into` to specify which parent to squash into"),
             );
         }
-        sources = vec![source];
+        sources = sources_evaluator
+            .evaluate_to_commits()?
+            .try_collect()
+            .await?;
         pre_existing_destination = Some(parents.pop().unwrap());
     }
 
@@ -419,7 +431,8 @@ pub(crate) async fn cmd_squash(
         }
 
         if let [only_path] = &*args.paths {
-            let no_rev_arg = args.revision.is_none() && args.from.is_empty() && args.into.is_none();
+            let no_rev_arg =
+                args.revision.is_empty() && args.from.is_empty() && args.into.is_none();
             if no_rev_arg
                 && tx
                     .base_workspace_helper()

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -3247,7 +3247,7 @@ Move changes from a revision into another revision
 
 Without any options, moves the changes from the working-copy revision to the parent revision.
 
-With the `-r` option, moves the changes from the specified revision to the parent revision. Fails if there are several parent revisions (i.e., the given revision is a merge).
+With the `-r` option, moves the changes from the specified revision to the parent revision, or more specifically, `-r REVSET` squashes into `roots(REVSET)-`. Fails if there are more than one parent revisions.
 
 With the `--from` and/or `--into` options, moves changes from/to the given revisions. If either is left out, it defaults to the working-copy commit. For example, `jj squash --into @--` moves changes from the working-copy commit to the grandparent.
 
@@ -3271,7 +3271,7 @@ An alternative squashing UI is available via the `-o`, `-A`, and `-B` options. U
 
 ###### **Options:**
 
-* `-r`, `--revision <REVSET>` — Revision to squash into its parent (default: @). Incompatible with the experimental `-o`/`-A`/`-B` options
+* `-r`, `--revision <REVSETS>` — Revision(s) to squash into their parent (default: @). Incompatible with the experimental `-o`/`-A`/`-B` options
 * `-f`, `--from <REVSETS>` — Revision(s) to squash from (default: @)
 * `-t`, `--into <REVSET>` [alias: `to`] — Revision to squash into (default: @)
 * `-o`, `--onto <REVSETS>` [alias: `destination`] — (Experimental) The revision(s) to use as parent for the new commit (can be repeated to create a merge commit)

--- a/cli/tests/test_squash_command.rs
+++ b/cli/tests/test_squash_command.rs
@@ -126,7 +126,7 @@ fn test_squash() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Error: Cannot squash merge commits without a specified destination
-    Hint: Use `--into` to specify which parent to squash into
+    Hint: Use `--from` with `--into` to specify which parent to squash into
     [EOF]
     [exit status: 1]
     ");
@@ -982,6 +982,76 @@ fn test_squash_from_multiple() {
     Nothing changed.
     [EOF]
     ");
+
+    // Squash a connected set of commits using -r
+    work_dir.run_jj(["op", "restore", &setup_opid]).success();
+    let output = work_dir.run_jj(["squash", "-r=b", "-r=c|d|e"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    Rebased 1 descendant commits.
+    Working copy  (@) now at: kpqxywon b49d0b6c f | (no description set)
+    Parent commit (@-)      : qpvuntsm b4722061 a b c d e | (no description set)
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&work_dir), @"
+    @  b49d0b6cebc8 f
+    ○  b4722061a2f9 a b c d e
+    ◆  000000000000 (empty)
+    [EOF]
+    ");
+    // The changes from the sources have been applied
+    let output = work_dir.run_jj(["file", "show", "-r=d", "file"]);
+    insta::assert_snapshot!(output, @"
+    e
+    [EOF]
+    ");
+
+    // Squash a couple of parallel commits using -r
+    work_dir.run_jj(["op", "restore", &setup_opid]).success();
+    let output = work_dir.run_jj(["squash", "-r=b", "-r=c"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    Rebased 3 descendant commits.
+    Working copy  (@) now at: kpqxywon e08f4cb9 f | (no description set)
+    Parent commit (@-)      : yostqsxw 7556e483 e | (no description set)
+    New conflicts appeared in 2 commits:
+      yqosqzyt 604ed2f5 d | (conflict) (no description set)
+      qpvuntsm 8dc2972c a b c | (conflict) (no description set)
+    Hint: To resolve the conflicts, start by creating a commit on top of
+    the first conflicted commit:
+      jj new qpvuntsm
+    Then use `jj resolve`, or edit the conflict markers in the file directly.
+    Once the conflicts are resolved, you can inspect the result with `jj diff`.
+    Then run `jj squash` to move the resolution into the conflicted commit.
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&work_dir), @"
+    @  e08f4cb913ba f
+    ○    7556e483294f e
+    ├─╮
+    × │  604ed2f54760 d
+    ├─╯
+    ×  8dc2972c843b a b c
+    ◆  000000000000 (empty)
+    [EOF]
+    ");
+    // The changes from the sources have been applied
+    let output = work_dir.run_jj(["file", "show", "-r=d", "file"]);
+    insta::assert_snapshot!(output, @r"
+    <<<<<<< conflict 1 of 1
+    %%%%%%% diff from: qpvuntsm e88768e6 (parents of squashed revision)
+    \\\\\\\        to: mzvwutvl d7e94ec7 (squashed revision)
+    -a
+    +c
+    %%%%%%% diff from: qpvuntsm e88768e6 (parents of rebased revision)
+    \\\\\\\        to: kkmpptxz fed4d1a2 (squashed revision)
+    -a
+    +b
+    +++++++ yqosqzyt 8acbb715 (rebased revision)
+    d
+    >>>>>>> conflict 1 of 1 ends
+    [EOF]
+    ");
 }
 
 #[test]
@@ -1727,9 +1797,9 @@ fn test_squash_option_exclusion() {
         "--into=@-"
     ]), @"
     ------- stderr -------
-    error: the argument '--revision <REVSET>' cannot be used with '--into <REVSET>'
+    error: the argument '--revision <REVSETS>' cannot be used with '--into <REVSET>'
 
-    Usage: jj squash --revision <REVSET> [FILESETS]...
+    Usage: jj squash --revision <REVSETS> [FILESETS]...
 
     For more information, try '--help'.
     [EOF]
@@ -1742,9 +1812,9 @@ fn test_squash_option_exclusion() {
         "--onto=@-"
     ]), @"
     ------- stderr -------
-    error: the argument '--revision <REVSET>' cannot be used with '--onto <REVSETS>'
+    error: the argument '--revision <REVSETS>' cannot be used with '--onto <REVSETS>'
 
-    Usage: jj squash --revision <REVSET> [FILESETS]...
+    Usage: jj squash --revision <REVSETS> [FILESETS]...
 
     For more information, try '--help'.
     [EOF]
@@ -1757,9 +1827,9 @@ fn test_squash_option_exclusion() {
         "--after=@-"
     ]), @"
     ------- stderr -------
-    error: the argument '--revision <REVSET>' cannot be used with '--insert-after <REVSETS>'
+    error: the argument '--revision <REVSETS>' cannot be used with '--insert-after <REVSETS>'
 
-    Usage: jj squash --revision <REVSET> [FILESETS]...
+    Usage: jj squash --revision <REVSETS> [FILESETS]...
 
     For more information, try '--help'.
     [EOF]
@@ -1772,9 +1842,9 @@ fn test_squash_option_exclusion() {
         "--before=@-"
     ]), @"
     ------- stderr -------
-    error: the argument '--revision <REVSET>' cannot be used with '--insert-before <REVSETS>'
+    error: the argument '--revision <REVSETS>' cannot be used with '--insert-before <REVSETS>'
 
-    Usage: jj squash --revision <REVSET> [FILESETS]...
+    Usage: jj squash --revision <REVSETS> [FILESETS]...
 
     For more information, try '--help'.
     [EOF]


### PR DESCRIPTION
This is to address https://github.com/jj-vcs/jj/issues/5301

Merge `-r` and `-f` options, and add a new config `squash-into` to allow customization of default destination when it is not specified in the arguments.

Additionally,  `squash-into` has access to the source revset using the `from` local variable. This is in line with `bookmark-advance` revsets.

On a side note, I do not like how the local variable is constructed and added into `local_variables`, and tried other things. One of them is to compose `ExpressionNode` on the fly, but a naive approach causes issues with borrow checking when trying to mutate `local_variables` (because a `ExpressionNode` in source can hold a reference to `context`).

Ideally there should be a way to extract some machinery to make it easy for one argument in a command to refer to another. But I was not able to find a way to do so without making tons of changes.

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [x] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
