### PR TITLE
Fix gitattributes filter snapshot edge cases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1265,7 +1265,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae54ae0ebd1a5a3c3f8d95dd3b5ca6e63f4fed9bfd585e13801a97d7bde8f9ce"
 dependencies = [
  "gix-actor",
- "gix-attributes 0.33.1",
+ "gix-attributes",
  "gix-command",
  "gix-commitgraph",
  "gix-config",
@@ -1274,10 +1274,10 @@ dependencies = [
  "gix-dir",
  "gix-discover",
  "gix-error",
- "gix-features 0.48.1",
+ "gix-features",
  "gix-filter",
  "gix-fs",
- "gix-glob 0.26.1",
+ "gix-glob",
  "gix-hash",
  "gix-hashtable",
  "gix-ignore",
@@ -1286,7 +1286,7 @@ dependencies = [
  "gix-object",
  "gix-odb",
  "gix-pack",
- "gix-path 0.12.1",
+ "gix-path",
  "gix-pathspec",
  "gix-protocol",
  "gix-ref",
@@ -1324,30 +1324,13 @@ dependencies = [
 
 [[package]]
 name = "gix-attributes"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c233d6eaa098c0ca5ce03236fd7a96e27f1abe72fad74b46003fbd11fe49563c"
-dependencies = [
- "bstr",
- "gix-glob 0.24.0",
- "gix-path 0.11.3",
- "gix-quote",
- "gix-trace",
- "kstring",
- "smallvec",
- "thiserror 2.0.18",
- "unicode-bom",
-]
-
-[[package]]
-name = "gix-attributes"
 version = "0.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d43f12e246d3bf7ec624c8fc15ac4a4b62b7c4c6f586cb82be6c90bf84c9d02"
 dependencies = [
  "bstr",
- "gix-glob 0.26.1",
- "gix-path 0.12.1",
+ "gix-glob",
+ "gix-path",
  "gix-quote",
  "gix-trace",
  "kstring",
@@ -1381,7 +1364,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00706d4fef135ef4b01680d5218c6ee40cda8baf697b864296cbc887d19118f6"
 dependencies = [
  "bstr",
- "gix-path 0.12.1",
+ "gix-path",
  "gix-quote",
  "gix-trace",
  "shell-words",
@@ -1409,9 +1392,9 @@ checksum = "4f2372d4b49ca28431e7d150cab9d25edc1890f0184bd57eb0e917c7799e63de"
 dependencies = [
  "bstr",
  "gix-config-value",
- "gix-features 0.48.1",
- "gix-glob 0.26.1",
- "gix-path 0.12.1",
+ "gix-features",
+ "gix-glob",
+ "gix-path",
  "gix-ref",
  "gix-sec",
  "smallvec",
@@ -1427,7 +1410,7 @@ checksum = "ed42168329552f6c2e5df09665c104199d45d84bedb53683738a49b57fe1baab"
 dependencies = [
  "bitflags 2.11.1",
  "bstr",
- "gix-path 0.12.1",
+ "gix-path",
  "libc",
  "thiserror 2.0.18",
 ]
@@ -1451,7 +1434,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b6d9528f32d94cef2edf39a1ac01fe5a0fc44ddbb18d9e44099936047c3302b"
 dependencies = [
  "bstr",
- "gix-attributes 0.33.1",
+ "gix-attributes",
  "gix-command",
  "gix-filter",
  "gix-fs",
@@ -1459,7 +1442,7 @@ dependencies = [
  "gix-imara-diff",
  "gix-index",
  "gix-object",
- "gix-path 0.12.1",
+ "gix-path",
  "gix-pathspec",
  "gix-tempfile",
  "gix-trace",
@@ -1480,7 +1463,7 @@ dependencies = [
  "gix-ignore",
  "gix-index",
  "gix-object",
- "gix-path 0.12.1",
+ "gix-path",
  "gix-pathspec",
  "gix-trace",
  "gix-utils",
@@ -1497,7 +1480,7 @@ dependencies = [
  "bstr",
  "dunce",
  "gix-fs",
- "gix-path 0.12.1",
+ "gix-path",
  "gix-ref",
  "gix-sec",
  "thiserror 2.0.18",
@@ -1514,16 +1497,6 @@ dependencies = [
 
 [[package]]
 name = "gix-features"
-version = "0.46.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "752493cd4b1d5eaaa0138a7493f65c96863fefa990fc021e0e519579e389ab20"
-dependencies = [
- "gix-trace",
- "libc",
-]
-
-[[package]]
-name = "gix-features"
 version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1849ae154d38bc403185be14fa871e38e3c93ee606875d94e207fdb9fba52dbc"
@@ -1531,7 +1504,7 @@ dependencies = [
  "bytes",
  "crc32fast",
  "crossbeam-channel",
- "gix-path 0.12.1",
+ "gix-path",
  "gix-trace",
  "gix-utils",
  "libc",
@@ -1551,12 +1524,12 @@ checksum = "ecf74b7d16f6694ce4a3049074c41be0c7987105743674f1671807bd6dce09fa"
 dependencies = [
  "bstr",
  "encoding_rs",
- "gix-attributes 0.33.1",
+ "gix-attributes",
  "gix-command",
  "gix-hash",
  "gix-object",
  "gix-packetline",
- "gix-path 0.12.1",
+ "gix-path",
  "gix-quote",
  "gix-trace",
  "gix-utils",
@@ -1572,22 +1545,10 @@ checksum = "6cdff46db8798e47e2f727d84b9379aac5add3dd3d9d0b07bb4d7d5d640771fe"
 dependencies = [
  "bstr",
  "fastrand",
- "gix-features 0.48.1",
- "gix-path 0.12.1",
+ "gix-features",
+ "gix-path",
  "gix-utils",
  "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-glob"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b03e6cd88cc0dc1eafa1fddac0fb719e4e74b6ea58dd016e71125fde4a326bee"
-dependencies = [
- "bitflags 2.11.1",
- "bstr",
- "gix-features 0.46.2",
- "gix-path 0.11.3",
 ]
 
 [[package]]
@@ -1598,8 +1559,8 @@ checksum = "d1fcb8ef5b16bcf874abe9b68d8abb3c0493c876d367ab824151f30a0f3f3756"
 dependencies = [
  "bitflags 2.11.1",
  "bstr",
- "gix-features 0.48.1",
- "gix-path 0.12.1",
+ "gix-features",
+ "gix-path",
 ]
 
 [[package]]
@@ -1609,7 +1570,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0926d3819c837750b4e03c7754901e73f68b8c9b690753a6372a1bed4eedce"
 dependencies = [
  "faster-hex",
- "gix-features 0.48.1",
+ "gix-features",
  "sha1-checked",
  "thiserror 2.0.18",
 ]
@@ -1632,8 +1593,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d491bab9bf2c9f341dc754f425c31d5d3f63aca615312167b82e1deeaca97d8d"
 dependencies = [
  "bstr",
- "gix-glob 0.26.1",
- "gix-path 0.12.1",
+ "gix-glob",
+ "gix-path",
  "gix-trace",
  "unicode-bom",
 ]
@@ -1659,7 +1620,7 @@ dependencies = [
  "filetime",
  "fnv",
  "gix-bitmap",
- "gix-features 0.48.1",
+ "gix-features",
  "gix-fs",
  "gix-hash",
  "gix-lock",
@@ -1696,7 +1657,7 @@ dependencies = [
  "bstr",
  "gix-actor",
  "gix-date",
- "gix-features 0.48.1",
+ "gix-features",
  "gix-hash",
  "gix-hashtable",
  "gix-utils",
@@ -1713,13 +1674,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d004c32858b1556f2d7874405edb3c97dc78fc09beaa87d57bb077ee2858a7d"
 dependencies = [
  "arc-swap",
- "gix-features 0.48.1",
+ "gix-features",
  "gix-fs",
  "gix-hash",
  "gix-hashtable",
  "gix-object",
  "gix-pack",
- "gix-path 0.12.1",
+ "gix-path",
  "gix-quote",
  "memmap2",
  "parking_lot",
@@ -1736,11 +1697,11 @@ dependencies = [
  "clru",
  "gix-chunk",
  "gix-error",
- "gix-features 0.48.1",
+ "gix-features",
  "gix-hash",
  "gix-hashtable",
  "gix-object",
- "gix-path 0.12.1",
+ "gix-path",
  "memmap2",
  "smallvec",
  "thiserror 2.0.18",
@@ -1756,18 +1717,6 @@ dependencies = [
  "bstr",
  "faster-hex",
  "gix-trace",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-path"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8fd1fe596dc393b538e1d5492c5585971a9311475b3255f7b889023df208476"
-dependencies = [
- "bstr",
- "gix-trace",
- "gix-validate",
  "thiserror 2.0.18",
 ]
 
@@ -1791,10 +1740,10 @@ checksum = "3050783b41ee11511e1e8fb35623df81806194f4030395f14f48ea37c2798c9f"
 dependencies = [
  "bitflags 2.11.1",
  "bstr",
- "gix-attributes 0.33.1",
+ "gix-attributes",
  "gix-config-value",
- "gix-glob 0.26.1",
- "gix-path 0.12.1",
+ "gix-glob",
+ "gix-path",
  "thiserror 2.0.18",
 ]
 
@@ -1806,7 +1755,7 @@ checksum = "51dea3acb390707ab868f1f9584f18449eb95d869deffae96768e47d303595ee"
 dependencies = [
  "bstr",
  "gix-date",
- "gix-features 0.48.1",
+ "gix-features",
  "gix-hash",
  "gix-ref",
  "gix-shallow",
@@ -1835,12 +1784,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c04f64c37eb7e6feb73c7060f8dc6f381cc5de5d53249bfd450bc48a86b2e8b"
 dependencies = [
  "gix-actor",
- "gix-features 0.48.1",
+ "gix-features",
  "gix-fs",
  "gix-hash",
  "gix-lock",
  "gix-object",
- "gix-path 0.12.1",
+ "gix-path",
  "gix-tempfile",
  "gix-utils",
  "gix-validate",
@@ -1856,7 +1805,7 @@ checksum = "b216ae06ec74b5f24ad0142026a997fb0a935b7410eaf9c1616fc3f0e6c5a6d3"
 dependencies = [
  "bstr",
  "gix-error",
- "gix-glob 0.26.1",
+ "gix-glob",
  "gix-hash",
  "gix-revision",
  "gix-validate",
@@ -1903,7 +1852,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab8519976e4c7e486270740a5400369f37940779b80bd1377d94cfa1125d01b3"
 dependencies = [
  "bitflags 2.11.1",
- "gix-path 0.12.1",
+ "gix-path",
  "libc",
  "windows-sys 0.61.2",
 ]
@@ -1931,13 +1880,13 @@ dependencies = [
  "filetime",
  "gix-diff",
  "gix-dir",
- "gix-features 0.48.1",
+ "gix-features",
  "gix-filter",
  "gix-fs",
  "gix-hash",
  "gix-index",
  "gix-object",
- "gix-path 0.12.1",
+ "gix-path",
  "gix-pathspec",
  "gix-worktree",
  "portable-atomic",
@@ -1952,7 +1901,7 @@ checksum = "3059890ef054066c22a94bfc6a3eaba0d806aedcd630a0bc9e5783fd88884781"
 dependencies = [
  "bstr",
  "gix-config",
- "gix-path 0.12.1",
+ "gix-path",
  "gix-pathspec",
  "gix-refspec",
  "gix-url",
@@ -1986,7 +1935,7 @@ checksum = "7cd0e34995b1aab0fa8dff2af8db726a0bfad3e119c89302604463264046e7ff"
 dependencies = [
  "bstr",
  "gix-command",
- "gix-features 0.48.1",
+ "gix-features",
  "gix-packetline",
  "gix-quote",
  "gix-sec",
@@ -2018,7 +1967,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65bb01ec69d55e82ccb7a19e264501ead4e6aac38463a8cebfdd81e22bb67ab2"
 dependencies = [
  "bstr",
- "gix-path 0.12.1",
+ "gix-path",
  "percent-encoding",
  "thiserror 2.0.18",
 ]
@@ -2050,14 +1999,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cef414ed275e8407cd5d53d301e83be19700b0dd3f859d2434417b58f454a2d1"
 dependencies = [
  "bstr",
- "gix-attributes 0.33.1",
+ "gix-attributes",
  "gix-fs",
- "gix-glob 0.26.1",
+ "gix-glob",
  "gix-hash",
  "gix-ignore",
  "gix-index",
  "gix-object",
- "gix-path 0.12.1",
+ "gix-path",
  "gix-validate",
 ]
 
@@ -2068,12 +2017,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bffae8b3ca258fdd50370cd51f06deb4c76a3b43db3868bc28dde45ffa77d69"
 dependencies = [
  "bstr",
- "gix-features 0.48.1",
+ "gix-features",
  "gix-filter",
  "gix-fs",
  "gix-index",
  "gix-object",
- "gix-path 0.12.1",
+ "gix-path",
  "gix-worktree",
  "io-close",
  "thiserror 2.0.18",
@@ -2085,14 +2034,14 @@ version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25e9ed30100c63f7590bc581c225e53f731a53e06aa79a245739c07f7dcc557"
 dependencies = [
- "gix-attributes 0.33.1",
+ "gix-attributes",
  "gix-error",
- "gix-features 0.48.1",
+ "gix-features",
  "gix-filter",
  "gix-fs",
  "gix-hash",
  "gix-object",
- "gix-path 0.12.1",
+ "gix-path",
  "gix-traverse",
  "parking_lot",
 ]
@@ -2576,7 +2525,7 @@ dependencies = [
  "eyre",
  "futures 0.3.32",
  "gix",
- "gix-attributes 0.31.0",
+ "gix-attributes",
  "gix-ignore",
  "globset",
  "hashbrown 0.17.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ gix = { version = "0.84.0", default-features = false, features = [
     "sha1",
     "zlib-rs",
 ] }
-gix-attributes = "0.31.0"
+gix-attributes = "0.33.1"
 gix-ignore = { version = "0.21.0" }
 globset = "0.4.18"
 hashbrown = { version = "0.17.1", default-features = false, features = ["inline-more"] }

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -157,7 +157,6 @@ use crate::command_error::config_error_with_message;
 use crate::command_error::handle_command_result;
 use crate::command_error::internal_error;
 use crate::command_error::internal_error_with_message;
-use crate::command_error::print_error_sources;
 use crate::command_error::print_parse_diagnostics;
 use crate::command_error::user_error;
 use crate::command_error::user_error_with_message;
@@ -2257,6 +2256,8 @@ to the current parents may contain changes from multiple commits.
         #[cfg(feature = "git")]
         if self.working_copy_shared_with_git && self.env.command.should_commit_transaction() {
             use std::error::Error as _;
+
+            use crate::command_error::print_error_sources;
             if let Some(wc_commit) = &maybe_new_wc_commit {
                 // Export Git HEAD while holding the git-head lock to prevent races:
                 // - Between two finish_transaction calls updating HEAD

--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -195,27 +195,31 @@ struct RunJob {
     status: Option<ExitStatus>,
 }
 
-// TODO: make this more revset/commit stream friendly.
-async fn run_inner(
-    tx: &WorkspaceCommandTransaction<'_>,
-    sender: Sender<RunJob>,
-    handle: &tokio::runtime::Handle,
+struct RunContext {
     spec: Arc<CommandSpec>,
     base_path: Arc<PathBuf>,
     commits: Arc<Vec<Commit>>,
     ignore_filters: HashSet<String>,
     jobs: usize,
+}
+
+// TODO: make this more revset/commit stream friendly.
+async fn run_inner(
+    tx: &WorkspaceCommandTransaction<'_>,
+    sender: Sender<RunJob>,
+    handle: &tokio::runtime::Handle,
+    context: RunContext,
 ) -> Result<(), RunError> {
     let base_ignores = tx.base_workspace_helper().base_ignores().unwrap().clone();
-    let semaphore = Arc::new(Semaphore::new(jobs));
+    let semaphore = Arc::new(Semaphore::new(context.jobs));
     let mut command_futures: JoinSet<Result<RunJob, RunError>> = JoinSet::new();
-    for commit in commits.iter() {
+    for commit in context.commits.iter() {
         let permit_future = semaphore.clone().acquire_owned();
         let base_ignores = base_ignores.clone();
-        let base_path = base_path.clone();
+        let base_path = context.base_path.clone();
         let commit = commit.clone();
-        let ignore_filters = ignore_filters.clone();
-        let spec = spec.clone();
+        let ignore_filters = context.ignore_filters.clone();
+        let spec = context.spec.clone();
         command_futures.spawn_on(
             async move {
                 let _permit: OwnedSemaphorePermit =
@@ -516,6 +520,13 @@ pub async fn cmd_run(
         args: args.args.clone(),
         subdir,
     });
+    let run_context = RunContext {
+        spec: spec.clone(),
+        base_path,
+        commits: Arc::new(resolved_commits.clone()),
+        ignore_filters,
+        jobs: args.jobs,
+    };
     let mut rewritten_commits = HashMap::new();
 
     // Drive the producer (run_inner) and consumer (receive loop) concurrently
@@ -523,18 +534,9 @@ pub async fn cmd_run(
     // than after all subprocesses complete.
     let ((), visited) = futures::try_join!(
         async {
-            run_inner(
-                &tx,
-                sender_tx,
-                rt.handle(),
-                spec.clone(),
-                base_path,
-                Arc::new(resolved_commits.clone()),
-                ignore_filters,
-                args.jobs,
-            )
-            .await
-            .map_err(CommandError::from)
+            run_inner(&tx, sender_tx, rt.handle(), run_context)
+                .await
+                .map_err(CommandError::from)
         },
         async {
             let mut visited = 0;

--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -99,6 +99,7 @@ impl From<RunError> for CommandError {
 async fn create_working_copy(
     base_path: &Path,
     commit: &Commit,
+    ignore_filters: HashSet<String>,
 ) -> Result<(PathBuf, TreeState), RunError> {
     // Per-commit working-copy directory, keyed by commit id so concurrent jobs
     // don't collide and so the working copy is reproducible across runs.
@@ -135,7 +136,7 @@ async fn create_working_copy(
         eol_conversion_mode: EolConversionMode::None,
         exec_change_setting: ExecChangeSetting::Auto,
         fsmonitor_settings: FsmonitorSettings::None,
-        ignore_filters: std::collections::HashSet::new(),
+        ignore_filters,
     };
     let mut tree_state = TreeState::init(
         commit.store().clone(),
@@ -202,6 +203,7 @@ async fn run_inner(
     spec: Arc<CommandSpec>,
     base_path: Arc<PathBuf>,
     commits: Arc<Vec<Commit>>,
+    ignore_filters: HashSet<String>,
     jobs: usize,
 ) -> Result<(), RunError> {
     let base_ignores = tx.base_workspace_helper().base_ignores().unwrap().clone();
@@ -212,13 +214,14 @@ async fn run_inner(
         let base_ignores = base_ignores.clone();
         let base_path = base_path.clone();
         let commit = commit.clone();
+        let ignore_filters = ignore_filters.clone();
         let spec = spec.clone();
         command_futures.spawn_on(
             async move {
                 let _permit: OwnedSemaphorePermit =
                     permit_future.await.expect("semaphore not closed");
                 // TODO: handle/propagate error here
-                rewrite_commit(base_ignores, base_path, commit, spec).await
+                rewrite_commit(base_ignores, base_path, commit, ignore_filters, spec).await
             },
             handle,
         );
@@ -251,12 +254,14 @@ async fn rewrite_commit(
     base_ignores: Arc<GitIgnoreFile>,
     base_path: Arc<PathBuf>,
     commit: Commit,
+    ignore_filters: HashSet<String>,
     spec: Arc<CommandSpec>,
 ) -> Result<RunJob, RunError> {
     let old_id = commit.id().clone();
     let old_tree = commit.tree();
 
-    let (working_copy_dir, mut tree_state) = create_working_copy(&base_path, &commit).await?;
+    let (working_copy_dir, mut tree_state) =
+        create_working_copy(&base_path, &commit, ignore_filters).await?;
 
     // Resolve where the command should run. If the subdir doesn't exist in this
     // commit's checked-out tree, skip the commit entirely.
@@ -483,6 +488,20 @@ pub async fn cmd_run(
     };
 
     let store = workspace_command.repo().store().clone();
+    let ignore_filters = {
+        #[cfg(feature = "git")]
+        {
+            use jj_lib::git::GitSettings;
+            GitSettings::from_settings(workspace_command.settings())?
+                .ignore_filters
+                .into_iter()
+                .collect()
+        }
+        #[cfg(not(feature = "git"))]
+        {
+            HashSet::new()
+        }
+    };
     let mut tx = workspace_command.start_transaction();
 
     // A previous run's cleanup (that may have finished while we waited for the
@@ -511,6 +530,7 @@ pub async fn cmd_run(
                 spec.clone(),
                 base_path,
                 Arc::new(resolved_commits.clone()),
+                ignore_filters,
                 args.jobs,
             )
             .await

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -546,7 +546,7 @@
                     "items": {
                         "type": "string"
                     },
-                    "description": "Names of `.gitattributes` filter attributes whose matching files should be excluded from snapshots",
+                    "description": "Names of `.gitattributes` filter attributes whose matching files should be excluded from snapshots in Git-backed repositories",
                     "default": ["lfs"]
                 }
             }

--- a/cli/src/merge_tools/diff_working_copies.rs
+++ b/cli/src/merge_tools/diff_working_copies.rs
@@ -157,6 +157,7 @@ pub(crate) async fn check_out_trees(
     matcher: &dyn Matcher,
     diff_type: DiffType,
     conflict_marker_style: ConflictMarkerStyle,
+    ignore_filters: HashSet<String>,
 ) -> Result<DiffWorkingCopies, DiffCheckoutError> {
     let store = trees.before.store();
     let changed_files: Vec<_> = trees
@@ -180,7 +181,7 @@ pub(crate) async fn check_out_trees(
             eol_conversion_mode: EolConversionMode::None,
             exec_change_setting: ExecChangeSetting::Auto,
             fsmonitor_settings: FsmonitorSettings::None,
-            ignore_filters: HashSet::new(),
+            ignore_filters: ignore_filters.clone(),
         };
         let mut state = TreeState::init(store.clone(), wc_path, state_dir, &tree_state_settings)?;
         state.set_sparse_patterns(changed_files.clone())?;
@@ -216,9 +217,16 @@ impl DiffEditWorkingCopies {
         diff_type: DiffType,
         instructions: Option<&str>,
         conflict_marker_style: ConflictMarkerStyle,
+        ignore_filters: HashSet<String>,
     ) -> Result<Self, DiffEditError> {
-        let working_copies =
-            check_out_trees(trees, matcher, diff_type, conflict_marker_style).await?;
+        let working_copies = check_out_trees(
+            trees,
+            matcher,
+            diff_type,
+            conflict_marker_style,
+            ignore_filters,
+        )
+        .await?;
         working_copies.set_left_readonly()?;
         if diff_type == DiffType::ThreeWay {
             working_copies.set_right_readonly()?;

--- a/cli/src/merge_tools/external.rs
+++ b/cli/src/merge_tools/external.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::io;
 use std::io::Write;
 use std::path::Path;
@@ -387,6 +388,7 @@ pub async fn edit_diff_external(
     instructions: Option<&str>,
     base_ignores: Arc<GitIgnoreFile>,
     default_conflict_marker_style: ConflictMarkerStyle,
+    ignore_filters: HashSet<String>,
 ) -> Result<MergedTree, DiffEditError> {
     let conflict_marker_style = editor
         .conflict_marker_style
@@ -404,6 +406,7 @@ pub async fn edit_diff_external(
         diff_type,
         instructions,
         conflict_marker_style,
+        ignore_filters,
     )
     .await?;
 
@@ -455,7 +458,14 @@ pub async fn generate_diff(
     let conflict_marker_style = tool
         .conflict_marker_style
         .unwrap_or(default_conflict_marker_style);
-    let diff_wc = check_out_trees(trees, matcher, DiffType::TwoWay, conflict_marker_style).await?;
+    let diff_wc = check_out_trees(
+        trees,
+        matcher,
+        DiffType::TwoWay,
+        conflict_marker_style,
+        HashSet::new(),
+    )
+    .await?;
     diff_wc.set_left_readonly()?;
     diff_wc.set_right_readonly()?;
     let mut patterns = diff_wc.to_command_variables(true);

--- a/cli/src/merge_tools/mod.rs
+++ b/cli/src/merge_tools/mod.rs
@@ -16,6 +16,7 @@ mod builtin;
 mod diff_working_copies;
 mod external;
 
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use futures::future::try_join_all;
@@ -234,6 +235,7 @@ pub fn get_external_tool_config(
 pub struct DiffEditor {
     tool: DiffEditTool,
     base_ignores: Arc<GitIgnoreFile>,
+    ignore_filters: HashSet<String>,
     use_instructions: bool,
     conflict_marker_style: ConflictMarkerStyle,
 }
@@ -283,9 +285,24 @@ impl DiffEditor {
                 tool_name: name.to_string(),
             });
         }
+        let ignore_filters = {
+            #[cfg(feature = "git")]
+            {
+                use jj_lib::git::GitSettings;
+                GitSettings::from_settings(settings)?
+                    .ignore_filters
+                    .into_iter()
+                    .collect()
+            }
+            #[cfg(not(feature = "git"))]
+            {
+                HashSet::new()
+            }
+        };
         Ok(Self {
             tool,
             base_ignores,
+            ignore_filters,
             use_instructions: settings.get_bool("ui.diff-instructions")?,
             conflict_marker_style,
         })
@@ -315,6 +332,7 @@ impl DiffEditor {
                     instructions.as_deref(),
                     self.base_ignores.clone(),
                     self.conflict_marker_style,
+                    self.ignore_filters.clone(),
                 )
                 .await
             }

--- a/cli/tests/test_diffedit_command.rs
+++ b/cli/tests/test_diffedit_command.rs
@@ -19,6 +19,47 @@ use testutils::TestResult;
 use crate::common::TestEnvironment;
 
 #[test]
+fn test_diffedit_gitattributes_filter_in_temp_snapshot() -> TestResult {
+    let mut test_env = TestEnvironment::default();
+    let edit_script = test_env.set_up_fake_diff_editor();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    work_dir.write_file(".gitattributes", "*.bin filter=lfs\n");
+    work_dir.write_file("file.bin", "original\n");
+    work_dir
+        .run_jj(["--config=git.ignore-filters=[]", "commit", "-m", "base"])
+        .success();
+    work_dir.write_file("file.bin", "after\n");
+    work_dir
+        .run_jj(["--config=git.ignore-filters=[]", "debug", "snapshot"])
+        .success();
+
+    std::fs::write(
+        &edit_script,
+        "files-before file.bin\0files-after JJ-INSTRUCTIONS file.bin\0write file.bin\nedited\n",
+    )?;
+    work_dir.run_jj(["diffedit"]).success();
+
+    // Regression test for a bug found during development.
+    //
+    // This creates a tracked LFS-filtered modification by disabling filter
+    // ignores only for setup. `diffedit` then operates with normal settings.
+    // This characterizes the pre-fix behavior: the external editor writes into
+    // a temporary output working copy whose snapshot ignores configured
+    // .gitattributes filters and rewrites the tracked LFS-filtered file.
+    insta::assert_snapshot!(
+        work_dir.run_jj(["file", "show", "file.bin"]).success().stdout,
+        @r"
+    edited
+    [EOF]
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
 fn test_diffedit() -> TestResult {
     let mut test_env = TestEnvironment::default();
     let edit_script = test_env.set_up_fake_diff_editor();

--- a/cli/tests/test_diffedit_command.rs
+++ b/cli/tests/test_diffedit_command.rs
@@ -45,13 +45,14 @@ fn test_diffedit_gitattributes_filter_in_temp_snapshot() -> TestResult {
     //
     // This creates a tracked LFS-filtered modification by disabling filter
     // ignores only for setup. `diffedit` then operates with normal settings.
-    // This characterizes the pre-fix behavior: the external editor writes into
-    // a temporary output working copy whose snapshot ignores configured
-    // .gitattributes filters and rewrites the tracked LFS-filtered file.
+    // Its external editor writes into a temporary output working copy, and
+    // snapshotting that output must use the configured .gitattributes filters.
+    // Otherwise the editor can rewrite a tracked LFS-filtered file even though
+    // normal snapshots would ignore it.
     insta::assert_snapshot!(
         work_dir.run_jj(["file", "show", "file.bin"]).success().stdout,
         @r"
-    edited
+    after
     [EOF]
     "
     );

--- a/cli/tests/test_run_command.rs
+++ b/cli/tests/test_run_command.rs
@@ -64,6 +64,48 @@ fn test_run_simple() {
 }
 
 #[test]
+fn test_run_gitattributes_filter_in_temp_snapshot() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let fake_formatter = assert_cmd::cargo::cargo_bin("fake-formatter");
+    assert!(fake_formatter.is_file());
+    let fake_formatter_path = fake_formatter.to_string_lossy().into_owned();
+    let work_dir = test_env.work_dir("repo");
+
+    work_dir.write_file(".gitattributes", "*.bin filter=lfs\n");
+    work_dir.write_file("file.bin", "original");
+    work_dir
+        .run_jj(["--config=git.ignore-filters=[]", "commit", "-m", "base"])
+        .success();
+
+    work_dir
+        .run_jj([
+            "run",
+            "-r",
+            "@-",
+            "--",
+            &fake_formatter_path,
+            "--stdout",
+            "modified",
+            "--tee",
+            "file.bin",
+        ])
+        .success();
+
+    // Regression test for a bug found during development.
+    //
+    // This creates a legitimately tracked file by disabling filter ignores only
+    // for setup. `jj run` then operates with normal settings. This
+    // characterizes the pre-fix behavior: the temporary working copy ignores
+    // configured .gitattributes filters and rewrites the tracked LFS-filtered
+    // file even though normal snapshots would ignore it.
+    insta::assert_snapshot!(
+        work_dir.run_jj(["file", "show", "-r", "@-", "file.bin"]).success().stdout,
+        @"originalmodified[EOF]"
+    );
+}
+
+#[test]
 fn test_run_on_immutable() {
     let test_env = TestEnvironment::default();
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();

--- a/cli/tests/test_run_command.rs
+++ b/cli/tests/test_run_command.rs
@@ -95,13 +95,13 @@ fn test_run_gitattributes_filter_in_temp_snapshot() {
     // Regression test for a bug found during development.
     //
     // This creates a legitimately tracked file by disabling filter ignores only
-    // for setup. `jj run` then operates with normal settings. This
-    // characterizes the pre-fix behavior: the temporary working copy ignores
-    // configured .gitattributes filters and rewrites the tracked LFS-filtered
-    // file even though normal snapshots would ignore it.
+    // for setup. `jj run` then operates with normal settings. Its temporary
+    // working copy is snapshotted after the command runs, and that snapshot must
+    // use the configured .gitattributes filters. Otherwise a command can rewrite
+    // a tracked LFS-filtered file even though normal snapshots would ignore it.
     insta::assert_snapshot!(
         work_dir.run_jj(["file", "show", "-r", "@-", "file.bin"]).success().stdout,
-        @"originalmodified[EOF]"
+        @"original[EOF]"
     );
 }
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -1740,6 +1740,23 @@ default. Set `git.colocate` to `false` to disable it.
 See [Colocated Jujutsu/Git workspaces](git-compatibility.md#colocated-jujutsugit-repos)
 for more information.
 
+### Ignoring files by `.gitattributes` filter
+
+In Git-backed repositories, `jj` can skip files during snapshot based on the
+`filter` attribute in `.gitattributes`. The `git.ignore-filters` setting lists
+the filter values to skip, and defaults to `["lfs"]`.
+
+```toml
+[git]
+ignore-filters = ["lfs", "git-crypt"]
+```
+
+This only affects snapshotting from disk to the store. Checkout still writes
+the files from the tree, so external tools such as `git lfs pull` or
+`git lfs checkout` can hydrate them afterward. Files already tracked by `jj` may
+need to be removed with `jj file untrack <path>` before this setting affects
+future snapshots.
+
 ### Default remotes for `jj git fetch` and `jj git push`
 
 By default, if a single remote exists it is used for `jj git fetch` and `jj git

--- a/docs/git-compatibility.md
+++ b/docs/git-compatibility.md
@@ -35,8 +35,13 @@ a comparison with Git, including how workflows are different, see the
   working-copy commit. It's recommended to set up the ignore patterns earlier.
   The `.gitignore` support uses a native implementation, so please report a bug
   if you notice any difference compared to `git`.
-* **.gitattributes: No.** There's [#53](https://github.com/jj-vcs/jj/issues/53)
-  about adding support for at least the `eol` attribute.
+* **.gitattributes: Partial.** In Git-backed repositories, `jj` reads
+  `.gitattributes` `filter` attributes during snapshot and skips files whose
+  filter is listed in `git.ignore-filters`, which defaults to `["lfs"]`. This
+  is snapshot-only; checkout still writes files from the tree. Other attributes
+  such as `eol`, `text`, `diff`, and `merge` are not otherwise supported.
+  There's [#53](https://github.com/jj-vcs/jj/issues/53) about adding support for
+  at least the `eol` attribute.
 * **Hooks: No.** There's [#405](https://github.com/jj-vcs/jj/issues/405)
   specifically for providing the checks from <https://pre-commit.com>.
 * **Merge commits: Yes.** Octopus merges (i.e. with more than 2 parents) are
@@ -69,7 +74,12 @@ a comparison with Git, including how workflows are different, see the
 * **Signed commits: Yes.**
   You can sign commits automatically [by configuration](config.md#commit-signing),
   or use the `jj sign` command.
-* **Git LFS: No.** ([#80](https://github.com/jj-vcs/jj/issues/80))
+* **Git LFS: Partial.** In Git-backed repositories, files with `filter=lfs` are
+  ignored during snapshot by default. `jj` does not fetch, clean, smudge, or
+  hydrate LFS contents; use Git LFS commands such as `git lfs pull` or
+  `git lfs checkout` for those steps. Existing tracked files may need
+  `jj file untrack <path>` before the snapshot ignore takes effect.
+  ([#80](https://github.com/jj-vcs/jj/issues/80))
 
 ## Creating an empty repo
 

--- a/lib/src/gitattributes.rs
+++ b/lib/src/gitattributes.rs
@@ -348,8 +348,7 @@ pub(crate) enum SearchPriority {
 }
 
 impl GitAttributes {
-    /// Creates a new instance by receiving a Store File Loader, a Disk File
-    /// Loader and a list of filters to be ignored.
+    /// Creates a new instance with store and disk file loaders.
     pub fn new(
         store_file_loader: impl FileLoader + 'static,
         disk_file_loader: impl FileLoader + 'static,
@@ -675,7 +674,7 @@ mod tests {
                     [attr]override_macro c
                     # this macro definition shouldn't take effect.
                     [attr]new_macro e
-                    bar base_macro override_macro new_macro 
+                    bar base_macro override_macro new_macro
                 "},
             ),
             (
@@ -772,12 +771,12 @@ mod tests {
         )]);
         let attributes = GitAttributes::new(HashMap::new(), data);
 
-            attributes
-                .filter_matches(
-                    repo_path(path),
-                    &HashSet::from(["lfs".to_string()]),
-                    SearchPriority::Disk,
-                )
+        attributes
+            .filter_matches(
+                repo_path(path),
+                &HashSet::from(["lfs".to_string()]),
+                SearchPriority::Disk,
+            )
             .block_on()
             .unwrap()
     }

--- a/lib/src/gitattributes.rs
+++ b/lib/src/gitattributes.rs
@@ -764,13 +764,38 @@ mod tests {
         )]);
         let attributes = GitAttributes::new(HashMap::new(), data);
 
-        attributes
-            .filter_matches(
-                repo_path(path),
-                &HashSet::from(["lfs".to_string()]),
-                SearchPriority::Disk,
-            )
-            .block_on()
+            attributes
+                .filter_matches(
+                    repo_path(path),
+                    &HashSet::from(["lfs".to_string()]),
+                    SearchPriority::Disk,
+                )
+                .block_on()
+    }
+
+    // Regression test for a bug found during development.
+    //
+    // `filter_matches()` is used by snapshot to decide whether a matching file
+    // should be omitted. This characterizes the pre-fix behavior: if loading
+    // .gitattributes fails, the error is treated as a non-match. That can make
+    // snapshot continue with a file that may be intentionally excluded.
+    #[test]
+    fn test_filter_matches_swallows_error() {
+        let store: TestStore = TestStore::from([(
+            repo_path(".gitattributes").to_owned(),
+            Err("There was an IO error".to_string()),
+        )]);
+        let attributes = GitAttributes::new(store, HashMap::new());
+
+        assert!(
+            !attributes
+                .filter_matches(
+                    repo_path("file.bin"),
+                    &HashSet::from(["lfs".to_string()]),
+                    SearchPriority::Disk,
+                )
+                .block_on()
+        );
     }
 
     #[test]

--- a/lib/src/gitattributes.rs
+++ b/lib/src/gitattributes.rs
@@ -172,7 +172,9 @@ impl FileLoader for DiskFileLoader {
         // we use symlink_metadata to not follow symlinks to follow Git's behavior.
         let metadata = match path.symlink_metadata() {
             Ok(metadata) => metadata,
-            Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(err) if matches!(err.kind(), ErrorKind::NotFound | ErrorKind::NotADirectory) => {
+                return Ok(None);
+            }
             Err(err) => {
                 return Err(GitAttributesError {
                     message: format!("Failed to obtain the file metadata of {}", path.display()),
@@ -186,7 +188,14 @@ impl FileLoader for DiskFileLoader {
 
         let file = match File::open(&path) {
             Ok(file) => file,
-            Err(error) if error.kind() == ErrorKind::NotFound => return Ok(None),
+            Err(error)
+                if matches!(
+                    error.kind(),
+                    ErrorKind::NotFound | ErrorKind::NotADirectory
+                ) =>
+            {
+                return Ok(None);
+            }
             Err(err) => {
                 return Err(GitAttributesError {
                     message: format!("Failed to open the file at {}", path.display()),
@@ -431,19 +440,17 @@ impl GitAttributes {
         path: &RepoPath,
         ignore_filters: &HashSet<String>,
         priority: SearchPriority,
-    ) -> bool {
+    ) -> Result<bool, GitAttributesError> {
         if ignore_filters.is_empty() {
-            return false;
+            return Ok(false);
         }
-        let Ok(result) = self.search(path, ["filter"], priority).await else {
-            return false;
-        };
+        let result = self.search(path, ["filter"], priority).await?;
 
         let Some(State::Value(value)) = result.get("filter") else {
-            return false;
+            return Ok(false);
         };
         let value = value.as_ref().as_bstr();
-        ignore_filters.iter().any(|state| value == state.as_str())
+        Ok(ignore_filters.iter().any(|state| value == state.as_str()))
     }
 }
 
@@ -465,6 +472,7 @@ mod tests {
     use pollster::FutureExt as _;
 
     use super::*;
+    use crate::tests::new_temp_dir;
 
     type TestStore = HashMap<RepoPathBuf, Result<String, String>>;
 
@@ -770,32 +778,56 @@ mod tests {
                     &HashSet::from(["lfs".to_string()]),
                     SearchPriority::Disk,
                 )
-                .block_on()
+            .block_on()
+            .unwrap()
     }
 
     // Regression test for a bug found during development.
     //
     // `filter_matches()` is used by snapshot to decide whether a matching file
-    // should be omitted. This characterizes the pre-fix behavior: if loading
-    // .gitattributes fails, the error is treated as a non-match. That can make
-    // snapshot continue with a file that may be intentionally excluded.
+    // should be omitted. If loading .gitattributes fails, returning false would
+    // silently snapshot a file that may be intentionally excluded. Preserve the
+    // error so snapshot fails visibly instead.
     #[test]
-    fn test_filter_matches_swallows_error() {
+    fn test_filter_matches_propagates_error() {
         let store: TestStore = TestStore::from([(
             repo_path(".gitattributes").to_owned(),
             Err("There was an IO error".to_string()),
         )]);
         let attributes = GitAttributes::new(store, HashMap::new());
 
-        assert!(
-            !attributes
-                .filter_matches(
-                    repo_path("file.bin"),
-                    &HashSet::from(["lfs".to_string()]),
-                    SearchPriority::Disk,
-                )
-                .block_on()
-        );
+        let error = attributes
+            .filter_matches(
+                repo_path("file.bin"),
+                &HashSet::from(["lfs".to_string()]),
+                SearchPriority::Disk,
+            )
+            .block_on()
+            .unwrap_err();
+
+        assert_eq!(error.message, "There was an IO error");
+    }
+
+    // Regression test for a bug found during development.
+    //
+    // This is distinct from `test_filter_matches_propagates_error()`: probing
+    // for optional `.gitattributes` files below a path component that is
+    // actually a file means no attributes file exists at that path. Treating
+    // `NotADirectory` as fatal caused unrelated snapshot operations, such as
+    // rename detection, to fail when they evaluated attributes for paths like
+    // `file/.gitattributes`.
+    #[test]
+    fn test_disk_file_loader_ignores_file_in_attributes_path() {
+        let temp_dir = new_temp_dir();
+        std::fs::write(temp_dir.path().join("file"), "contents").unwrap();
+        let loader = DiskFileLoader::new(temp_dir.path().to_owned());
+
+        let loaded = loader
+            .load(repo_path("file/.gitattributes"))
+            .block_on()
+            .unwrap();
+
+        assert!(loaded.is_none());
     }
 
     #[test]
@@ -861,16 +893,19 @@ mod tests {
             attributes
                 .filter_matches(repo_path("file.bin"), filters, SearchPriority::Disk)
                 .block_on()
+                .unwrap()
         );
         assert!(
             attributes
                 .filter_matches(repo_path("subdir/file.txt"), filters, SearchPriority::Disk)
                 .block_on()
+                .unwrap()
         );
         assert!(
             !attributes
                 .filter_matches(repo_path("file.txt"), filters, SearchPriority::Disk)
                 .block_on()
+                .unwrap()
         ); // Not in subdir
     }
 
@@ -911,6 +946,7 @@ mod tests {
             attributes
                 .filter_matches(repo_path("file.bin"), filters, SearchPriority::Disk)
                 .block_on()
+                .unwrap()
         );
         // Test with git-crypt filter
         assert!(
@@ -921,18 +957,21 @@ mod tests {
                     SearchPriority::Disk
                 )
                 .block_on()
+                .unwrap()
         );
         // Not In the filter
         assert!(
             !attributes
                 .filter_matches(repo_path("file.bin2"), filters, SearchPriority::Disk)
                 .block_on()
+                .unwrap()
         );
         // Test that other filters don't match
         assert!(
             !attributes
                 .filter_matches(repo_path("file.txt"), filters, SearchPriority::Disk)
                 .block_on()
+                .unwrap()
         );
     }
 }

--- a/lib/src/gitattributes.rs
+++ b/lib/src/gitattributes.rs
@@ -189,10 +189,7 @@ impl FileLoader for DiskFileLoader {
         let file = match File::open(&path) {
             Ok(file) => file,
             Err(error)
-                if matches!(
-                    error.kind(),
-                    ErrorKind::NotFound | ErrorKind::NotADirectory
-                ) =>
+                if matches!(error.kind(), ErrorKind::NotFound | ErrorKind::NotADirectory) =>
             {
                 return Ok(None);
             }

--- a/lib/src/local_working_copy.rs
+++ b/lib/src/local_working_copy.rs
@@ -1612,7 +1612,7 @@ impl FileSnapshotter<'_> {
             })
             .collect::<Result<_, _>>()?;
         let present_entries = PresentDirEntries { dirs, files };
-        self.emit_deleted_files(&dir, file_states, &present_entries);
+        self.emit_deleted_files(&dir, file_states, &present_entries)?;
         Ok(())
     }
 
@@ -1690,7 +1690,7 @@ impl FileSnapshotter<'_> {
             if self
                 .git_attributes
                 .filter_matches(&path, &self.ignore_filters, SearchPriority::Disk)
-                .block_on()
+                .block_on()?
             {
                 // Skip gitattributes files that we want to ignore - this
                 // would result in them showing up as deleted, but we also
@@ -1760,7 +1760,7 @@ impl FileSnapshotter<'_> {
             if self
                 .git_attributes
                 .filter_matches(tracked_path, &self.ignore_filters, SearchPriority::Disk)
-                .await
+                .await?
             {
                 continue;
             }
@@ -1825,7 +1825,7 @@ impl FileSnapshotter<'_> {
         dir: &RepoPath,
         file_states: FileStates<'_>,
         present_entries: &PresentDirEntries,
-    ) {
+    ) -> Result<(), SnapshotError> {
         let file_state_chunks = file_states.iter().chunk_by(|(path, _state)| {
             // Extract <name> from <dir>, <dir>/<name>, or <dir>/<name>/**.
             // (file_states may contain <dir> file on file->dir transition.)
@@ -1838,25 +1838,33 @@ impl FileSnapshotter<'_> {
                 None => (PresentDirEntryKind::File, tail),
             }
         });
-        file_state_chunks
+        for (_, chunk) in file_state_chunks
             .into_iter()
             .filter(|&((kind, name), _)| match kind {
                 PresentDirEntryKind::Dir => !present_entries.dirs.contains(name),
                 PresentDirEntryKind::File => !present_entries.files.contains(name),
             })
-            .flat_map(|(_, chunk)| chunk)
-            // Whether or not the entry exists, submodule should be ignored
-            .filter(|(_, state)| state.file_type != FileType::GitSubmodule)
-            // Whether or not the entry exists, ignored gitattributes files should be omitted
-            .filter(|(path, _)| {
-                !self
+        {
+            for (path, state) in chunk {
+                // Whether or not the entry exists, submodule should be ignored.
+                if state.file_type == FileType::GitSubmodule {
+                    continue;
+                }
+                if self
                     .git_attributes
                     .filter_matches(path, &self.ignore_filters, SearchPriority::Disk)
-                    .block_on()
-            })
-            .filter(|(path, _)| self.matcher.matches(path))
-            .try_for_each(|(path, _)| self.deleted_files_tx.send(path.to_owned()))
-            .ok();
+                    .block_on()?
+                {
+                    // Whether or not the entry exists, ignored gitattributes
+                    // files should be omitted.
+                    continue;
+                }
+                if self.matcher.matches(path) {
+                    self.deleted_files_tx.send(path.to_owned()).ok();
+                }
+            }
+        }
+        Ok(())
     }
 
     async fn get_updated_tree_value(

--- a/lib/src/local_working_copy.rs
+++ b/lib/src/local_working_copy.rs
@@ -1031,8 +1031,6 @@ pub struct TreeState {
     fsmonitor_settings: FsmonitorSettings,
     target_eol_strategy: TargetEolStrategy,
 
-    // attributes
-    git_attributes: Arc<GitAttributes>,
     ignore_filters: HashSet<String>,
 }
 
@@ -1098,12 +1096,6 @@ impl TreeState {
         }: &TreeStateSettings,
     ) -> Self {
         let exec_policy = ExecChangePolicy::new(*exec_change_setting, &state_path);
-        let tree = store.empty_merged_tree();
-
-        let store_file_loader = TreeFileLoader::new(tree.clone());
-        let disk_file_loader = DiskFileLoader::new(working_copy_path.clone());
-
-        let git_attributes = Arc::new(GitAttributes::new(store_file_loader, disk_file_loader));
 
         // Only enable ignore filters when using Git.
         let ignore_filters = if store.backend().name() == "git" {
@@ -1116,7 +1108,7 @@ impl TreeState {
             store: store.clone(),
             working_copy_path,
             state_path,
-            tree,
+            tree: store.empty_merged_tree(),
             file_states: FileStatesMap::new(),
             sparse_patterns: vec![RepoPathBuf::root()],
             own_mtime: MillisSinceEpoch(0),
@@ -1126,8 +1118,6 @@ impl TreeState {
             exec_policy,
             fsmonitor_settings: fsmonitor_settings.clone(),
             target_eol_strategy: TargetEolStrategy::new(*eol_conversion_mode),
-            // TODO We should update git_attributes every time TreeState::tree_id is updated
-            git_attributes,
             ignore_filters,
         }
     }
@@ -1361,6 +1351,10 @@ impl TreeState {
         let (file_states_tx, file_states_rx) = channel();
         let (untracked_paths_tx, untracked_paths_rx) = channel();
         let (deleted_files_tx, deleted_files_rx) = channel();
+        let git_attributes = Arc::new(GitAttributes::new(
+            TreeFileLoader::new(self.tree.clone()),
+            DiskFileLoader::new(self.working_copy_path.clone()),
+        ));
 
         trace_span!("traverse filesystem").in_scope(|| -> Result<(), SnapshotError> {
             let snapshotter = FileSnapshotter {
@@ -1377,7 +1371,7 @@ impl TreeState {
                 error: OnceLock::new(),
                 progress: *progress,
                 max_new_file_size: *max_new_file_size,
-                git_attributes: self.git_attributes.clone(),
+                git_attributes,
                 ignore_filters: self.ignore_filters.clone(),
             };
             let directory_to_visit = DirectoryToVisit {
@@ -1761,6 +1755,13 @@ impl FileSnapshotter<'_> {
                 continue;
             }
             if !self.matcher.matches(tracked_path) {
+                continue;
+            }
+            if self
+                .git_attributes
+                .filter_matches(tracked_path, &self.ignore_filters, SearchPriority::Disk)
+                .await
+            {
                 continue;
             }
             let disk_path = tracked_path.to_fs_path(&self.tree_state.working_copy_path)?;

--- a/lib/tests/test_local_working_copy.rs
+++ b/lib/tests/test_local_working_copy.rs
@@ -3178,11 +3178,9 @@ fn test_gitattributes_ignore_only_on_git_backend(backend: TestRepoBackend) -> Te
 // Snapshot prefers .gitattributes from disk but falls back to the current tree
 // when the disk file is missing. TreeState starts with an empty tree before
 // checkout, so caching GitAttributes there can leave the fallback pointed at
-// the empty tree even after checkout updates TreeState::tree.
-//
-// Removing the disk .gitattributes file exercises the fallback; the tracked LFS
-// file must keep the tree contents instead of snapshotting the modified disk
-// contents.
+// the empty tree even after checkout updates TreeState::tree. Removing the disk
+// .gitattributes file exercises that fallback; the tracked LFS file must keep
+// the tree contents instead of snapshotting the modified disk contents.
 #[test]
 fn test_gitattributes_use_store_fallback_after_checkout() -> TestResult {
     let mut test_workspace = TestWorkspace::init_with_backend(TestRepoBackend::Git);
@@ -3216,11 +3214,50 @@ fn test_gitattributes_use_store_fallback_after_checkout() -> TestResult {
 
 // Regression test for a bug found during development.
 //
-// When .gitignore ignores an entire directory, snapshot uses a shortcut that
-// scans only already-tracked files in that directory. This test puts a tracked
-// file under that shortcut and marks it with filter=lfs. Modifying the disk
-// file must not update the tree: the .gitattributes filter should still apply
-// even though traversal used the ignored-directory path.
+// Snapshot handles files that are present on disk and files that were deleted
+// from disk through separate paths. If deletion emission does not apply the
+// .gitattributes filter check, removing a tracked LFS-filtered file from disk
+// records a deletion even though normal snapshots would ignore changes to that
+// file. The tree should keep the tracked contents instead.
+#[test]
+fn test_gitattributes_ignore_deleted_tracked_file() -> TestResult {
+    let mut test_workspace = TestWorkspace::init_with_backend(TestRepoBackend::Git);
+    let repo = test_workspace.repo.clone();
+    let workspace_root = test_workspace.workspace.workspace_root().to_owned();
+
+    let tracked_path = repo_path("file.bin");
+    let tree = create_tree(
+        &repo,
+        &[
+            (repo_path(".gitattributes"), "*.bin filter=lfs\n"),
+            (tracked_path, "original\n"),
+        ],
+    );
+    let commit = commit_with_tree(repo.store(), tree.clone());
+    test_workspace
+        .workspace
+        .check_out(repo.op_id().clone(), None, &commit)
+        .block_on()?;
+
+    std::fs::remove_file(tracked_path.to_fs_path_unchecked(&workspace_root))?;
+
+    let new_tree = test_workspace.snapshot()?;
+    assert_eq!(
+        new_tree.path_value(tracked_path).block_on()?,
+        tree.path_value(tracked_path).block_on()?,
+    );
+
+    Ok(())
+}
+
+// Regression test for a bug found during development.
+//
+// The normal snapshot path checks .gitattributes before updating or deleting a
+// file. When .gitignore ignores an entire directory, snapshot uses a shortcut
+// that scans only already-tracked files in that directory. This test puts a
+// tracked file under that shortcut and marks it with filter=lfs. Modifying the
+// disk file must not update the tree: the .gitattributes filter should still
+// apply even though traversal used the ignored-directory path.
 #[test]
 fn test_gitattributes_ignore_tracked_file_in_gitignored_dir() -> TestResult {
     let mut test_workspace = TestWorkspace::init_with_backend(TestRepoBackend::Git);
@@ -3248,6 +3285,9 @@ fn test_gitattributes_ignore_tracked_file_in_gitignored_dir() -> TestResult {
     )?;
 
     let new_tree = test_workspace.snapshot()?;
+
+    // The .gitattributes filter should still apply when .gitignore sends
+    // tracked files through the ignored-directory shortcut.
     assert_eq!(
         new_tree.path_value(tracked_path).block_on()?,
         tree.path_value(tracked_path).block_on()?,

--- a/lib/tests/test_local_working_copy.rs
+++ b/lib/tests/test_local_working_copy.rs
@@ -3180,11 +3180,11 @@ fn test_gitattributes_ignore_only_on_git_backend(backend: TestRepoBackend) -> Te
 // checkout, so caching GitAttributes there can leave the fallback pointed at
 // the empty tree even after checkout updates TreeState::tree.
 //
-// This characterizes the pre-fix behavior: removing the disk .gitattributes
-// file makes snapshot miss the tracked filter rule and incorrectly snapshot the
-// modified disk contents.
+// Removing the disk .gitattributes file exercises the fallback; the tracked LFS
+// file must keep the tree contents instead of snapshotting the modified disk
+// contents.
 #[test]
-fn test_gitattributes_store_fallback_after_checkout_is_stale() -> TestResult {
+fn test_gitattributes_use_store_fallback_after_checkout() -> TestResult {
     let mut test_workspace = TestWorkspace::init_with_backend(TestRepoBackend::Git);
     let repo = &test_workspace.repo;
     let workspace_root = test_workspace.workspace.workspace_root().to_owned();
@@ -3206,7 +3206,7 @@ fn test_gitattributes_store_fallback_after_checkout_is_stale() -> TestResult {
     std::fs::write(workspace_root.join("file.txt"), "modified\n")?;
 
     let new_tree = test_workspace.snapshot()?;
-    assert_ne!(
+    assert_eq!(
         new_tree.path_value(repo_path("file.txt")).block_on()?,
         tree.path_value(repo_path("file.txt")).block_on()?,
     );
@@ -3217,11 +3217,12 @@ fn test_gitattributes_store_fallback_after_checkout_is_stale() -> TestResult {
 // Regression test for a bug found during development.
 //
 // When .gitignore ignores an entire directory, snapshot uses a shortcut that
-// scans only already-tracked files in that directory. This characterizes the
-// pre-fix behavior: that shortcut misses the .gitattributes filter check and
-// incorrectly snapshots a modified tracked LFS-filtered file.
+// scans only already-tracked files in that directory. This test puts a tracked
+// file under that shortcut and marks it with filter=lfs. Modifying the disk
+// file must not update the tree: the .gitattributes filter should still apply
+// even though traversal used the ignored-directory path.
 #[test]
-fn test_gitattributes_tracked_file_in_gitignored_dir_is_updated() -> TestResult {
+fn test_gitattributes_ignore_tracked_file_in_gitignored_dir() -> TestResult {
     let mut test_workspace = TestWorkspace::init_with_backend(TestRepoBackend::Git);
     let repo = test_workspace.repo.clone();
     let workspace_root = test_workspace.workspace.workspace_root().to_owned();
@@ -3247,7 +3248,7 @@ fn test_gitattributes_tracked_file_in_gitignored_dir_is_updated() -> TestResult 
     )?;
 
     let new_tree = test_workspace.snapshot()?;
-    assert_ne!(
+    assert_eq!(
         new_tree.path_value(tracked_path).block_on()?,
         tree.path_value(tracked_path).block_on()?,
     );

--- a/lib/tests/test_local_working_copy.rs
+++ b/lib/tests/test_local_working_copy.rs
@@ -3172,3 +3172,85 @@ fn test_gitattributes_ignore_only_on_git_backend(backend: TestRepoBackend) -> Te
 
     Ok(())
 }
+
+// Regression test for a bug found during development.
+//
+// Snapshot prefers .gitattributes from disk but falls back to the current tree
+// when the disk file is missing. TreeState starts with an empty tree before
+// checkout, so caching GitAttributes there can leave the fallback pointed at
+// the empty tree even after checkout updates TreeState::tree.
+//
+// This characterizes the pre-fix behavior: removing the disk .gitattributes
+// file makes snapshot miss the tracked filter rule and incorrectly snapshot the
+// modified disk contents.
+#[test]
+fn test_gitattributes_store_fallback_after_checkout_is_stale() -> TestResult {
+    let mut test_workspace = TestWorkspace::init_with_backend(TestRepoBackend::Git);
+    let repo = &test_workspace.repo;
+    let workspace_root = test_workspace.workspace.workspace_root().to_owned();
+
+    let tree = create_tree(
+        repo,
+        &[
+            (repo_path(".gitattributes"), "*.txt filter=lfs\n"),
+            (repo_path("file.txt"), "original\n"),
+        ],
+    );
+    let commit = commit_with_tree(repo.store(), tree.clone());
+    test_workspace
+        .workspace
+        .check_out(repo.op_id().clone(), None, &commit)
+        .block_on()?;
+
+    std::fs::remove_file(workspace_root.join(".gitattributes"))?;
+    std::fs::write(workspace_root.join("file.txt"), "modified\n")?;
+
+    let new_tree = test_workspace.snapshot()?;
+    assert_ne!(
+        new_tree.path_value(repo_path("file.txt")).block_on()?,
+        tree.path_value(repo_path("file.txt")).block_on()?,
+    );
+
+    Ok(())
+}
+
+// Regression test for a bug found during development.
+//
+// When .gitignore ignores an entire directory, snapshot uses a shortcut that
+// scans only already-tracked files in that directory. This characterizes the
+// pre-fix behavior: that shortcut misses the .gitattributes filter check and
+// incorrectly snapshots a modified tracked LFS-filtered file.
+#[test]
+fn test_gitattributes_tracked_file_in_gitignored_dir_is_updated() -> TestResult {
+    let mut test_workspace = TestWorkspace::init_with_backend(TestRepoBackend::Git);
+    let repo = test_workspace.repo.clone();
+    let workspace_root = test_workspace.workspace.workspace_root().to_owned();
+
+    let tracked_path = repo_path("ignored/file.bin");
+    let tree = create_tree(
+        &repo,
+        &[
+            (repo_path(".gitignore"), "/ignored/\n"),
+            (repo_path(".gitattributes"), "ignored/file.bin filter=lfs\n"),
+            (tracked_path, "original\n"),
+        ],
+    );
+    let commit = commit_with_tree(repo.store(), tree.clone());
+    test_workspace
+        .workspace
+        .check_out(repo.op_id().clone(), None, &commit)
+        .block_on()?;
+
+    std::fs::write(
+        tracked_path.to_fs_path_unchecked(&workspace_root),
+        "modified\n",
+    )?;
+
+    let new_tree = test_workspace.snapshot()?;
+    assert_ne!(
+        new_tree.path_value(tracked_path).block_on()?,
+        tree.path_value(tracked_path).block_on()?,
+    );
+
+    Ok(())
+}

--- a/web/docs/src/content/docs/config.md
+++ b/web/docs/src/content/docs/config.md
@@ -1497,6 +1497,23 @@ default. Set `git.colocate` to `false` to disable it.
 See [Colocated Jujutsu/Git workspaces](git-compatibility.md#colocated-jujutsugit-repos)
 for more information.
 
+### Ignoring files by `.gitattributes` filter
+
+In Git-backed repositories, `jj` can skip files during snapshot based on the
+`filter` attribute in `.gitattributes`. The `git.ignore-filters` setting lists
+the filter values to skip, and defaults to `["lfs"]`.
+
+```toml
+[git]
+ignore-filters = ["lfs", "git-crypt"]
+```
+
+This only affects snapshotting from disk to the store. Checkout still writes
+the files from the tree, so external tools such as `git lfs pull` or
+`git lfs checkout` can hydrate them afterward. Files already tracked by `jj` may
+need to be removed with `jj file untrack <path>` before this setting affects
+future snapshots.
+
 ### Default remotes for `jj git fetch` and `jj git push`
 
 By default, if a single remote exists it is used for `jj git fetch` and `jj git

--- a/web/docs/src/content/docs/git-compatibility.md
+++ b/web/docs/src/content/docs/git-compatibility.md
@@ -37,8 +37,13 @@ a comparison with Git, including how workflows are different, see the
   working-copy commit. It's recommended to set up the ignore patterns earlier.
   The `.gitignore` support uses a native implementation, so please report a bug
   if you notice any difference compared to `git`.
-* **.gitattributes: No.** There's [#53](https://github.com/jj-vcs/jj/issues/53)
-  about adding support for at least the `eol` attribute.
+* **.gitattributes: Partial.** In Git-backed repositories, `jj` reads
+  `.gitattributes` `filter` attributes during snapshot and skips files whose
+  filter is listed in `git.ignore-filters`, which defaults to `["lfs"]`. This
+  is snapshot-only; checkout still writes files from the tree. Other attributes
+  such as `eol`, `text`, `diff`, and `merge` are not otherwise supported.
+  There's [#53](https://github.com/jj-vcs/jj/issues/53) about adding support for
+  at least the `eol` attribute.
 * **Hooks: No.** There's [#405](https://github.com/jj-vcs/jj/issues/405)
   specifically for providing the checks from <https://pre-commit.com>.
 * **Merge commits: Yes.** Octopus merges (i.e. with more than 2 parents) are
@@ -71,7 +76,12 @@ a comparison with Git, including how workflows are different, see the
 * **Signed commits: Yes.**
   You can sign commits automatically [by configuration](config.md#commit-signing),
   or use the `jj sign` command.
-* **Git LFS: No.** ([#80](https://github.com/jj-vcs/jj/issues/80))
+* **Git LFS: Partial.** In Git-backed repositories, files with `filter=lfs` are
+  ignored during snapshot by default. `jj` does not fetch, clean, smudge, or
+  hydrate LFS contents; use Git LFS commands such as `git lfs pull` or
+  `git lfs checkout` for those steps. Existing tracked files may need
+  `jj file untrack <path>` before the snapshot ignore takes effect.
+  ([#80](https://github.com/jj-vcs/jj/issues/80))
 
 ## Creating an empty repo
 


### PR DESCRIPTION
This splits the follow-up to #9635 into focused review commits. The first commits characterize the wrong behavior found during review, and the following commits update those same tests while fixing the corresponding path.

Review guide:

- `test: characterize filtered snapshot paths` / `git-lfs: fix filtered snapshot paths` cover stale `.gitattributes` fallback and tracked files under ignored directories.
- `test: characterize gitattributes lookup errors` / `git-lfs: propagate gitattributes lookup errors` cover parse and read errors from attributes lookup. The fix commit also keeps optional `.gitattributes` probes from failing when an ancestor path is a file, with a separate regression test for the `NotADirectory` case found after CI exercised rename detection.
- `test: characterize run temp snapshot filters` / `git-lfs: pass ignore filters to run snapshots` cover temporary snapshots created by `jj run`.
- `test: characterize diffedit temp snapshot filters` / `git-lfs: pass ignore filters to diffedit snapshots` cover temporary snapshots created by diff editing.
- The remaining commits add deletion-path coverage, update `gix-attributes`, keep no-default-features builds clean, document the snapshot-only behavior, and group `jj run` worker inputs in a small context struct so clippy's argument-count lint stays green.

The rebuilt stack was compared against the previous flat version of this PR. The intentionally new follow-up delta is limited to the `NotADirectory` `.gitattributes` regression fix/test and the `RunContext` clippy cleanup.

Validation run locally:

- `cargo test -p jj-lib test_disk_file_loader_ignores_file_in_attributes_path -- --nocapture`
- `cargo test -p jj-cli test_diff_renamed_file_and_dir -- --nocapture`
- `cargo clippy -p jj-cli --all-targets --all-features -- -D warnings`
- `cargo +nightly fmt --all -- --check`

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [x] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code I'm changing, even if it was initially suggested/generated by an AI assistant
- [x] For any prose generated by an AI assistant, I have proof-read and copy-edited it for correctness, clarity, and voice
