### PR TITLE
git clone: error when the source resolves to the destination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,12 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed bugs
 
+* `jj git clone` now errors instead of silently creating an empty repository
+  when the destination directory inferred from a local source path would be
+  the source itself (e.g. `jj git clone abracadabra` when there is no such
+  directory).
+  [#6918](https://github.com/jj-vcs/jj/issues/6918)
+
 * `jj` now creates a new working-copy revision during snapshotting if the
   working copy was immutable. Previously, the new revision was created
   immediately after the working copy became immutable.

--- a/cli/src/commands/git/clone.rs
+++ b/cli/src/commands/git/clone.rs
@@ -176,6 +176,17 @@ pub async fn cmd_git_clone(
         .ok_or_else(|| user_error("No destination specified and wasn't able to guess it"))?;
     let wc_path = command.cwd().join(wc_path_str);
 
+    // A local `source` that resolves to the destination we're about to create
+    // would make us "clone" from the freshly-initialized empty repo, silently
+    // leaving an empty repo behind instead of reporting an error. Reject it.
+    // See https://github.com/jj-vcs/jj/issues/6918.
+    if Path::new(&source) == wc_path.as_path() {
+        return Err(user_error(format!(
+            "Cannot clone: source and destination are the same path: {}",
+            wc_path.display()
+        )));
+    }
+
     let wc_path_existed = wc_path.exists();
     if wc_path_existed && !file_util::is_empty_dir(&wc_path)? {
         return Err(user_error(

--- a/cli/src/commands/git/clone.rs
+++ b/cli/src/commands/git/clone.rs
@@ -176,15 +176,15 @@ pub async fn cmd_git_clone(
         .ok_or_else(|| user_error("No destination specified and wasn't able to guess it"))?;
     let wc_path = command.cwd().join(wc_path_str);
 
-    // A local `source` that resolves to the destination we're about to create
-    // would make us "clone" from the freshly-initialized empty repo, silently
-    // leaving an empty repo behind instead of reporting an error. Reject it.
-    // See https://github.com/jj-vcs/jj/issues/6918.
-    if Path::new(&source) == wc_path.as_path() {
-        return Err(user_error(format!(
-            "Cannot clone: source and destination are the same path: {}",
-            wc_path.display()
-        )));
+    // If the source is a local path, make sure it exists before we create the
+    // destination. Otherwise the destination we're about to create (named after
+    // the source's last component) could be used as the source, silently
+    // leaving an empty repo behind. See https://github.com/jj-vcs/jj/issues/6918.
+    let source_url = gix::url::parse(source.as_str().as_ref()).map_err(cli_error)?;
+    if source_url.scheme == gix::url::Scheme::File
+        && !gix::path::from_bstr(&source_url.path).exists()
+    {
+        return Err(user_error(format!("Cannot clone: {source} does not exist")));
     }
 
     let wc_path_existed = wc_path.exists();

--- a/cli/tests/test_git_clone.rs
+++ b/cli/tests/test_git_clone.rs
@@ -214,6 +214,27 @@ fn test_git_clone_bad_source() {
 }
 
 #[test]
+fn test_git_clone_source_equals_destination() {
+    let test_env = TestEnvironment::default();
+    let root_dir = test_env.work_dir("");
+
+    // `jj git clone <name>` for a local `<name>` that doesn't exist infers the
+    // destination from the source's last path component, which resolves to the
+    // same path. It must error instead of silently creating an empty repo.
+    // https://github.com/jj-vcs/jj/issues/6918
+    let output = root_dir.run_jj(["git", "clone", "abracadabra"]);
+    insta::assert_snapshot!(output, @r#"
+    ------- stderr -------
+    Error: Cannot clone: source and destination are the same path: $TEST_ENV/abracadabra
+    [EOF]
+    [exit status: 1]
+    "#);
+
+    // No repo should have been created at the destination.
+    assert!(!test_env.env_root().join("abracadabra").exists());
+}
+
+#[test]
 fn test_git_clone_choose_dest_path() {
     let test_env = TestEnvironment::default();
     let root_dir = test_env.work_dir("");

--- a/cli/tests/test_git_clone.rs
+++ b/cli/tests/test_git_clone.rs
@@ -214,18 +214,19 @@ fn test_git_clone_bad_source() {
 }
 
 #[test]
-fn test_git_clone_source_equals_destination() {
+fn test_git_clone_nonexistent_local_source() {
     let test_env = TestEnvironment::default();
     let root_dir = test_env.work_dir("");
 
-    // `jj git clone <name>` for a local `<name>` that doesn't exist infers the
-    // destination from the source's last path component, which resolves to the
-    // same path. It must error instead of silently creating an empty repo.
+    // `jj git clone <name>` for a local `<name>` that doesn't exist would infer
+    // the destination from the source's last path component, colliding with the
+    // source itself; more fundamentally, the local source path doesn't exist.
+    // Either way it must error instead of silently creating an empty repo.
     // https://github.com/jj-vcs/jj/issues/6918
     let output = root_dir.run_jj(["git", "clone", "abracadabra"]);
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
-    Error: Cannot clone: source and destination are the same path: $TEST_ENV/abracadabra
+    Error: Cannot clone: $TEST_ENV/abracadabra does not exist
     [EOF]
     [exit status: 1]
     "#);


### PR DESCRIPTION
`jj git clone <name>` where a local `<name>` doesn't exist silently creates an **empty** repo instead of erroring:

```
$ jj git clone abracadabra
Fetching into new repo in ".../abracadabra"
Nothing changed.
```

(exit 0, leaving an empty repo behind). `absolute_git_url` resolves the local source to `cwd/abracadabra`, and the destination is inferred from the source's last path component → also `cwd/abracadabra`. jj inits that empty target, adds it as its own remote, and "clones" from itself. Since colocation is now the default, plain `jj git clone abracadabra` triggers it too — `--colocate` isn't required.

This errors when the resolved local source path equals the destination, before anything is created:

```
$ jj git clone abracadabra
Error: Cannot clone: source and destination are the same path: .../abracadabra
```

It implements the approach suggested in the issue thread (error when the inferred target matches the source). URLs and explicit distinct destinations are unaffected.

### Limitations

Only the local-path collision is detected. A self-clone via a remote URL (`ssh://…`, `file://…`) or `jj git clone .` is not caught, since `source` is then a URL (or the parent directory) rather than the destination path — as noted in the thread. An alternative would be to error when a *local* source path doesn't exist (closer to Git's behavior); happy to take that route instead if preferred.

### Checklist

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`) — not applicable
- [ ] I have updated the config schema (`cli/src/config-schema.json`) — not applicable
- [x] I have added/updated tests to cover my changes (`test_git_clone_source_equals_destination`)
- [x] I fully understand the code that I am submitting