### PR TITLE
cli: use `default_value_t` to accept typed values for CLI flags

### DIFF
--- a/cli/src/commands/bisect/run.rs
+++ b/cli/src/commands/bisect/run.rs
@@ -104,7 +104,7 @@ pub(crate) struct BisectRunArgs {
     /// The interpretation of exit statuses will be inverted (excluding special
     /// exit statuses), so status 0 means bad and other non-zero statuses mean
     /// good.
-    #[arg(long, value_name = "TARGET", default_value = "false")]
+    #[arg(long, value_name = "TARGET", default_value_t = false)]
     find_good: bool,
 }
 

--- a/cli/src/commands/next.rs
+++ b/cli/src/commands/next.rs
@@ -52,7 +52,7 @@ use crate::ui::Ui;
 pub(crate) struct NextArgs {
     /// How many revisions to move forward. Advances to the next child by
     /// default
-    #[arg(default_value = "1")]
+    #[arg(default_value_t = 1)]
     offset: u64,
 
     /// Instead of creating a new working-copy commit on top of the target

--- a/cli/src/commands/prev.rs
+++ b/cli/src/commands/prev.rs
@@ -50,7 +50,7 @@ use crate::ui::Ui;
 #[command(verbatim_doc_comment)]
 pub(crate) struct PrevArgs {
     /// How many revisions to move backward. Moves to the parent by default
-    #[arg(default_value = "1")]
+    #[arg(default_value_t = 1)]
     offset: u64,
 
     /// Edit the parent directly, instead of moving the working-copy commit


### PR DESCRIPTION
# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [ ] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
