### PR TITLE
change-id: avoid prefix collisions when generating new change-ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * `jj gerrit upload` now supports the `-o` (`--option`) flag, which works like
   `git push -o` (`--push-option`).
 
+* Newly created changes now avoid reusing change-ID short prefixes that
+  are already taken by existing changes. This highly reduces the chance
+  that a short prefix (e.g. 1-2 characters) becomes ambiguous after
+  creating a new revision.
+
 ### Fixed bugs
 
 * `jj` now creates a new working-copy revision during snapshotting if the

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -2643,6 +2643,17 @@ impl WorkspaceCommandTransaction<'_> {
         self.tx.repo_mut().edit(name, commit).block_on()
     }
 
+    pub fn generate_new_change_id(&self) -> ChangeId {
+        let id_prefix_context = self
+            .id_prefix_context
+            .get_or_init(|| self.helper.env.new_id_prefix_context());
+        let id_prefix_index = id_prefix_context.populate(self.repo()).unwrap();
+        id_prefix_index.generate_new_change_id(
+            self.settings().get_rng().as_ref(),
+            self.repo().store().change_id_length(),
+        )
+    }
+
     pub fn format_commit_summary(&self, commit: &Commit) -> String {
         let output = self.commit_summary_template().format_plain_text(commit);
         output.into_string_lossy()

--- a/cli/src/commands/bench/generate_change_id.rs
+++ b/cli/src/commands/bench/generate_change_id.rs
@@ -33,9 +33,13 @@ pub async fn cmd_bench_generate_change_id(
     args: &BenchGenerateChangeIdArgs,
 ) -> Result<(), CommandError> {
     let workspace_command = command.workspace_helper(ui).await?;
+    let id_prefix_context = workspace_command.id_prefix_context();
+    let id_prefix_index = id_prefix_context
+        .populate(workspace_command.repo().as_ref())
+        .unwrap();
     let rng = workspace_command.settings().get_rng();
     let length = workspace_command.repo().store().change_id_length();
-    let routine = || rng.new_change_id(length);
+    let routine = || id_prefix_index.generate_new_change_id(&rng, length);
     run_bench(ui, "generate-change-id", &args.criterion, routine)?;
     Ok(())
 }

--- a/cli/src/commands/bench/generate_change_id.rs
+++ b/cli/src/commands/bench/generate_change_id.rs
@@ -1,0 +1,41 @@
+// Copyright 2026 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use jj_lib::repo::Repo as _;
+
+use super::CriterionArgs;
+use super::run_bench;
+use crate::cli_util::CommandHelper;
+use crate::command_error::CommandError;
+use crate::ui::Ui;
+
+/// Generate a change-ID
+#[derive(clap::Args, Clone, Debug)]
+pub struct BenchGenerateChangeIdArgs {
+    #[command(flatten)]
+    criterion: CriterionArgs,
+}
+
+pub async fn cmd_bench_generate_change_id(
+    ui: &mut Ui,
+    command: &CommandHelper,
+    args: &BenchGenerateChangeIdArgs,
+) -> Result<(), CommandError> {
+    let workspace_command = command.workspace_helper(ui).await?;
+    let rng = workspace_command.settings().get_rng();
+    let length = workspace_command.repo().store().change_id_length();
+    let routine = || rng.new_change_id(length);
+    run_bench(ui, "generate-change-id", &args.criterion, routine)?;
+    Ok(())
+}

--- a/cli/src/commands/bench/mod.rs
+++ b/cli/src/commands/bench/mod.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 mod common_ancestors;
+mod generate_change_id;
 mod is_ancestor;
 mod resolve_prefix;
 mod revset;
@@ -26,6 +27,8 @@ use criterion::Criterion;
 
 use self::common_ancestors::BenchCommonAncestorsArgs;
 use self::common_ancestors::cmd_bench_common_ancestors;
+use self::generate_change_id::BenchGenerateChangeIdArgs;
+use self::generate_change_id::cmd_bench_generate_change_id;
 use self::is_ancestor::BenchIsAncestorArgs;
 use self::is_ancestor::cmd_bench_is_ancestor;
 use self::resolve_prefix::BenchResolvePrefixArgs;
@@ -41,6 +44,7 @@ use crate::ui::Ui;
 #[command(hide = true)]
 pub enum BenchCommand {
     CommonAncestors(BenchCommonAncestorsArgs),
+    GenerateChangeId(BenchGenerateChangeIdArgs),
     IsAncestor(BenchIsAncestorArgs),
     ResolvePrefix(BenchResolvePrefixArgs),
     Revset(BenchRevsetArgs),
@@ -53,6 +57,9 @@ pub(crate) async fn cmd_bench(
 ) -> Result<(), CommandError> {
     match subcommand {
         BenchCommand::CommonAncestors(args) => cmd_bench_common_ancestors(ui, command, args).await,
+        BenchCommand::GenerateChangeId(args) => {
+            cmd_bench_generate_change_id(ui, command, args).await
+        }
         BenchCommand::IsAncestor(args) => cmd_bench_is_ancestor(ui, command, args).await,
         BenchCommand::ResolvePrefix(args) => cmd_bench_resolve_prefix(ui, command, args).await,
         BenchCommand::Revset(args) => cmd_bench_revset(ui, command, args).await,

--- a/cli/src/commands/new.rs
+++ b/cli/src/commands/new.rs
@@ -208,9 +208,11 @@ pub(crate) async fn cmd_new(
 
     let mut tx = workspace_command.start_transaction();
     let merged_tree = merge_commit_trees(tx.repo(), &parent_commits).await?;
+    let change_id = tx.generate_new_change_id();
     let mut commit_builder = tx
         .repo_mut()
         .new_commit(parent_commit_ids, merged_tree)
+        .set_change_id(change_id)
         .detach();
     let description = if !args.message_paragraphs.is_empty() {
         join_message_paragraphs(&args.message_paragraphs)

--- a/cli/tests/test_abandon_command.rs
+++ b/cli/tests/test_abandon_command.rs
@@ -30,15 +30,15 @@ fn test_basics() {
     create_commit(&work_dir, "e", &["a", "d"]);
     // Test the setup
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @    [znk] e
+    @    [nnkkp] e
     ├─╮
-    │ ○  [vru] d
-    │ ○  [roy] c
-    │ │ ○  [zsu] b
+    │ ○  [truxw] d
+    │ ○  [ooyxm] c
+    │ │ ○  [psusk] b
     ├───╯
-    ○ │  [rlv] a
+    ○ │  [ylvkp] a
     ├─╯
-    ◆  [zzz]
+    ◆  [zzzzz]
     [EOF]
     ");
     let setup_opid = work_dir.current_operation_id();
@@ -47,23 +47,23 @@ fn test_basics() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Abandoned 1 commits:
-      vruxwmqv 636920e4 d | d
+      truxwmqv 295a5aee d | d
     Rebased 1 descendant commits onto parents of abandoned commits
-    Working copy  (@) now at: znkkpsqq 38e96a1f e | e
-    Parent commit (@-)      : rlvkpnrz 7d980be7 a | a
-    Parent commit (@-)      : royxmykx c12952d9 c d | c
+    Working copy  (@) now at: nnkkpsqq 0f3014db e | e
+    Parent commit (@-)      : ylvkpnrz a1afb583 a | a
+    Parent commit (@-)      : ooyxmykx 8d67ed49 c d | c
     Added 0 files, modified 0 files, removed 1 files
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @    [znk] e
+    @    [nnkkp] e
     ├─╮
-    │ ○  [roy] c d
-    │ │ ○  [zsu] b
+    │ ○  [ooyxm] c d
+    │ │ ○  [psusk] b
     ├───╯
-    ○ │  [rlv] a
+    ○ │  [ylvkp] a
     ├─╯
-    ◆  [zzz]
+    ◆  [zzzzz]
     [EOF]
     ");
 
@@ -72,23 +72,23 @@ fn test_basics() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Abandoned 1 commits:
-      znkkpsqq 03e0d4bf e | e
-    Working copy  (@) now at: nkmrtpmo 179731fc (empty) (no description set)
-    Parent commit (@-)      : rlvkpnrz 7d980be7 a e?? | a
-    Parent commit (@-)      : vruxwmqv 636920e4 d e?? | d
+      nnkkpsqq 5ba56987 e | e
+    Working copy  (@) now at: nkmrtpmo 57904f85 (empty) (no description set)
+    Parent commit (@-)      : ylvkpnrz a1afb583 a e?? | a
+    Parent commit (@-)      : truxwmqv 295a5aee d e?? | d
     Added 0 files, modified 0 files, removed 1 files
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @    [nkm]
+    @    [nkmrt]
     ├─╮
-    │ ○  [vru] d e??
-    │ ○  [roy] c
-    │ │ ○  [zsu] b
+    │ ○  [truxw] d e??
+    │ ○  [ooyxm] c
+    │ │ ○  [psusk] b
     ├───╯
-    ○ │  [rlv] a e??
+    ○ │  [ylvkp] a e??
     ├─╯
-    ◆  [zzz]
+    ◆  [zzzzz]
     [EOF]
     ");
 
@@ -97,24 +97,24 @@ fn test_basics() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Abandoned 2 commits:
-      znkkpsqq 03e0d4bf e | e
-      vruxwmqv 636920e4 d | d
+      nnkkpsqq 5ba56987 e | e
+      truxwmqv 295a5aee d | d
     Deleted bookmarks: d, e
-    Working copy  (@) now at: xtnwkqum 1c70f4d2 (empty) (no description set)
-    Parent commit (@-)      : rlvkpnrz 7d980be7 a | a
-    Parent commit (@-)      : royxmykx c12952d9 c | c
+    Working copy  (@) now at: xtnwkqum a36f99b7 (empty) (no description set)
+    Parent commit (@-)      : ylvkpnrz a1afb583 a | a
+    Parent commit (@-)      : ooyxmykx 8d67ed49 c | c
     Added 0 files, modified 0 files, removed 2 files
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @    [xtn]
+    @    [xtnwk]
     ├─╮
-    │ ○  [roy] c
-    │ │ ○  [zsu] b
+    │ ○  [ooyxm] c
+    │ │ ○  [psusk] b
     ├───╯
-    ○ │  [rlv] a
+    ○ │  [ylvkp] a
     ├─╯
-    ◆  [zzz]
+    ◆  [zzzzz]
     [EOF]
     ");
 
@@ -124,18 +124,18 @@ fn test_basics() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Abandoned 1 commits:
-      zsuskuln 123b4d91 b | b
+      psuskuln dd148a1b b | b
     Deleted bookmarks: b
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @    [znk] e
+    @    [nnkkp] e
     ├─╮
-    │ ○  [vru] d
-    │ ○  [roy] c
-    ○ │  [rlv] a
+    │ ○  [truxw] d
+    │ ○  [ooyxm] c
+    ○ │  [ylvkp] a
     ├─╯
-    ◆  [zzz]
+    ◆  [zzzzz]
     [EOF]
     ");
 
@@ -145,24 +145,24 @@ fn test_basics() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Abandoned 2 commits:
-      znkkpsqq 03e0d4bf e | e
-      vruxwmqv 636920e4 d | d
+      nnkkpsqq 5ba56987 e | e
+      truxwmqv 295a5aee d | d
     Deleted bookmarks: d, e
-    Working copy  (@) now at: xlzxqlsl 55d5c4c2 (empty) (no description set)
-    Parent commit (@-)      : rlvkpnrz 7d980be7 a | a
-    Parent commit (@-)      : royxmykx c12952d9 c | c
+    Working copy  (@) now at: xlzxqlsl 48c7fefa (empty) (no description set)
+    Parent commit (@-)      : ylvkpnrz a1afb583 a | a
+    Parent commit (@-)      : ooyxmykx 8d67ed49 c | c
     Added 0 files, modified 0 files, removed 2 files
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @    [xlz]
+    @    [xlzxq]
     ├─╮
-    │ ○  [roy] c
-    │ │ ○  [zsu] b
+    │ ○  [ooyxm] c
+    │ │ ○  [psusk] b
     ├───╯
-    ○ │  [rlv] a
+    ○ │  [ylvkp] a
     ├─╯
-    ◆  [zzz]
+    ◆  [zzzzz]
     [EOF]
     ");
 
@@ -189,16 +189,16 @@ fn test_abandon_many() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Abandoned 11 commits:
-      kpqxywon 6faec5d1 (empty) commit9
-      znkkpsqq 80f67a53 (empty) commit8
-      yostqsxw 8bd72fcc (empty) commit7
-      vruxwmqv 06c46771 (empty) commit6
-      yqosqzyt 168813e3 (empty) commit5
-      royxmykx bd8c3571 (empty) commit4
-      mzvwutvl 57958fa0 (empty) commit3
-      zsuskuln 59515644 (empty) commit2
-      kkmpptxz a969596d (empty) commit1
-      rlvkpnrz 02fe38c9 (empty) commit0
+      kpqxywon 2903c8b6 (empty) commit9
+      snkkpsqq f825fefa (empty) commit8
+      tostqsxw 552f0060 (empty) commit7
+      vruxwmqv ab1c7c55 (empty) commit6
+      mqosqzyt 43b92eab (empty) commit5
+      ooyxmykx 56237244 (empty) commit4
+      rzvwutvl 24d10c5f (empty) commit3
+      psuskuln 0541396e (empty) commit2
+      nkmpptxz 81825895 (empty) commit1
+      ylvkpnrz 22772eda (empty) commit0
       ...
     Working copy  (@) now at: kmkuslsw a36a913b (empty) (no description set)
     Parent commit (@-)      : zzzzzzzz 00000000 (empty) (no description set)
@@ -225,14 +225,14 @@ fn test_bug_2600() {
 
     // Test the setup
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  [znk] c
-    ○    [vru] b
+    @  [nnkkp] c
+    ○    [truxw] b
     ├─╮
-    │ ○  [roy] a
+    │ ○  [ooyxm] a
     ├─╯
-    ○  [zsu] base
-    ○  [rlv] nottherootcommit
-    ◆  [zzz]
+    ○  [psusk] base
+    ○  [ylvkp] nottherootcommit
+    ◆  [zzzzz]
     [EOF]
     ");
     let setup_opid = work_dir.current_operation_id();
@@ -242,24 +242,24 @@ fn test_bug_2600() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Abandoned 1 commits:
-      zsuskuln 67c2f714 base | base
+      psuskuln 2c0a0f28 base | base
     Deleted bookmarks: base
     Rebased 3 descendant commits onto parents of abandoned commits
-    Working copy  (@) now at: znkkpsqq c1223866 c | c
-    Parent commit (@-)      : vruxwmqv 1dfaa834 b | b
+    Working copy  (@) now at: nnkkpsqq e4e03c6b c | c
+    Parent commit (@-)      : truxwmqv 0b196c6f b | b
     Added 0 files, modified 0 files, removed 1 files
     [EOF]
     ");
     // Commits "a" and "b" should both have "nottherootcommit" as parent, and "b"
     // should keep "a" as second parent.
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  [znk] c
-    ○    [vru] b
+    @  [nnkkp] c
+    ○    [truxw] b
     ├─╮
-    │ ○  [roy] a
+    │ ○  [ooyxm] a
     ├─╯
-    ○  [rlv] nottherootcommit
-    ◆  [zzz]
+    ○  [ylvkp] nottherootcommit
+    ◆  [zzzzz]
     [EOF]
     ");
 
@@ -268,11 +268,11 @@ fn test_bug_2600() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Abandoned 1 commits:
-      royxmykx 183dbbca a | a
+      ooyxmykx 290e5e8d a | a
     Deleted bookmarks: a
     Rebased 2 descendant commits onto parents of abandoned commits
-    Working copy  (@) now at: znkkpsqq f863da3f c | c
-    Parent commit (@-)      : vruxwmqv d7aed853 b | b
+    Working copy  (@) now at: nnkkpsqq 01ebc121 c | c
+    Parent commit (@-)      : truxwmqv 16219805 b | b
     Added 0 files, modified 0 files, removed 1 files
     [EOF]
     ");
@@ -280,11 +280,11 @@ fn test_bug_2600() {
     // pointers to that commit even though it was a merge commit before we abandoned
     // "a".
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  [znk] c
-    ○  [vru] b
-    ○  [zsu] base
-    ○  [rlv] nottherootcommit
-    ◆  [zzz]
+    @  [nnkkp] c
+    ○  [truxw] b
+    ○  [psusk] base
+    ○  [ylvkp] nottherootcommit
+    ◆  [zzzzz]
     [EOF]
     ");
 
@@ -293,64 +293,64 @@ fn test_bug_2600() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Abandoned 1 commits:
-      vruxwmqv cedee197 b | b
+      truxwmqv 41d5097e b | b
     Deleted bookmarks: b
     Rebased 1 descendant commits onto parents of abandoned commits
-    Working copy  (@) now at: znkkpsqq 4dc308fb c | c
-    Parent commit (@-)      : zsuskuln 67c2f714 base | base
-    Parent commit (@-)      : royxmykx 183dbbca a | a
+    Working copy  (@) now at: nnkkpsqq 058d8551 c | c
+    Parent commit (@-)      : psuskuln 2c0a0f28 base | base
+    Parent commit (@-)      : ooyxmykx 290e5e8d a | a
     Added 0 files, modified 0 files, removed 1 files
     [EOF]
     ");
     // Commit "c" should inherit the parents from the abndoned commit "b".
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @    [znk] c
+    @    [nnkkp] c
     ├─╮
-    │ ○  [roy] a
+    │ ○  [ooyxm] a
     ├─╯
-    ○  [zsu] base
-    ○  [rlv] nottherootcommit
-    ◆  [zzz]
+    ○  [psusk] base
+    ○  [ylvkp] nottherootcommit
+    ◆  [zzzzz]
     [EOF]
     ");
 
     work_dir.run_jj(["op", "restore", &setup_opid]).success();
     // ========= Reminder of the setup ===========
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  [znk] c
-    ○    [vru] b
+    @  [nnkkp] c
+    ○    [truxw] b
     ├─╮
-    │ ○  [roy] a
+    │ ○  [ooyxm] a
     ├─╯
-    ○  [zsu] base
-    ○  [rlv] nottherootcommit
-    ◆  [zzz]
+    ○  [psusk] base
+    ○  [ylvkp] nottherootcommit
+    ◆  [zzzzz]
     [EOF]
     ");
     let output = work_dir.run_jj(["abandon", "--retain-bookmarks", "a", "b"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Abandoned 2 commits:
-      vruxwmqv cedee197 b | b
-      royxmykx 183dbbca a | a
+      truxwmqv 41d5097e b | b
+      ooyxmykx 290e5e8d a | a
     Rebased 1 descendant commits onto parents of abandoned commits
-    Working copy  (@) now at: znkkpsqq b350f44b c | c
-    Parent commit (@-)      : zsuskuln 67c2f714 a b base | base
+    Working copy  (@) now at: nnkkpsqq 2289a28e c | c
+    Parent commit (@-)      : psuskuln 2c0a0f28 a b base | base
     Added 0 files, modified 0 files, removed 2 files
     [EOF]
     ");
     // Commit "c" should have "base" as parent. As when we abandoned "a", it should
     // not have two parent pointers to the same commit.
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  [znk] c
-    ○  [zsu] a b base
-    ○  [rlv] nottherootcommit
-    ◆  [zzz]
+    @  [nnkkp] c
+    ○  [psusk] a b base
+    ○  [ylvkp] nottherootcommit
+    ◆  [zzzzz]
     [EOF]
     ");
     let output = work_dir.run_jj(["bookmark", "list", "b"]);
     insta::assert_snapshot!(output, @"
-    b: zsuskuln 67c2f714 base
+    b: psuskuln 2c0a0f28 base
     [EOF]
     ");
 }
@@ -369,13 +369,13 @@ fn test_bug_2600_rootcommit_special_case() {
 
     // Setup
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  [vru] c
-    ○    [roy] b
+    @  [truxw] c
+    ○    [ooyxm] b
     ├─╮
-    │ ○  [zsu] a
+    │ ○  [psusk] a
     ├─╯
-    ○  [rlv] base
-    ◆  [zzz]
+    ○  [ylvkp] base
+    ◆  [zzzzz]
     [EOF]
     ");
 
@@ -398,7 +398,7 @@ fn test_double_abandon() {
     create_commit(&work_dir, "a", &[]);
     // Test the setup
     insta::assert_snapshot!(work_dir.run_jj(["log", "--no-graph", "-r", "a"]), @"
-    rlvkpnrz test.user@example.com 2001-02-03 08:05:09 a 7d980be7
+    ylvkpnrz test.user@example.com 2001-02-03 08:05:09 a a1afb583
     a
     [EOF]
     ");
@@ -413,7 +413,7 @@ fn test_double_abandon() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Abandoned 1 commits:
-      rlvkpnrz 7d980be7 a | a
+      ylvkpnrz a1afb583 a | a
     Deleted bookmarks: a
     Working copy  (@) now at: royxmykx 0cff017c (empty) (no description set)
     Parent commit (@-)      : zzzzzzzz 00000000 (empty) (no description set)
@@ -446,9 +446,9 @@ fn test_abandon_restore_descendants() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Abandoned 1 commits:
-      rlvkpnrz b23f92c3 (no description set)
+      ylvkpnrz ab2bba2b (no description set)
     Rebased 1 descendant commits (while preserving their content) onto parents of abandoned commits
-    Working copy  (@) now at: kkmpptxz 2b575035 (no description set)
+    Working copy  (@) now at: nkmpptxz 2d2eb500 (no description set)
     Parent commit (@-)      : qpvuntsm d0c049cd (no description set)
     [EOF]
     ");
@@ -495,10 +495,10 @@ fn test_abandon_tracking_bookmarks() {
         .run_jj(["bookmark", "set", "-r@", "bar"])
         .success();
     insta::assert_snapshot!(get_log_output(&local_dir), @"
-    @  [zsu] bar
-    │ ○  [qpv] foo
+    @  [zsusk] bar
+    │ ○  [qpvun] foo
     ├─╯
-    ◆  [zzz]
+    ◆  [zzzzz]
     [EOF]
     ");
 
@@ -525,6 +525,6 @@ fn test_abandon_tracking_bookmarks() {
 
 #[must_use]
 fn get_log_output(work_dir: &TestWorkDir) -> CommandOutput {
-    let template = r#"separate(" ", "[" ++ change_id.short(3) ++ "]", bookmarks)"#;
+    let template = r#"separate(" ", "[" ++ change_id.short(5) ++ "]", bookmarks)"#;
     work_dir.run_jj(["log", "-T", template])
 }

--- a/cli/tests/test_absorb_command.rs
+++ b/cli/tests/test_absorb_command.rs
@@ -46,10 +46,10 @@ fn test_absorb_simple() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Absorbed changes into 2 revisions:
-      zsuskuln 95568809 2
-      kkmpptxz bd7d4016 1
-    Working copy  (@) now at: yqosqzyt 977269ac (empty) (no description set)
-    Parent commit (@-)      : zsuskuln 95568809 2
+      psuskuln 0c056974 2
+      nkmpptxz 4d9a0137 1
+    Working copy  (@) now at: yqosqzyt 7f603d94 (empty) (no description set)
+    Parent commit (@-)      : psuskuln 0c056974 2
     [EOF]
     ");
 
@@ -59,10 +59,10 @@ fn test_absorb_simple() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Absorbed changes into 1 revisions:
-      kkmpptxz 5810eb0f 1
+      nkmpptxz 77c93e38 1
     Rebased 1 descendant commits.
-    Working copy  (@) now at: vruxwmqv 48c7d8fa (empty) (no description set)
-    Parent commit (@-)      : zsuskuln 8edd60a2 2
+    Working copy  (@) now at: vruxwmqv 514689f2 (empty) (no description set)
+    Parent commit (@-)      : psuskuln a4ded13e 2
     [EOF]
     ");
 
@@ -72,9 +72,9 @@ fn test_absorb_simple() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Absorbed changes into 1 revisions:
-      zsuskuln dd109863 2
-    Working copy  (@) now at: yostqsxw 7482f74b (empty) (no description set)
-    Parent commit (@-)      : zsuskuln dd109863 2
+      psuskuln a921d371 2
+    Working copy  (@) now at: yostqsxw 3c9fe9e5 (empty) (no description set)
+    Parent commit (@-)      : psuskuln a921d371 2
     [EOF]
     ");
 
@@ -88,7 +88,7 @@ fn test_absorb_simple() {
     ");
 
     insta::assert_snapshot!(get_diffs(&work_dir, "mutable()"), @"
-    @  yostqsxw bde51bc9 (no description set)
+    @  yostqsxw 454dbb8d (no description set)
     │  diff --git a/file1 b/file1
     │  index 8653ca354d..88eb438902 100644
     │  --- a/file1
@@ -100,7 +100,7 @@ fn test_absorb_simple() {
     │  +Y
     │   2a
     │   2Z
-    ○  zsuskuln dd109863 2
+    ○  psuskuln a921d371 2
     │  diff --git a/file1 b/file1
     │  index ed237b5112..8653ca354d 100644
     │  --- a/file1
@@ -111,7 +111,7 @@ fn test_absorb_simple() {
     │   1b
     │  +2a
     │  +2Z
-    ○  kkmpptxz 5810eb0f 1
+    ○  nkmpptxz 77c93e38 1
     │  diff --git a/file1 b/file1
     │  index e69de29bb2..ed237b5112 100644
     │  --- a/file1
@@ -127,30 +127,30 @@ fn test_absorb_simple() {
     [EOF]
     ");
     insta::assert_snapshot!(get_evolog(&work_dir, "subject(1)"), @"
-    ○    kkmpptxz 5810eb0f 1
+    ○    nkmpptxz 77c93e38 1
     ├─╮
-    │ ○  yqosqzyt/0 39b42898 (hidden) (no description set)
-    │ ○  yqosqzyt/1 977269ac (hidden) (empty) (no description set)
-    ○    kkmpptxz/1 bd7d4016 (hidden) 1
+    │ ○  yqosqzyt/0 0671b638 (hidden) (no description set)
+    │ ○  yqosqzyt/1 7f603d94 (hidden) (empty) (no description set)
+    ○    nkmpptxz/1 4d9a0137 (hidden) 1
     ├─╮
-    │ ○  mzvwutvl/0 0b307741 (hidden) (no description set)
-    │ ○  mzvwutvl/1 f2709b4e (hidden) (empty) (no description set)
-    ○  kkmpptxz/2 1553c5e8 (hidden) 1
-    ○  kkmpptxz/3 eb943711 (hidden) (empty) 1
+    │ ○  rzvwutvl/0 920fc1a2 (hidden) (no description set)
+    │ ○  rzvwutvl/1 24d635bf (hidden) (empty) (no description set)
+    ○  nkmpptxz/2 fba67b7f (hidden) 1
+    ○  nkmpptxz/3 b7cae760 (hidden) (empty) 1
     [EOF]
     ");
     insta::assert_snapshot!(get_evolog(&work_dir, "subject(2)"), @"
-    ○    zsuskuln dd109863 2
+    ○    psuskuln a921d371 2
     ├─╮
-    │ ○  vruxwmqv/0 761492a8 (hidden) (no description set)
-    │ ○  vruxwmqv/1 48c7d8fa (hidden) (empty) (no description set)
-    ○  zsuskuln/1 8edd60a2 (hidden) 2
-    ○    zsuskuln/2 95568809 (hidden) 2
+    │ ○  vruxwmqv/0 b6ce19f1 (hidden) (no description set)
+    │ ○  vruxwmqv/1 514689f2 (hidden) (empty) (no description set)
+    ○  psuskuln/1 a4ded13e (hidden) 2
+    ○    psuskuln/2 0c056974 (hidden) 2
     ├─╮
-    │ ○  mzvwutvl/0 0b307741 (hidden) (no description set)
-    │ ○  mzvwutvl/1 f2709b4e (hidden) (empty) (no description set)
-    ○  zsuskuln/3 36fad385 (hidden) 2
-    ○  zsuskuln/4 561fbce9 (hidden) (empty) 2
+    │ ○  rzvwutvl/0 920fc1a2 (hidden) (no description set)
+    │ ○  rzvwutvl/1 24d635bf (hidden) (empty) (no description set)
+    ○  psuskuln/3 2765f110 (hidden) 2
+    ○  psuskuln/4 62522982 (hidden) (empty) 2
     [EOF]
     ");
 }
@@ -176,12 +176,12 @@ fn test_absorb_replace_single_line_hunk() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Absorbed changes into 1 revisions:
-      qpvuntsm 125fba68 (conflict) 1
+      qpvuntsm 48ca8eae (conflict) 1
     Rebased 1 descendant commits.
-    Working copy  (@) now at: mzvwutvl deeb043a (empty) (no description set)
-    Parent commit (@-)      : kkmpptxz 732472fb 2
+    Working copy  (@) now at: mzvwutvl 051a3554 (empty) (no description set)
+    Parent commit (@-)      : nkmpptxz fd5cf161 2
     New conflicts appeared in 1 commits:
-      qpvuntsm 125fba68 (conflict) 1
+      qpvuntsm 48ca8eae (conflict) 1
     Hint: To resolve the conflicts, start by creating a commit on top of
     the conflicted commit:
       jj new qpvuntsm
@@ -192,25 +192,25 @@ fn test_absorb_replace_single_line_hunk() {
     ");
 
     insta::assert_snapshot!(get_diffs(&work_dir, "mutable()"), @r#"
-    @  mzvwutvl deeb043a (empty) (no description set)
-    ○  kkmpptxz 732472fb 2
+    @  mzvwutvl 051a3554 (empty) (no description set)
+    ○  nkmpptxz fd5cf161 2
     │  diff --git a/file1 b/file1
     │  index 0000000000..2f87e8e465 100644
     │  --- a/file1
     │  +++ b/file1
     │  @@ -1,11 +1,3 @@
     │  -<<<<<<< conflict 1 of 1
-    │  -%%%%%%% diff from: kkmpptxz 9d700628 "2" (parents of absorbed revision)
+    │  -%%%%%%% diff from: nkmpptxz 88f716ed "2" (parents of absorbed revision)
     │  -\\\\\\\        to: qpvuntsm aa6cb9bc "1" (absorb destination)
     │  --2a
     │  - 1a
     │  --2b
-    │  -+++++++ absorbed changes (from zsuskuln 5d926f12)
+    │  -+++++++ absorbed changes (from psuskuln 5e4818df)
     │   2a
     │   1A
     │   2b
     │  ->>>>>>> conflict 1 of 1 ends
-    ×  qpvuntsm 125fba68 (conflict) 1
+    ×  qpvuntsm 48ca8eae (conflict) 1
     │  diff --git a/file1 b/file1
     ~  new file mode 100644
        index 0000000000..0000000000
@@ -218,12 +218,12 @@ fn test_absorb_replace_single_line_hunk() {
        +++ b/file1
        @@ -0,0 +1,11 @@
        +<<<<<<< conflict 1 of 1
-       +%%%%%%% diff from: kkmpptxz 9d700628 "2" (parents of absorbed revision)
+       +%%%%%%% diff from: nkmpptxz 88f716ed "2" (parents of absorbed revision)
        +\\\\\\\        to: qpvuntsm aa6cb9bc "1" (absorb destination)
        +-2a
        + 1a
        +-2b
-       ++++++++ absorbed changes (from zsuskuln 5d926f12)
+       ++++++++ absorbed changes (from psuskuln 5e4818df)
        +2a
        +1A
        +2b
@@ -250,9 +250,9 @@ fn test_absorb_merge() {
     let output = work_dir.run_jj(["new", "-m3", "subject(1)", "subject(2)"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: mzvwutvl 42875bf7 (empty) 3
-    Parent commit (@-)      : kkmpptxz 9c66f62f 1
-    Parent commit (@-)      : zsuskuln 6a3dcbcf 2
+    Working copy  (@) now at: rzvwutvl f5f962b5 (empty) 3
+    Parent commit (@-)      : nkmpptxz dfe04031 1
+    Parent commit (@-)      : psuskuln f1b76666 2
     Added 0 files, modified 1 files, removed 0 files
     [EOF]
     ");
@@ -263,12 +263,12 @@ fn test_absorb_merge() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Absorbed changes into 2 revisions:
-      zsuskuln a6fde7ea 2
-      kkmpptxz 00ecc958 1
+      psuskuln e63c9c73 2
+      nkmpptxz 22f900e7 1
     Rebased 1 descendant commits.
-    Working copy  (@) now at: mzvwutvl 30499858 (empty) 3
-    Parent commit (@-)      : kkmpptxz 00ecc958 1
-    Parent commit (@-)      : zsuskuln a6fde7ea 2
+    Working copy  (@) now at: rzvwutvl 72d5d8f6 (empty) 3
+    Parent commit (@-)      : nkmpptxz 22f900e7 1
+    Parent commit (@-)      : psuskuln e63c9c73 2
     [EOF]
     ");
 
@@ -282,15 +282,15 @@ fn test_absorb_merge() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Absorbed changes into 1 revisions:
-      mzvwutvl faf778a4 3
-    Working copy  (@) now at: vruxwmqv cec519a1 (empty) (no description set)
-    Parent commit (@-)      : mzvwutvl faf778a4 3
+      rzvwutvl 5747a2e0 3
+    Working copy  (@) now at: vruxwmqv 584b2efb (empty) (no description set)
+    Parent commit (@-)      : rzvwutvl 5747a2e0 3
     [EOF]
     ");
 
     insta::assert_snapshot!(get_diffs(&work_dir, "mutable()"), @"
-    @  vruxwmqv cec519a1 (empty) (no description set)
-    ○    mzvwutvl faf778a4 3
+    @  vruxwmqv 584b2efb (empty) (no description set)
+    ○    rzvwutvl 5747a2e0 3
     ├─╮  diff --git a/file2 b/file2
     │ │  new file mode 100644
     │ │  index 0000000000..44442d2d7b
@@ -298,7 +298,7 @@ fn test_absorb_merge() {
     │ │  +++ b/file2
     │ │  @@ -0,0 +1,1 @@
     │ │  +3A
-    │ ○  zsuskuln a6fde7ea 2
+    │ ○  psuskuln e63c9c73 2
     │ │  diff --git a/file1 b/file1
     │ │  index eb6e8821f1..4907935b9f 100644
     │ │  --- a/file1
@@ -307,7 +307,7 @@ fn test_absorb_merge() {
     │ │   0a
     │ │  +2a
     │ │  +2B
-    ○ │  kkmpptxz 00ecc958 1
+    ○ │  nkmpptxz 22f900e7 1
     ├─╯  diff --git a/file1 b/file1
     │    index eb6e8821f1..902dd8ef13 100644
     │    --- a/file1
@@ -346,9 +346,9 @@ fn test_absorb_discardable_merge_with_descendant() {
     let output = work_dir.run_jj(["new", "subject(1)", "subject(2)"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: mzvwutvl ad00b91a (empty) (no description set)
-    Parent commit (@-)      : kkmpptxz 9c66f62f 1
-    Parent commit (@-)      : zsuskuln 6a3dcbcf 2
+    Working copy  (@) now at: rzvwutvl 3f769dfb (empty) (no description set)
+    Parent commit (@-)      : nkmpptxz dfe04031 1
+    Parent commit (@-)      : psuskuln f1b76666 2
     Added 0 files, modified 1 files, removed 0 files
     [EOF]
     ");
@@ -363,17 +363,17 @@ fn test_absorb_discardable_merge_with_descendant() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Absorbed changes into 2 revisions:
-      zsuskuln a6cd8e87 2
-      kkmpptxz 98b7d214 1
+      psuskuln 758a8c8f 2
+      nkmpptxz c11e4738 1
     Rebased 1 descendant commits.
-    Working copy  (@) now at: royxmykx df946e9b 3
-    Parent commit (@-)      : kkmpptxz 98b7d214 1
-    Parent commit (@-)      : zsuskuln a6cd8e87 2
+    Working copy  (@) now at: soyxmykx f1656123 3
+    Parent commit (@-)      : nkmpptxz c11e4738 1
+    Parent commit (@-)      : psuskuln 758a8c8f 2
     [EOF]
     ");
 
     insta::assert_snapshot!(get_diffs(&work_dir, "mutable()"), @"
-    @    royxmykx df946e9b 3
+    @    soyxmykx f1656123 3
     ├─╮  diff --git a/file2 b/file2
     │ │  new file mode 100644
     │ │  index 0000000000..31cd755d20
@@ -381,7 +381,7 @@ fn test_absorb_discardable_merge_with_descendant() {
     │ │  +++ b/file2
     │ │  @@ -0,0 +1,1 @@
     │ │  +3a
-    │ ○  zsuskuln a6cd8e87 2
+    │ ○  psuskuln 758a8c8f 2
     │ │  diff --git a/file1 b/file1
     │ │  index eb6e8821f1..4907935b9f 100644
     │ │  --- a/file1
@@ -390,7 +390,7 @@ fn test_absorb_discardable_merge_with_descendant() {
     │ │   0a
     │ │  +2a
     │ │  +2B
-    ○ │  kkmpptxz 98b7d214 1
+    ○ │  nkmpptxz c11e4738 1
     ├─╯  diff --git a/file1 b/file1
     │    index eb6e8821f1..902dd8ef13 100644
     │    --- a/file1
@@ -426,16 +426,16 @@ fn test_absorb_conflict() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Rebased 1 commits to destination
-    Working copy  (@) now at: kkmpptxz 628e2b00 (conflict) (no description set)
+    Working copy  (@) now at: nkmpptxz d9a2b48c (conflict) (no description set)
     Parent commit (@-)      : qpvuntsm e35bcaff 1
     Added 0 files, modified 1 files, removed 0 files
     Warning: There are unresolved conflicts at these paths:
     file1    2-sided conflict
     New conflicts appeared in 1 commits:
-      kkmpptxz 628e2b00 (conflict) (no description set)
+      nkmpptxz d9a2b48c (conflict) (no description set)
     Hint: To resolve the conflicts, start by creating a commit on top of
     the conflicted commit:
-      jj new kkmpptxz
+      jj new nkmpptxz
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you can inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
@@ -449,7 +449,7 @@ fn test_absorb_conflict() {
     \\\\\\\        to: qpvuntsm e35bcaff "1" (rebase destination)
     +1a
     +1b
-    +++++++ kkmpptxz e05db987 (rebased revision)
+    +++++++ nkmpptxz d0657adb (rebased revision)
     2a
     2b
     >>>>>>> conflict 1 of 1 ends
@@ -500,7 +500,7 @@ fn test_absorb_deleted_file() {
     Absorbed changes into 1 revisions:
       qpvuntsm 38af7fd3 1
     Rebased 1 descendant commits.
-    Working copy  (@) now at: kkmpptxz efd883f6 (no description set)
+    Working copy  (@) now at: nkmpptxz 0a3e1516 (no description set)
     Parent commit (@-)      : qpvuntsm 38af7fd3 1
     Remaining changes:
     D file3
@@ -508,7 +508,7 @@ fn test_absorb_deleted_file() {
     ");
 
     insta::assert_snapshot!(get_diffs(&work_dir, "mutable()"), @"
-    @  kkmpptxz efd883f6 (no description set)
+    @  nkmpptxz 0a3e1516 (no description set)
     │  diff --git a/file3 b/file3
     │  deleted file mode 100644
     │  index e69de29bb2..0000000000
@@ -553,14 +553,14 @@ fn test_absorb_deleted_file_with_multiple_hunks() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Absorbed changes into 2 revisions:
-      kkmpptxz 3e1b2472 (conflict) 2
-      qpvuntsm c49bcdd3 (conflict) 1
+      nkmpptxz f65da26b (conflict) 2
+      qpvuntsm 2f3fb785 (conflict) 1
     Rebased 1 descendant commits.
-    Working copy  (@) now at: zsuskuln 9376eb56 (no description set)
-    Parent commit (@-)      : kkmpptxz 3e1b2472 (conflict) 2
+    Working copy  (@) now at: psuskuln fd14dc63 (no description set)
+    Parent commit (@-)      : nkmpptxz f65da26b (conflict) 2
     New conflicts appeared in 2 commits:
-      kkmpptxz 3e1b2472 (conflict) 2
-      qpvuntsm c49bcdd3 (conflict) 1
+      nkmpptxz f65da26b (conflict) 2
+      qpvuntsm 2f3fb785 (conflict) 1
     Hint: To resolve the conflicts, start by creating a commit on top of
     the first conflicted commit:
       jj new qpvuntsm
@@ -573,7 +573,7 @@ fn test_absorb_deleted_file_with_multiple_hunks() {
     ");
 
     insta::assert_snapshot!(get_diffs(&work_dir, "mutable()"), @r#"
-    @  zsuskuln 9376eb56 (no description set)
+    @  psuskuln fd14dc63 (no description set)
     │  diff --git a/file2 b/file2
     │  deleted file mode 100644
     │  index 0000000000..0000000000
@@ -581,14 +581,14 @@ fn test_absorb_deleted_file_with_multiple_hunks() {
     │  +++ /dev/null
     │  @@ -1,8 +0,0 @@
     │  -<<<<<<< conflict 1 of 1
-    │  -%%%%%%% diff from: kkmpptxz 33662096 "2" (parents of absorbed revision)
-    │  -\\\\\\\        to: kkmpptxz 33662096 "2" (absorb destination)
+    │  -%%%%%%% diff from: nkmpptxz e9447767 "2" (parents of absorbed revision)
+    │  -\\\\\\\        to: nkmpptxz e9447767 "2" (absorb destination)
     │  --1a
     │  - 1b
-    │  -+++++++ absorbed changes (from zsuskuln d6492c8f)
+    │  -+++++++ absorbed changes (from psuskuln 77b1664e)
     │  -1a
     │  ->>>>>>> conflict 1 of 1 ends
-    ×  kkmpptxz 3e1b2472 (conflict) 2
+    ×  nkmpptxz f65da26b (conflict) 2
     │  diff --git a/file1 b/file1
     │  deleted file mode 100644
     │  index 0000000000..0000000000
@@ -596,29 +596,29 @@ fn test_absorb_deleted_file_with_multiple_hunks() {
     │  +++ /dev/null
     │  @@ -1,7 +0,0 @@
     │  -<<<<<<< conflict 1 of 1
-    │  -%%%%%%% diff from: kkmpptxz 33662096 "2" (parents of absorbed revision)
+    │  -%%%%%%% diff from: nkmpptxz e9447767 "2" (parents of absorbed revision)
     │  -\\\\\\\        to: qpvuntsm 66b2ce5b "1" (absorb destination)
     │  - 1a
     │  -+1b
-    │  -+++++++ absorbed changes (from zsuskuln d6492c8f)
+    │  -+++++++ absorbed changes (from psuskuln 77b1664e)
     │  ->>>>>>> conflict 1 of 1 ends
     │  diff --git a/file2 b/file2
     │  --- a/file2
     │  +++ b/file2
     │  @@ -1,8 +1,8 @@
     │   <<<<<<< conflict 1 of 1
-    │   %%%%%%% diff from: kkmpptxz 33662096 "2" (parents of absorbed revision)
+    │   %%%%%%% diff from: nkmpptxz e9447767 "2" (parents of absorbed revision)
     │  -\\\\\\\        to: qpvuntsm 66b2ce5b "1" (absorb destination)
     │  - 1a
     │  --1b
-    │  +\\\\\\\        to: kkmpptxz 33662096 "2" (absorb destination)
+    │  +\\\\\\\        to: nkmpptxz e9447767 "2" (absorb destination)
     │  +-1a
     │  + 1b
-    │   +++++++ absorbed changes (from zsuskuln d6492c8f)
+    │   +++++++ absorbed changes (from psuskuln 77b1664e)
     │  -1b
     │  +1a
     │   >>>>>>> conflict 1 of 1 ends
-    ×  qpvuntsm c49bcdd3 (conflict) 1
+    ×  qpvuntsm 2f3fb785 (conflict) 1
     │  diff --git a/file1 b/file1
     ~  new file mode 100644
        index 0000000000..0000000000
@@ -626,11 +626,11 @@ fn test_absorb_deleted_file_with_multiple_hunks() {
        +++ b/file1
        @@ -0,0 +1,7 @@
        +<<<<<<< conflict 1 of 1
-       +%%%%%%% diff from: kkmpptxz 33662096 "2" (parents of absorbed revision)
+       +%%%%%%% diff from: nkmpptxz e9447767 "2" (parents of absorbed revision)
        +\\\\\\\        to: qpvuntsm 66b2ce5b "1" (absorb destination)
        + 1a
        ++1b
-       ++++++++ absorbed changes (from zsuskuln d6492c8f)
+       ++++++++ absorbed changes (from psuskuln 77b1664e)
        +>>>>>>> conflict 1 of 1 ends
        diff --git a/file2 b/file2
        new file mode 100644
@@ -639,11 +639,11 @@ fn test_absorb_deleted_file_with_multiple_hunks() {
        +++ b/file2
        @@ -0,0 +1,8 @@
        +<<<<<<< conflict 1 of 1
-       +%%%%%%% diff from: kkmpptxz 33662096 "2" (parents of absorbed revision)
+       +%%%%%%% diff from: nkmpptxz e9447767 "2" (parents of absorbed revision)
        +\\\\\\\        to: qpvuntsm 66b2ce5b "1" (absorb destination)
        + 1a
        +-1b
-       ++++++++ absorbed changes (from zsuskuln d6492c8f)
+       ++++++++ absorbed changes (from psuskuln 77b1664e)
        +1b
        +>>>>>>> conflict 1 of 1 ends
     [EOF]
@@ -672,7 +672,7 @@ fn test_absorb_file_mode() {
     Absorbed changes into 1 revisions:
       qpvuntsm 2a0c7f1d 1
     Rebased 1 descendant commits.
-    Working copy  (@) now at: zsuskuln 8ca9761d (no description set)
+    Working copy  (@) now at: psuskuln 925e709c (no description set)
     Parent commit (@-)      : qpvuntsm 2a0c7f1d 1
     Remaining changes:
     M file1
@@ -680,7 +680,7 @@ fn test_absorb_file_mode() {
     ");
 
     insta::assert_snapshot!(get_diffs(&work_dir, "mutable()"), @"
-    @  zsuskuln 8ca9761d (no description set)
+    @  psuskuln 925e709c (no description set)
     │  diff --git a/file1 b/file1
     │  old mode 100755
     │  new mode 100644
@@ -716,17 +716,17 @@ fn test_absorb_from_into() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Absorbed changes into 1 revisions:
-      kkmpptxz cae507ef 2
+      nkmpptxz fcebd2e6 2
     Rebased 1 descendant commits.
-    Working copy  (@) now at: zsuskuln f02fd9ea (no description set)
-    Parent commit (@-)      : kkmpptxz cae507ef 2
+    Working copy  (@) now at: psuskuln e3a70cc4 (no description set)
+    Parent commit (@-)      : nkmpptxz fcebd2e6 2
     Remaining changes:
     M file1
     [EOF]
     ");
 
     insta::assert_snapshot!(get_diffs(&work_dir, "@-::"), @"
-    @  zsuskuln f02fd9ea (no description set)
+    @  psuskuln e3a70cc4 (no description set)
     │  diff --git a/file1 b/file1
     │  index faf62af049..c2d0b12547 100644
     │  --- a/file1
@@ -739,7 +739,7 @@ fn test_absorb_from_into() {
     │   1c
     │   2b
     │   Z
-    ○  kkmpptxz cae507ef 2
+    ○  nkmpptxz fcebd2e6 2
     │  diff --git a/file1 b/file1
     ~  index 352e9b3794..faf62af049 100644
        --- a/file1
@@ -761,15 +761,15 @@ fn test_absorb_from_into() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Absorbed changes into 1 revisions:
-      rlvkpnrz ddaed33d 1
+      ylvkpnrz 57ca49d7 1
     Rebased 2 descendant commits.
-    Working copy  (@) now at: zsuskuln 3652e5e5 (no description set)
-    Parent commit (@-)      : kkmpptxz 7f4339e7 (empty) 2
+    Working copy  (@) now at: psuskuln fbdb1ba9 (no description set)
+    Parent commit (@-)      : nkmpptxz 53b94fc0 (empty) 2
     [EOF]
     ");
 
     insta::assert_snapshot!(get_diffs(&work_dir, "mutable()"), @"
-    @  zsuskuln 3652e5e5 (no description set)
+    @  psuskuln fbdb1ba9 (no description set)
     │  diff --git a/file1 b/file1
     │  index faf62af049..c2d0b12547 100644
     │  --- a/file1
@@ -782,8 +782,8 @@ fn test_absorb_from_into() {
     │   1c
     │   2b
     │   Z
-    ○  kkmpptxz 7f4339e7 (empty) 2
-    ○  rlvkpnrz ddaed33d 1
+    ○  nkmpptxz 53b94fc0 (empty) 2
+    ○  ylvkpnrz 57ca49d7 1
     │  diff --git a/file1 b/file1
     │  new file mode 100644
     │  index 0000000000..faf62af049
@@ -833,7 +833,7 @@ fn test_absorb_paths() {
     Absorbed changes into 1 revisions:
       qpvuntsm ca07fabe 1
     Rebased 1 descendant commits.
-    Working copy  (@) now at: kkmpptxz 4d80ada8 (no description set)
+    Working copy  (@) now at: nkmpptxz 52cfdaa4 (no description set)
     Parent commit (@-)      : qpvuntsm ca07fabe 1
     Remaining changes:
     M file2
@@ -841,7 +841,7 @@ fn test_absorb_paths() {
     ");
 
     insta::assert_snapshot!(get_diffs(&work_dir, "mutable()"), @"
-    @  kkmpptxz 4d80ada8 (no description set)
+    @  nkmpptxz 52cfdaa4 (no description set)
     │  diff --git a/file2 b/file2
     │  index a8994dc188..268de3f3ec 100644
     │  --- a/file2
@@ -892,10 +892,10 @@ fn test_absorb_immutable() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Absorbed changes into 1 revisions:
-      kkmpptxz e68cc3e2 2
+      nkmpptxz 974aaab6 2
     Rebased 1 descendant commits.
-    Working copy  (@) now at: mzvwutvl 88443af7 (no description set)
-    Parent commit (@-)      : kkmpptxz e68cc3e2 2
+    Working copy  (@) now at: pzvwutvl 171aa6df (no description set)
+    Parent commit (@-)      : nkmpptxz 974aaab6 2
     Remaining changes:
     M file1
     [EOF]
@@ -917,7 +917,7 @@ fn test_absorb_immutable() {
     "#);
 
     insta::assert_snapshot!(get_diffs(&work_dir, ".."), @"
-    @  mzvwutvl 88443af7 (no description set)
+    @  pzvwutvl 171aa6df (no description set)
     │  diff --git a/file1 b/file1
     │  index 75e4047831..428796ca20 100644
     │  --- a/file1
@@ -928,7 +928,7 @@ fn test_absorb_immutable() {
     │   1b
     │   2a
     │   2B
-    ○  kkmpptxz e68cc3e2 2
+    ○  nkmpptxz 974aaab6 2
     │  diff --git a/file1 b/file1
     │  index 8c5268f893..75e4047831 100644
     │  --- a/file1

--- a/cli/tests/test_arrange_command.rs
+++ b/cli/tests/test_arrange_command.rs
@@ -38,7 +38,7 @@ fn test_arrange_bad_revisions() {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Error: Cannot arrange revset with gaps in.
-    Hint: Revision 123b4d91f6e5 would need to be in the set.
+    Hint: Revision dd148a1be8f0 would need to be in the set.
     [EOF]
     [exit status: 1]
     ");
@@ -48,7 +48,7 @@ fn test_arrange_bad_revisions() {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Error: Cannot arrange revset with gaps in.
-    Hint: Revision 123b4d91f6e5 would need to be in the set.
+    Hint: Revision dd148a1be8f0 would need to be in the set.
     [EOF]
     [exit status: 1]
     ");
@@ -58,7 +58,7 @@ fn test_arrange_bad_revisions() {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Error: Cannot arrange revset with gaps in.
-    Hint: Revision 123b4d91f6e5 would need to be in the set.
+    Hint: Revision dd148a1be8f0 would need to be in the set.
     [EOF]
     [exit status: 1]
     ");
@@ -68,7 +68,7 @@ fn test_arrange_bad_revisions() {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Error: Cannot arrange revset with gaps in.
-    Hint: Revision 123b4d91f6e5 would need to be in the set.
+    Hint: Revision dd148a1be8f0 would need to be in the set.
     [EOF]
     [exit status: 1]
     ");

--- a/cli/tests/test_bisect_command.rs
+++ b/cli/tests/test_bisect_command.rs
@@ -73,37 +73,37 @@ fn test_bisect_run() -> TestResult {
     std::fs::write(&bisection_script, ["fail"].join("\0"))?;
     insta::assert_snapshot!(work_dir.run_jj(["bisect", "run", "--range=..", &bisector_path]), @"
     Bisecting: 5 revisions left to test after this (roughly 3 steps)
-    Now evaluating: royxmykx dffaa0d4 c | c
-    fake-bisector testing commit dffaa0d4daccf6cee70bac3498fae3b3fd5d6b5b
+    Now evaluating: ooyxmykx 26c624f4 c | c
+    fake-bisector testing commit 26c624f4f2a7c2f9bc22924698172f94245aaa35
     The revision is bad.
 
     Bisecting: 2 revisions left to test after this (roughly 2 steps)
-    Now evaluating: rlvkpnrz 7d980be7 a | a
-    fake-bisector testing commit 7d980be7a1d499e4d316ab4c01242885032f7eaf
+    Now evaluating: ylvkpnrz a1afb583 a | a
+    fake-bisector testing commit a1afb5834d8ee4dcb61b59db0f682c7a53f96f53
     The revision is bad.
 
     Search complete. To discard any revisions created during search, run:
-      jj op restore 6f4b9c7057b1
-    The first bad revision is: rlvkpnrz 7d980be7 a | a
+      jj op restore b4e8abf5e7b2
+    The first bad revision is: ylvkpnrz a1afb583 a | a
     [EOF]
     ------- stderr -------
-    Working copy  (@) now at: lylxulpl 68b3a16f (empty) (no description set)
-    Parent commit (@-)      : royxmykx dffaa0d4 c | c
+    Working copy  (@) now at: lylxulpl 0120f5b7 (empty) (no description set)
+    Parent commit (@-)      : ooyxmykx 26c624f4 c | c
     Added 0 files, modified 0 files, removed 3 files
-    Working copy  (@) now at: rsllmpnm 5f328bc5 (empty) (no description set)
-    Parent commit (@-)      : rlvkpnrz 7d980be7 a | a
+    Working copy  (@) now at: rsllmpnm 750510fa (empty) (no description set)
+    Parent commit (@-)      : ylvkpnrz a1afb583 a | a
     Added 0 files, modified 0 files, removed 2 files
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  rsllmpnmslon 5f328bc5fde0 '' files:
-    │ ○  kmkuslswpqwq 8b67af288466 'f' files: f
-    │ ○  znkkpsqqskkl 62d30ded0e8f 'e' files: e
-    │ ○  vruxwmqvtpmx 86be7a223919 'd' files: d
-    │ ○  royxmykxtrkr dffaa0d4dacc 'c' files: c
-    │ ○  zsuskulnrvyr 123b4d91f6e5 'b' files: b
+    @  rsllmpnmslon 750510fa4b31 '' files:
+    │ ○  wmkuslswpqwq dd4393d7d8e1 'f' files: f
+    │ ○  nnkkpsqqskkl 0cd0d3a4354b 'e' files: e
+    │ ○  truxwmqvtpmx e87eb7e7ce86 'd' files: d
+    │ ○  ooyxmykxtrkr 26c624f4f2a7 'c' files: c
+    │ ○  psuskulnrvyr dd148a1be8f0 'b' files: b
     ├─╯
-    ○  rlvkpnrzqnoo 7d980be7a1d4 'a' files: a
+    ○  ylvkpnrzqnoo a1afb5834d8e 'a' files: a
     ◆  zzzzzzzzzzzz 000000000000 '' files:
     [EOF]
     ");
@@ -113,23 +113,23 @@ fn test_bisect_run() -> TestResult {
     // Testing only stderr to avoid a variable op id in the stdout.
     insta::assert_snapshot!(work_dir.run_jj(["bisect", "run", "--range=..", "--command", &bisector_path]).success().stderr, @"
     Warning: `--command` is deprecated; use positional arguments instead: `jj bisect run --range=... -- $FAKE_BISECTOR_PATH`
-    Working copy  (@) now at: nkmrtpmo 1601f7b4 (empty) (no description set)
-    Parent commit (@-)      : royxmykx dffaa0d4 c | c
+    Working copy  (@) now at: nkmrtpmo 959aed7c (empty) (no description set)
+    Parent commit (@-)      : ooyxmykx 26c624f4 c | c
     Added 2 files, modified 0 files, removed 0 files
-    Working copy  (@) now at: ruktrxxu fb9e625c (empty) (no description set)
-    Parent commit (@-)      : rlvkpnrz 7d980be7 a | a
+    Working copy  (@) now at: ruktrxxu fbf4b3a0 (empty) (no description set)
+    Parent commit (@-)      : ylvkpnrz a1afb583 a | a
     Added 0 files, modified 0 files, removed 2 files
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  ruktrxxusqqp fb9e625c1023 '' files:
-    │ ○  kmkuslswpqwq 8b67af288466 'f' files: f
-    │ ○  znkkpsqqskkl 62d30ded0e8f 'e' files: e
-    │ ○  vruxwmqvtpmx 86be7a223919 'd' files: d
-    │ ○  royxmykxtrkr dffaa0d4dacc 'c' files: c
-    │ ○  zsuskulnrvyr 123b4d91f6e5 'b' files: b
+    @  ruktrxxusqqp fbf4b3a025e8 '' files:
+    │ ○  wmkuslswpqwq dd4393d7d8e1 'f' files: f
+    │ ○  nnkkpsqqskkl 0cd0d3a4354b 'e' files: e
+    │ ○  truxwmqvtpmx e87eb7e7ce86 'd' files: d
+    │ ○  ooyxmykxtrkr 26c624f4f2a7 'c' files: c
+    │ ○  psuskulnrvyr dd148a1be8f0 'b' files: b
     ├─╯
-    ○  rlvkpnrzqnoo 7d980be7a1d4 'a' files: a
+    ○  ylvkpnrzqnoo a1afb5834d8e 'a' files: a
     ◆  zzzzzzzzzzzz 000000000000 '' files:
     [EOF]
     ");
@@ -153,37 +153,37 @@ fn test_bisect_run_find_first_good() {
 
     insta::assert_snapshot!(work_dir.run_jj(["bisect", "run", "--range=..", "--find-good", &bisector_path]), @"
     Bisecting: 5 revisions left to test after this (roughly 3 steps)
-    Now evaluating: royxmykx dffaa0d4 c | c
-    fake-bisector testing commit dffaa0d4daccf6cee70bac3498fae3b3fd5d6b5b
+    Now evaluating: ooyxmykx 26c624f4 c | c
+    fake-bisector testing commit 26c624f4f2a7c2f9bc22924698172f94245aaa35
     The revision is good.
 
     Bisecting: 2 revisions left to test after this (roughly 2 steps)
-    Now evaluating: rlvkpnrz 7d980be7 a | a
-    fake-bisector testing commit 7d980be7a1d499e4d316ab4c01242885032f7eaf
+    Now evaluating: ylvkpnrz a1afb583 a | a
+    fake-bisector testing commit a1afb5834d8ee4dcb61b59db0f682c7a53f96f53
     The revision is good.
 
     Search complete. To discard any revisions created during search, run:
-      jj op restore 6f4b9c7057b1
-    The first good revision is: rlvkpnrz 7d980be7 a | a
+      jj op restore b4e8abf5e7b2
+    The first good revision is: ylvkpnrz a1afb583 a | a
     [EOF]
     ------- stderr -------
-    Working copy  (@) now at: lylxulpl 68b3a16f (empty) (no description set)
-    Parent commit (@-)      : royxmykx dffaa0d4 c | c
+    Working copy  (@) now at: lylxulpl 0120f5b7 (empty) (no description set)
+    Parent commit (@-)      : ooyxmykx 26c624f4 c | c
     Added 0 files, modified 0 files, removed 3 files
-    Working copy  (@) now at: rsllmpnm 5f328bc5 (empty) (no description set)
-    Parent commit (@-)      : rlvkpnrz 7d980be7 a | a
+    Working copy  (@) now at: rsllmpnm 750510fa (empty) (no description set)
+    Parent commit (@-)      : ylvkpnrz a1afb583 a | a
     Added 0 files, modified 0 files, removed 2 files
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  rsllmpnmslon 5f328bc5fde0 '' files:
-    │ ○  kmkuslswpqwq 8b67af288466 'f' files: f
-    │ ○  znkkpsqqskkl 62d30ded0e8f 'e' files: e
-    │ ○  vruxwmqvtpmx 86be7a223919 'd' files: d
-    │ ○  royxmykxtrkr dffaa0d4dacc 'c' files: c
-    │ ○  zsuskulnrvyr 123b4d91f6e5 'b' files: b
+    @  rsllmpnmslon 750510fa4b31 '' files:
+    │ ○  wmkuslswpqwq dd4393d7d8e1 'f' files: f
+    │ ○  nnkkpsqqskkl 0cd0d3a4354b 'e' files: e
+    │ ○  truxwmqvtpmx e87eb7e7ce86 'd' files: d
+    │ ○  ooyxmykxtrkr 26c624f4f2a7 'c' files: c
+    │ ○  psuskulnrvyr dd148a1be8f0 'b' files: b
     ├─╯
-    ○  rlvkpnrzqnoo 7d980be7a1d4 'a' files: a
+    ○  ylvkpnrzqnoo a1afb5834d8e 'a' files: a
     ◆  zzzzzzzzzzzz 000000000000 '' files:
     [EOF]
     ");
@@ -206,11 +206,11 @@ fn test_bisect_run_missing_bisector() {
     if cfg!(unix) {
         insta::assert_snapshot!(output, @r"
         Bisecting: 5 revisions left to test after this (roughly 3 steps)
-        Now evaluating: royxmykx dffaa0d4 c | c
+        Now evaluating: ooyxmykx 26c624f4 c | c
         [EOF]
         ------- stderr -------
-        Working copy  (@) now at: lylxulpl 68b3a16f (empty) (no description set)
-        Parent commit (@-)      : royxmykx dffaa0d4 c | c
+        Working copy  (@) now at: lylxulpl 0120f5b7 (empty) (no description set)
+        Parent commit (@-)      : ooyxmykx 26c624f4 c | c
         Added 0 files, modified 0 files, removed 3 files
         Error: Failed to run evaluation command
         Caused by: No such file or directory (os error 2)
@@ -220,11 +220,11 @@ fn test_bisect_run_missing_bisector() {
     } else if cfg!(windows) {
         insta::assert_snapshot!(output, @"
         Bisecting: 5 revisions left to test after this (roughly 3 steps)
-        Now evaluating: royxmykx dffaa0d4 c | c
+        Now evaluating: ooyxmykx 26c624f4 c | c
         [EOF]
         ------- stderr -------
-        Working copy  (@) now at: lylxulpl 68b3a16f (empty) (no description set)
-        Parent commit (@-)      : royxmykx dffaa0d4 c | c
+        Working copy  (@) now at: lylxulpl 0120f5b7 (empty) (no description set)
+        Parent commit (@-)      : ooyxmykx 26c624f4 c | c
         Added 0 files, modified 0 files, removed 3 files
         Error: Failed to run evaluation command
         Caused by: program not found
@@ -251,45 +251,45 @@ fn test_bisect_run_with_args() {
 
     insta::assert_snapshot!(work_dir.run_jj(["bisect", "run", "--range=..", "--find-good", "--", &bisector_path, "--require-file=c"]), @"
     Bisecting: 5 revisions left to test after this (roughly 3 steps)
-    Now evaluating: royxmykx dffaa0d4 c | c
-    fake-bisector testing commit dffaa0d4daccf6cee70bac3498fae3b3fd5d6b5b
+    Now evaluating: ooyxmykx 26c624f4 c | c
+    fake-bisector testing commit 26c624f4f2a7c2f9bc22924698172f94245aaa35
     The revision is good.
 
     Bisecting: 2 revisions left to test after this (roughly 2 steps)
-    Now evaluating: rlvkpnrz 7d980be7 a | a
-    fake-bisector testing commit 7d980be7a1d499e4d316ab4c01242885032f7eaf
+    Now evaluating: ylvkpnrz a1afb583 a | a
+    fake-bisector testing commit a1afb5834d8ee4dcb61b59db0f682c7a53f96f53
     The revision is bad.
 
     Bisecting: 1 revisions left to test after this (roughly 1 steps)
-    Now evaluating: zsuskuln 123b4d91 b | b
-    fake-bisector testing commit 123b4d91f6e5e39bfed39bae3bacf9380dc79078
+    Now evaluating: psuskuln dd148a1b b | b
+    fake-bisector testing commit dd148a1be8f066ab36432210eec075e69aefef49
     The revision is bad.
 
     Search complete. To discard any revisions created during search, run:
-      jj op restore 6f4b9c7057b1
-    The first good revision is: royxmykx dffaa0d4 c | c
+      jj op restore b4e8abf5e7b2
+    The first good revision is: ooyxmykx 26c624f4 c | c
     [EOF]
     ------- stderr -------
-    Working copy  (@) now at: lylxulpl 68b3a16f (empty) (no description set)
-    Parent commit (@-)      : royxmykx dffaa0d4 c | c
+    Working copy  (@) now at: lylxulpl 0120f5b7 (empty) (no description set)
+    Parent commit (@-)      : ooyxmykx 26c624f4 c | c
     Added 0 files, modified 0 files, removed 3 files
-    Working copy  (@) now at: rsllmpnm 5f328bc5 (empty) (no description set)
-    Parent commit (@-)      : rlvkpnrz 7d980be7 a | a
+    Working copy  (@) now at: rsllmpnm 750510fa (empty) (no description set)
+    Parent commit (@-)      : ylvkpnrz a1afb583 a | a
     Added 0 files, modified 0 files, removed 2 files
-    Working copy  (@) now at: zqsquwqt 042badd2 (empty) (no description set)
-    Parent commit (@-)      : zsuskuln 123b4d91 b | b
+    Working copy  (@) now at: zqsquwqt d89179d3 (empty) (no description set)
+    Parent commit (@-)      : psuskuln dd148a1b b | b
     Added 1 files, modified 0 files, removed 0 files
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  zqsquwqtrvts 042badd28c1d '' files:
-    │ ○  kmkuslswpqwq 8b67af288466 'f' files: f
-    │ ○  znkkpsqqskkl 62d30ded0e8f 'e' files: e
-    │ ○  vruxwmqvtpmx 86be7a223919 'd' files: d
-    │ ○  royxmykxtrkr dffaa0d4dacc 'c' files: c
+    @  zqsquwqtrvts d89179d31512 '' files:
+    │ ○  wmkuslswpqwq dd4393d7d8e1 'f' files: f
+    │ ○  nnkkpsqqskkl 0cd0d3a4354b 'e' files: e
+    │ ○  truxwmqvtpmx e87eb7e7ce86 'd' files: d
+    │ ○  ooyxmykxtrkr 26c624f4f2a7 'c' files: c
     ├─╯
-    ○  zsuskulnrvyr 123b4d91f6e5 'b' files: b
-    ○  rlvkpnrzqnoo 7d980be7a1d4 'a' files: a
+    ○  psuskulnrvyr dd148a1be8f0 'b' files: b
+    ○  ylvkpnrzqnoo a1afb5834d8e 'a' files: a
     ◆  zzzzzzzzzzzz 000000000000 '' files:
     [EOF]
     ");
@@ -314,25 +314,25 @@ fn test_bisect_run_crash() -> TestResult {
     std::fs::write(&bisection_script, ["crash"].join("\0"))?;
     insta::assert_snapshot!(work_dir.run_jj(["bisect", "run", "--range=..", &bisector_path]), @"
     Bisecting: 5 revisions left to test after this (roughly 3 steps)
-    Now evaluating: royxmykx dffaa0d4 c | c
-    fake-bisector testing commit dffaa0d4daccf6cee70bac3498fae3b3fd5d6b5b
+    Now evaluating: ooyxmykx 26c624f4 c | c
+    fake-bisector testing commit 26c624f4f2a7c2f9bc22924698172f94245aaa35
     The revision is bad.
 
     Bisecting: 2 revisions left to test after this (roughly 2 steps)
-    Now evaluating: rlvkpnrz 7d980be7 a | a
-    fake-bisector testing commit 7d980be7a1d499e4d316ab4c01242885032f7eaf
+    Now evaluating: ylvkpnrz a1afb583 a | a
+    fake-bisector testing commit a1afb5834d8ee4dcb61b59db0f682c7a53f96f53
     The revision is bad.
 
     Search complete. To discard any revisions created during search, run:
-      jj op restore 6f4b9c7057b1
-    The first bad revision is: rlvkpnrz 7d980be7 a | a
+      jj op restore b4e8abf5e7b2
+    The first bad revision is: ylvkpnrz a1afb583 a | a
     [EOF]
     ------- stderr -------
-    Working copy  (@) now at: lylxulpl 68b3a16f (empty) (no description set)
-    Parent commit (@-)      : royxmykx dffaa0d4 c | c
+    Working copy  (@) now at: lylxulpl 0120f5b7 (empty) (no description set)
+    Parent commit (@-)      : ooyxmykx 26c624f4 c | c
     Added 0 files, modified 0 files, removed 3 files
-    Working copy  (@) now at: rsllmpnm 5f328bc5 (empty) (no description set)
-    Parent commit (@-)      : rlvkpnrz 7d980be7 a | a
+    Working copy  (@) now at: rsllmpnm 750510fa (empty) (no description set)
+    Parent commit (@-)      : ylvkpnrz a1afb583 a | a
     Added 0 files, modified 0 files, removed 2 files
     [EOF]
     ");
@@ -355,16 +355,16 @@ fn test_bisect_run_abort() -> TestResult {
     std::fs::write(&bisection_script, ["abort"].join("\0"))?;
     insta::assert_snapshot!(work_dir.run_jj(["bisect", "run", "--range=..", &bisector_path]), @"
     Bisecting: 2 revisions left to test after this (roughly 2 steps)
-    Now evaluating: rlvkpnrz 7d980be7 a | a
-    fake-bisector testing commit 7d980be7a1d499e4d316ab4c01242885032f7eaf
+    Now evaluating: ylvkpnrz a1afb583 a | a
+    fake-bisector testing commit a1afb5834d8ee4dcb61b59db0f682c7a53f96f53
     Evaluation command returned 127 (command not found) - aborting bisection.
 
     Search complete. To discard any revisions created during search, run:
-      jj op restore e229f77ca8de
+      jj op restore ab395827f1de
     [EOF]
     ------- stderr -------
-    Working copy  (@) now at: vruxwmqv 538d9e7f (empty) (no description set)
-    Parent commit (@-)      : rlvkpnrz 7d980be7 a | a
+    Working copy  (@) now at: vruxwmqv 680590b7 (empty) (no description set)
+    Parent commit (@-)      : ylvkpnrz a1afb583 a | a
     Added 0 files, modified 0 files, removed 2 files
     Error: Bisection aborted
     [EOF]
@@ -388,17 +388,17 @@ fn test_bisect_run_skip() -> TestResult {
     std::fs::write(&bisection_script, ["skip"].join("\0"))?;
     insta::assert_snapshot!(work_dir.run_jj(["bisect", "run", "--range=..", &bisector_path]), @"
     Bisecting: 1 revisions left to test after this (roughly 1 steps)
-    Now evaluating: rlvkpnrz 7d980be7 a | a
-    fake-bisector testing commit 7d980be7a1d499e4d316ab4c01242885032f7eaf
+    Now evaluating: ylvkpnrz a1afb583 a | a
+    fake-bisector testing commit a1afb5834d8ee4dcb61b59db0f682c7a53f96f53
     It could not be determined if the revision is good or bad.
 
     Search complete. To discard any revisions created during search, run:
-      jj op restore 07d6c9360663
-    The first bad revision is: zsuskuln 123b4d91 b | b
+      jj op restore ba9728ecc7c5
+    The first bad revision is: psuskuln dd148a1b b | b
     [EOF]
     ------- stderr -------
-    Working copy  (@) now at: royxmykx 2144134b (empty) (no description set)
-    Parent commit (@-)      : rlvkpnrz 7d980be7 a | a
+    Working copy  (@) now at: royxmykx ad414a38 (empty) (no description set)
+    Parent commit (@-)      : ylvkpnrz a1afb583 a | a
     Added 0 files, modified 0 files, removed 1 files
     [EOF]
     ");
@@ -421,27 +421,27 @@ fn test_bisect_run_multiple_results() {
 
     insta::assert_snapshot!(work_dir.run_jj(["bisect", "run", "--range=a|b|c|d", &bisector_path]), @"
     Bisecting: 2 revisions left to test after this (roughly 2 steps)
-    Now evaluating: rlvkpnrz 7d980be7 a | a
-    fake-bisector testing commit 7d980be7a1d499e4d316ab4c01242885032f7eaf
+    Now evaluating: ylvkpnrz a1afb583 a | a
+    fake-bisector testing commit a1afb5834d8ee4dcb61b59db0f682c7a53f96f53
     The revision is good.
 
     Bisecting: 1 revisions left to test after this (roughly 1 steps)
-    Now evaluating: royxmykx 991a7501 c | c
-    fake-bisector testing commit 991a7501d660abb6a80e8b00f77c651d76d845d7
+    Now evaluating: ooyxmykx 45ee1acd c | c
+    fake-bisector testing commit 45ee1acd6076b9fb29763ef077fd51adfb3eee6c
     The revision is good.
 
     Search complete. To discard any revisions created during search, run:
-      jj op restore 854a7d496ee7
+      jj op restore 1967458ead7b
     The first bad revisions are:
-    vruxwmqv a2dbb1aa d | d
-    zsuskuln 123b4d91 b | b
+    truxwmqv 278414ea d | d
+    psuskuln dd148a1b b | b
     [EOF]
     ------- stderr -------
-    Working copy  (@) now at: znkkpsqq 1b117fe7 (empty) (no description set)
-    Parent commit (@-)      : rlvkpnrz 7d980be7 a | a
+    Working copy  (@) now at: znkkpsqq 88ec4f47 (empty) (no description set)
+    Parent commit (@-)      : ylvkpnrz a1afb583 a | a
     Added 0 files, modified 0 files, removed 2 files
-    Working copy  (@) now at: uuzqqzqu 6bf5f5e7 (empty) (no description set)
-    Parent commit (@-)      : royxmykx 991a7501 c | c
+    Working copy  (@) now at: uuzqqzqu d3f77fc4 (empty) (no description set)
+    Parent commit (@-)      : ooyxmykx 45ee1acd c | c
     Added 1 files, modified 0 files, removed 0 files
     [EOF]
     ");
@@ -467,38 +467,38 @@ fn test_bisect_run_write_file() -> TestResult {
     )?;
     insta::assert_snapshot!(work_dir.run_jj(["bisect", "run", "--range=..", &bisector_path]), @"
     Bisecting: 4 revisions left to test after this (roughly 3 steps)
-    Now evaluating: zsuskuln 123b4d91 b | b
-    fake-bisector testing commit 123b4d91f6e5e39bfed39bae3bacf9380dc79078
+    Now evaluating: psuskuln dd148a1b b | b
+    fake-bisector testing commit dd148a1be8f066ab36432210eec075e69aefef49
     The revision is bad.
 
     Bisecting: 1 revisions left to test after this (roughly 1 steps)
-    Now evaluating: rlvkpnrz 7d980be7 a | a
-    fake-bisector testing commit 7d980be7a1d499e4d316ab4c01242885032f7eaf
+    Now evaluating: ylvkpnrz a1afb583 a | a
+    fake-bisector testing commit a1afb5834d8ee4dcb61b59db0f682c7a53f96f53
     The revision is bad.
 
     Search complete. To discard any revisions created during search, run:
-      jj op restore 621116e08872
-    The first bad revision is: rlvkpnrz 7d980be7 a | a
+      jj op restore f4784f88004a
+    The first bad revision is: ylvkpnrz a1afb583 a | a
     [EOF]
     ------- stderr -------
-    Working copy  (@) now at: kmkuslsw 17e2a972 (empty) (no description set)
-    Parent commit (@-)      : zsuskuln 123b4d91 b | b
+    Working copy  (@) now at: kmkuslsw 1b61b030 (empty) (no description set)
+    Parent commit (@-)      : psuskuln dd148a1b b | b
     Added 0 files, modified 0 files, removed 3 files
-    Working copy  (@) now at: msksykpx 2f6e298d (empty) (no description set)
-    Parent commit (@-)      : rlvkpnrz 7d980be7 a | a
+    Working copy  (@) now at: msksykpx 27fab395 (empty) (no description set)
+    Parent commit (@-)      : ylvkpnrz a1afb583 a | a
     Added 0 files, modified 0 files, removed 2 files
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  msksykpxotkr 891aeb03b623 '' files: new-file
-    │ ○  kmkuslswpqwq 2bae881dc1bc '' files: new-file
-    │ │ ○  znkkpsqqskkl 62d30ded0e8f 'e' files: e
-    │ │ ○  vruxwmqvtpmx 86be7a223919 'd' files: d
-    │ │ ○  royxmykxtrkr dffaa0d4dacc 'c' files: c
+    @  msksykpxotkr b96eaf357888 '' files: new-file
+    │ ○  kmkuslswpqwq 8c70693e7499 '' files: new-file
+    │ │ ○  nnkkpsqqskkl 0cd0d3a4354b 'e' files: e
+    │ │ ○  truxwmqvtpmx e87eb7e7ce86 'd' files: d
+    │ │ ○  ooyxmykxtrkr 26c624f4f2a7 'c' files: c
     │ ├─╯
-    │ ○  zsuskulnrvyr 123b4d91f6e5 'b' files: b
+    │ ○  psuskulnrvyr dd148a1be8f0 'b' files: b
     ├─╯
-    ○  rlvkpnrzqnoo 7d980be7a1d4 'a' files: a
+    ○  ylvkpnrzqnoo a1afb5834d8e 'a' files: a
     ◆  zzzzzzzzzzzz 000000000000 '' files:
     [EOF]
     ");
@@ -507,10 +507,10 @@ fn test_bisect_run_write_file() -> TestResult {
     let output = work_dir.run_jj(["op", "log", "-n=5", "-T=description"]);
     insta::assert_snapshot!(output, @"
     @  snapshot working copy
-    ○  Updated to revision 7d980be7a1d499e4d316ab4c01242885032f7eaf for bisection
+    ○  Updated to revision a1afb5834d8ee4dcb61b59db0f682c7a53f96f53 for bisection
     ○  snapshot working copy
-    ○  Updated to revision 123b4d91f6e5e39bfed39bae3bacf9380dc79078 for bisection
-    ○  create bookmark e pointing to commit 62d30ded0e8fdf8cf87012e6223898b97977fc8e
+    ○  Updated to revision dd148a1be8f066ab36432210eec075e69aefef49 for bisection
+    ○  create bookmark e pointing to commit 0cd0d3a4354bd9ae486b7bf7bca0c04de119ba94
     [EOF]
     ");
     Ok(())
@@ -533,44 +533,44 @@ fn test_bisect_run_jj_command() -> TestResult {
     std::fs::write(&bisection_script, ["jj new -mtesting", "fail"].join("\0"))?;
     insta::assert_snapshot!(work_dir.run_jj(["bisect", "run", "--range=..", &bisector_path]), @"
     Bisecting: 4 revisions left to test after this (roughly 3 steps)
-    Now evaluating: zsuskuln 123b4d91 b | b
-    fake-bisector testing commit 123b4d91f6e5e39bfed39bae3bacf9380dc79078
+    Now evaluating: psuskuln dd148a1b b | b
+    fake-bisector testing commit dd148a1be8f066ab36432210eec075e69aefef49
     The revision is bad.
 
     Bisecting: 1 revisions left to test after this (roughly 1 steps)
-    Now evaluating: rlvkpnrz 7d980be7 a | a
-    fake-bisector testing commit 7d980be7a1d499e4d316ab4c01242885032f7eaf
+    Now evaluating: ylvkpnrz a1afb583 a | a
+    fake-bisector testing commit a1afb5834d8ee4dcb61b59db0f682c7a53f96f53
     The revision is bad.
 
     Search complete. To discard any revisions created during search, run:
-      jj op restore 621116e08872
-    The first bad revision is: rlvkpnrz 7d980be7 a | a
+      jj op restore f4784f88004a
+    The first bad revision is: ylvkpnrz a1afb583 a | a
     [EOF]
     ------- stderr -------
-    Working copy  (@) now at: kmkuslsw 17e2a972 (empty) (no description set)
-    Parent commit (@-)      : zsuskuln 123b4d91 b | b
+    Working copy  (@) now at: kmkuslsw 1b61b030 (empty) (no description set)
+    Parent commit (@-)      : psuskuln dd148a1b b | b
     Added 0 files, modified 0 files, removed 3 files
-    Working copy  (@) now at: kmkuslsw/0 55b3b4a8 (divergent) (empty) testing
-    Parent commit (@-)      : kmkuslsw/1 17e2a972 (divergent) (empty) (no description set)
-    Working copy  (@) now at: msksykpx 2f6e298d (empty) (no description set)
-    Parent commit (@-)      : rlvkpnrz 7d980be7 a | a
+    Working copy  (@) now at: wmkuslsw 9f916afb (empty) testing
+    Parent commit (@-)      : kmkuslsw 1b61b030 (empty) (no description set)
+    Working copy  (@) now at: msksykpx 27fab395 (empty) (no description set)
+    Parent commit (@-)      : ylvkpnrz a1afb583 a | a
     Added 0 files, modified 0 files, removed 1 files
-    Working copy  (@) now at: kmkuslsw/0 2f80658c (divergent) (empty) testing
-    Parent commit (@-)      : msksykpx 2f6e298d (empty) (no description set)
+    Working copy  (@) now at: xmkuslsw 5acfc6c3 (empty) testing
+    Parent commit (@-)      : msksykpx 27fab395 (empty) (no description set)
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  kmkuslswpqwq 2f80658c4d26 'testing' files:
-    ○  msksykpxotkr 2f6e298d59bd '' files:
-    │ ○  kmkuslswpqwq 55b3b4a8b253 'testing' files:
-    │ ○  kmkuslswpqwq 17e2a9721f61 '' files:
-    │ │ ○  znkkpsqqskkl 62d30ded0e8f 'e' files: e
-    │ │ ○  vruxwmqvtpmx 86be7a223919 'd' files: d
-    │ │ ○  royxmykxtrkr dffaa0d4dacc 'c' files: c
+    @  xmkuslswpqwq 5acfc6c308c2 'testing' files:
+    ○  msksykpxotkr 27fab395ffae '' files:
+    │ ○  wmkuslswpqwq 9f916afb1c77 'testing' files:
+    │ ○  kmkuslswpqwq 1b61b030fef0 '' files:
+    │ │ ○  nnkkpsqqskkl 0cd0d3a4354b 'e' files: e
+    │ │ ○  truxwmqvtpmx e87eb7e7ce86 'd' files: d
+    │ │ ○  ooyxmykxtrkr 26c624f4f2a7 'c' files: c
     │ ├─╯
-    │ ○  zsuskulnrvyr 123b4d91f6e5 'b' files: b
+    │ ○  psuskulnrvyr dd148a1be8f0 'b' files: b
     ├─╯
-    ○  rlvkpnrzqnoo 7d980be7a1d4 'a' files: a
+    ○  ylvkpnrzqnoo a1afb5834d8e 'a' files: a
     ◆  zzzzzzzzzzzz 000000000000 '' files:
     [EOF]
     ");
@@ -579,10 +579,10 @@ fn test_bisect_run_jj_command() -> TestResult {
     let output = work_dir.run_jj(["op", "log", "-n=5", "-T=description"]);
     insta::assert_snapshot!(output, @"
     @  new empty commit
-    ○  Updated to revision 7d980be7a1d499e4d316ab4c01242885032f7eaf for bisection
+    ○  Updated to revision a1afb5834d8ee4dcb61b59db0f682c7a53f96f53 for bisection
     ○  new empty commit
-    ○  Updated to revision 123b4d91f6e5e39bfed39bae3bacf9380dc79078 for bisection
-    ○  create bookmark e pointing to commit 62d30ded0e8fdf8cf87012e6223898b97977fc8e
+    ○  Updated to revision dd148a1be8f066ab36432210eec075e69aefef49 for bisection
+    ○  create bookmark e pointing to commit 0cd0d3a4354bd9ae486b7bf7bca0c04de119ba94
     [EOF]
     ");
     Ok(())

--- a/cli/tests/test_bookmark_command.rs
+++ b/cli/tests/test_bookmark_command.rs
@@ -66,11 +66,11 @@ fn test_bookmark_multiple_names() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Warning: Target revision is empty.
-    Moved 2 bookmarks to zsuskuln 0e555a27 bar foo | (empty) (no description set)
+    Moved 2 bookmarks to psuskuln c590b1c4 bar foo | (empty) (no description set)
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  bar foo 0e555a27ac99
+    @  bar foo c590b1c4cf0f
     ○   e8849ae12c70
     ◆   000000000000
     [EOF]
@@ -83,7 +83,7 @@ fn test_bookmark_multiple_names() {
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @   0e555a27ac99
+    @   c590b1c4cf0f
     ○   e8849ae12c70
     ◆   000000000000
     [EOF]
@@ -103,8 +103,8 @@ fn test_bookmark_multiple_names() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Warning: Target revision is empty.
-    Created 1 bookmarks pointing to zsuskuln 0e555a27 bar baz | (empty) (no description set)
-    Moved 1 bookmarks to zsuskuln 0e555a27 bar baz | (empty) (no description set)
+    Created 1 bookmarks pointing to psuskuln c590b1c4 bar baz | (empty) (no description set)
+    Moved 1 bookmarks to psuskuln c590b1c4 bar baz | (empty) (no description set)
     [EOF]
     ");
 
@@ -113,7 +113,7 @@ fn test_bookmark_multiple_names() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Warning: Target revision is empty.
-    Moved 1 bookmarks to zsuskuln 0e555a27 bar baz foo | (empty) (no description set)
+    Moved 1 bookmarks to psuskuln c590b1c4 bar baz foo | (empty) (no description set)
     [EOF]
     ");
 }
@@ -286,7 +286,7 @@ fn test_bookmark_move() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Warning: Target revision is empty.
-    Moved 1 bookmarks to mzvwutvl 8afc18ff foo | (empty) (no description set)
+    Moved 1 bookmarks to pzvwutvl e6d58305 foo | (empty) (no description set)
     [EOF]
     ");
 
@@ -311,7 +311,7 @@ fn test_bookmark_move() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Warning: Target revision is empty.
-    Moved 1 bookmarks to mzvwutvl 8afc18ff foo | (empty) (no description set)
+    Moved 1 bookmarks to pzvwutvl e6d58305 foo | (empty) (no description set)
     [EOF]
     ");
 
@@ -357,11 +357,11 @@ fn test_bookmark_move() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Warning: Target revision is empty.
-    Moved 1 bookmarks to mzvwutvl 91b59745 foo* | (empty) (no description set)
+    Moved 1 bookmarks to pzvwutvl 9ec33bfb foo* | (empty) (no description set)
     [EOF]
     ");
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @"
-    foo: mzvwutvl 91b59745 (empty) (no description set)
+    foo: pzvwutvl 9ec33bfb (empty) (no description set)
       @origin (behind by 1 commits): qpvuntsm 5f3ceb1e (empty) commit
     [EOF]
     ");
@@ -373,11 +373,11 @@ fn test_bookmark_move() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Warning: Target revision is empty.
-    Created 1 bookmarks pointing to mzvwutvl 91b59745 foo | (empty) (no description set)
+    Created 1 bookmarks pointing to pzvwutvl 9ec33bfb foo | (empty) (no description set)
     [EOF]
     ");
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @"
-    foo: mzvwutvl 91b59745 (empty) (no description set)
+    foo: pzvwutvl 9ec33bfb (empty) (no description set)
     foo@origin: qpvuntsm 5f3ceb1e (empty) commit
     [EOF]
     ");
@@ -399,10 +399,10 @@ fn test_bookmark_move_matching() {
     work_dir.run_jj(["bookmark", "create", "c1"]).success();
     work_dir.run_jj(["new", "-mhead2"]).success();
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @   0dd9a4b12283
-    ○  c1 2cbf65662e56
-    ○  b1 c2934cfbfb19
-    │ ○   9328ecc52471
+    @   147864bc17cc
+    ○  c1 60d6e961968f
+    ○  b1 78fad9fc172e
+    │ ○   fcb89834c3e5
     │ ○  a1 a2 e8849ae12c70
     ├─╯
     ◆   000000000000
@@ -452,15 +452,15 @@ fn test_bookmark_move_matching() {
     let output = work_dir.run_jj(["bookmark", "move", "--from=::@"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Moved 2 bookmarks to vruxwmqv 0dd9a4b1 b1 c1 | (empty) head2
+    Moved 2 bookmarks to uruxwmqv 147864bc b1 c1 | (empty) head2
     Hint: Specify bookmark by name to update just one of the bookmarks.
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  b1 c1 0dd9a4b12283
-    ○   2cbf65662e56
-    ○   c2934cfbfb19
-    │ ○   9328ecc52471
+    @  b1 c1 147864bc17cc
+    ○   60d6e961968f
+    ○   78fad9fc172e
+    │ ○   fcb89834c3e5
     │ ○  a1 a2 e8849ae12c70
     ├─╯
     ◆   000000000000
@@ -472,14 +472,14 @@ fn test_bookmark_move_matching() {
     let output = work_dir.run_jj(["bookmark", "move", "b1", "c1"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Moved 2 bookmarks to vruxwmqv 0dd9a4b1 b1 c1 | (empty) head2
+    Moved 2 bookmarks to uruxwmqv 147864bc b1 c1 | (empty) head2
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  b1 c1 0dd9a4b12283
-    ○   2cbf65662e56
-    ○   c2934cfbfb19
-    │ ○   9328ecc52471
+    @  b1 c1 147864bc17cc
+    ○   60d6e961968f
+    ○   78fad9fc172e
+    │ ○   fcb89834c3e5
     │ ○  a1 a2 e8849ae12c70
     ├─╯
     ◆   000000000000
@@ -497,10 +497,10 @@ fn test_bookmark_move_matching() {
     [exit status: 1]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @   0dd9a4b12283
-    ○  c1 2cbf65662e56
-    ○  b1 c2934cfbfb19
-    │ ○   9328ecc52471
+    @   147864bc17cc
+    ○  c1 60d6e961968f
+    ○  b1 78fad9fc172e
+    │ ○   fcb89834c3e5
     │ ○  a1 a2 e8849ae12c70
     ├─╯
     ◆   000000000000
@@ -511,14 +511,14 @@ fn test_bookmark_move_matching() {
     let output = work_dir.run_jj(["bookmark", "move", "--from=::a1+", "--to=a1+", "'?1'"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Moved 1 bookmarks to kkmpptxz 9328ecc5 a1 | (empty) head1
+    Moved 1 bookmarks to nkmpptxz fcb89834 a1 | (empty) head1
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @   0dd9a4b12283
-    ○  c1 2cbf65662e56
-    ○  b1 c2934cfbfb19
-    │ ○  a1 9328ecc52471
+    @   147864bc17cc
+    ○  c1 60d6e961968f
+    ○  b1 78fad9fc172e
+    │ ○  a1 fcb89834c3e5
     │ ○  a2 e8849ae12c70
     ├─╯
     ◆   000000000000
@@ -577,7 +577,7 @@ fn test_bookmark_move_conflicting() {
     let output = work_dir.run_jj(["bookmark", "set", "-rsubject(A1)", "foo"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Moved 1 bookmarks to mzvwutvl 0f5f3e2c foo | (empty) A1
+    Moved 1 bookmarks to qzvwutvl dbffe920 foo | (empty) A1
     [EOF]
     ");
     insta::assert_snapshot!(get_log(), @"
@@ -669,7 +669,7 @@ fn test_bookmark_rename() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Changes to push to origin:
-      bookmark: bremote2 [add to 1e76d54fcfce]
+      bookmark: bremote2 [add to 5555adc17845]
     [EOF]
     ");
     work_dir
@@ -761,18 +761,18 @@ fn test_bookmark_rename_overwrite() {
         .success();
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @"
     DST: qpvuntsm b3bfa1df (empty) DST
-    SRC: zsuskuln 1acdc981 (empty) SRC
-    a-absent-tracked: zsuskuln 1acdc981 (empty) SRC
+    SRC: psuskuln ed05e306 (empty) SRC
+    a-absent-tracked: psuskuln ed05e306 (empty) SRC
       @origin (not created yet)
-    a-present-tracked: zsuskuln 1acdc981 (empty) SRC
-      @origin: zsuskuln 1acdc981 (empty) SRC
-    a-present-untracked: zsuskuln 1acdc981 (empty) SRC
-    a-present-untracked@origin: zsuskuln 1acdc981 (empty) SRC
-    b-absent-tracked: zsuskuln 1acdc981 (empty) SRC
+    a-present-tracked: psuskuln ed05e306 (empty) SRC
+      @origin: psuskuln ed05e306 (empty) SRC
+    a-present-untracked: psuskuln ed05e306 (empty) SRC
+    a-present-untracked@origin: psuskuln ed05e306 (empty) SRC
+    b-absent-tracked: psuskuln ed05e306 (empty) SRC
       @origin (not created yet)
-    c-absent-tracked: zsuskuln 1acdc981 (empty) SRC
+    c-absent-tracked: psuskuln ed05e306 (empty) SRC
       @origin (not created yet)
-    d-absent-tracked: zsuskuln 1acdc981 (empty) SRC
+    d-absent-tracked: psuskuln ed05e306 (empty) SRC
       @origin (not created yet)
     [EOF]
     ");
@@ -807,15 +807,15 @@ fn test_bookmark_rename_overwrite() {
     insta::assert_snapshot!(output, @"");
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @"
     DST: qpvuntsm b3bfa1df (empty) DST
-    SRC: zsuskuln 1acdc981 (empty) SRC
+    SRC: psuskuln ed05e306 (empty) SRC
     a-present-tracked (deleted)
-      @origin: zsuskuln 1acdc981 (empty) SRC
-    a-present-untracked@origin: zsuskuln 1acdc981 (empty) SRC
-    b-absent-tracked: zsuskuln 1acdc981 (empty) SRC
+      @origin: psuskuln ed05e306 (empty) SRC
+    a-present-untracked@origin: psuskuln ed05e306 (empty) SRC
+    b-absent-tracked: psuskuln ed05e306 (empty) SRC
       @origin (not created yet)
-    c-absent-tracked: zsuskuln 1acdc981 (empty) SRC
+    c-absent-tracked: psuskuln ed05e306 (empty) SRC
       @origin (not created yet)
-    d-absent-tracked: zsuskuln 1acdc981 (empty) SRC
+    d-absent-tracked: psuskuln ed05e306 (empty) SRC
     [EOF]
     ");
     work_dir.run_jj(["op", "restore", &setup_opid]).success();
@@ -823,13 +823,13 @@ fn test_bookmark_rename_overwrite() {
     // Overwrite absent, untracked (non-existent) bookmarks
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @"
     DST: qpvuntsm b3bfa1df (empty) DST
-    SRC: zsuskuln 1acdc981 (empty) SRC
-    a-absent-tracked: zsuskuln 1acdc981 (empty) SRC
+    SRC: psuskuln ed05e306 (empty) SRC
+    a-absent-tracked: psuskuln ed05e306 (empty) SRC
       @origin (not created yet)
-    a-present-tracked: zsuskuln 1acdc981 (empty) SRC
-      @origin: zsuskuln 1acdc981 (empty) SRC
-    a-present-untracked: zsuskuln 1acdc981 (empty) SRC
-    a-present-untracked@origin: zsuskuln 1acdc981 (empty) SRC
+    a-present-tracked: psuskuln ed05e306 (empty) SRC
+      @origin: psuskuln ed05e306 (empty) SRC
+    a-present-untracked: psuskuln ed05e306 (empty) SRC
+    a-present-untracked@origin: psuskuln ed05e306 (empty) SRC
     [EOF]
     ");
     let output = work_dir.run_jj([
@@ -863,15 +863,15 @@ fn test_bookmark_rename_overwrite() {
     insta::assert_snapshot!(output, @"");
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @"
     DST: qpvuntsm b3bfa1df (empty) DST
-    SRC: zsuskuln 1acdc981 (empty) SRC
+    SRC: psuskuln ed05e306 (empty) SRC
     a-present-tracked (deleted)
-      @origin: zsuskuln 1acdc981 (empty) SRC
-    a-present-untracked@origin: zsuskuln 1acdc981 (empty) SRC
-    b-absent-untracked: zsuskuln 1acdc981 (empty) SRC
+      @origin: psuskuln ed05e306 (empty) SRC
+    a-present-untracked@origin: psuskuln ed05e306 (empty) SRC
+    b-absent-untracked: psuskuln ed05e306 (empty) SRC
       @origin (not created yet)
-    c-absent-untracked: zsuskuln 1acdc981 (empty) SRC
+    c-absent-untracked: psuskuln ed05e306 (empty) SRC
       @origin (not created yet)
-    d-absent-untracked: zsuskuln 1acdc981 (empty) SRC
+    d-absent-untracked: psuskuln ed05e306 (empty) SRC
     [EOF]
     ");
     work_dir.run_jj(["op", "restore", &setup_opid]).success();
@@ -888,13 +888,13 @@ fn test_bookmark_rename_overwrite() {
         .success();
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @"
     DST: qpvuntsm b3bfa1df (empty) DST
-    SRC: zsuskuln 1acdc981 (empty) SRC
-    a-absent-tracked: zsuskuln 1acdc981 (empty) SRC
+    SRC: psuskuln ed05e306 (empty) SRC
+    a-absent-tracked: psuskuln ed05e306 (empty) SRC
       @origin (not created yet)
-    a-present-tracked: zsuskuln 1acdc981 (empty) SRC
-      @origin: zsuskuln 1acdc981 (empty) SRC
-    a-present-untracked: zsuskuln 1acdc981 (empty) SRC
-    a-present-untracked@origin: zsuskuln 1acdc981 (empty) SRC
+    a-present-tracked: psuskuln ed05e306 (empty) SRC
+      @origin: psuskuln ed05e306 (empty) SRC
+    a-present-untracked: psuskuln ed05e306 (empty) SRC
+    a-present-untracked@origin: psuskuln ed05e306 (empty) SRC
     b-present-tracked: qpvuntsm b3bfa1df (empty) DST
       @origin: qpvuntsm b3bfa1df (empty) DST
     c-present-tracked: qpvuntsm b3bfa1df (empty) DST
@@ -946,15 +946,15 @@ fn test_bookmark_rename_overwrite() {
     ");
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @"
     DST: qpvuntsm b3bfa1df (empty) DST
-    SRC: zsuskuln 1acdc981 (empty) SRC
+    SRC: psuskuln ed05e306 (empty) SRC
     a-present-tracked (deleted)
-      @origin: zsuskuln 1acdc981 (empty) SRC
-    a-present-untracked@origin: zsuskuln 1acdc981 (empty) SRC
-    b-present-tracked: zsuskuln 1acdc981 (empty) SRC
+      @origin: psuskuln ed05e306 (empty) SRC
+    a-present-untracked@origin: psuskuln ed05e306 (empty) SRC
+    b-present-tracked: psuskuln ed05e306 (empty) SRC
     b-present-tracked@origin: qpvuntsm b3bfa1df (empty) DST
-    c-present-tracked: zsuskuln 1acdc981 (empty) SRC
+    c-present-tracked: psuskuln ed05e306 (empty) SRC
     c-present-tracked@origin: qpvuntsm b3bfa1df (empty) DST
-    d-present-tracked: zsuskuln 1acdc981 (empty) SRC
+    d-present-tracked: psuskuln ed05e306 (empty) SRC
     d-present-tracked@origin: qpvuntsm b3bfa1df (empty) DST
     [EOF]
     ");
@@ -975,13 +975,13 @@ fn test_bookmark_rename_overwrite() {
         .success();
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @"
     DST: qpvuntsm b3bfa1df (empty) DST
-    SRC: zsuskuln 1acdc981 (empty) SRC
-    a-absent-tracked: zsuskuln 1acdc981 (empty) SRC
+    SRC: psuskuln ed05e306 (empty) SRC
+    a-absent-tracked: psuskuln ed05e306 (empty) SRC
       @origin (not created yet)
-    a-present-tracked: zsuskuln 1acdc981 (empty) SRC
-      @origin: zsuskuln 1acdc981 (empty) SRC
-    a-present-untracked: zsuskuln 1acdc981 (empty) SRC
-    a-present-untracked@origin: zsuskuln 1acdc981 (empty) SRC
+    a-present-tracked: psuskuln ed05e306 (empty) SRC
+      @origin: psuskuln ed05e306 (empty) SRC
+    a-present-untracked: psuskuln ed05e306 (empty) SRC
+    a-present-untracked@origin: psuskuln ed05e306 (empty) SRC
     b-present-untracked: qpvuntsm b3bfa1df (empty) DST
     b-present-untracked@origin: qpvuntsm b3bfa1df (empty) DST
     c-present-untracked: qpvuntsm b3bfa1df (empty) DST
@@ -1028,15 +1028,15 @@ fn test_bookmark_rename_overwrite() {
     insta::assert_snapshot!(output, @"");
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @"
     DST: qpvuntsm b3bfa1df (empty) DST
-    SRC: zsuskuln 1acdc981 (empty) SRC
+    SRC: psuskuln ed05e306 (empty) SRC
     a-present-tracked (deleted)
-      @origin: zsuskuln 1acdc981 (empty) SRC
-    a-present-untracked@origin: zsuskuln 1acdc981 (empty) SRC
-    b-present-untracked: zsuskuln 1acdc981 (empty) SRC
+      @origin: psuskuln ed05e306 (empty) SRC
+    a-present-untracked@origin: psuskuln ed05e306 (empty) SRC
+    b-present-untracked: psuskuln ed05e306 (empty) SRC
     b-present-untracked@origin: qpvuntsm b3bfa1df (empty) DST
-    c-present-untracked: zsuskuln 1acdc981 (empty) SRC
+    c-present-untracked: psuskuln ed05e306 (empty) SRC
     c-present-untracked@origin: qpvuntsm b3bfa1df (empty) DST
-    d-present-untracked: zsuskuln 1acdc981 (empty) SRC
+    d-present-untracked: psuskuln ed05e306 (empty) SRC
     d-present-untracked@origin: qpvuntsm b3bfa1df (empty) DST
     [EOF]
     ");
@@ -1088,7 +1088,7 @@ fn test_bookmark_rename_colocated() {
     insta::assert_snapshot!(output, @"
     bpushed: qpvuntsm f18f73f2 (empty) commit-0
       @git: qpvuntsm f18f73f2 (empty) commit-0
-    bpushed@origin: royxmykx b6e46c10 (empty) commit-1
+    bpushed@origin: poyxmykx bdae5c18 (empty) commit-1
     [EOF]
     ");
 }
@@ -1310,7 +1310,7 @@ fn test_bookmark_delete_export() {
     let output = work_dir.run_jj(["bookmark", "list", "--all-remotes"]);
     insta::assert_snapshot!(output, @"
     foo (deleted)
-      @git: rlvkpnrz 43444d88 (empty) (no description set)
+      @git: ylvkpnrz e521ae80 (empty) (no description set)
     [EOF]
     ------- stderr -------
     Hint: Bookmarks marked as deleted will be deleted from the underlying Git repo on the next `jj git export`.
@@ -1330,7 +1330,7 @@ fn test_bookmark_forget_export() {
     work_dir.run_jj(["new"]).success();
     work_dir.run_jj(["bookmark", "create", "foo"]).success();
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @"
-    foo: rlvkpnrz 43444d88 (empty) (no description set)
+    foo: ylvkpnrz e521ae80 (empty) (no description set)
     [EOF]
     ");
 
@@ -2316,14 +2316,14 @@ fn test_bookmark_list() -> TestResult {
     // default
     let output = local_dir.run_jj(["bookmark", "list"]);
     insta::assert_snapshot!(output, @"
-    absent-tracked: wqnwkozp 0353dd35 (empty) local-only
+    absent-tracked: vqnwkozp c36f69fc (empty) local-only
       @origin (not created yet)
-    local-only: wqnwkozp 0353dd35 (empty) local-only
+    local-only: vqnwkozp c36f69fc (empty) local-only
     remote-delete (deleted)
-      @origin: vruxwmqv b32031cf (empty) remote-delete
-    remote-sync: rlvkpnrz 7a07dbee (empty) remote-sync
-    remote-unsync: wqnwkozp 0353dd35 (empty) local-only
-      @origin (ahead by 1 commits, behind by 1 commits): zsuskuln 553203ba (empty) remote-unsync
+      @origin: truxwmqv 9d47d6bb (empty) remote-delete
+    remote-sync: ylvkpnrz 552ea326 (empty) remote-sync
+    remote-unsync: vqnwkozp c36f69fc (empty) local-only
+      @origin (ahead by 1 commits, behind by 1 commits): psuskuln d957151e (empty) remote-unsync
     [EOF]
     ------- stderr -------
     Hint: Bookmarks marked as deleted can be *deleted permanently* on the remote by running `jj git push --deleted`. Use `jj bookmark forget` if you don't want that.
@@ -2332,16 +2332,16 @@ fn test_bookmark_list() -> TestResult {
 
     let output = local_dir.run_jj(["bookmark", "list", "--all-remotes"]);
     insta::assert_snapshot!(output, @"
-    absent-tracked: wqnwkozp 0353dd35 (empty) local-only
+    absent-tracked: vqnwkozp c36f69fc (empty) local-only
       @origin (not created yet)
-    local-only: wqnwkozp 0353dd35 (empty) local-only
+    local-only: vqnwkozp c36f69fc (empty) local-only
     remote-delete (deleted)
-      @origin: vruxwmqv b32031cf (empty) remote-delete
-    remote-sync: rlvkpnrz 7a07dbee (empty) remote-sync
-      @origin: rlvkpnrz 7a07dbee (empty) remote-sync
-    remote-unsync: wqnwkozp 0353dd35 (empty) local-only
-      @origin (ahead by 1 commits, behind by 1 commits): zsuskuln 553203ba (empty) remote-unsync
-    remote-untrack@origin: royxmykx 149bc756 (empty) remote-untrack
+      @origin: truxwmqv 9d47d6bb (empty) remote-delete
+    remote-sync: ylvkpnrz 552ea326 (empty) remote-sync
+      @origin: ylvkpnrz 552ea326 (empty) remote-sync
+    remote-unsync: vqnwkozp c36f69fc (empty) local-only
+      @origin (ahead by 1 commits, behind by 1 commits): psuskuln d957151e (empty) remote-unsync
+    remote-untrack@origin: ooyxmykx 2b839a01 (empty) remote-untrack
     [EOF]
     ------- stderr -------
     Hint: Bookmarks marked as deleted can be *deleted permanently* on the remote by running `jj git push --deleted`. Use `jj bookmark forget` if you don't want that.
@@ -2350,16 +2350,16 @@ fn test_bookmark_list() -> TestResult {
 
     let output = local_dir.run_jj(["bookmark", "list", "--all-remotes", "--color=always"]);
     insta::assert_snapshot!(output, @"
-    [38;5;5mabsent-tracked[39m: [1m[38;5;13mw[38;5;8mqnwkozp[39m [38;5;12m03[38;5;8m53dd35[39m [38;5;10m(empty)[39m local-only[0m
+    [38;5;5mabsent-tracked[39m: [1m[38;5;13mv[38;5;8mqnwkozp[39m [38;5;12mc[38;5;8m36f69fc[39m [38;5;10m(empty)[39m local-only[0m
       [38;5;5m@origin[39m (not created yet)
-    [38;5;5mlocal-only[39m: [1m[38;5;13mw[38;5;8mqnwkozp[39m [38;5;12m03[38;5;8m53dd35[39m [38;5;10m(empty)[39m local-only[0m
+    [38;5;5mlocal-only[39m: [1m[38;5;13mv[38;5;8mqnwkozp[39m [38;5;12mc[38;5;8m36f69fc[39m [38;5;10m(empty)[39m local-only[0m
     [38;5;5mremote-delete[39m (deleted)
-      [38;5;5m@origin[39m: [1m[38;5;5mv[0m[38;5;8mruxwmqv[39m [1m[38;5;4mb[0m[38;5;8m32031cf[39m [38;5;2m(empty)[39m remote-delete
-    [38;5;5mremote-sync[39m: [1m[38;5;5mr[0m[38;5;8mlvkpnrz[39m [1m[38;5;4m7[0m[38;5;8ma07dbee[39m [38;5;2m(empty)[39m remote-sync
-      [38;5;5m@origin[39m: [1m[38;5;5mr[0m[38;5;8mlvkpnrz[39m [1m[38;5;4m7[0m[38;5;8ma07dbee[39m [38;5;2m(empty)[39m remote-sync
-    [38;5;5mremote-unsync[39m: [1m[38;5;13mw[38;5;8mqnwkozp[39m [38;5;12m03[38;5;8m53dd35[39m [38;5;10m(empty)[39m local-only[0m
-      [38;5;5m@origin[39m (ahead by 1 commits, behind by 1 commits): [1m[38;5;5mzs[0m[38;5;8muskuln[39m [1m[38;5;4m5[0m[38;5;8m53203ba[39m [38;5;2m(empty)[39m remote-unsync
-    [38;5;5mremote-untrack@origin[39m: [1m[38;5;5mro[0m[38;5;8myxmykx[39m [1m[38;5;4m1[0m[38;5;8m49bc756[39m [38;5;2m(empty)[39m remote-untrack
+      [38;5;5m@origin[39m: [1m[38;5;5mt[0m[38;5;8mruxwmqv[39m [1m[38;5;4m9[0m[38;5;8md47d6bb[39m [38;5;2m(empty)[39m remote-delete
+    [38;5;5mremote-sync[39m: [1m[38;5;5my[0m[38;5;8mlvkpnrz[39m [1m[38;5;4m5[0m[38;5;8m52ea326[39m [38;5;2m(empty)[39m remote-sync
+      [38;5;5m@origin[39m: [1m[38;5;5my[0m[38;5;8mlvkpnrz[39m [1m[38;5;4m5[0m[38;5;8m52ea326[39m [38;5;2m(empty)[39m remote-sync
+    [38;5;5mremote-unsync[39m: [1m[38;5;13mv[38;5;8mqnwkozp[39m [38;5;12mc[38;5;8m36f69fc[39m [38;5;10m(empty)[39m local-only[0m
+      [38;5;5m@origin[39m (ahead by 1 commits, behind by 1 commits): [1m[38;5;5mp[0m[38;5;8msuskuln[39m [1m[38;5;4md[0m[38;5;8m957151e[39m [38;5;2m(empty)[39m remote-unsync
+    [38;5;5mremote-untrack@origin[39m: [1m[38;5;5mo[0m[38;5;8moyxmykx[39m [1m[38;5;4m2[0m[38;5;8mb839a01[39m [38;5;2m(empty)[39m remote-untrack
     [EOF]
     ------- stderr -------
     [1m[38;5;6mHint: [0m[39mBookmarks marked as deleted can be *deleted permanently* on the remote by running `jj git push --deleted`. Use `jj bookmark forget` if you don't want that.[39m
@@ -2490,14 +2490,14 @@ fn test_bookmark_list() -> TestResult {
 
     let output = local_dir.run_jj(["bookmark", "list", r#"-Tjson(self) ++ "\n""#]);
     insta::assert_snapshot!(output, @r#"
-    {"name":"absent-tracked","target":["0353dd35c56156971ce5f023a1db7a6196160a8a"]}
-    {"name":"absent-tracked","remote":"origin","target":[null],"tracking_target":["0353dd35c56156971ce5f023a1db7a6196160a8a"]}
-    {"name":"local-only","target":["0353dd35c56156971ce5f023a1db7a6196160a8a"]}
+    {"name":"absent-tracked","target":["c36f69fc997c6eed1a90c59902786d4c07db1a7f"]}
+    {"name":"absent-tracked","remote":"origin","target":[null],"tracking_target":["c36f69fc997c6eed1a90c59902786d4c07db1a7f"]}
+    {"name":"local-only","target":["c36f69fc997c6eed1a90c59902786d4c07db1a7f"]}
     {"name":"remote-delete","target":[null]}
-    {"name":"remote-delete","remote":"origin","target":["b32031cf329fbb90d042635c295b4e3fa2ca2651"],"tracking_target":[null]}
-    {"name":"remote-sync","target":["7a07dbeef135886b7ba7adb27d05190c39cd92ab"]}
-    {"name":"remote-unsync","target":["0353dd35c56156971ce5f023a1db7a6196160a8a"]}
-    {"name":"remote-unsync","remote":"origin","target":["553203baa52803406124962dbc0bcdc0227b20b2"],"tracking_target":["0353dd35c56156971ce5f023a1db7a6196160a8a"]}
+    {"name":"remote-delete","remote":"origin","target":["9d47d6bb61d817b1833621163fa70dd61a492c11"],"tracking_target":[null]}
+    {"name":"remote-sync","target":["552ea326844bbe49f70418a9369198b28e011f26"]}
+    {"name":"remote-unsync","target":["c36f69fc997c6eed1a90c59902786d4c07db1a7f"]}
+    {"name":"remote-unsync","remote":"origin","target":["d957151ec044e9a3a63ecc9cc0fd252946abd4c0"],"tracking_target":["c36f69fc997c6eed1a90c59902786d4c07db1a7f"]}
     [EOF]
     ------- stderr -------
     Hint: Bookmarks marked as deleted can be *deleted permanently* on the remote by running `jj git push --deleted`. Use `jj bookmark forget` if you don't want that.
@@ -2560,13 +2560,13 @@ fn test_bookmark_list_filtered() -> TestResult {
     insta::assert_snapshot!(
         local_dir.run_jj(["log", "-r::(bookmarks() | remote_bookmarks())", "-T", template]), @"
     @  4b2bc95cbda6 local-keep
-    │ ○  e6970e0e1f55 remote-rewrite*
+    │ ○  3426cd3899af remote-rewrite*
     ├─╯
-    │ ○  331d500d2fda remote-rewrite@origin (hidden)
+    │ ○  247f6adc2a47 remote-rewrite@origin (hidden)
     ├─╯
-    │ ○  0e6b796871e6 remote-delete@origin
+    │ ○  0d393d959499 remote-delete@origin
     ├─╯
-    │ ○  c2f2ee40f03a remote-keep
+    │ ○  ad66f729653e remote-keep
     ├─╯
     ◆  000000000000
     [EOF]
@@ -2577,10 +2577,10 @@ fn test_bookmark_list_filtered() -> TestResult {
     insta::assert_snapshot!(output, @"
     local-keep: kpqxywon 4b2bc95c (empty) local-keep
     remote-delete (deleted)
-      @origin: zsuskuln 0e6b7968 (empty) remote-delete
-    remote-keep: rlvkpnrz c2f2ee40 (empty) remote-keep
-    remote-rewrite: royxmykx e6970e0e (empty) rewritten
-      @origin (ahead by 1 commits, behind by 1 commits): royxmykx/1 331d500d (hidden) (empty) remote-rewrite
+      @origin: psuskuln 0d393d95 (empty) remote-delete
+    remote-keep: ylvkpnrz ad66f729 (empty) remote-keep
+    remote-rewrite: ooyxmykx 3426cd38 (empty) rewritten
+      @origin (ahead by 1 commits, behind by 1 commits): ooyxmykx/1 247f6adc (hidden) (empty) remote-rewrite
     [EOF]
     ------- stderr -------
     Hint: Bookmarks marked as deleted can be *deleted permanently* on the remote by running `jj git push --deleted`. Use `jj bookmark forget` if you don't want that.
@@ -2594,9 +2594,9 @@ fn test_bookmark_list_filtered() -> TestResult {
     // So "all()" is identical to "bookmarks()".
     insta::assert_snapshot!(query(&["-rall()"]), @"
     local-keep: kpqxywon 4b2bc95c (empty) local-keep
-    remote-keep: rlvkpnrz c2f2ee40 (empty) remote-keep
-    remote-rewrite: royxmykx e6970e0e (empty) rewritten
-      @origin (ahead by 1 commits, behind by 1 commits): royxmykx/1 331d500d (hidden) (empty) remote-rewrite
+    remote-keep: ylvkpnrz ad66f729 (empty) remote-keep
+    remote-rewrite: ooyxmykx 3426cd38 (empty) rewritten
+      @origin (ahead by 1 commits, behind by 1 commits): ooyxmykx/1 247f6adc (hidden) (empty) remote-rewrite
     [EOF]
     ");
 
@@ -2604,47 +2604,47 @@ fn test_bookmark_list_filtered() -> TestResult {
     // local "remote-rewrite" target matches.
     insta::assert_snapshot!(query(&["-rbookmarks()"]), @"
     local-keep: kpqxywon 4b2bc95c (empty) local-keep
-    remote-keep: rlvkpnrz c2f2ee40 (empty) remote-keep
-    remote-rewrite: royxmykx e6970e0e (empty) rewritten
-      @origin (ahead by 1 commits, behind by 1 commits): royxmykx/1 331d500d (hidden) (empty) remote-rewrite
+    remote-keep: ylvkpnrz ad66f729 (empty) remote-keep
+    remote-rewrite: ooyxmykx 3426cd38 (empty) rewritten
+      @origin (ahead by 1 commits, behind by 1 commits): ooyxmykx/1 247f6adc (hidden) (empty) remote-rewrite
     [EOF]
     ");
 
     // Select bookmarks by name.
     insta::assert_snapshot!(query(&["remote-rewrite"]), @"
-    remote-rewrite: royxmykx e6970e0e (empty) rewritten
-      @origin (ahead by 1 commits, behind by 1 commits): royxmykx/1 331d500d (hidden) (empty) remote-rewrite
+    remote-rewrite: ooyxmykx 3426cd38 (empty) rewritten
+      @origin (ahead by 1 commits, behind by 1 commits): ooyxmykx/1 247f6adc (hidden) (empty) remote-rewrite
     [EOF]
     ");
     insta::assert_snapshot!(query(&["-rbookmarks(remote-rewrite)"]), @"
-    remote-rewrite: royxmykx e6970e0e (empty) rewritten
-      @origin (ahead by 1 commits, behind by 1 commits): royxmykx/1 331d500d (hidden) (empty) remote-rewrite
+    remote-rewrite: ooyxmykx 3426cd38 (empty) rewritten
+      @origin (ahead by 1 commits, behind by 1 commits): ooyxmykx/1 247f6adc (hidden) (empty) remote-rewrite
     [EOF]
     ");
 
     // Select bookmarks by name, combined with --all-remotes
     local_dir.run_jj(["git", "export"]).success();
     insta::assert_snapshot!(query(&["--all-remotes", "remote-rewrite"]), @"
-    remote-rewrite: royxmykx e6970e0e (empty) rewritten
-      @git: royxmykx e6970e0e (empty) rewritten
-      @origin (ahead by 1 commits, behind by 1 commits): royxmykx/1 331d500d (hidden) (empty) remote-rewrite
+    remote-rewrite: ooyxmykx 3426cd38 (empty) rewritten
+      @git: ooyxmykx 3426cd38 (empty) rewritten
+      @origin (ahead by 1 commits, behind by 1 commits): ooyxmykx/1 247f6adc (hidden) (empty) remote-rewrite
     [EOF]
     ");
     insta::assert_snapshot!(query(&["--all-remotes", "-rbookmarks(remote-rewrite)"]), @"
-    remote-rewrite: royxmykx e6970e0e (empty) rewritten
-      @git: royxmykx e6970e0e (empty) rewritten
-      @origin (ahead by 1 commits, behind by 1 commits): royxmykx/1 331d500d (hidden) (empty) remote-rewrite
+    remote-rewrite: ooyxmykx 3426cd38 (empty) rewritten
+      @git: ooyxmykx 3426cd38 (empty) rewritten
+      @origin (ahead by 1 commits, behind by 1 commits): ooyxmykx/1 247f6adc (hidden) (empty) remote-rewrite
     [EOF]
     ");
 
     // Select bookmarks with --remote
     insta::assert_snapshot!(query(&["--remote", "origin"]), @"
     remote-delete (deleted)
-      @origin: zsuskuln 0e6b7968 (empty) remote-delete
-    remote-keep: rlvkpnrz c2f2ee40 (empty) remote-keep
-      @origin: rlvkpnrz c2f2ee40 (empty) remote-keep
-    remote-rewrite: royxmykx e6970e0e (empty) rewritten
-      @origin (ahead by 1 commits, behind by 1 commits): royxmykx/1 331d500d (hidden) (empty) remote-rewrite
+      @origin: psuskuln 0d393d95 (empty) remote-delete
+    remote-keep: ylvkpnrz ad66f729 (empty) remote-keep
+      @origin: ylvkpnrz ad66f729 (empty) remote-keep
+    remote-rewrite: ooyxmykx 3426cd38 (empty) rewritten
+      @origin (ahead by 1 commits, behind by 1 commits): ooyxmykx/1 247f6adc (hidden) (empty) remote-rewrite
     [EOF]
     ------- stderr -------
     Hint: Bookmarks marked as deleted can be *deleted permanently* on the remote by running `jj git push --deleted`. Use `jj bookmark forget` if you don't want that.
@@ -2653,23 +2653,23 @@ fn test_bookmark_list_filtered() -> TestResult {
     insta::assert_snapshot!(query(&["--remote", "'gi?'"]), @"
     local-keep: kpqxywon 4b2bc95c (empty) local-keep
       @git: kpqxywon 4b2bc95c (empty) local-keep
-    remote-keep: rlvkpnrz c2f2ee40 (empty) remote-keep
-      @git: rlvkpnrz c2f2ee40 (empty) remote-keep
-    remote-rewrite: royxmykx e6970e0e (empty) rewritten
-      @git: royxmykx e6970e0e (empty) rewritten
+    remote-keep: ylvkpnrz ad66f729 (empty) remote-keep
+      @git: ylvkpnrz ad66f729 (empty) remote-keep
+    remote-rewrite: ooyxmykx 3426cd38 (empty) rewritten
+      @git: ooyxmykx 3426cd38 (empty) rewritten
     [EOF]
     ");
     insta::assert_snapshot!(query(&["--remote", "origin", "--remote", "git"]), @"
     local-keep: kpqxywon 4b2bc95c (empty) local-keep
       @git: kpqxywon 4b2bc95c (empty) local-keep
     remote-delete (deleted)
-      @origin: zsuskuln 0e6b7968 (empty) remote-delete
-    remote-keep: rlvkpnrz c2f2ee40 (empty) remote-keep
-      @git: rlvkpnrz c2f2ee40 (empty) remote-keep
-      @origin: rlvkpnrz c2f2ee40 (empty) remote-keep
-    remote-rewrite: royxmykx e6970e0e (empty) rewritten
-      @git: royxmykx e6970e0e (empty) rewritten
-      @origin (ahead by 1 commits, behind by 1 commits): royxmykx/1 331d500d (hidden) (empty) remote-rewrite
+      @origin: psuskuln 0d393d95 (empty) remote-delete
+    remote-keep: ylvkpnrz ad66f729 (empty) remote-keep
+      @git: ylvkpnrz ad66f729 (empty) remote-keep
+      @origin: ylvkpnrz ad66f729 (empty) remote-keep
+    remote-rewrite: ooyxmykx 3426cd38 (empty) rewritten
+      @git: ooyxmykx 3426cd38 (empty) rewritten
+      @origin (ahead by 1 commits, behind by 1 commits): ooyxmykx/1 247f6adc (hidden) (empty) remote-rewrite
     [EOF]
     ------- stderr -------
     Hint: Bookmarks marked as deleted can be *deleted permanently* on the remote by running `jj git push --deleted`. Use `jj bookmark forget` if you don't want that.
@@ -2679,7 +2679,7 @@ fn test_bookmark_list_filtered() -> TestResult {
     // Can select deleted bookmark by name pattern, but not by revset.
     insta::assert_snapshot!(query(&["remote-delete"]), @"
     remote-delete (deleted)
-      @origin: zsuskuln 0e6b7968 (empty) remote-delete
+      @origin: psuskuln 0d393d95 (empty) remote-delete
     [EOF]
     ------- stderr -------
     Hint: Bookmarks marked as deleted can be *deleted permanently* on the remote by running `jj git push --deleted`. Use `jj bookmark forget` if you don't want that.
@@ -2698,8 +2698,8 @@ fn test_bookmark_list_filtered() -> TestResult {
     insta::assert_snapshot!(query(&["*-keep", "remote-* & *-delete"]), @"
     local-keep: kpqxywon 4b2bc95c (empty) local-keep
     remote-delete (deleted)
-      @origin: zsuskuln 0e6b7968 (empty) remote-delete
-    remote-keep: rlvkpnrz c2f2ee40 (empty) remote-keep
+      @origin: psuskuln 0d393d95 (empty) remote-delete
+    remote-keep: ylvkpnrz ad66f729 (empty) remote-keep
     [EOF]
     ------- stderr -------
     Hint: Bookmarks marked as deleted can be *deleted permanently* on the remote by running `jj git push --deleted`. Use `jj bookmark forget` if you don't want that.
@@ -2712,7 +2712,7 @@ fn test_bookmark_list_filtered() -> TestResult {
         query(&["local-keep", "push-*", "unknown | remote-delete ~ remote-rewrite"]), @"
     local-keep: kpqxywon 4b2bc95c (empty) local-keep
     remote-delete (deleted)
-      @origin: zsuskuln 0e6b7968 (empty) remote-delete
+      @origin: psuskuln 0d393d95 (empty) remote-delete
     [EOF]
     ------- stderr -------
     Warning: No matching bookmarks for names: unknown
@@ -2723,8 +2723,8 @@ fn test_bookmark_list_filtered() -> TestResult {
     // Name pattern and revset are OR-ed.
     insta::assert_snapshot!(query(&["local-keep", "-rbookmarks(remote-rewrite)"]), @"
     local-keep: kpqxywon 4b2bc95c (empty) local-keep
-    remote-rewrite: royxmykx e6970e0e (empty) rewritten
-      @origin (ahead by 1 commits, behind by 1 commits): royxmykx/1 331d500d (hidden) (empty) remote-rewrite
+    remote-rewrite: ooyxmykx 3426cd38 (empty) rewritten
+      @origin (ahead by 1 commits, behind by 1 commits): ooyxmykx/1 247f6adc (hidden) (empty) remote-rewrite
     [EOF]
     ");
 
@@ -2737,8 +2737,8 @@ fn test_bookmark_list_filtered() -> TestResult {
     ]), @"
     local-keep: kpqxywon 4b2bc95c (empty) local-keep
       @git: kpqxywon 4b2bc95c (empty) local-keep
-    remote-rewrite: royxmykx e6970e0e (empty) rewritten
-      @git: royxmykx e6970e0e (empty) rewritten
+    remote-rewrite: ooyxmykx 3426cd38 (empty) rewritten
+      @git: ooyxmykx 3426cd38 (empty) rewritten
     [EOF]
     ");
 
@@ -2843,9 +2843,9 @@ fn test_bookmark_list_much_remote_divergence() -> TestResult {
 
     let output = local_dir.run_jj(["bookmark", "list"]);
     insta::assert_snapshot!(output, @"
-    local-only: zkyosouw a30800ad (empty) local-only
-    remote-unsync: zkyosouw a30800ad (empty) local-only
-      @origin (ahead by at least 10 commits, behind by at least 10 commits): uyznsvlq a52367f8 (empty) remote-unsync
+    local-only: lvyosouw 7aff776a (empty) local-only
+    remote-unsync: lvyosouw 7aff776a (empty) local-only
+      @origin (ahead by at least 10 commits, behind by at least 10 commits): xkznsvlq 89eefcda (empty) remote-unsync
     [EOF]
     ");
     Ok(())
@@ -2965,21 +2965,21 @@ fn test_bookmark_list_tracked() -> TestResult {
 
     let output = local_dir.run_jj(["bookmark", "list", "--all-remotes"]);
     insta::assert_snapshot!(output, @"
-    local-only: nmzmmopx 2a685e16 (empty) local-only
-      @git: nmzmmopx 2a685e16 (empty) local-only
+    local-only: rmzmmopx f0a91409 (empty) local-only
+      @git: rmzmmopx f0a91409 (empty) local-only
     remote-delete (deleted)
-      @origin: vruxwmqv b32031cf (empty) remote-delete
-    remote-sync: rlvkpnrz 7a07dbee (empty) remote-sync
-      @git: rlvkpnrz 7a07dbee (empty) remote-sync
-      @origin: rlvkpnrz 7a07dbee (empty) remote-sync
-    remote-unsync: nmzmmopx 2a685e16 (empty) local-only
-      @git: nmzmmopx 2a685e16 (empty) local-only
-      @origin (ahead by 1 commits, behind by 1 commits): zsuskuln 553203ba (empty) remote-unsync
-      @upstream (ahead by 1 commits, behind by 1 commits): zsuskuln 553203ba (empty) remote-unsync
-    remote-untrack@origin: royxmykx 149bc756 (empty) remote-untrack
-    upstream-sync: lylxulpl 169ba7d9 (empty) upstream-sync
-      @git: lylxulpl 169ba7d9 (empty) upstream-sync
-      @upstream: lylxulpl 169ba7d9 (empty) upstream-sync
+      @origin: truxwmqv 9d47d6bb (empty) remote-delete
+    remote-sync: ylvkpnrz 552ea326 (empty) remote-sync
+      @git: ylvkpnrz 552ea326 (empty) remote-sync
+      @origin: ylvkpnrz 552ea326 (empty) remote-sync
+    remote-unsync: rmzmmopx f0a91409 (empty) local-only
+      @git: rmzmmopx f0a91409 (empty) local-only
+      @origin (ahead by 1 commits, behind by 1 commits): psuskuln d957151e (empty) remote-unsync
+      @upstream (ahead by 1 commits, behind by 1 commits): psuskuln d957151e (empty) remote-unsync
+    remote-untrack@origin: ooyxmykx 2b839a01 (empty) remote-untrack
+    upstream-sync: mylxulpl 8c1c6eca (empty) upstream-sync
+      @git: mylxulpl 8c1c6eca (empty) upstream-sync
+      @upstream: mylxulpl 8c1c6eca (empty) upstream-sync
     [EOF]
     ------- stderr -------
     Hint: Bookmarks marked as deleted can be *deleted permanently* on the remote by running `jj git push --deleted`. Use `jj bookmark forget` if you don't want that.
@@ -2989,14 +2989,14 @@ fn test_bookmark_list_tracked() -> TestResult {
     let output = local_dir.run_jj(["bookmark", "list", "--tracked"]);
     insta::assert_snapshot!(output, @"
     remote-delete (deleted)
-      @origin: vruxwmqv b32031cf (empty) remote-delete
-    remote-sync: rlvkpnrz 7a07dbee (empty) remote-sync
-      @origin: rlvkpnrz 7a07dbee (empty) remote-sync
-    remote-unsync: nmzmmopx 2a685e16 (empty) local-only
-      @origin (ahead by 1 commits, behind by 1 commits): zsuskuln 553203ba (empty) remote-unsync
-      @upstream (ahead by 1 commits, behind by 1 commits): zsuskuln 553203ba (empty) remote-unsync
-    upstream-sync: lylxulpl 169ba7d9 (empty) upstream-sync
-      @upstream: lylxulpl 169ba7d9 (empty) upstream-sync
+      @origin: truxwmqv 9d47d6bb (empty) remote-delete
+    remote-sync: ylvkpnrz 552ea326 (empty) remote-sync
+      @origin: ylvkpnrz 552ea326 (empty) remote-sync
+    remote-unsync: rmzmmopx f0a91409 (empty) local-only
+      @origin (ahead by 1 commits, behind by 1 commits): psuskuln d957151e (empty) remote-unsync
+      @upstream (ahead by 1 commits, behind by 1 commits): psuskuln d957151e (empty) remote-unsync
+    upstream-sync: mylxulpl 8c1c6eca (empty) upstream-sync
+      @upstream: mylxulpl 8c1c6eca (empty) upstream-sync
     [EOF]
     ------- stderr -------
     Hint: Bookmarks marked as deleted can be *deleted permanently* on the remote by running `jj git push --deleted`. Use `jj bookmark forget` if you don't want that.
@@ -3006,11 +3006,11 @@ fn test_bookmark_list_tracked() -> TestResult {
     let output = local_dir.run_jj(["bookmark", "list", "--tracked", "--remote", "origin"]);
     insta::assert_snapshot!(output, @"
     remote-delete (deleted)
-      @origin: vruxwmqv b32031cf (empty) remote-delete
-    remote-sync: rlvkpnrz 7a07dbee (empty) remote-sync
-      @origin: rlvkpnrz 7a07dbee (empty) remote-sync
-    remote-unsync: nmzmmopx 2a685e16 (empty) local-only
-      @origin (ahead by 1 commits, behind by 1 commits): zsuskuln 553203ba (empty) remote-unsync
+      @origin: truxwmqv 9d47d6bb (empty) remote-delete
+    remote-sync: ylvkpnrz 552ea326 (empty) remote-sync
+      @origin: ylvkpnrz 552ea326 (empty) remote-sync
+    remote-unsync: rmzmmopx f0a91409 (empty) local-only
+      @origin (ahead by 1 commits, behind by 1 commits): psuskuln d957151e (empty) remote-unsync
     [EOF]
     ------- stderr -------
     Hint: Bookmarks marked as deleted can be *deleted permanently* on the remote by running `jj git push --deleted`. Use `jj bookmark forget` if you don't want that.
@@ -3019,22 +3019,22 @@ fn test_bookmark_list_tracked() -> TestResult {
 
     let output = local_dir.run_jj(["bookmark", "list", "--tracked", "--remote=git"]);
     insta::assert_snapshot!(output, @"
-    local-only: nmzmmopx 2a685e16 (empty) local-only
-      @git: nmzmmopx 2a685e16 (empty) local-only
-    remote-sync: rlvkpnrz 7a07dbee (empty) remote-sync
-      @git: rlvkpnrz 7a07dbee (empty) remote-sync
-    remote-unsync: nmzmmopx 2a685e16 (empty) local-only
-      @git: nmzmmopx 2a685e16 (empty) local-only
-    upstream-sync: lylxulpl 169ba7d9 (empty) upstream-sync
-      @git: lylxulpl 169ba7d9 (empty) upstream-sync
+    local-only: rmzmmopx f0a91409 (empty) local-only
+      @git: rmzmmopx f0a91409 (empty) local-only
+    remote-sync: ylvkpnrz 552ea326 (empty) remote-sync
+      @git: ylvkpnrz 552ea326 (empty) remote-sync
+    remote-unsync: rmzmmopx f0a91409 (empty) local-only
+      @git: rmzmmopx f0a91409 (empty) local-only
+    upstream-sync: mylxulpl 8c1c6eca (empty) upstream-sync
+      @git: mylxulpl 8c1c6eca (empty) upstream-sync
     [EOF]
     ");
 
     let output = local_dir.run_jj(["bookmark", "list", "--tracked", "remote-unsync"]);
     insta::assert_snapshot!(output, @"
-    remote-unsync: nmzmmopx 2a685e16 (empty) local-only
-      @origin (ahead by 1 commits, behind by 1 commits): zsuskuln 553203ba (empty) remote-unsync
-      @upstream (ahead by 1 commits, behind by 1 commits): zsuskuln 553203ba (empty) remote-unsync
+    remote-unsync: rmzmmopx f0a91409 (empty) local-only
+      @origin (ahead by 1 commits, behind by 1 commits): psuskuln d957151e (empty) remote-unsync
+      @upstream (ahead by 1 commits, behind by 1 commits): psuskuln d957151e (empty) remote-unsync
     [EOF]
     ");
 
@@ -3047,8 +3047,8 @@ fn test_bookmark_list_tracked() -> TestResult {
 
     let output = local_dir.run_jj(["bookmark", "list", "--tracked", "remote-unsync"]);
     insta::assert_snapshot!(output, @"
-    remote-unsync: nmzmmopx 2a685e16 (empty) local-only
-      @origin (ahead by 1 commits, behind by 1 commits): zsuskuln 553203ba (empty) remote-unsync
+    remote-unsync: rmzmmopx f0a91409 (empty) local-only
+      @origin (ahead by 1 commits, behind by 1 commits): psuskuln d957151e (empty) remote-unsync
     [EOF]
     ");
     Ok(())
@@ -3072,16 +3072,16 @@ fn test_bookmark_list_conflicted() {
         .success();
     work_dir.run_jj(["status"]).success();
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @"
-    bar: kkmpptxz a82129fb (empty) b
+    bar: nkmpptxz 40784354 (empty) b
     foo (conflicted):
-      + rlvkpnrz 4e1b2d80 (empty) a
-      + kkmpptxz a82129fb (empty) b
+      + ylvkpnrz 87526ef8 (empty) a
+      + nkmpptxz 40784354 (empty) b
     [EOF]
     ");
     insta::assert_snapshot!(work_dir.run_jj(["bookmark", "list", "--conflicted"]), @"
     foo (conflicted):
-      + rlvkpnrz 4e1b2d80 (empty) a
-      + kkmpptxz a82129fb (empty) b
+      + ylvkpnrz 87526ef8 (empty) a
+      + nkmpptxz 40784354 (empty) b
     [EOF]
     ------- stderr -------
     Hint: Some bookmarks have conflicts. Use `jj bookmark set <name> -r <rev>` to resolve.
@@ -3451,10 +3451,10 @@ fn test_bookmark_advance_default() -> TestResult {
     std::fs::write(work_dir.root().join("file"), "newer_content")?;
 
     insta::assert_snapshot!(get_log(), @r"
-    @  vruxwmqv e
-    ○  yqosqzyt d (empty)
-    ○  royxmykx c
-    ○  zsuskuln b B
+    @  uruxwmqv e
+    ○  nqosqzyt d (empty)
+    ○  ooyxmykx c
+    ○  psuskuln b B
     ○  qpvuntsm a (empty) A
     ◆  zzzzzzzz (empty)
     [EOF]
@@ -3466,16 +3466,16 @@ fn test_bookmark_advance_default() -> TestResult {
     let output = work_dir.run_jj(["bookmark", "advance"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Advanced 1 bookmarks to vruxwmqv 7753a73e B | e
+    Advanced 1 bookmarks to uruxwmqv 950fe37c B | e
     [EOF]
     ");
     work_dir.run_jj(["op", "restore", &setup_opid]).success();
 
     // To target specified by --to.
-    let output = work_dir.run_jj(["bookmark", "advance", "--to", "royxmykx"]);
-    insta::assert_snapshot!(output, @r"
+    let output = work_dir.run_jj(["bookmark", "advance", "--to", "ooyxmykx"]);
+    insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Advanced 1 bookmarks to royxmykx 26554c67 B | c
+    Advanced 1 bookmarks to ooyxmykx ed76810b B | c
     [EOF]
     ");
     work_dir.run_jj(["op", "restore", &setup_opid]).success();
@@ -3484,16 +3484,16 @@ fn test_bookmark_advance_default() -> TestResult {
     let output = work_dir.run_jj(["bookmark", "advance", "A"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Advanced 1 bookmarks to vruxwmqv 7753a73e A | e
+    Advanced 1 bookmarks to uruxwmqv 950fe37c A | e
     [EOF]
     ");
     work_dir.run_jj(["op", "restore", &setup_opid]).success();
 
     // A -> target specified by --to.
-    let output = work_dir.run_jj(["bookmark", "advance", "A", "--to", "zsuskuln"]);
-    insta::assert_snapshot!(output, @r"
+    let output = work_dir.run_jj(["bookmark", "advance", "A", "--to", "psuskuln"]);
+    insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Advanced 1 bookmarks to zsuskuln 4112c46e A B | b
+    Advanced 1 bookmarks to psuskuln 061eba0f A B | b
     [EOF]
     ");
     work_dir.run_jj(["op", "restore", &setup_opid]).success();
@@ -3504,7 +3504,7 @@ fn test_bookmark_advance_default() -> TestResult {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Warning: Target revision is empty.
-    Advanced 1 bookmarks to xznxytkn ced0e1e4 A | (empty) (no description set)
+    Advanced 1 bookmarks to lznxytkn 712f915e A | (empty) (no description set)
     [EOF]
     ");
     work_dir.run_jj(["op", "restore", &setup_opid]).success();
@@ -3513,7 +3513,7 @@ fn test_bookmark_advance_default() -> TestResult {
     let output = work_dir.run_jj(["bookmark", "advance", "A|B"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Advanced 2 bookmarks to vruxwmqv 7753a73e A B | e
+    Advanced 2 bookmarks to uruxwmqv 950fe37c A B | e
     [EOF]
     ");
     work_dir.run_jj(["op", "restore", &setup_opid]).success();
@@ -3526,14 +3526,14 @@ fn test_bookmark_advance_default() -> TestResult {
     ]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Advanced 2 bookmarks to vruxwmqv 7753a73e A B | e
+    Advanced 2 bookmarks to uruxwmqv 950fe37c A B | e
     Hint: Specify bookmark by name to update just one of the bookmarks.
     [EOF]
     ");
     work_dir.run_jj(["op", "restore", &setup_opid]).success();
 
     // At a bookmark.
-    work_dir.run_jj(["edit", "zsuskuln"]).success();
+    work_dir.run_jj(["edit", "psuskuln"]).success();
     let output = work_dir.run_jj(["bookmark", "advance"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------

--- a/cli/tests/test_commit_command.rs
+++ b/cli/tests/test_commit_command.rs
@@ -262,8 +262,8 @@ fn test_commit_interactive_with_paths() -> TestResult {
     let output = work_dir.run_jj(["commit", "-i", "file1", "file2"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: kkmpptxz 50f426df (no description set)
-    Parent commit (@-)      : rlvkpnrz eb640375 edit
+    Working copy  (@) now at: kkmpptxz 64246285 (no description set)
+    Parent commit (@-)      : ylvkpnrz 83e7c3ae edit
     [EOF]
     ");
 
@@ -271,7 +271,7 @@ fn test_commit_interactive_with_paths() -> TestResult {
         std::fs::read_to_string(test_env.env_root().join("editor"))?, @r#"
     edit
 
-    JJ: Change ID: rlvkpnrz
+    JJ: Change ID: ylvkpnrz
     JJ: This commit contains the following changes:
     JJ:     A file1
     JJ:
@@ -280,11 +280,11 @@ fn test_commit_interactive_with_paths() -> TestResult {
 
     let output = work_dir.run_jj(["log", "--summary"]);
     insta::assert_snapshot!(output, @"
-    @  kkmpptxz test.user@example.com 2001-02-03 08:05:09 50f426df
+    @  kkmpptxz test.user@example.com 2001-02-03 08:05:09 64246285
     │  (no description set)
     │  M file2
     │  M file3
-    ○  rlvkpnrz test.user@example.com 2001-02-03 08:05:09 eb640375
+    ○  ylvkpnrz test.user@example.com 2001-02-03 08:05:09 83e7c3ae
     │  edit
     │  A file1
     ○  qpvuntsm test.user@example.com 2001-02-03 08:05:08 ff687a2f

--- a/cli/tests/test_commit_template.rs
+++ b/cli/tests/test_commit_template.rs
@@ -32,9 +32,9 @@ fn test_log_parents() {
         r#"commit_id ++ "\nP: " ++ parents.len() ++ " " ++ parents.map(|c| c.commit_id()) ++ "\n""#;
     let output = work_dir.run_jj(["log", "-T", template]);
     insta::assert_snapshot!(output, @"
-    @    8b93ef7a3ceefa4e4b1a506945588dd0da2d9e3e
-    ├─╮  P: 2 1c1c95df80e53b1e654608d7589f5baabb10ebb2 e8849ae12c709f2321908879bc724fdb2ab8a781
-    ○ │  1c1c95df80e53b1e654608d7589f5baabb10ebb2
+    @    d5ed01e904a24cc3c9a17de5fd2ac7d13e61ce2f
+    ├─╮  P: 2 3babb3519b2924ce319a29ca20c239b64b19a01a e8849ae12c709f2321908879bc724fdb2ab8a781
+    ○ │  3babb3519b2924ce319a29ca20c239b64b19a01a
     ├─╯  P: 1 e8849ae12c709f2321908879bc724fdb2ab8a781
     ○  e8849ae12c709f2321908879bc724fdb2ab8a781
     │  P: 1 0000000000000000000000000000000000000000
@@ -48,7 +48,7 @@ fn test_log_parents() {
         r#""P: " ++ parents.filter(|c| !c.root()).map(|c| c.commit_id().short()) ++ "\n""#;
     let output = work_dir.run_jj(["log", "-T", template]);
     insta::assert_snapshot!(output, @"
-    @    P: 1c1c95df80e5 e8849ae12c70
+    @    P: 3babb3519b29 e8849ae12c70
     ├─╮
     ○ │  P: e8849ae12c70
     ├─╯
@@ -60,7 +60,7 @@ fn test_log_parents() {
     let template = r#"parents.map(|c| c.commit_id().shortest(4))"#;
     let output = work_dir.run_jj(["log", "-T", template, "-r@", "--color=always"]);
     insta::assert_snapshot!(output, @"
-    [1m[38;5;2m@[0m  [1m[38;5;4m1[0m[38;5;8mc1c[39m [1m[38;5;4me[0m[38;5;8m884[39m
+    [1m[38;5;2m@[0m  [1m[38;5;4m3[0m[38;5;8mbab[39m [1m[38;5;4me[0m[38;5;8m884[39m
     │
     ~
     [EOF]
@@ -254,7 +254,7 @@ fn test_log_json() {
 
     let output = work_dir.run_jj(["log", r#"-Tjson(self) ++ "\n""#]);
     insta::assert_snapshot!(output, @r#"
-    @  {"commit_id":"b1cb6b2f9141e6ffee18532a8bf9a2075ca02606","parents":["68a505386f936fff6d718f55005e77ea72589bc1"],"change_id":"kkmpptxzrspxrzommnulwmwkkqwworpl","description":"second\n","author":{"name":"Test User","email":"test.user@example.com","timestamp":"2001-02-03T04:05:09+07:00"},"committer":{"name":"Test User","email":"test.user@example.com","timestamp":"2001-02-03T04:05:09+07:00"}}
+    @  {"commit_id":"141cadf4720a43faed83bd1f3ae8f35372d9d3ad","parents":["68a505386f936fff6d718f55005e77ea72589bc1"],"change_id":"nkmpptxzrspxrzommnulwmwkkqwworpl","description":"second\n","author":{"name":"Test User","email":"test.user@example.com","timestamp":"2001-02-03T04:05:09+07:00"},"committer":{"name":"Test User","email":"test.user@example.com","timestamp":"2001-02-03T04:05:09+07:00"}}
     ○  {"commit_id":"68a505386f936fff6d718f55005e77ea72589bc1","parents":["0000000000000000000000000000000000000000"],"change_id":"qpvuntsmwlqtpsluzzsnyyzlmlwvmlnu","description":"first\n","author":{"name":"Test User","email":"test.user@example.com","timestamp":"2001-02-03T04:05:08+07:00"},"committer":{"name":"Test User","email":"test.user@example.com","timestamp":"2001-02-03T04:05:08+07:00"}}
     ◆  {"commit_id":"0000000000000000000000000000000000000000","parents":[],"change_id":"zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz","description":"","author":{"name":"","email":"","timestamp":"1970-01-01T00:00:00Z"},"committer":{"name":"","email":"","timestamp":"1970-01-01T00:00:00Z"}}
     [EOF]
@@ -277,7 +277,7 @@ fn test_log_default() {
     // Test default log output format
     let output = work_dir.run_jj(["log"]);
     insta::assert_snapshot!(output, @"
-    @  kkmpptxz test.user@example.com 2001-02-03 08:05:09 my-bookmark c938c088
+    @  nkmpptxz test.user@example.com 2001-02-03 08:05:09 my-bookmark 4f6ef8b0
     │  (empty) description 1
     ○  qpvuntsm test.user@example.com 2001-02-03 08:05:08 007859d3
     │  add a file
@@ -288,7 +288,7 @@ fn test_log_default() {
     // Color
     let output = work_dir.run_jj(["log", "--color=always"]);
     insta::assert_snapshot!(output, @"
-    [1m[38;5;2m@[0m  [1m[38;5;13mk[38;5;8mkmpptxz[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 08:05:09[39m [38;5;13mmy-bookmark[39m [38;5;12mc[38;5;8m938c088[39m[0m
+    [1m[38;5;2m@[0m  [1m[38;5;13mn[38;5;8mkmpptxz[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 08:05:09[39m [38;5;13mmy-bookmark[39m [38;5;12m4[38;5;8mf6ef8b0[39m[0m
     │  [1m[38;5;10m(empty)[39m description 1[0m
     ○  [1m[38;5;5mq[0m[38;5;8mpvuntsm[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:08[39m [1m[38;5;4m007[0m[38;5;8m859d3[39m
     │  add a file
@@ -299,7 +299,7 @@ fn test_log_default() {
     // Color without graph
     let output = work_dir.run_jj(["log", "--color=always", "--no-graph"]);
     insta::assert_snapshot!(output, @"
-    [1m[38;5;13mk[38;5;8mkmpptxz[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 08:05:09[39m [38;5;13mmy-bookmark[39m [38;5;12mc[38;5;8m938c088[39m[0m
+    [1m[38;5;13mn[38;5;8mkmpptxz[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 08:05:09[39m [38;5;13mmy-bookmark[39m [38;5;12m4[38;5;8mf6ef8b0[39m[0m
     [1m[38;5;10m(empty)[39m description 1[0m
     [1m[38;5;5mq[0m[38;5;8mpvuntsm[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:08[39m [1m[38;5;4m007[0m[38;5;8m859d3[39m
     add a file
@@ -338,14 +338,14 @@ fn test_log_builtin_templates() {
         .success();
 
     insta::assert_snapshot!(render(r#"builtin_log_oneline"#), @"
-    rlvkpnrz (no email set) 2001-02-03 08:05:08 my-bookmark aec3ec96 (empty) (no description set)
+    ylvkpnrz (no email set) 2001-02-03 08:05:08 my-bookmark a2294f19 (empty) (no description set)
     qpvuntsm test.user 2001-02-03 08:05:07 e8849ae1 (empty) (no description set)
     zzzzzzzz root() 00000000
     [EOF]
     ");
 
     insta::assert_snapshot!(render(r#"builtin_log_compact"#), @"
-    rlvkpnrz (no email set) 2001-02-03 08:05:08 my-bookmark aec3ec96
+    ylvkpnrz (no email set) 2001-02-03 08:05:08 my-bookmark a2294f19
     (empty) (no description set)
     qpvuntsm test.user@example.com 2001-02-03 08:05:07 e8849ae1
     (empty) (no description set)
@@ -354,7 +354,7 @@ fn test_log_builtin_templates() {
     ");
 
     insta::assert_snapshot!(render(r#"builtin_log_comfortable"#), @"
-    rlvkpnrz (no email set) 2001-02-03 08:05:08 my-bookmark aec3ec96
+    ylvkpnrz (no email set) 2001-02-03 08:05:08 my-bookmark a2294f19
     (empty) (no description set)
 
     qpvuntsm test.user@example.com 2001-02-03 08:05:07 e8849ae1
@@ -366,8 +366,8 @@ fn test_log_builtin_templates() {
     ");
 
     insta::assert_snapshot!(render(r#"builtin_log_detailed"#), @"
-    Commit ID: aec3ec964d0771edea9da48a2a170bc6ffa1c725
-    Change ID: rlvkpnrzqnoowoytxnquwvuryrwnrmlp
+    Commit ID: a2294f19ef78dd9f7b52f9e8d9f84f213991df75
+    Change ID: ylvkpnrzqnoowoytxnquwvuryrwnrmlp
     Bookmarks: my-bookmark
     Author   : (no name set) <(no email set)> (2001-02-03 08:05:08)
     Committer: (no name set) <(no email set)> (2001-02-03 08:05:08)
@@ -407,14 +407,14 @@ fn test_log_builtin_templates_colored() {
         .success();
 
     insta::assert_snapshot!(render(r#"builtin_log_oneline"#), @"
-    [1m[38;5;2m@[0m  [1m[38;5;13mr[38;5;8mlvkpnrz[39m [38;5;9m(no email set)[39m [38;5;14m2001-02-03 08:05:08[39m [38;5;13mmy-bookmark[39m [38;5;12ma[38;5;8mec3ec96[39m [38;5;10m(empty)[39m [38;5;10m(no description set)[39m[0m
+    [1m[38;5;2m@[0m  [1m[38;5;13my[38;5;8mlvkpnrz[39m [38;5;9m(no email set)[39m [38;5;14m2001-02-03 08:05:08[39m [38;5;13mmy-bookmark[39m [38;5;12ma[38;5;8m2294f19[39m [38;5;10m(empty)[39m [38;5;10m(no description set)[39m[0m
     ○  [1m[38;5;5mq[0m[38;5;8mpvuntsm[39m [38;5;3mtest.user[39m [38;5;6m2001-02-03 08:05:07[39m [1m[38;5;4me[0m[38;5;8m8849ae1[39m [38;5;2m(empty)[39m [38;5;2m(no description set)[39m
     [1m[38;5;14m◆[0m  [1m[38;5;5mz[0m[38;5;8mzzzzzzz[39m [38;5;2mroot()[39m [1m[38;5;4m0[0m[38;5;8m0000000[39m
     [EOF]
     ");
 
     insta::assert_snapshot!(render(r#"builtin_log_compact"#), @"
-    [1m[38;5;2m@[0m  [1m[38;5;13mr[38;5;8mlvkpnrz[39m [38;5;9m(no email set)[39m [38;5;14m2001-02-03 08:05:08[39m [38;5;13mmy-bookmark[39m [38;5;12ma[38;5;8mec3ec96[39m[0m
+    [1m[38;5;2m@[0m  [1m[38;5;13my[38;5;8mlvkpnrz[39m [38;5;9m(no email set)[39m [38;5;14m2001-02-03 08:05:08[39m [38;5;13mmy-bookmark[39m [38;5;12ma[38;5;8m2294f19[39m[0m
     │  [1m[38;5;10m(empty)[39m [38;5;10m(no description set)[39m[0m
     ○  [1m[38;5;5mq[0m[38;5;8mpvuntsm[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:07[39m [1m[38;5;4me[0m[38;5;8m8849ae1[39m
     │  [38;5;2m(empty)[39m [38;5;2m(no description set)[39m
@@ -423,7 +423,7 @@ fn test_log_builtin_templates_colored() {
     ");
 
     insta::assert_snapshot!(render(r#"builtin_log_comfortable"#), @"
-    [1m[38;5;2m@[0m  [1m[38;5;13mr[38;5;8mlvkpnrz[39m [38;5;9m(no email set)[39m [38;5;14m2001-02-03 08:05:08[39m [38;5;13mmy-bookmark[39m [38;5;12ma[38;5;8mec3ec96[39m[0m
+    [1m[38;5;2m@[0m  [1m[38;5;13my[38;5;8mlvkpnrz[39m [38;5;9m(no email set)[39m [38;5;14m2001-02-03 08:05:08[39m [38;5;13mmy-bookmark[39m [38;5;12ma[38;5;8m2294f19[39m[0m
     │  [1m[38;5;10m(empty)[39m [38;5;10m(no description set)[39m[0m
     │
     ○  [1m[38;5;5mq[0m[38;5;8mpvuntsm[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:07[39m [1m[38;5;4me[0m[38;5;8m8849ae1[39m
@@ -435,8 +435,8 @@ fn test_log_builtin_templates_colored() {
     ");
 
     insta::assert_snapshot!(render(r#"builtin_log_detailed"#), @"
-    [1m[38;5;2m@[0m  Commit ID: [38;5;4maec3ec964d0771edea9da48a2a170bc6ffa1c725[39m
-    │  Change ID: [38;5;5mrlvkpnrzqnoowoytxnquwvuryrwnrmlp[39m
+    [1m[38;5;2m@[0m  Commit ID: [38;5;4ma2294f19ef78dd9f7b52f9e8d9f84f213991df75[39m
+    │  Change ID: [38;5;5mylvkpnrzqnoowoytxnquwvuryrwnrmlp[39m
     │  Bookmarks: [38;5;5mmy-bookmark[39m
     │  Author   : [38;5;1m(no name set)[39m <[38;5;1m(no email set)[39m> ([38;5;6m2001-02-03 08:05:08[39m)
     │  Committer: [38;5;1m(no name set)[39m <[38;5;1m(no email set)[39m> ([38;5;6m2001-02-03 08:05:08[39m)
@@ -476,14 +476,14 @@ fn test_log_builtin_templates_colored_debug() {
         .success();
 
     insta::assert_snapshot!(render(r#"builtin_log_oneline"#), @"
-    [1m[38;5;2m<<log commit node working_copy mutable::@>>[0m  [1m[38;5;13m<<log commit working_copy mutable change_id shortest prefix::r>>[38;5;8m<<log commit working_copy mutable change_id shortest rest::lvkpnrz>>[39m<<log commit working_copy mutable:: >>[38;5;9m<<log commit working_copy mutable email placeholder::(no email set)>>[39m<<log commit working_copy mutable:: >>[38;5;14m<<log commit working_copy mutable committer timestamp local format::2001-02-03 08:05:08>>[39m<<log commit working_copy mutable:: >>[38;5;13m<<log commit working_copy mutable bookmarks name::my-bookmark>>[39m<<log commit working_copy mutable:: >>[38;5;12m<<log commit working_copy mutable commit_id shortest prefix::a>>[38;5;8m<<log commit working_copy mutable commit_id shortest rest::ec3ec96>>[39m<<log commit working_copy mutable:: >>[38;5;10m<<log commit working_copy mutable empty::(empty)>>[39m<<log commit working_copy mutable:: >>[38;5;10m<<log commit working_copy mutable empty description placeholder::(no description set)>>[39m<<log commit working_copy mutable::>>[0m
+    [1m[38;5;2m<<log commit node working_copy mutable::@>>[0m  [1m[38;5;13m<<log commit working_copy mutable change_id shortest prefix::y>>[38;5;8m<<log commit working_copy mutable change_id shortest rest::lvkpnrz>>[39m<<log commit working_copy mutable:: >>[38;5;9m<<log commit working_copy mutable email placeholder::(no email set)>>[39m<<log commit working_copy mutable:: >>[38;5;14m<<log commit working_copy mutable committer timestamp local format::2001-02-03 08:05:08>>[39m<<log commit working_copy mutable:: >>[38;5;13m<<log commit working_copy mutable bookmarks name::my-bookmark>>[39m<<log commit working_copy mutable:: >>[38;5;12m<<log commit working_copy mutable commit_id shortest prefix::a>>[38;5;8m<<log commit working_copy mutable commit_id shortest rest::2294f19>>[39m<<log commit working_copy mutable:: >>[38;5;10m<<log commit working_copy mutable empty::(empty)>>[39m<<log commit working_copy mutable:: >>[38;5;10m<<log commit working_copy mutable empty description placeholder::(no description set)>>[39m<<log commit working_copy mutable::>>[0m
     <<log commit node mutable::○>>  [1m[38;5;5m<<log commit mutable change_id shortest prefix::q>>[0m[38;5;8m<<log commit mutable change_id shortest rest::pvuntsm>>[39m<<log commit mutable:: >>[38;5;3m<<log commit mutable author email local::test.user>>[39m<<log commit mutable:: >>[38;5;6m<<log commit mutable committer timestamp local format::2001-02-03 08:05:07>>[39m<<log commit mutable:: >>[1m[38;5;4m<<log commit mutable commit_id shortest prefix::e>>[0m[38;5;8m<<log commit mutable commit_id shortest rest::8849ae1>>[39m<<log commit mutable:: >>[38;5;2m<<log commit mutable empty::(empty)>>[39m<<log commit mutable:: >>[38;5;2m<<log commit mutable empty description placeholder::(no description set)>>[39m<<log commit mutable::>>
     [1m[38;5;14m<<log commit node immutable::◆>>[0m  [1m[38;5;5m<<log commit immutable change_id shortest prefix::z>>[0m[38;5;8m<<log commit immutable change_id shortest rest::zzzzzzz>>[39m<<log commit immutable:: >>[38;5;2m<<log commit immutable root::root()>>[39m<<log commit immutable:: >>[1m[38;5;4m<<log commit immutable commit_id shortest prefix::0>>[0m[38;5;8m<<log commit immutable commit_id shortest rest::0000000>>[39m<<log commit immutable::>>
     [EOF]
     ");
 
     insta::assert_snapshot!(render(r#"builtin_log_compact"#), @"
-    [1m[38;5;2m<<log commit node working_copy mutable::@>>[0m  [1m[38;5;13m<<log commit working_copy mutable change_id shortest prefix::r>>[38;5;8m<<log commit working_copy mutable change_id shortest rest::lvkpnrz>>[39m<<log commit working_copy mutable:: >>[38;5;9m<<log commit working_copy mutable email placeholder::(no email set)>>[39m<<log commit working_copy mutable:: >>[38;5;14m<<log commit working_copy mutable committer timestamp local format::2001-02-03 08:05:08>>[39m<<log commit working_copy mutable:: >>[38;5;13m<<log commit working_copy mutable bookmarks name::my-bookmark>>[39m<<log commit working_copy mutable:: >>[38;5;12m<<log commit working_copy mutable commit_id shortest prefix::a>>[38;5;8m<<log commit working_copy mutable commit_id shortest rest::ec3ec96>>[39m<<log commit working_copy mutable::>>[0m
+    [1m[38;5;2m<<log commit node working_copy mutable::@>>[0m  [1m[38;5;13m<<log commit working_copy mutable change_id shortest prefix::y>>[38;5;8m<<log commit working_copy mutable change_id shortest rest::lvkpnrz>>[39m<<log commit working_copy mutable:: >>[38;5;9m<<log commit working_copy mutable email placeholder::(no email set)>>[39m<<log commit working_copy mutable:: >>[38;5;14m<<log commit working_copy mutable committer timestamp local format::2001-02-03 08:05:08>>[39m<<log commit working_copy mutable:: >>[38;5;13m<<log commit working_copy mutable bookmarks name::my-bookmark>>[39m<<log commit working_copy mutable:: >>[38;5;12m<<log commit working_copy mutable commit_id shortest prefix::a>>[38;5;8m<<log commit working_copy mutable commit_id shortest rest::2294f19>>[39m<<log commit working_copy mutable::>>[0m
     │  [1m[38;5;10m<<log commit working_copy mutable empty::(empty)>>[39m<<log commit working_copy mutable:: >>[38;5;10m<<log commit working_copy mutable empty description placeholder::(no description set)>>[39m<<log commit working_copy mutable::>>[0m
     <<log commit node mutable::○>>  [1m[38;5;5m<<log commit mutable change_id shortest prefix::q>>[0m[38;5;8m<<log commit mutable change_id shortest rest::pvuntsm>>[39m<<log commit mutable:: >>[38;5;3m<<log commit mutable author email local::test.user>><<log commit mutable author email::@>><<log commit mutable author email domain::example.com>>[39m<<log commit mutable:: >>[38;5;6m<<log commit mutable committer timestamp local format::2001-02-03 08:05:07>>[39m<<log commit mutable:: >>[1m[38;5;4m<<log commit mutable commit_id shortest prefix::e>>[0m[38;5;8m<<log commit mutable commit_id shortest rest::8849ae1>>[39m<<log commit mutable::>>
     │  [38;5;2m<<log commit mutable empty::(empty)>>[39m<<log commit mutable:: >>[38;5;2m<<log commit mutable empty description placeholder::(no description set)>>[39m<<log commit mutable::>>
@@ -492,7 +492,7 @@ fn test_log_builtin_templates_colored_debug() {
     ");
 
     insta::assert_snapshot!(render(r#"builtin_log_comfortable"#), @"
-    [1m[38;5;2m<<log commit node working_copy mutable::@>>[0m  [1m[38;5;13m<<log commit working_copy mutable change_id shortest prefix::r>>[38;5;8m<<log commit working_copy mutable change_id shortest rest::lvkpnrz>>[39m<<log commit working_copy mutable:: >>[38;5;9m<<log commit working_copy mutable email placeholder::(no email set)>>[39m<<log commit working_copy mutable:: >>[38;5;14m<<log commit working_copy mutable committer timestamp local format::2001-02-03 08:05:08>>[39m<<log commit working_copy mutable:: >>[38;5;13m<<log commit working_copy mutable bookmarks name::my-bookmark>>[39m<<log commit working_copy mutable:: >>[38;5;12m<<log commit working_copy mutable commit_id shortest prefix::a>>[38;5;8m<<log commit working_copy mutable commit_id shortest rest::ec3ec96>>[39m<<log commit working_copy mutable::>>[0m
+    [1m[38;5;2m<<log commit node working_copy mutable::@>>[0m  [1m[38;5;13m<<log commit working_copy mutable change_id shortest prefix::y>>[38;5;8m<<log commit working_copy mutable change_id shortest rest::lvkpnrz>>[39m<<log commit working_copy mutable:: >>[38;5;9m<<log commit working_copy mutable email placeholder::(no email set)>>[39m<<log commit working_copy mutable:: >>[38;5;14m<<log commit working_copy mutable committer timestamp local format::2001-02-03 08:05:08>>[39m<<log commit working_copy mutable:: >>[38;5;13m<<log commit working_copy mutable bookmarks name::my-bookmark>>[39m<<log commit working_copy mutable:: >>[38;5;12m<<log commit working_copy mutable commit_id shortest prefix::a>>[38;5;8m<<log commit working_copy mutable commit_id shortest rest::2294f19>>[39m<<log commit working_copy mutable::>>[0m
     │  [1m[38;5;10m<<log commit working_copy mutable empty::(empty)>>[39m<<log commit working_copy mutable:: >>[38;5;10m<<log commit working_copy mutable empty description placeholder::(no description set)>>[39m<<log commit working_copy mutable::>>[0m
     │  <<log commit::>>
     <<log commit node mutable::○>>  [1m[38;5;5m<<log commit mutable change_id shortest prefix::q>>[0m[38;5;8m<<log commit mutable change_id shortest rest::pvuntsm>>[39m<<log commit mutable:: >>[38;5;3m<<log commit mutable author email local::test.user>><<log commit mutable author email::@>><<log commit mutable author email domain::example.com>>[39m<<log commit mutable:: >>[38;5;6m<<log commit mutable committer timestamp local format::2001-02-03 08:05:07>>[39m<<log commit mutable:: >>[1m[38;5;4m<<log commit mutable commit_id shortest prefix::e>>[0m[38;5;8m<<log commit mutable commit_id shortest rest::8849ae1>>[39m<<log commit mutable::>>
@@ -504,8 +504,8 @@ fn test_log_builtin_templates_colored_debug() {
     ");
 
     insta::assert_snapshot!(render(r#"builtin_log_detailed"#), @"
-    [1m[38;5;2m<<log commit node working_copy mutable::@>>[0m  <<log commit::Commit ID: >>[38;5;4m<<log commit commit_id::aec3ec964d0771edea9da48a2a170bc6ffa1c725>>[39m<<log commit::>>
-    │  <<log commit::Change ID: >>[38;5;5m<<log commit change_id::rlvkpnrzqnoowoytxnquwvuryrwnrmlp>>[39m<<log commit::>>
+    [1m[38;5;2m<<log commit node working_copy mutable::@>>[0m  <<log commit::Commit ID: >>[38;5;4m<<log commit commit_id::a2294f19ef78dd9f7b52f9e8d9f84f213991df75>>[39m<<log commit::>>
+    │  <<log commit::Change ID: >>[38;5;5m<<log commit change_id::ylvkpnrzqnoowoytxnquwvuryrwnrmlp>>[39m<<log commit::>>
     │  <<log commit::Bookmarks: >>[38;5;5m<<log commit local_bookmarks name::my-bookmark>>[39m<<log commit::>>
     │  <<log commit::Author   : >>[38;5;1m<<log commit name placeholder::(no name set)>>[39m<<log commit:: <>>[38;5;1m<<log commit email placeholder::(no email set)>>[39m<<log commit::> (>>[38;5;6m<<log commit author timestamp local format::2001-02-03 08:05:08>>[39m<<log commit::)>>
     │  <<log commit::Committer: >>[38;5;1m<<log commit name placeholder::(no name set)>>[39m<<log commit:: <>>[38;5;1m<<log commit email placeholder::(no email set)>>[39m<<log commit::> (>>[38;5;6m<<log commit committer timestamp local format::2001-02-03 08:05:08>>[39m<<log commit::)>>
@@ -680,11 +680,11 @@ fn test_log_bookmarks() {
     let template = r#"commit_id.short() ++ " " ++ if(bookmarks, bookmarks, "(no bookmarks)")"#;
     let output = work_dir.run_jj(["log", "-T", template]);
     insta::assert_snapshot!(output, @"
-    @  4bc3723efff8 bookmark2* new-bookmark
-    ○  38a204733702 bookmark2@origin unchanged
-    │ ○  1c14797dac42 bookmark3?? bookmark3@origin
+    @  f2054b524a9f bookmark2* new-bookmark
+    ○  7ac95915695d bookmark2@origin unchanged
+    │ ○  4a4193d5c144 bookmark3?? bookmark3@origin
     ├─╯
-    │ ○  8223b15ac1f1 bookmark3??
+    │ ○  1a352a12a80f bookmark3??
     ├─╯
     │ ○  a156ef717a61 bookmark1*
     ├─╯
@@ -1033,27 +1033,27 @@ fn test_short_prefix_in_transaction() {
     }
 
     // Short prefix should be used for commit summary inside the transaction
-    let parent_id = "c0b41"; // Force id lookup to build index before mutation.
+    let parent_id = "f8f45b6f"; // Force id lookup to build index before mutation.
     // If the cached index wasn't invalidated, the
     // newly created commit wouldn't be found in it.
     let output = work_dir.run_jj(["new", parent_id, "--no-edit", "-m", "test"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Created new commit km[kuslswpqwq] a[5d12a825adf] test
+    Created new commit y[mkuslswpqwq] 4[e0cf904ae83] test
     [EOF]
     ");
 
     // Should match log's short prefixes
     let output = work_dir.run_jj(["log", "--no-graph"]);
     insta::assert_snapshot!(output, @"
-    km[kuslswpqwq] a[5d12a825adf] test
-    y[qosqzytrlsw] c0[b41b9a1b34] commit4
-    r[oyxmykxtrkr] 1[2124aa50a07] commit3
-    m[zvwutvlkqwt] c7[673aedfb82] commit2
-    zs[uskulnrvyr] 4[36497fbfb9d] commit1
-    kk[mpptxzrspx] d[70e8b9aa12b] commit0
-    q[pvuntsmwlqt] 8[216f646c36d] initial
-    zz[zzzzzzzzzz] 0[00000000000]
+    y[mkuslswpqwq] 4[e0cf904ae83] test
+    oq[npsmvxstuu] f[8f45b6f7c16] commit4
+    p[vuryyxzkwns] af[8ca8a641fc] commit3
+    ox[ksrouukrux] 5[1e82abe1c5c] commit2
+    w[vkykwnropow] d[394e91a0084] commit1
+    qm[oqmnpmlxnw] ac[6a56ad5c9c] commit0
+    qp[vuntsmwlqt] 8[216f646c36d] initial
+    z[zzzzzzzzzzz] 0[00000000000]
     [EOF]
     ");
 
@@ -1061,12 +1061,12 @@ fn test_short_prefix_in_transaction() {
 
     let output = work_dir.run_jj(["log", "--no-graph"]);
     insta::assert_snapshot!(output, @"
-    kmk[uslswpqwq] a5[d12a825adf] test
-    yq[osqzytrlsw] c0b[41b9a1b34] commit4
-    ro[yxmykxtrkr] 121[24aa50a07] commit3
-    mz[vwutvlkqwt] c7[673aedfb82] commit2
-    zs[uskulnrvyr] 43[6497fbfb9d] commit1
-    kk[mpptxzrspx] d7[0e8b9aa12b] commit0
+    ym[kuslswpqwq] 4e0[cf904ae83] test
+    oqn[psmvxstuu] f8[f45b6f7c16] commit4
+    pv[uryyxzkwns] af8[ca8a641fc] commit3
+    ox[ksrouukrux] 51e[82abe1c5c] commit2
+    wv[kykwnropow] d3[94e91a0084] commit1
+    qm[oqmnpmlxnw] ac[6a56ad5c9c] commit0
     qp[vuntsmwlqt] 82[16f646c36d] initial
     zz[zzzzzzzzzz] 00[0000000000]
     [EOF]
@@ -1364,7 +1364,7 @@ fn test_log_diff_predefined_formats() -> TestResult {
     "#};
     let output = work_dir.run_jj(["log", "--no-graph", "-T", template]);
     insta::assert_snapshot!(output, @"
-    === d9ea8f447a3b ===
+    === a3d71295d3e8 ===
     file1 [modified] source=file1 [file] target=file1 [file]
     file2 [modified] source=file2 [file] target=file2 [file]
     rename-target [renamed] source=rename-source [file] target=rename-target [file]
@@ -1391,7 +1391,7 @@ fn test_log_diff_predefined_formats() -> TestResult {
     "#};
     let output = work_dir.run_jj(["log", "--no-graph", "-T", template]);
     insta::assert_snapshot!(output, @"
-    === d9ea8f447a3b ===
+    === a3d71295d3e8 ===
     * total_added=3 total_removed=1
     === 20bc00d202c2 ===
     * total_added=4 total_removed=0
@@ -1727,7 +1727,7 @@ fn test_log_git_format_patch_template() {
         "-r@",
     ]);
     insta::assert_snapshot!(output, @"
-    From fee27496968a4347a49d69c0a634fc0d5cf7fbc0 Mon Sep 17 00:00:00 2001
+    From a38362fe47fc26f52e5eef302d1f5ed31daa1970 Mon Sep 17 00:00:00 2001
     From: Test User <test.user@example.com>
     Date: Sat, 3 Feb 2001 04:05:08 +0700
     Subject: [PATCH] some change

--- a/cli/tests/test_completion.rs
+++ b/cli/tests/test_completion.rs
@@ -1103,11 +1103,11 @@ fn test_revisions() {
     deleted_bookmark	(deleted bookmark)
     immutable_bookmark	immutable
     mutable_bookmark	mutable 1
-    wv	working_copy
-    x	conflicted
-    u	mutable 3
-    wq/0	mutable 2
-    wq/1	mutable 1
+    s	working_copy
+    o	conflicted
+    v	mutable 3
+    w/0	mutable 2
+    w/1	mutable 1
     q	immutable
     m	deleted_remote_commit
     r	remote_commit
@@ -1126,11 +1126,11 @@ fn test_revisions() {
     ..deleted_bookmark	(deleted bookmark)
     ..immutable_bookmark	immutable
     ..mutable_bookmark	mutable 1
-    ..wv	working_copy
-    ..x	conflicted
-    ..u	mutable 3
-    ..wq/0	mutable 2
-    ..wq/1	mutable 1
+    ..s	working_copy
+    ..o	conflicted
+    ..v	mutable 3
+    ..w/0	mutable 2
+    ..w/1	mutable 1
     ..q	immutable
     ..m	deleted_remote_commit
     ..r	remote_commit
@@ -1147,11 +1147,11 @@ fn test_revisions() {
     insta::assert_snapshot!(output, @"
     conflicted_bookmark	conflicted
     mutable_bookmark	mutable 1
-    wv	working_copy
-    x	conflicted
-    u	mutable 3
-    wq/0	mutable 2
-    wq/1	mutable 1
+    s	working_copy
+    o	conflicted
+    v	mutable 3
+    w/0	mutable 2
+    w/1	mutable 1
     m	deleted_remote_commit
     r	remote_commit
     alias_with_newline	    roots(
@@ -1164,11 +1164,11 @@ fn test_revisions() {
     insta::assert_snapshot!(output, @"
     y::conflicted_bookmark	conflicted
     y::mutable_bookmark	mutable 1
-    y::wv	working_copy
-    y::x	conflicted
-    y::u	mutable 3
-    y::wq/0	mutable 2
-    y::wq/1	mutable 1
+    y::s	working_copy
+    y::o	conflicted
+    y::v	mutable 3
+    y::w/0	mutable 2
+    y::w/1	mutable 1
     y::m	deleted_remote_commit
     y::r	remote_commit
     y::alias_with_newline	    roots(
@@ -1187,7 +1187,7 @@ fn test_revisions() {
     let output = work_dir.complete_fish(["resolve", "-r", ""]);
     insta::assert_snapshot!(output, @"
     conflicted_bookmark	conflicted
-    x	conflicted
+    o	conflicted
     alias_with_newline	    roots(
     siblings	@-+ ~@
     [EOF]
@@ -1201,11 +1201,11 @@ fn test_revisions() {
     deleted_bookmark	(deleted bookmark)
     immutable_bookmark	immutable
     mutable_bookmark	mutable 1
-    wv	working_copy
-    x	conflicted
-    u	mutable 3
-    wq/0	mutable 2
-    wq/1	mutable 1
+    s	working_copy
+    o	conflicted
+    v	mutable 3
+    w/0	mutable 2
+    w/1	mutable 1
     q	immutable
     m	deleted_remote_commit
     r	remote_commit
@@ -1232,11 +1232,11 @@ fn test_revisions() {
     a=deleted_bookmark	(deleted bookmark)
     a=immutable_bookmark	immutable
     a=mutable_bookmark	mutable 1
-    a=wv	working_copy
-    a=x	conflicted
-    a=u	mutable 3
-    a=wq/0	mutable 2
-    a=wq/1	mutable 1
+    a=s	working_copy
+    a=o	conflicted
+    a=v	mutable 3
+    a=w/0	mutable 2
+    a=w/1	mutable 1
     a=q	immutable
     a=m	deleted_remote_commit
     a=r	remote_commit
@@ -1772,11 +1772,11 @@ fn test_files() {
 
     let output = work_dir.run_jj(["log", "-r", "all()", "--summary"]);
     insta::assert_snapshot!(output.normalize_backslash(), @"
-    @  wqnwkozp test.user@example.com 2001-02-03 08:05:20 working_copy 5e0882cf
+    @  vqnwkozp test.user@example.com 2001-02-03 08:05:20 working_copy 62eb5eb5
     │  working_copy
     │  A f_added_2
     │  M f_modified
-    ○  zsuskuln test.user@example.com 2001-02-03 08:05:11 second 5d65dc93
+    ○  psuskuln test.user@example.com 2001-02-03 08:05:11 second bdac7f81
     │  second
     │  A f_added
     │  R {f_not_yet_renamed_2 => f_another_renamed_2}
@@ -1789,14 +1789,14 @@ fn test_files() {
     │  M f_modified
     │  M f_not_yet_copied
     │  R {f_not_yet_renamed => f_renamed}
-    │ ×  royxmykx test.user@example.com 2001-02-03 08:05:14 conflicted 26ca82ca (conflict)
+    │ ×  ooyxmykx test.user@example.com 2001-02-03 08:05:14 conflicted 731855c0 (conflict)
     ├─╯  conflicted
     │    A f_added_2
     │    A f_dir/dir_file_1
     │    A f_dir/dir_file_2
     │    A f_dir/dir_file_3
     │    M f_modified
-    ○  rlvkpnrz test.user@example.com 2001-02-03 08:05:09 first 221854a7
+    ○  ylvkpnrz test.user@example.com 2001-02-03 08:05:09 first af0eb988
     │  first
     │  A f_deleted
     │  A f_modified
@@ -1809,7 +1809,7 @@ fn test_files() {
     ├─╯  interdiff_to
     │    A f_interdiff_only_to
     │    A f_interdiff_same
-    │ ○  yostqsxw test.user@example.com 2001-02-03 08:05:16 interdiff_from 039b07b8
+    │ ○  rostqsxw test.user@example.com 2001-02-03 08:05:16 interdiff_from 58997fb4
     ├─╯  interdiff_from
     │    A f_interdiff_only_from
     │    A f_interdiff_same

--- a/cli/tests/test_describe_command.rs
+++ b/cli/tests/test_describe_command.rs
@@ -290,8 +290,8 @@ fn test_describe_multiple_commits() -> TestResult {
     work_dir.run_jj(["new"]).success();
     work_dir.run_jj(["new"]).success();
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  3cd3b246e098
-    ○  43444d88b009
+    @  a07d0f877d2a
+    ○  e521ae80c3d7
     ○  e8849ae12c70
     ◆  000000000000
     [EOF]
@@ -303,13 +303,13 @@ fn test_describe_multiple_commits() -> TestResult {
     ------- stderr -------
     Updated 2 commits
     Rebased 1 descendant commits
-    Working copy  (@) now at: kkmpptxz 4c3ccb9d (empty) description from CLI
-    Parent commit (@-)      : rlvkpnrz 650ac8f2 (empty) (no description set)
+    Working copy  (@) now at: nkmpptxz ab62d288 (empty) description from CLI
+    Parent commit (@-)      : ylvkpnrz 31e70c16 (empty) (no description set)
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  4c3ccb9d4fb2 description from CLI
-    ○  650ac8f249be
+    @  ab62d288fd83 description from CLI
+    ○  31e70c16c565
     ○  0ff65c91377a description from CLI
     ◆  000000000000
     [EOF]
@@ -332,15 +332,15 @@ fn test_describe_multiple_commits() -> TestResult {
     JJ: - The text you enter will be lost on a syntax error.
     JJ: - The syntax of the separator lines may change in the future.
     JJ:
-    JJ: describe 650ac8f249be -------
+    JJ: describe 31e70c16c565 -------
 
 
-    JJ: Change ID: rlvkpnrz
+    JJ: Change ID: ylvkpnrz
     JJ:
-    JJ: describe 4c3ccb9d4fb2 -------
+    JJ: describe ab62d288fd83 -------
     description from CLI
 
-    JJ: Change ID: kkmpptxz
+    JJ: Change ID: nkmpptxz
     JJ:
     JJ: Lines starting with "JJ:" (like this one) will be removed.
     "#);
@@ -354,12 +354,12 @@ fn test_describe_multiple_commits() -> TestResult {
 
             JJ: More header tests. Library tests verify parsing in other situations.
 
-            JJ: describe 650ac8f249be -------
+            JJ: describe 31e70c16c565 -------
             description from editor of @-
 
             further commit message of @-
 
-            JJ: describe 4c3ccb9d4fb2 -------
+            JJ: describe ab62d288fd83 -------
             description from editor of @
 
             further commit message of @
@@ -371,15 +371,15 @@ fn test_describe_multiple_commits() -> TestResult {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Updated 2 commits
-    Working copy  (@) now at: kkmpptxz 87c0f3c7 (empty) description from editor of @
-    Parent commit (@-)      : rlvkpnrz 9b9041eb (empty) description from editor of @-
+    Working copy  (@) now at: nkmpptxz e815e741 (empty) description from editor of @
+    Parent commit (@-)      : ylvkpnrz 65673735 (empty) description from editor of @-
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  87c0f3c75a22 description from editor of @
+    @  e815e7414ec1 description from editor of @
     │
     │  further commit message of @
-    ○  9b9041eb2f04 description from editor of @-
+    ○  656737351c23 description from editor of @-
     │
     │  further commit message of @-
     ○  0ff65c91377a description from CLI
@@ -392,17 +392,17 @@ fn test_describe_multiple_commits() -> TestResult {
         &edit_script,
         indoc! {"
             write
-            JJ: describe 9b9041eb2f04 -------
+            JJ: describe 656737351c23 -------
             first description from editor of @-
 
             further commit message of @-
 
-            JJ: describe 9b9041eb2f04 -------
+            JJ: describe 656737351c23 -------
             second description from editor of @-
 
             further commit message of @-
 
-            JJ: describe 87c0f3c75a22 -------
+            JJ: describe e815e7414ec1 -------
             updated description from editor of @
 
             further commit message of @
@@ -413,7 +413,7 @@ fn test_describe_multiple_commits() -> TestResult {
     let output = work_dir.run_jj(["describe", "@", "@-"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Error: The following commits were found in the edited message multiple times: 9b9041eb2f04
+    Error: The following commits were found in the edited message multiple times: 656737351c23
     [EOF]
     [exit status: 1]
     ");
@@ -426,12 +426,12 @@ fn test_describe_multiple_commits() -> TestResult {
             JJ: describe 000000000000 -------
             unexpected commit ID
 
-            JJ: describe 9b9041eb2f04 -------
+            JJ: describe 656737351c23 -------
             description from editor of @-
 
             further commit message of @-
 
-            JJ: describe 87c0f3c75a22 -------
+            JJ: describe e815e7414ec1 -------
             description from editor of @
 
             further commit message of @
@@ -452,7 +452,7 @@ fn test_describe_multiple_commits() -> TestResult {
         &edit_script,
         indoc! {"
             write
-            JJ: describe 87c0f3c75a22 -------
+            JJ: describe e815e7414ec1 -------
             description from editor of @
 
             further commit message of @
@@ -463,7 +463,7 @@ fn test_describe_multiple_commits() -> TestResult {
     let output = work_dir.run_jj(["describe", "@", "@-"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Error: The description for the following commits were not found in the edited message: 9b9041eb2f04
+    Error: The description for the following commits were not found in the edited message: 656737351c23
     [EOF]
     [exit status: 1]
     ");
@@ -476,7 +476,7 @@ fn test_describe_multiple_commits() -> TestResult {
             write
             description from editor of @-
 
-            JJ: describe 9b9041eb2f04 -------
+            JJ: describe 656737351c23 -------
             description from editor of @
 
             JJ: Lines starting with \"JJ: \" (like this one) will be removed.
@@ -515,7 +515,7 @@ fn test_describe_multiple_commits() -> TestResult {
         &edit_script,
         indoc! {"
             write
-            JJ: describe 9b9041eb2f04 -------
+            JJ: describe 656737351c23 -------
             description from editor for @-
 
             JJ: ignore-rest
@@ -533,15 +533,15 @@ fn test_describe_multiple_commits() -> TestResult {
     ------- stderr -------
     Updated 2 commits
     Rebased 1 descendant commits
-    Working copy  (@) now at: kkmpptxz 5a6249e9 (empty) description from editor of @
-    Parent commit (@-)      : rlvkpnrz d1c1edbd (empty) description from editor for @-
+    Working copy  (@) now at: nkmpptxz 82913d75 (empty) description from editor of @
+    Parent commit (@-)      : ylvkpnrz 5d2b587a (empty) description from editor for @-
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  5a6249e9e71a description from editor of @
+    @  82913d75dc59 description from editor of @
     │
     │  further commit message of @
-    ○  d1c1edbd5595 description from editor for @-
+    ○  5d2b587a2a01 description from editor for @-
     ○  a8bf976d72fb description from editor for @--
     ◆  000000000000
     [EOF]
@@ -986,7 +986,7 @@ fn test_add_trailer() {
     let output = work_dir.run_jj(["new"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: yostqsxw dbea21e1 (empty) (no description set)
+    Working copy  (@) now at: rostqsxw 7a4d1c7e (empty) (no description set)
     Parent commit (@-)      : qpvuntsm 2b2e302d (empty) Message from CLI
     [EOF]
     ");
@@ -1102,7 +1102,7 @@ fn test_add_trailer_committer() -> TestResult {
     let output = work_dir.run_jj(["describe"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: vruxwmqv b6148729 (empty) Signed-off-by: test.user@example.com
+    Working copy  (@) now at: truxwmqv ad199853 (empty) Signed-off-by: test.user@example.com
     Parent commit (@-)      : qpvuntsm b7dafa2c (empty) Message from CLI
     [EOF]
     ");
@@ -1115,7 +1115,7 @@ fn test_add_trailer_committer() -> TestResult {
 
     Signed-off-by: test.user@example.com
 
-    JJ: Change ID: vruxwmqv
+    JJ: Change ID: truxwmqv
     JJ:
     JJ: Lines starting with "JJ:" (like this one) will be removed.
     -----

--- a/cli/tests/test_diff_command.rs
+++ b/cli/tests/test_diff_command.rs
@@ -2553,19 +2553,19 @@ fn test_diff_conflict_sides_differ() {
     // left1+right1.
     work_dir.run_jj(["new", "root()"]).success();
     insta::assert_snapshot!(work_dir.run_jj(["log", "-r~@"]), @"
-    ×    lylxulpl test.user@example.com 2001-02-03 08:05:20 left2+right2 9bdc15d2 (conflict)
+    ×    lylxulpl test.user@example.com 2001-02-03 08:05:20 left2+right2 eb31b480 (conflict)
     ├─╮  (empty) left2+right2
-    │ ○  znkkpsqq test.user@example.com 2001-02-03 08:05:17 right2 e57450eb
+    │ ○  nnkkpsqq test.user@example.com 2001-02-03 08:05:17 right2 423d82be
     │ │  right2
-    ○ │  royxmykx test.user@example.com 2001-02-03 08:05:13 left2 b50b218b
+    ○ │  ooyxmykx test.user@example.com 2001-02-03 08:05:13 left2 07184bf6
     │ │  left2
-    │ │ ×  kmkuslsw test.user@example.com 2001-02-03 08:05:18 left1+right1 b866d751 (conflict)
+    │ │ ×  wmkuslsw test.user@example.com 2001-02-03 08:05:18 left1+right1 0921c844 (conflict)
     ╭─┬─╯  (empty) left1+right1
-    │ ○  vruxwmqv test.user@example.com 2001-02-03 08:05:15 right1 3fe2e860
+    │ ○  truxwmqv test.user@example.com 2001-02-03 08:05:15 right1 9b436591
     │ │  right1
-    ○ │  zsuskuln test.user@example.com 2001-02-03 08:05:11 left1 713a980c
+    ○ │  psuskuln test.user@example.com 2001-02-03 08:05:11 left1 c3121775
     ├─╯  left1
-    ○  rlvkpnrz test.user@example.com 2001-02-03 08:05:09 base aa7e33ed
+    ○  ylvkpnrz test.user@example.com 2001-02-03 08:05:09 base 7953f024
     │  base
     ◆  zzzzzzzz root() 00000000
     [EOF]
@@ -2623,12 +2623,12 @@ fn test_diff_conflict_sides_differ() {
      line 2
     -line 3
     +<<<<<<< conflict 1 of 1
-    ++++++++ zsuskuln 713a980c "left1"
+    ++++++++ psuskuln c3121775 "left1"
     +left 3.1
     +left 3.2
     +left 3.3
-    +%%%%%%% diff from: rlvkpnrz aa7e33ed "base"
-    +\\\\\\\        to: vruxwmqv 3fe2e860 "right1"
+    +%%%%%%% diff from: ylvkpnrz 7953f024 "base"
+    +\\\\\\\        to: truxwmqv 9b436591 "right1"
     +-line 3
     ++right 3.1
     +>>>>>>> conflict 1 of 1 ends
@@ -2640,12 +2640,12 @@ fn test_diff_conflict_sides_differ() {
     [2m[38;5;1m   1[0m [2m[38;5;2m   1[0m: line 1
     [2m[38;5;1m   2[0m [2m[38;5;2m   2[0m: line 2
          [38;5;2m   3[39m: [4m[38;5;2m<<<<<<< conflict 1 of 1[24m[39m
-         [38;5;2m   4[39m: [4m[38;5;2m+++++++ zsuskuln 713a980c "left1"[24m[39m
+         [38;5;2m   4[39m: [4m[38;5;2m+++++++ psuskuln c3121775 "left1"[24m[39m
          [38;5;2m   5[39m: [4m[38;5;2mleft 3.1[24m[39m
          [38;5;2m   6[39m: [4m[38;5;2mleft 3.2[24m[39m
          [38;5;2m   7[39m: [4m[38;5;2mleft 3.3[24m[39m
-         [38;5;2m   8[39m: [4m[38;5;2m%%%%%%% diff from: rlvkpnrz aa7e33ed "base"[24m[39m
-         [38;5;2m   9[39m: [4m[38;5;2m\\\\\\\        to: vruxwmqv 3fe2e860 "right1"[24m[39m
+         [38;5;2m   8[39m: [4m[38;5;2m%%%%%%% diff from: ylvkpnrz 7953f024 "base"[24m[39m
+         [38;5;2m   9[39m: [4m[38;5;2m\\\\\\\        to: truxwmqv 9b436591 "right1"[24m[39m
     [38;5;1m   3[39m [38;5;2m  10[39m: [4m[38;5;2m-[24m[39mline 3
          [38;5;2m  11[39m: [4m[38;5;2m+right 3.1[24m[39m
          [38;5;2m  12[39m: [4m[38;5;2m>>>>>>> conflict 1 of 1 ends[24m[39m
@@ -2681,12 +2681,12 @@ fn test_diff_conflict_sides_differ() {
     @@ -2,12 +2,3 @@
      line 2
     -<<<<<<< conflict 1 of 1
-    -+++++++ zsuskuln 713a980c "left1"
+    -+++++++ psuskuln c3121775 "left1"
     -left 3.1
     -left 3.2
     -left 3.3
-    -%%%%%%% diff from: rlvkpnrz aa7e33ed "base"
-    -\\\\\\\        to: vruxwmqv 3fe2e860 "right1"
+    -%%%%%%% diff from: ylvkpnrz 7953f024 "base"
+    -\\\\\\\        to: truxwmqv 9b436591 "right1"
     --line 3
     -+right 3.1
     ->>>>>>> conflict 1 of 1 ends
@@ -2699,12 +2699,12 @@ fn test_diff_conflict_sides_differ() {
     [2m[38;5;1m   1[0m [2m[38;5;2m   1[0m: line 1
     [2m[38;5;1m   2[0m [2m[38;5;2m   2[0m: line 2
     [38;5;1m   3[39m     : [4m[38;5;1m<<<<<<< conflict 1 of 1[24m[39m
-    [38;5;1m   4[39m     : [4m[38;5;1m+++++++ zsuskuln 713a980c "left1"[24m[39m
+    [38;5;1m   4[39m     : [4m[38;5;1m+++++++ psuskuln c3121775 "left1"[24m[39m
     [38;5;1m   5[39m     : [4m[38;5;1mleft 3.1[24m[39m
     [38;5;1m   6[39m     : [4m[38;5;1mleft 3.2[24m[39m
     [38;5;1m   7[39m     : [4m[38;5;1mleft 3.3[24m[39m
-    [38;5;1m   8[39m     : [4m[38;5;1m%%%%%%% diff from: rlvkpnrz aa7e33ed "base"[24m[39m
-    [38;5;1m   9[39m     : [4m[38;5;1m\\\\\\\        to: vruxwmqv 3fe2e860 "right1"[24m[39m
+    [38;5;1m   8[39m     : [4m[38;5;1m%%%%%%% diff from: ylvkpnrz 7953f024 "base"[24m[39m
+    [38;5;1m   9[39m     : [4m[38;5;1m\\\\\\\        to: truxwmqv 9b436591 "right1"[24m[39m
     [38;5;1m  10[39m [38;5;2m   3[39m: [4m[38;5;1m-[24m[39mline 3
     [38;5;1m  11[39m     : [4m[38;5;1m+right 3.1[24m[39m
     [38;5;1m  12[39m     : [4m[38;5;1m>>>>>>> conflict 1 of 1 ends[24m[39m
@@ -2741,15 +2741,15 @@ fn test_diff_conflict_sides_differ() {
     +left 1.1
      line 2
      <<<<<<< conflict 1 of 1
-    -+++++++ zsuskuln 713a980c "left1"
-    ++++++++ royxmykx b50b218b "left2"
+    -+++++++ psuskuln c3121775 "left1"
+    ++++++++ ooyxmykx 07184bf6 "left2"
      left 3.1
     @@ -7,4 +7,5 @@
      left 3.3
     +left 3.4
-     %%%%%%% diff from: rlvkpnrz aa7e33ed "base"
-    -\\\\\\\        to: vruxwmqv 3fe2e860 "right1"
-    +\\\\\\\        to: znkkpsqq e57450eb "right2"
+     %%%%%%% diff from: ylvkpnrz 7953f024 "base"
+    -\\\\\\\        to: truxwmqv 9b436591 "right1"
+    +\\\\\\\        to: nnkkpsqq 423d82be "right2"
      -line 3
     @@ -13,2 +14,1 @@
      line 4
@@ -2761,15 +2761,15 @@ fn test_diff_conflict_sides_differ() {
     [38;5;1m   1[39m [38;5;2m   1[39m: [4m[38;5;1mline[38;5;2mleft[24m[39m [4m[38;5;2m1.[24m[39m1
     [2m[38;5;1m   2[0m [2m[38;5;2m   2[0m: line 2
     [2m[38;5;1m   3[0m [2m[38;5;2m   3[0m: <<<<<<< conflict 1 of 1
-    [38;5;1m   4[39m     : [38;5;1m+++++++ [4mzsuskuln[24m [4m713a980c[24m "[4mleft1[24m"[39m
-         [38;5;2m   4[39m: [38;5;2m+++++++ [4mroyxmykx[24m [4mb50b218b[24m "[4mleft2[24m"[39m
+    [38;5;1m   4[39m     : [38;5;1m+++++++ [4mpsuskuln[24m [4mc3121775[24m "[4mleft1[24m"[39m
+         [38;5;2m   4[39m: [38;5;2m+++++++ [4mooyxmykx[24m [4m07184bf6[24m "[4mleft2[24m"[39m
     [2m[38;5;1m   5[0m [2m[38;5;2m   5[0m: left 3.1
     [2m[38;5;1m   6[0m [2m[38;5;2m   6[0m: left 3.2
     [2m[38;5;1m   7[0m [2m[38;5;2m   7[0m: left 3.3
          [38;5;2m   8[39m: [4m[38;5;2mleft 3.4[24m[39m
-    [2m[38;5;1m   8[0m [2m[38;5;2m   9[0m: %%%%%%% diff from: rlvkpnrz aa7e33ed "base"
-    [38;5;1m   9[39m     : [38;5;1m\\\\\\\        to: [4mvruxwmqv[24m [4m3fe2e860[24m "[4mright1[24m"[39m
-         [38;5;2m  10[39m: [38;5;2m\\\\\\\        to: [4mznkkpsqq[24m [4me57450eb[24m "[4mright2[24m"[39m
+    [2m[38;5;1m   8[0m [2m[38;5;2m   9[0m: %%%%%%% diff from: ylvkpnrz 7953f024 "base"
+    [38;5;1m   9[39m     : [38;5;1m\\\\\\\        to: [4mtruxwmqv[24m [4m9b436591[24m "[4mright1[24m"[39m
+         [38;5;2m  10[39m: [38;5;2m\\\\\\\        to: [4mnnkkpsqq[24m [4m423d82be[24m "[4mright2[24m"[39m
     [2m[38;5;1m  10[0m [2m[38;5;2m  11[0m: -line 3
         ...
     [2m[38;5;1m  13[0m [2m[38;5;2m  14[0m: line 4
@@ -2865,21 +2865,21 @@ fn test_diff_conflict_bases_differ() {
     // left1+right1.
     work_dir.run_jj(["new", "root()"]).success();
     insta::assert_snapshot!(work_dir.run_jj(["log", "-r~@"]), @"
-    ×    nkmrtpmo test.user@example.com 2001-02-03 08:05:22 left2+right2 18348d27 (conflict)
+    ×    ukmrtpmo test.user@example.com 2001-02-03 08:05:22 left2+right2 caa21817 (conflict)
     ├─╮  (empty) left2+right2
-    │ ○  kmkuslsw test.user@example.com 2001-02-03 08:05:19 right2 656695c3
+    │ ○  wmkuslsw test.user@example.com 2001-02-03 08:05:19 right2 60c9bca0
     │ │  right2
-    ○ │  znkkpsqq test.user@example.com 2001-02-03 08:05:17 left2 218094ec
+    ○ │  nnkkpsqq test.user@example.com 2001-02-03 08:05:17 left2 2ebb86f7
     ├─╯  left2
-    ○  vruxwmqv test.user@example.com 2001-02-03 08:05:15 base2 3c4d67e6
+    ○  truxwmqv test.user@example.com 2001-02-03 08:05:15 base2 6d16668a
     │  base2
-    │ ×    lylxulpl test.user@example.com 2001-02-03 08:05:20 left1+right1 91e2d46a (conflict)
+    │ ×    lylxulpl test.user@example.com 2001-02-03 08:05:20 left1+right1 8dd9a211 (conflict)
     │ ├─╮  (empty) left1+right1
-    │ │ ○  royxmykx test.user@example.com 2001-02-03 08:05:13 right1 3087be1f
+    │ │ ○  ooyxmykx test.user@example.com 2001-02-03 08:05:13 right1 af53f139
     ├───╯  right1
-    │ ○  zsuskuln test.user@example.com 2001-02-03 08:05:11 left1 9e995075
+    │ ○  psuskuln test.user@example.com 2001-02-03 08:05:11 left1 dc799b14
     ├─╯  left1
-    ○  rlvkpnrz test.user@example.com 2001-02-03 08:05:09 base1 44cfbde6
+    ○  ylvkpnrz test.user@example.com 2001-02-03 08:05:09 base1 492e331f
     │  base1
     ◆  zzzzzzzz root() 00000000
     [EOF]
@@ -2923,16 +2923,16 @@ fn test_diff_conflict_bases_differ() {
     -line 1
      line 2
      <<<<<<< conflict 1 of 1
-    -+++++++ zsuskuln 9e995075 "left1"
-    ++++++++ znkkpsqq 218094ec "left2"
+    -+++++++ psuskuln dc799b14 "left1"
+    ++++++++ nnkkpsqq 2ebb86f7 "left2"
      left 3.1
     @@ -7,5 +6,6 @@
      left 3.3
-    -%%%%%%% diff from: rlvkpnrz 44cfbde6 "base1"
-    -\\\\\\\        to: royxmykx 3087be1f "right1"
+    -%%%%%%% diff from: ylvkpnrz 492e331f "base1"
+    -\\\\\\\        to: ooyxmykx af53f139 "right1"
     --line 3
-    +%%%%%%% diff from: vruxwmqv 3c4d67e6 "base2"
-    +\\\\\\\        to: kmkuslsw 656695c3 "right2"
+    +%%%%%%% diff from: truxwmqv 6d16668a "base2"
+    +\\\\\\\        to: wmkuslsw 60c9bca0 "right2"
     +-line 3.1
     +-line 3.2
      +right 3.1
@@ -2943,16 +2943,16 @@ fn test_diff_conflict_bases_differ() {
     [38;5;1m   1[39m     : [4m[38;5;1mline 1[24m[39m
     [2m[38;5;1m   2[0m [2m[38;5;2m   1[0m: line 2
     [2m[38;5;1m   3[0m [2m[38;5;2m   2[0m: <<<<<<< conflict 1 of 1
-    [38;5;1m   4[39m     : [38;5;1m+++++++ [4mzsuskuln[24m [4m9e995075[24m "[4mleft1[24m"[39m
-         [38;5;2m   3[39m: [38;5;2m+++++++ [4mznkkpsqq[24m [4m218094ec[24m "[4mleft2[24m"[39m
+    [38;5;1m   4[39m     : [38;5;1m+++++++ [4mpsuskuln[24m [4mdc799b14[24m "[4mleft1[24m"[39m
+         [38;5;2m   3[39m: [38;5;2m+++++++ [4mnnkkpsqq[24m [4m2ebb86f7[24m "[4mleft2[24m"[39m
     [2m[38;5;1m   5[0m [2m[38;5;2m   4[0m: left 3.1
     [2m[38;5;1m   6[0m [2m[38;5;2m   5[0m: left 3.2
     [2m[38;5;1m   7[0m [2m[38;5;2m   6[0m: left 3.3
-    [38;5;1m   8[39m     : [38;5;1m%%%%%%% diff from: [4mrlvkpnrz[24m [4m44cfbde6[24m "[4mbase1[24m"[39m
-    [38;5;1m   9[39m     : [38;5;1m\\\\\\\        to: [4mroyxmykx[24m [4m3087be1f[24m "[4mright1[24m"[39m
+    [38;5;1m   8[39m     : [38;5;1m%%%%%%% diff from: [4mylvkpnrz[24m [4m492e331f[24m "[4mbase1[24m"[39m
+    [38;5;1m   9[39m     : [38;5;1m\\\\\\\        to: [4mooyxmykx[24m [4maf53f139[24m "[4mright1[24m"[39m
     [38;5;1m  10[39m     : [38;5;1m-[4mline[24m [4m3[24m[39m
-         [38;5;2m   7[39m: [38;5;2m%%%%%%% diff from: [4mvruxwmqv[24m [4m3c4d67e6[24m "[4mbase2[24m"[39m
-         [38;5;2m   8[39m: [38;5;2m\\\\\\\        to: [4mkmkuslsw[24m [4m656695c3[24m "[4mright2[24m"[39m
+         [38;5;2m   7[39m: [38;5;2m%%%%%%% diff from: [4mtruxwmqv[24m [4m6d16668a[24m "[4mbase2[24m"[39m
+         [38;5;2m   8[39m: [38;5;2m\\\\\\\        to: [4mwmkuslsw[24m [4m60c9bca0[24m "[4mright2[24m"[39m
          [38;5;2m   9[39m: [38;5;2m-[4mline[24m [4m3.1[24m[39m
          [38;5;2m  10[39m: [4m[38;5;2m-line 3.2[24m[39m
     [2m[38;5;1m  11[0m [2m[38;5;2m  11[0m: +right 3.1
@@ -3038,19 +3038,19 @@ fn test_diff_conflict_three_sides() {
     // Test the setup
     work_dir.run_jj(["new", "root()"]).success();
     insta::assert_snapshot!(work_dir.run_jj(["log", "-r~@"]), @"
-    ×    lylxulpl test.user@example.com 2001-02-03 08:05:20 side1+side2+side3 90cd440f (conflict)
+    ×    lylxulpl test.user@example.com 2001-02-03 08:05:20 side1+side2+side3 163eba3f (conflict)
     ├─╮  (empty) side1+side2+side3
-    │ ○  znkkpsqq test.user@example.com 2001-02-03 08:05:17 side3 f73063c9
+    │ ○  nnkkpsqq test.user@example.com 2001-02-03 08:05:17 side3 ddd87c7e
     │ │  side3
-    × │    kmkuslsw test.user@example.com 2001-02-03 08:05:18 side1+side2 02d6c21d (conflict)
+    × │    wmkuslsw test.user@example.com 2001-02-03 08:05:18 side1+side2 4a9fb965 (conflict)
     ├───╮  (empty) side1+side2
-    │ │ ○  vruxwmqv test.user@example.com 2001-02-03 08:05:15 side2 bc176227
+    │ │ ○  truxwmqv test.user@example.com 2001-02-03 08:05:15 side2 b5249b46
     │ │ │  side2
-    ○ │ │  royxmykx test.user@example.com 2001-02-03 08:05:13 side1 3a079496
+    ○ │ │  ooyxmykx test.user@example.com 2001-02-03 08:05:13 side1 a6f323a0
     ├───╯  side1
-    ○ │  zsuskuln test.user@example.com 2001-02-03 08:05:11 base2 75289ea3
+    ○ │  psuskuln test.user@example.com 2001-02-03 08:05:11 base2 d6dfffea
     ├─╯  base2
-    ○  rlvkpnrz test.user@example.com 2001-02-03 08:05:09 base1 07965fa1
+    ○  ylvkpnrz test.user@example.com 2001-02-03 08:05:09 base1 f0c1c076
     │  base1
     ◆  zzzzzzzz root() 00000000
     [EOF]
@@ -3100,8 +3100,8 @@ fn test_diff_conflict_three_sides() {
     +++ b/file
     @@ -13,2 +13,6 @@
      line 4 b.2
-    +%%%%%%% diff from: rlvkpnrz 07965fa1 "base1"
-    +\\\\\\\        to: znkkpsqq f73063c9 "side3"
+    +%%%%%%% diff from: ylvkpnrz f0c1c076 "base1"
+    +\\\\\\\        to: nnkkpsqq ddd87c7e "side3"
     + line 2 base
     ++line 3 c.2
      >>>>>>> conflict 1 of 1 ends
@@ -3111,8 +3111,8 @@ fn test_diff_conflict_three_sides() {
     [38;5;3mModified conflict in file:[39m
         ...
     [2m[38;5;1m  13[0m [2m[38;5;2m  13[0m: line 4 b.2
-         [38;5;2m  14[39m: [4m[38;5;2m%%%%%%% diff from: rlvkpnrz 07965fa1 "base1"[24m[39m
-         [38;5;2m  15[39m: [4m[38;5;2m\\\\\\\        to: znkkpsqq f73063c9 "side3"[24m[39m
+         [38;5;2m  14[39m: [4m[38;5;2m%%%%%%% diff from: ylvkpnrz f0c1c076 "base1"[24m[39m
+         [38;5;2m  15[39m: [4m[38;5;2m\\\\\\\        to: nnkkpsqq ddd87c7e "side3"[24m[39m
          [38;5;2m  16[39m: [4m[38;5;2m line 2 base[24m[39m
          [38;5;2m  17[39m: [4m[38;5;2m+line 3 c.2[24m[39m
     [2m[38;5;1m  14[0m [2m[38;5;2m  18[0m: >>>>>>> conflict 1 of 1 ends
@@ -3232,7 +3232,7 @@ fn test_diff_external_tool() -> TestResult {
     ");
 
     insta::assert_snapshot!(work_dir.run_jj(["log", "-p", "--tool=fake-diff-editor"]), @"
-    @  rlvkpnrz test.user@example.com 2001-02-03 08:05:09 b1e84e17
+    @  ylvkpnrz test.user@example.com 2001-02-03 08:05:09 0027b000
     │  (no description set)
     │  file1
     │  file2
@@ -3250,8 +3250,8 @@ fn test_diff_external_tool() -> TestResult {
     ");
 
     insta::assert_snapshot!(work_dir.run_jj(["show", "--tool=fake-diff-editor"]), @"
-    Commit ID: b1e84e171e795eeb9cea971f052a30a21255a0a5
-    Change ID: rlvkpnrzqnoowoytxnquwvuryrwnrmlp
+    Commit ID: 0027b0000da4d2d2e6a450203ad7bb3f2b5dc624
+    Change ID: ylvkpnrzqnoowoytxnquwvuryrwnrmlp
     Author   : Test User <test.user@example.com> (2001-02-03 08:05:09)
     Committer: Test User <test.user@example.com> (2001-02-03 08:05:09)
 
@@ -3300,8 +3300,8 @@ fn test_diff_external_tool() -> TestResult {
     std::fs::write(&edit_script, "print diff\0fail")?;
     let output = work_dir.run_jj(["show", "--tool=fake-diff-editor"]);
     insta::assert_snapshot!(output.normalize_stderr_exit_status(), @"
-    Commit ID: b1e84e171e795eeb9cea971f052a30a21255a0a5
-    Change ID: rlvkpnrzqnoowoytxnquwvuryrwnrmlp
+    Commit ID: 0027b0000da4d2d2e6a450203ad7bb3f2b5dc624
+    Change ID: ylvkpnrzqnoowoytxnquwvuryrwnrmlp
     Author   : Test User <test.user@example.com> (2001-02-03 08:05:09)
     Committer: Test User <test.user@example.com> (2001-02-03 08:05:09)
 
@@ -3468,7 +3468,7 @@ fn test_diff_external_file_by_file_tool() -> TestResult {
     ");
     insta::assert_snapshot!(
         work_dir.run_jj_with(|cmd| cmd.args(["log", "-p"]).args(configs)), @"
-    @  rlvkpnrz test.user@example.com 2001-02-03 08:05:09 6e901d9d
+    @  ylvkpnrz test.user@example.com 2001-02-03 08:05:09 2eda6805
     │  (no description set)
     │  ==
     │  file2
@@ -3497,8 +3497,8 @@ fn test_diff_external_file_by_file_tool() -> TestResult {
     ");
 
     insta::assert_snapshot!(work_dir.run_jj_with(|cmd| cmd.arg("show").args(configs)), @"
-    Commit ID: 6e901d9d82f5cdfab386fc2b601186158d12cab7
-    Change ID: rlvkpnrzqnoowoytxnquwvuryrwnrmlp
+    Commit ID: 2eda6805d636ec3da79dd50c890d5311c74ef8b5
+    Change ID: ylvkpnrzqnoowoytxnquwvuryrwnrmlp
     Author   : Test User <test.user@example.com> (2001-02-03 08:05:09)
     Committer: Test User <test.user@example.com> (2001-02-03 08:05:09)
 
@@ -3658,7 +3658,7 @@ fn test_diff_external_tool_conflict_marker_style() -> TestResult {
     line 4.1
     ------- qpvuntsm 9bd2e004 "base"
     line 4
-    +++++++ zsuskuln 6982bce7 "side-b"
+    +++++++ osuskuln f12a16f8 "side-b"
     line 4.2
     line 4.3
     >>>>>>> conflict 1 of 1 ends
@@ -4034,7 +4034,7 @@ fn test_diff_revisions() {
     insta::assert_snapshot!(diff_revisions("A|C"), @"
     ------- stderr -------
     Error: Cannot diff revsets with gaps in.
-    Hint: Revision 2378873cd201 would need to be in the set.
+    Hint: Revision 03751a746f4e would need to be in the set.
     [EOF]
     [exit status: 1]
     ");
@@ -4044,7 +4044,7 @@ fn test_diff_revisions() {
     insta::assert_snapshot!(diff_revisions("C|E"), @"
     ------- stderr -------
     Error: Cannot diff revsets with gaps in.
-    Hint: Revision a90b2fff19e9 would need to be in the set.
+    Hint: Revision 00ab726847b2 would need to be in the set.
     [EOF]
     [exit status: 1]
     ");

--- a/cli/tests/test_diffedit_command.rs
+++ b/cli/tests/test_diffedit_command.rs
@@ -53,7 +53,7 @@ fn test_diffedit() -> TestResult {
     ");
     insta::assert_snapshot!(
         std::fs::read_to_string(test_env.env_root().join("instrs"))?, @"
-    You are editing changes in: kkmpptxz e4245972 (no description set)
+    You are editing changes in: nkmpptxz a74881e5 (no description set)
 
     The diff initially shows the commit's changes.
 
@@ -126,8 +126,8 @@ fn test_diffedit() -> TestResult {
     let output = work_dir.run_jj(["diffedit"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: kkmpptxz 40ad4f80 (no description set)
-    Parent commit (@-)      : rlvkpnrz 7e268da3 (no description set)
+    Working copy  (@) now at: nkmpptxz 6f60efec (no description set)
+    Parent commit (@-)      : ylvkpnrz 5cce707a (no description set)
     Added 0 files, modified 1 files, removed 0 files
     [EOF]
     ");
@@ -144,8 +144,8 @@ fn test_diffedit() -> TestResult {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Rebased 1 descendant commits
-    Working copy  (@) now at: kkmpptxz 9f0ebae1 (no description set)
-    Parent commit (@-)      : rlvkpnrz 72bcd8e9 (no description set)
+    Working copy  (@) now at: nkmpptxz 70605375 (no description set)
+    Parent commit (@-)      : ylvkpnrz bdfe7e54 (no description set)
     Added 0 files, modified 1 files, removed 0 files
     [EOF]
     ");
@@ -161,8 +161,8 @@ fn test_diffedit() -> TestResult {
     let output = work_dir.run_jj(["diffedit", "--from", "@--"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: kkmpptxz 215fca5f (no description set)
-    Parent commit (@-)      : rlvkpnrz 7e268da3 (no description set)
+    Working copy  (@) now at: nkmpptxz 8f31dd26 (no description set)
+    Parent commit (@-)      : ylvkpnrz 5cce707a (no description set)
     Added 0 files, modified 0 files, removed 1 files
     [EOF]
     ");
@@ -189,8 +189,8 @@ fn test_diffedit() -> TestResult {
     let output = work_dir.run_jj(["diffedit", "file2"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: tlkvzzqu 06bdff15 (no description set)
-    Parent commit (@-)      : kkmpptxz e4245972 (no description set)
+    Working copy  (@) now at: mlkvzzqu 2c777e74 (no description set)
+    Parent commit (@-)      : nkmpptxz a74881e5 (no description set)
     Added 0 files, modified 1 files, removed 0 files
     [EOF]
     ");
@@ -217,16 +217,16 @@ fn test_diffedit() -> TestResult {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Rebased 1 descendant commits
-    Working copy  (@) now at: kkmpptxz 9a4e9bcc (no description set)
-    Parent commit (@-)      : rlvkpnrz fb5c77f4 (no description set)
+    Working copy  (@) now at: nkmpptxz 679d29fc (no description set)
+    Parent commit (@-)      : ylvkpnrz 140ff69e (no description set)
     [EOF]
     ");
     insta::assert_snapshot!(
         std::fs::read_to_string(test_env.env_root().join("instrs"))?, @"
-    You are editing changes in: rlvkpnrz 7e268da3 (no description set)
+    You are editing changes in: ylvkpnrz 5cce707a (no description set)
 
     The diff initially shows the commit's changes relative to:
-    kkmpptxz e4245972 (no description set)
+    nkmpptxz a74881e5 (no description set)
 
     Adjust the right side until it shows the contents you want. If you
     don't make any changes, then the operation will be aborted.
@@ -330,7 +330,7 @@ fn test_diffedit_new_file() -> TestResult {
     let output = work_dir.run_jj(["diffedit"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: rlvkpnrz c26dcad1 (no description set)
+    Working copy  (@) now at: ylvkpnrz 678cedd4 (no description set)
     Parent commit (@-)      : qpvuntsm eb7b8a1f (no description set)
     Added 1 files, modified 0 files, removed 0 files
     [EOF]
@@ -480,9 +480,9 @@ fn test_diffedit_external_tool_conflict_marker_style() -> TestResult {
     let output = work_dir.run_jj(["diffedit"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: mzvwutvl a2e4617e (conflict) (empty) (no description set)
+    Working copy  (@) now at: pzvwutvl c5464774 (conflict) (empty) (no description set)
     Parent commit (@-)      : rlvkpnrz 74e448a1 side-a
-    Parent commit (@-)      : zsuskuln 6982bce7 side-b
+    Parent commit (@-)      : osuskuln f12a16f8 side-b
     Added 0 files, modified 1 files, removed 0 files
     Warning: There are unresolved conflicts at these paths:
     file    2-sided conflict
@@ -499,7 +499,7 @@ fn test_diffedit_external_tool_conflict_marker_style() -> TestResult {
     line 2.2
     ------- qpvuntsm 9bd2e004 "base"
     line 2
-    +++++++ zsuskuln 6982bce7 "side-b"
+    +++++++ osuskuln f12a16f8 "side-b"
     line 2.3
     >>>>>>> conflict 1 of 2 ends
     line 3
@@ -508,7 +508,7 @@ fn test_diffedit_external_tool_conflict_marker_style() -> TestResult {
     line 4.1
     ------- qpvuntsm 9bd2e004 "base"
     line 4
-    +++++++ zsuskuln 6982bce7 "side-b"
+    +++++++ osuskuln f12a16f8 "side-b"
     line 4.2
     line 4.3
     >>>>>>> conflict 2 of 2 ends
@@ -526,7 +526,7 @@ fn test_diffedit_external_tool_conflict_marker_style() -> TestResult {
     line 4.1
     ------- qpvuntsm 9bd2e004 "base"
     line 4
-    +++++++ zsuskuln 6982bce7 "side-b"
+    +++++++ osuskuln f12a16f8 "side-b"
     line 4.2
     line 4.3
     >>>>>>> conflict 1 of 1 ends
@@ -540,7 +540,7 @@ fn test_diffedit_external_tool_conflict_marker_style() -> TestResult {
     line 2.1
     line 2.2
     %%%%%%% diff from: qpvuntsm 9bd2e004 "base"
-    \\\\\\\        to: zsuskuln 6982bce7 "side-b"
+    \\\\\\\        to: osuskuln f12a16f8 "side-b"
     -line 2
     +line 2.3
     >>>>>>> conflict 1 of 2 ends
@@ -550,7 +550,7 @@ fn test_diffedit_external_tool_conflict_marker_style() -> TestResult {
     \\\\\\\        to: rlvkpnrz 74e448a1 "side-a"
     -line 4
     +line 4.1
-    +++++++ zsuskuln 6982bce7 "side-b"
+    +++++++ osuskuln f12a16f8 "side-b"
     line 4.2
     line 4.3
     >>>>>>> conflict 2 of 2 ends
@@ -561,9 +561,9 @@ fn test_diffedit_external_tool_conflict_marker_style() -> TestResult {
     let output = work_dir.run_jj(["st"]);
     insta::assert_snapshot!(output, @"
     The working copy has no changes.
-    Working copy  (@) : mzvwutvl a2e4617e (conflict) (empty) (no description set)
+    Working copy  (@) : pzvwutvl c5464774 (conflict) (empty) (no description set)
     Parent commit (@-): rlvkpnrz 74e448a1 side-a
-    Parent commit (@-): zsuskuln 6982bce7 side-b
+    Parent commit (@-): osuskuln f12a16f8 side-b
     Warning: There are unresolved conflicts at these paths:
     file    2-sided conflict
     [EOF]
@@ -632,8 +632,8 @@ fn test_diffedit_3pane() -> TestResult {
     let output = work_dir.run_jj(["diffedit", "--config", config_with_output_as_after]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: kkmpptxz 239413bd (no description set)
-    Parent commit (@-)      : rlvkpnrz 7e268da3 (no description set)
+    Working copy  (@) now at: nkmpptxz a864580b (no description set)
+    Parent commit (@-)      : ylvkpnrz 5cce707a (no description set)
     Added 0 files, modified 1 files, removed 0 files
     [EOF]
     ");
@@ -649,8 +649,8 @@ fn test_diffedit_3pane() -> TestResult {
     let output = work_dir.run_jj(["diffedit", "--config", config_with_output_as_after]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: kkmpptxz 95873a91 (no description set)
-    Parent commit (@-)      : rlvkpnrz 7e268da3 (no description set)
+    Working copy  (@) now at: nkmpptxz c605c6df (no description set)
+    Parent commit (@-)      : ylvkpnrz 5cce707a (no description set)
     Added 1 files, modified 0 files, removed 0 files
     [EOF]
     ");
@@ -723,8 +723,8 @@ fn test_diffedit_merge() -> TestResult {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Rebased 1 descendant commits
-    Working copy  (@) now at: yqosqzyt 9fc53f3e (conflict) (empty) (no description set)
-    Parent commit (@-)      : royxmykx 70ca98fe (conflict) merge
+    Working copy  (@) now at: nqosqzyt bbc1d471 (conflict) (empty) (no description set)
+    Parent commit (@-)      : royxmykx 64b907f4 (conflict) merge
     Added 0 files, modified 0 files, removed 1 files
     Warning: There are unresolved conflicts at these paths:
     file2    2-sided conflict
@@ -741,10 +741,10 @@ fn test_diffedit_merge() -> TestResult {
     insta::assert_snapshot!(output, @r"
     <<<<<<< conflict 1 of 1
     %%%%%%% diff from: qpvuntsm fc6f5e82
-    \\\\\\\        to: mzvwutvl e3b18dc7
+    \\\\\\\        to: pzvwutvl 7aa1e4f6
     -a
     +c
-    +++++++ rlvkpnrz 7027fb26
+    +++++++ ylvkpnrz 8b74f12a
     b
     >>>>>>> conflict 1 of 1 ends
     [EOF]
@@ -806,7 +806,7 @@ fn test_diffedit_old_restore_interactive_tests() -> TestResult {
     let output = work_dir.run_jj(["diffedit", "--from", "@-"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: rlvkpnrz 83b62f75 (no description set)
+    Working copy  (@) now at: ylvkpnrz 747ffcb0 (no description set)
     Parent commit (@-)      : qpvuntsm fc6f5e82 (no description set)
     Added 0 files, modified 1 files, removed 1 files
     [EOF]
@@ -823,7 +823,7 @@ fn test_diffedit_old_restore_interactive_tests() -> TestResult {
     let output = work_dir.run_jj(["diffedit", "--from", "@-"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: rlvkpnrz 8119c685 (no description set)
+    Working copy  (@) now at: ylvkpnrz e260dd2c (no description set)
     Parent commit (@-)      : qpvuntsm fc6f5e82 (no description set)
     Added 0 files, modified 1 files, removed 0 files
     [EOF]
@@ -875,8 +875,8 @@ fn test_diffedit_restore_descendants() -> TestResult {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Rebased 1 descendant commits (while preserving their content)
-    Working copy  (@) now at: kkmpptxz a35ef1a5 (no description set)
-    Parent commit (@-)      : rlvkpnrz 2e949a84 (no description set)
+    Working copy  (@) now at: nkmpptxz 6e7036ea (no description set)
+    Parent commit (@-)      : ylvkpnrz 71c86c94 (no description set)
     [EOF]
     ");
     let output = work_dir.run_jj(["diff", "--git"]);

--- a/cli/tests/test_duplicate_command.rs
+++ b/cli/tests/test_duplicate_command.rs
@@ -28,10 +28,10 @@ fn test_duplicate() {
     create_commit(&work_dir, "c", &["a", "b"]);
     // Test the setup
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @    387b928721d9   c
+    @    d9eeb5edcc43   c
     ├─╮
-    │ ○  d18ca3e87135   b
-    ○ │  7d980be7a1d4   a
+    │ ○  6819720393db   b
+    ○ │  a1afb5834d8e   a
     ├─╯
     ◆  000000000000
     [EOF]
@@ -55,14 +55,14 @@ fn test_duplicate() {
     let output = work_dir.run_jj(["duplicate", "a"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Duplicated 7d980be7a1d4 as kpqxywon 13eb8bd0 a
+    Duplicated a1afb5834d8e as kpqxywon 13eb8bd0 a
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @    387b928721d9   c
+    @    d9eeb5edcc43   c
     ├─╮
-    │ ○  d18ca3e87135   b
-    ○ │  7d980be7a1d4   a
+    │ ○  6819720393db   b
+    ○ │  a1afb5834d8e   a
     ├─╯
     │ ○  13eb8bd0a547   a
     ├─╯
@@ -73,23 +73,23 @@ fn test_duplicate() {
     let output = work_dir.run_jj(["undo"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Undid operation: 220a81883828 (2001-02-03 08:05:17) duplicate 1 commit(s)
-    Restored to operation: 76be3a90546e (2001-02-03 08:05:13) create bookmark c pointing to commit 387b928721d9f2efff819ccce81868f32537d71f
+    Undid operation: c4b5a9bbf559 (2001-02-03 08:05:17) duplicate 1 commit(s)
+    Restored to operation: 1f185bd7a742 (2001-02-03 08:05:13) create bookmark c pointing to commit d9eeb5edcc43595ec2df4bbcbc539e863e0a550a
     [EOF]
     ");
     let output = work_dir.run_jj(["duplicate" /* duplicates `c` */]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Duplicated 387b928721d9 as lylxulpl 71c64df5 c
+    Duplicated d9eeb5edcc43 as lylxulpl 39c49b11 c
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @    387b928721d9   c
+    @    d9eeb5edcc43   c
     ├─╮
-    │ │ ○  71c64df584dc   c
+    │ │ ○  39c49b11cf6d   c
     ╭─┬─╯
-    │ ○  d18ca3e87135   b
-    ○ │  7d980be7a1d4   a
+    │ ○  6819720393db   b
+    ○ │  a1afb5834d8e   a
     ├─╯
     ◆  000000000000
     [EOF]
@@ -109,13 +109,13 @@ fn test_duplicate_many() {
     create_commit(&work_dir, "e", &["b", "d"]);
     // Test the setup
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @    0559be9bd4d0   e
+    @    e7e415348f77   e
     ├─╮
-    │ ○  a2dbb1aad514   d
-    │ ○  991a7501d660   c
-    ○ │  123b4d91f6e5   b
+    │ ○  278414eace87   d
+    │ ○  45ee1acd6076   c
+    ○ │  dd148a1be8f0   b
     ├─╯
-    ○  7d980be7a1d4   a
+    ○  a1afb5834d8e   a
     ◆  000000000000
     [EOF]
     ");
@@ -124,22 +124,22 @@ fn test_duplicate_many() {
     let output = work_dir.run_jj(["duplicate", "b::"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Duplicated 123b4d91f6e5 as wqnwkozp 10059c86 b
-    Duplicated 0559be9bd4d0 as mouksmqu 0afe2f34 e
+    Duplicated dd148a1be8f0 as wqnwkozp d7f94df8 b
+    Duplicated e7e415348f77 as mouksmqu c1babd61 e
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @    0559be9bd4d0   e
+    @    e7e415348f77   e
     ├─╮
-    ○ │  123b4d91f6e5   b
-    │ │ ○  0afe2f348a93   e
+    ○ │  dd148a1be8f0   b
+    │ │ ○  c1babd613375   e
     │ ╭─┤
-    │ ○ │  a2dbb1aad514   d
-    │ ○ │  991a7501d660   c
+    │ ○ │  278414eace87   d
+    │ ○ │  45ee1acd6076   c
     ├─╯ │
-    │   ○  10059c8651d7   b
+    │   ○  d7f94df81143   b
     ├───╯
-    ○  7d980be7a1d4   a
+    ○  a1afb5834d8e   a
     ◆  000000000000
     [EOF]
     ");
@@ -149,19 +149,19 @@ fn test_duplicate_many() {
     let output = work_dir.run_jj(["duplicate", "b", "b"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Duplicated 123b4d91f6e5 as nkmrtpmo 1ccf2589 b
+    Duplicated dd148a1be8f0 as nkmrtpmo f8a8d54e b
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @    0559be9bd4d0   e
+    @    e7e415348f77   e
     ├─╮
-    │ ○  a2dbb1aad514   d
-    │ ○  991a7501d660   c
-    ○ │  123b4d91f6e5   b
+    │ ○  278414eace87   d
+    │ ○  45ee1acd6076   c
+    ○ │  dd148a1be8f0   b
     ├─╯
-    │ ○  1ccf2589bfd1   b
+    │ ○  f8a8d54e5bca   b
     ├─╯
-    ○  7d980be7a1d4   a
+    ○  a1afb5834d8e   a
     ◆  000000000000
     [EOF]
     ");
@@ -171,25 +171,25 @@ fn test_duplicate_many() {
     let output = work_dir.run_jj(["duplicate", "b::", "d::"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Duplicated 123b4d91f6e5 as xtnwkqum 1a94ffc6 b
-    Duplicated a2dbb1aad514 as pqrnrkux 6a17a96d d
-    Duplicated 0559be9bd4d0 as ztxkyksq b113bd5c e
+    Duplicated dd148a1be8f0 as xtnwkqum a8d4c220 b
+    Duplicated 278414eace87 as pqrnrkux 531366d3 d
+    Duplicated e7e415348f77 as ztxkyksq c47b2bae e
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @    0559be9bd4d0   e
+    @    e7e415348f77   e
     ├─╮
-    │ ○  a2dbb1aad514   d
-    ○ │  123b4d91f6e5   b
-    │ │ ○    b113bd5c550a   e
+    │ ○  278414eace87   d
+    ○ │  dd148a1be8f0   b
+    │ │ ○    c47b2bae5ce3   e
     │ │ ├─╮
-    │ │ │ ○  6a17a96d77d2   d
+    │ │ │ ○  531366d31b84   d
     │ ├───╯
-    │ ○ │  991a7501d660   c
+    │ ○ │  45ee1acd6076   c
     ├─╯ │
-    │   ○  1a94ffc6e6aa   b
+    │   ○  a8d4c22086db   b
     ├───╯
-    ○  7d980be7a1d4   a
+    ○  a1afb5834d8e   a
     ◆  000000000000
     [EOF]
     ");
@@ -197,36 +197,36 @@ fn test_duplicate_many() {
     work_dir.run_jj(["op", "restore", &setup_opid]).success();
     // Reminder of the setup
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @    0559be9bd4d0   e
+    @    e7e415348f77   e
     ├─╮
-    │ ○  a2dbb1aad514   d
-    │ ○  991a7501d660   c
-    ○ │  123b4d91f6e5   b
+    │ ○  278414eace87   d
+    │ ○  45ee1acd6076   c
+    ○ │  dd148a1be8f0   b
     ├─╯
-    ○  7d980be7a1d4   a
+    ○  a1afb5834d8e   a
     ◆  000000000000
     [EOF]
     ");
     let output = work_dir.run_jj(["duplicate", "d::", "a"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Duplicated 7d980be7a1d4 as nlrtlrxv 117dd806 a
-    Duplicated a2dbb1aad514 as plymsszl f2ec1b7f d
-    Duplicated 0559be9bd4d0 as urrlptpw 9e54f34c e
+    Duplicated a1afb5834d8e as nlrtlrxv 117dd806 a
+    Duplicated 278414eace87 as plymsszl f8ea2332 d
+    Duplicated e7e415348f77 as urrlptpw 66f0d2b4 e
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @    0559be9bd4d0   e
+    @    e7e415348f77   e
     ├─╮
-    │ ○  a2dbb1aad514   d
-    │ │ ○  9e54f34ca238   e
+    │ ○  278414eace87   d
+    │ │ ○  66f0d2b41a0a   e
     ╭───┤
-    │ │ ○  f2ec1b7f4e82   d
+    │ │ ○  f8ea2332db89   d
     │ ├─╯
-    │ ○  991a7501d660   c
-    ○ │  123b4d91f6e5   b
+    │ ○  45ee1acd6076   c
+    ○ │  dd148a1be8f0   b
     ├─╯
-    ○  7d980be7a1d4   a
+    ○  a1afb5834d8e   a
     │ ○  117dd80623e6   a
     ├─╯
     ◆  000000000000
@@ -238,21 +238,21 @@ fn test_duplicate_many() {
     let output = work_dir.run_jj(["duplicate", "a::"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Duplicated 7d980be7a1d4 as uuuvxpvw cb730319 a
-    Duplicated 123b4d91f6e5 as nmpuuozl b00a23f6 b
-    Duplicated 991a7501d660 as kzpokyyw 7c1b86d5 c
-    Duplicated a2dbb1aad514 as yxrlprzz 2f5494bb d
-    Duplicated 0559be9bd4d0 as mvkzkxrl 8a4c81fe e
+    Duplicated a1afb5834d8e as uuuvxpvw cb730319 a
+    Duplicated dd148a1be8f0 as nmpuuozl b00a23f6 b
+    Duplicated 45ee1acd6076 as kzpokyyw 7c1b86d5 c
+    Duplicated 278414eace87 as yxrlprzz 2f5494bb d
+    Duplicated e7e415348f77 as mvkzkxrl 8a4c81fe e
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @    0559be9bd4d0   e
+    @    e7e415348f77   e
     ├─╮
-    │ ○  a2dbb1aad514   d
-    │ ○  991a7501d660   c
-    ○ │  123b4d91f6e5   b
+    │ ○  278414eace87   d
+    │ ○  45ee1acd6076   c
+    ○ │  dd148a1be8f0   b
     ├─╯
-    ○  7d980be7a1d4   a
+    ○  a1afb5834d8e   a
     │ ○    8a4c81fee5f1   e
     │ ├─╮
     │ │ ○  2f5494bb9bce   d
@@ -282,14 +282,14 @@ fn test_duplicate_destination() {
 
     // Test the setup
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  5248650c3314   d
-    │ ○  22370aa928dc   c
+    @  37ccb2c26fd4   d
+    │ ○  5e749d71532c   c
     ├─╯
-    │ ○  c406dbab05ac   b
+    │ ○  f7702717b8e8   b
     ├─╯
-    │ ○  5fb83d2b58d6   a3
-    │ ○  7bfd9fbe959c   a2
-    │ ○  5d93a4b8f4bd   a1
+    │ ○  fb5b814db965   a3
+    │ ○  932fb7b4fc1e   a2
+    │ ○  94078b99a3ab   a1
     ├─╯
     ◆  000000000000
     [EOF]
@@ -299,19 +299,19 @@ fn test_duplicate_destination() {
     let output = work_dir.run_jj(["duplicate", "a1", "-o", "c"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Duplicated 5d93a4b8f4bd as kxryzmor 08f0f980 a1
+    Duplicated 94078b99a3ab as kxryzmor 3aa99cfa a1
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  5248650c3314   d
-    │ ○  08f0f980b8ad   a1
-    │ ○  22370aa928dc   c
+    @  37ccb2c26fd4   d
+    │ ○  3aa99cfaac35   a1
+    │ ○  5e749d71532c   c
     ├─╯
-    │ ○  c406dbab05ac   b
+    │ ○  f7702717b8e8   b
     ├─╯
-    │ ○  5fb83d2b58d6   a3
-    │ ○  7bfd9fbe959c   a2
-    │ ○  5d93a4b8f4bd   a1
+    │ ○  fb5b814db965   a3
+    │ ○  932fb7b4fc1e   a2
+    │ ○  94078b99a3ab   a1
     ├─╯
     ◆  000000000000
     [EOF]
@@ -322,20 +322,20 @@ fn test_duplicate_destination() {
     let output = work_dir.run_jj(["duplicate", "a1", "-o", "c", "-o", "d"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Duplicated 5d93a4b8f4bd as xznxytkn 0bad88fb a1
+    Duplicated 94078b99a3ab as xznxytkn 47234b89 a1
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    ○    0bad88fbab2e   a1
+    ○    47234b8989dd   a1
     ├─╮
-    │ @  5248650c3314   d
-    ○ │  22370aa928dc   c
+    │ @  37ccb2c26fd4   d
+    ○ │  5e749d71532c   c
     ├─╯
-    │ ○  c406dbab05ac   b
+    │ ○  f7702717b8e8   b
     ├─╯
-    │ ○  5fb83d2b58d6   a3
-    │ ○  7bfd9fbe959c   a2
-    │ ○  5d93a4b8f4bd   a1
+    │ ○  fb5b814db965   a3
+    │ ○  932fb7b4fc1e   a2
+    │ ○  94078b99a3ab   a1
     ├─╯
     ◆  000000000000
     [EOF]
@@ -346,20 +346,20 @@ fn test_duplicate_destination() {
     let output = work_dir.run_jj(["duplicate", "a1", "-o", "a3"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Warning: Duplicating commit 5d93a4b8f4bd as a descendant of itself
-    Duplicated 5d93a4b8f4bd as tlkvzzqu 8351ae70 (empty) a1
+    Warning: Duplicating commit 94078b99a3ab as a descendant of itself
+    Duplicated 94078b99a3ab as tlkvzzqu e72119f1 (empty) a1
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  5248650c3314   d
-    │ ○  22370aa928dc   c
+    @  37ccb2c26fd4   d
+    │ ○  5e749d71532c   c
     ├─╯
-    │ ○  c406dbab05ac   b
+    │ ○  f7702717b8e8   b
     ├─╯
-    │ ○  8351ae7027e4   a1
-    │ ○  5fb83d2b58d6   a3
-    │ ○  7bfd9fbe959c   a2
-    │ ○  5d93a4b8f4bd   a1
+    │ ○  e72119f1aa17   a1
+    │ ○  fb5b814db965   a3
+    │ ○  932fb7b4fc1e   a2
+    │ ○  94078b99a3ab   a1
     ├─╯
     ◆  000000000000
     [EOF]
@@ -371,22 +371,22 @@ fn test_duplicate_destination() {
     let output = work_dir.run_jj(["duplicate", "-r=a1", "-r=b", "-o", "c"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Duplicated 5d93a4b8f4bd as pzsxstzt 663f101c a1
-    Duplicated c406dbab05ac as nxkxtmvy b8a86167 b
+    Duplicated 94078b99a3ab as pzsxstzt baf4e167 a1
+    Duplicated f7702717b8e8 as nxkxtmvy 0f23e3a3 b
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  5248650c3314   d
-    │ ○  b8a8616787a4   b
-    │ │ ○  663f101c476a   a1
+    @  37ccb2c26fd4   d
+    │ ○  0f23e3a3cf38   b
+    │ │ ○  baf4e167593f   a1
     │ ├─╯
-    │ ○  22370aa928dc   c
+    │ ○  5e749d71532c   c
     ├─╯
-    │ ○  c406dbab05ac   b
+    │ ○  f7702717b8e8   b
     ├─╯
-    │ ○  5fb83d2b58d6   a3
-    │ ○  7bfd9fbe959c   a2
-    │ ○  5d93a4b8f4bd   a1
+    │ ○  fb5b814db965   a3
+    │ ○  932fb7b4fc1e   a2
+    │ ○  94078b99a3ab   a1
     ├─╯
     ◆  000000000000
     [EOF]
@@ -398,23 +398,23 @@ fn test_duplicate_destination() {
     let output = work_dir.run_jj(["duplicate", "-r=a1", "b", "-o", "c", "-o", "d"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Duplicated 5d93a4b8f4bd as qmkrwlvp b0f531b0 a1
-    Duplicated c406dbab05ac as pkqrwoqq 0df6b6b2 b
+    Duplicated 94078b99a3ab as qmkrwlvp e622db81 a1
+    Duplicated f7702717b8e8 as pkqrwoqq e6c7af33 b
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    ○    0df6b6b21bfe   b
+    ○    e6c7af331f0c   b
     ├─╮
-    │ │ ○  b0f531b01b33   a1
+    │ │ ○  e622db8157e5   a1
     ╭─┬─╯
-    │ @  5248650c3314   d
-    ○ │  22370aa928dc   c
+    │ @  37ccb2c26fd4   d
+    ○ │  5e749d71532c   c
     ├─╯
-    │ ○  c406dbab05ac   b
+    │ ○  f7702717b8e8   b
     ├─╯
-    │ ○  5fb83d2b58d6   a3
-    │ ○  7bfd9fbe959c   a2
-    │ ○  5d93a4b8f4bd   a1
+    │ ○  fb5b814db965   a3
+    │ ○  932fb7b4fc1e   a2
+    │ ○  94078b99a3ab   a1
     ├─╯
     ◆  000000000000
     [EOF]
@@ -426,21 +426,21 @@ fn test_duplicate_destination() {
     let output = work_dir.run_jj(["duplicate", "a1", "a3", "-o", "c"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Duplicated 5d93a4b8f4bd as qwyusntz 5f1c245f a1
-    Duplicated 5fb83d2b58d6 as pwpvvyov 2a209b65 a3
+    Duplicated 94078b99a3ab as qwyusntz 46ae14e0 a1
+    Duplicated fb5b814db965 as pwpvvyov d5b9939e a3
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  5248650c3314   d
-    │ ○  2a209b658cd6   a3
-    │ ○  5f1c245fb9ae   a1
-    │ ○  22370aa928dc   c
+    @  37ccb2c26fd4   d
+    │ ○  d5b9939eaa52   a3
+    │ ○  46ae14e05cf5   a1
+    │ ○  5e749d71532c   c
     ├─╯
-    │ ○  c406dbab05ac   b
+    │ ○  f7702717b8e8   b
     ├─╯
-    │ ○  5fb83d2b58d6   a3
-    │ ○  7bfd9fbe959c   a2
-    │ ○  5d93a4b8f4bd   a1
+    │ ○  fb5b814db965   a3
+    │ ○  932fb7b4fc1e   a2
+    │ ○  94078b99a3ab   a1
     ├─╯
     ◆  000000000000
     [EOF]
@@ -452,22 +452,22 @@ fn test_duplicate_destination() {
     let output = work_dir.run_jj(["duplicate", "a1", "a3", "-o", "c", "-o", "d"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Duplicated 5d93a4b8f4bd as soqnvnyz bc6678fd a1
-    Duplicated 5fb83d2b58d6 as nmmmqslz a35b7e76 a3
+    Duplicated 94078b99a3ab as soqnvnyz 4813e2a9 a1
+    Duplicated fb5b814db965 as nmmmqslz 27e49f8c a3
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    ○  a35b7e76b4dd   a3
-    ○    bc6678fdf2a5   a1
+    ○  27e49f8c36cb   a3
+    ○    4813e2a9ac9e   a1
     ├─╮
-    │ @  5248650c3314   d
-    ○ │  22370aa928dc   c
+    │ @  37ccb2c26fd4   d
+    ○ │  5e749d71532c   c
     ├─╯
-    │ ○  c406dbab05ac   b
+    │ ○  f7702717b8e8   b
     ├─╯
-    │ ○  5fb83d2b58d6   a3
-    │ ○  7bfd9fbe959c   a2
-    │ ○  5d93a4b8f4bd   a1
+    │ ○  fb5b814db965   a3
+    │ ○  932fb7b4fc1e   a2
+    │ ○  94078b99a3ab   a1
     ├─╯
     ◆  000000000000
     [EOF]
@@ -494,18 +494,18 @@ fn test_duplicate_insert_after() {
 
     // Test the setup
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  3e122d6a4b70   d2
-    ○  ae61a031221a   d1
-    │ ○  47a79ab4bbc6   c2
+    @  d7fd293d0ee4   d2
+    ○  8aae10eecc84   d1
+    │ ○  10855af02fff   c2
     │ ○  9b24b49f717e   c1
     ├─╯
-    │ ○  65b6f1fe6b41   b2
-    │ ○  6a9343b8797a   b1
+    │ ○  06712178d528   b2
+    │ ○  e7241b6b0079   b1
     ├─╯
-    │ ○  e9b68b6313be   a4
-    │ ○  5fb83d2b58d6   a3
-    │ ○  7bfd9fbe959c   a2
-    │ ○  5d93a4b8f4bd   a1
+    │ ○  31f05d9b8a41   a4
+    │ ○  fb5b814db965   a3
+    │ ○  932fb7b4fc1e   a2
+    │ ○  94078b99a3ab   a1
     ├─╯
     ◆  000000000000
     [EOF]
@@ -515,24 +515,24 @@ fn test_duplicate_insert_after() {
     let output = work_dir.run_jj(["duplicate", "a1", "--after", "b1"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Duplicated 5d93a4b8f4bd as nlrtlrxv 52959024 a1
+    Duplicated 94078b99a3ab as nlrtlrxv 403a87a9 a1
     Rebased 1 commits onto duplicated commits
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  3e122d6a4b70   d2
-    ○  ae61a031221a   d1
-    │ ○  47a79ab4bbc6   c2
+    @  d7fd293d0ee4   d2
+    ○  8aae10eecc84   d1
+    │ ○  10855af02fff   c2
     │ ○  9b24b49f717e   c1
     ├─╯
-    │ ○  8124402d0ebe   b2
-    │ ○  52959024d93a   a1
-    │ ○  6a9343b8797a   b1
+    │ ○  e03525446a4f   b2
+    │ ○  403a87a97264   a1
+    │ ○  e7241b6b0079   b1
     ├─╯
-    │ ○  e9b68b6313be   a4
-    │ ○  5fb83d2b58d6   a3
-    │ ○  7bfd9fbe959c   a2
-    │ ○  5d93a4b8f4bd   a1
+    │ ○  31f05d9b8a41   a4
+    │ ○  fb5b814db965   a3
+    │ ○  932fb7b4fc1e   a2
+    │ ○  94078b99a3ab   a1
     ├─╯
     ◆  000000000000
     [EOF]
@@ -543,25 +543,25 @@ fn test_duplicate_insert_after() {
     let output = work_dir.run_jj(["duplicate", "a3", "--after", "a1"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Warning: Duplicating commit 5fb83d2b58d6 as an ancestor of itself
-    Duplicated 5fb83d2b58d6 as uuuvxpvw f626655e a3
+    Warning: Duplicating commit fb5b814db965 as an ancestor of itself
+    Duplicated fb5b814db965 as uuuvxpvw 82ae0465 a3
     Rebased 3 commits onto duplicated commits
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  3e122d6a4b70   d2
-    ○  ae61a031221a   d1
-    │ ○  47a79ab4bbc6   c2
+    @  d7fd293d0ee4   d2
+    ○  8aae10eecc84   d1
+    │ ○  10855af02fff   c2
     │ ○  9b24b49f717e   c1
     ├─╯
-    │ ○  65b6f1fe6b41   b2
-    │ ○  6a9343b8797a   b1
+    │ ○  06712178d528   b2
+    │ ○  e7241b6b0079   b1
     ├─╯
-    │ ○  cfea8bb13adf   a4
-    │ ○  3a595c648b6d   a3
-    │ ○  307ab42af890   a2
-    │ ○  f626655ef3dd   a3
-    │ ○  5d93a4b8f4bd   a1
+    │ ○  8767667a6595   a4
+    │ ○  a6238b8a4ee7   a3
+    │ ○  e50feabdd2c0   a2
+    │ ○  82ae04656204   a3
+    │ ○  94078b99a3ab   a1
     ├─╯
     ◆  000000000000
     [EOF]
@@ -572,25 +572,25 @@ fn test_duplicate_insert_after() {
     let output = work_dir.run_jj(["duplicate", "a1", "--after", "a3"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Warning: Duplicating commit 5d93a4b8f4bd as a descendant of itself
-    Duplicated 5d93a4b8f4bd as pkstwlsy 610e8ba1 (empty) a1
+    Warning: Duplicating commit 94078b99a3ab as a descendant of itself
+    Duplicated 94078b99a3ab as pkstwlsy 2ef408af (empty) a1
     Rebased 1 commits onto duplicated commits
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  3e122d6a4b70   d2
-    ○  ae61a031221a   d1
-    │ ○  47a79ab4bbc6   c2
+    @  d7fd293d0ee4   d2
+    ○  8aae10eecc84   d1
+    │ ○  10855af02fff   c2
     │ ○  9b24b49f717e   c1
     ├─╯
-    │ ○  65b6f1fe6b41   b2
-    │ ○  6a9343b8797a   b1
+    │ ○  06712178d528   b2
+    │ ○  e7241b6b0079   b1
     ├─╯
-    │ ○  f8077bd38256   a4
-    │ ○  610e8ba113f6   a1
-    │ ○  5fb83d2b58d6   a3
-    │ ○  7bfd9fbe959c   a2
-    │ ○  5d93a4b8f4bd   a1
+    │ ○  e315705b0c3b   a4
+    │ ○  2ef408af2f15   a1
+    │ ○  fb5b814db965   a3
+    │ ○  932fb7b4fc1e   a2
+    │ ○  94078b99a3ab   a1
     ├─╯
     ◆  000000000000
     [EOF]
@@ -602,26 +602,26 @@ fn test_duplicate_insert_after() {
     let output = work_dir.run_jj(["duplicate", "a1", "--after", "b1", "--after", "c1"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Duplicated 5d93a4b8f4bd as zowrlwsv a78c25cc a1
+    Duplicated 94078b99a3ab as zowrlwsv 1c771e05 a1
     Rebased 2 commits onto duplicated commits
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  3e122d6a4b70   d2
-    ○  ae61a031221a   d1
-    │ ○  4150b5a5466e   c2
-    │ │ ○  4a1f33498a39   b2
+    @  d7fd293d0ee4   d2
+    ○  8aae10eecc84   d1
+    │ ○  71854ffefce7   c2
+    │ │ ○  0f42648eec8e   b2
     │ ├─╯
-    │ ○    a78c25cc7d58   a1
+    │ ○    1c771e05c0d3   a1
     │ ├─╮
     │ │ ○  9b24b49f717e   c1
     ├───╯
-    │ ○  6a9343b8797a   b1
+    │ ○  e7241b6b0079   b1
     ├─╯
-    │ ○  e9b68b6313be   a4
-    │ ○  5fb83d2b58d6   a3
-    │ ○  7bfd9fbe959c   a2
-    │ ○  5d93a4b8f4bd   a1
+    │ ○  31f05d9b8a41   a4
+    │ ○  fb5b814db965   a3
+    │ ○  932fb7b4fc1e   a2
+    │ ○  94078b99a3ab   a1
     ├─╯
     ◆  000000000000
     [EOF]
@@ -632,26 +632,26 @@ fn test_duplicate_insert_after() {
     let output = work_dir.run_jj(["duplicate", "a3", "--after", "a2", "--after", "b2"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Warning: Duplicating commit 5fb83d2b58d6 as an ancestor of itself
-    Duplicated 5fb83d2b58d6 as wvmqtotl 0824a995 a3
+    Warning: Duplicating commit fb5b814db965 as an ancestor of itself
+    Duplicated fb5b814db965 as wvmqtotl 91120b34 a3
     Rebased 2 commits onto duplicated commits
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  3e122d6a4b70   d2
-    ○  ae61a031221a   d1
-    │ ○  47a79ab4bbc6   c2
+    @  d7fd293d0ee4   d2
+    ○  8aae10eecc84   d1
+    │ ○  10855af02fff   c2
     │ ○  9b24b49f717e   c1
     ├─╯
-    │ ○  a916f82ba67e   a4
-    │ ○  3568f02a532c   a3
-    │ ○    0824a99549cc   a3
+    │ ○  56ff50de5055   a4
+    │ ○  704308de44cc   a3
+    │ ○    91120b348523   a3
     │ ├─╮
-    │ │ ○  65b6f1fe6b41   b2
-    │ │ ○  6a9343b8797a   b1
+    │ │ ○  06712178d528   b2
+    │ │ ○  e7241b6b0079   b1
     ├───╯
-    │ ○  7bfd9fbe959c   a2
-    │ ○  5d93a4b8f4bd   a1
+    │ ○  932fb7b4fc1e   a2
+    │ ○  94078b99a3ab   a1
     ├─╯
     ◆  000000000000
     [EOF]
@@ -662,26 +662,26 @@ fn test_duplicate_insert_after() {
     let output = work_dir.run_jj(["duplicate", "a1", "--after", "a3", "--after", "b2"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Warning: Duplicating commit 5d93a4b8f4bd as a descendant of itself
-    Duplicated 5d93a4b8f4bd as opwsxtwu 7548fb00 (empty) a1
+    Warning: Duplicating commit 94078b99a3ab as a descendant of itself
+    Duplicated 94078b99a3ab as opwsxtwu 0e7d347c (empty) a1
     Rebased 1 commits onto duplicated commits
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  3e122d6a4b70   d2
-    ○  ae61a031221a   d1
-    │ ○  47a79ab4bbc6   c2
+    @  d7fd293d0ee4   d2
+    ○  8aae10eecc84   d1
+    │ ○  10855af02fff   c2
     │ ○  9b24b49f717e   c1
     ├─╯
-    │ ○  784c89a5ba72   a4
-    │ ○    7548fb00a50a   a1
+    │ ○  8f26be7aab41   a4
+    │ ○    0e7d347c5b52   a1
     │ ├─╮
-    │ │ ○  65b6f1fe6b41   b2
-    │ │ ○  6a9343b8797a   b1
+    │ │ ○  06712178d528   b2
+    │ │ ○  e7241b6b0079   b1
     ├───╯
-    │ ○  5fb83d2b58d6   a3
-    │ ○  7bfd9fbe959c   a2
-    │ ○  5d93a4b8f4bd   a1
+    │ ○  fb5b814db965   a3
+    │ ○  932fb7b4fc1e   a2
+    │ ○  94078b99a3ab   a1
     ├─╯
     ◆  000000000000
     [EOF]
@@ -693,28 +693,28 @@ fn test_duplicate_insert_after() {
     let output = work_dir.run_jj(["duplicate", "a1", "b1", "--after", "c1"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Duplicated 5d93a4b8f4bd as ukwxllxp 0cedc1c7 a1
-    Duplicated 6a9343b8797a as yrwmsomt 0d18a4ba b1
+    Duplicated 94078b99a3ab as ukwxllxp 0cedc1c7 a1
+    Duplicated e7241b6b0079 as yrwmsomt 0d18a4ba b1
     Rebased 1 commits onto duplicated commits
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  3e122d6a4b70   d2
-    ○  ae61a031221a   d1
-    │ ○    133e5ef54093   c2
+    @  d7fd293d0ee4   d2
+    ○  8aae10eecc84   d1
+    │ ○    78b9a5a33939   c2
     │ ├─╮
     │ │ ○  0d18a4ba8860   b1
     │ ○ │  0cedc1c7f5dc   a1
     │ ├─╯
     │ ○  9b24b49f717e   c1
     ├─╯
-    │ ○  65b6f1fe6b41   b2
-    │ ○  6a9343b8797a   b1
+    │ ○  06712178d528   b2
+    │ ○  e7241b6b0079   b1
     ├─╯
-    │ ○  e9b68b6313be   a4
-    │ ○  5fb83d2b58d6   a3
-    │ ○  7bfd9fbe959c   a2
-    │ ○  5d93a4b8f4bd   a1
+    │ ○  31f05d9b8a41   a4
+    │ ○  fb5b814db965   a3
+    │ ○  932fb7b4fc1e   a2
+    │ ○  94078b99a3ab   a1
     ├─╯
     ◆  000000000000
     [EOF]
@@ -726,29 +726,29 @@ fn test_duplicate_insert_after() {
     let output = work_dir.run_jj(["duplicate", "a3", "b1", "--after", "a2"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Warning: Duplicating commit 5fb83d2b58d6 as an ancestor of itself
-    Duplicated 5fb83d2b58d6 as szrrkvty 5ea1ddf1 a3
-    Duplicated 6a9343b8797a as wvmrymqu 8081d164 b1
+    Warning: Duplicating commit fb5b814db965 as an ancestor of itself
+    Duplicated fb5b814db965 as szrrkvty d914610f a3
+    Duplicated e7241b6b0079 as wvmrymqu e07aeee7 b1
     Rebased 2 commits onto duplicated commits
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  3e122d6a4b70   d2
-    ○  ae61a031221a   d1
-    │ ○  47a79ab4bbc6   c2
+    @  d7fd293d0ee4   d2
+    ○  8aae10eecc84   d1
+    │ ○  10855af02fff   c2
     │ ○  9b24b49f717e   c1
     ├─╯
-    │ ○  65b6f1fe6b41   b2
-    │ ○  6a9343b8797a   b1
+    │ ○  06712178d528   b2
+    │ ○  e7241b6b0079   b1
     ├─╯
-    │ ○  e5be4d6a351f   a4
-    │ ○    d6fe9e37ad2e   a3
+    │ ○  4c8edef23e44   a4
+    │ ○    69d7338e773e   a3
     │ ├─╮
-    │ │ ○  8081d1648811   b1
-    │ ○ │  5ea1ddf11f02   a3
+    │ │ ○  e07aeee7dc3d   b1
+    │ ○ │  d914610fbc0d   a3
     │ ├─╯
-    │ ○  7bfd9fbe959c   a2
-    │ ○  5d93a4b8f4bd   a1
+    │ ○  932fb7b4fc1e   a2
+    │ ○  94078b99a3ab   a1
     ├─╯
     ◆  000000000000
     [EOF]
@@ -760,29 +760,29 @@ fn test_duplicate_insert_after() {
     let output = work_dir.run_jj(["duplicate", "a1", "b1", "--after", "a3"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Warning: Duplicating commit 5d93a4b8f4bd as a descendant of itself
-    Duplicated 5d93a4b8f4bd as ztnvrxlv 896deede (empty) a1
-    Duplicated 6a9343b8797a as upuzqpxs ad048f81 b1
+    Warning: Duplicating commit 94078b99a3ab as a descendant of itself
+    Duplicated 94078b99a3ab as ztnvrxlv 650404f6 (empty) a1
+    Duplicated e7241b6b0079 as upuzqpxs a76583cc b1
     Rebased 1 commits onto duplicated commits
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  3e122d6a4b70   d2
-    ○  ae61a031221a   d1
-    │ ○  47a79ab4bbc6   c2
+    @  d7fd293d0ee4   d2
+    ○  8aae10eecc84   d1
+    │ ○  10855af02fff   c2
     │ ○  9b24b49f717e   c1
     ├─╯
-    │ ○  65b6f1fe6b41   b2
-    │ ○  6a9343b8797a   b1
+    │ ○  06712178d528   b2
+    │ ○  e7241b6b0079   b1
     ├─╯
-    │ ○    87ec7e281ad9   a4
+    │ ○    f0a61c7aee36   a4
     │ ├─╮
-    │ │ ○  ad048f810d3c   b1
-    │ ○ │  896deede3c03   a1
+    │ │ ○  a76583cc72f4   b1
+    │ ○ │  650404f6e8b5   a1
     │ ├─╯
-    │ ○  5fb83d2b58d6   a3
-    │ ○  7bfd9fbe959c   a2
-    │ ○  5d93a4b8f4bd   a1
+    │ ○  fb5b814db965   a3
+    │ ○  932fb7b4fc1e   a2
+    │ ○  94078b99a3ab   a1
     ├─╯
     ◆  000000000000
     [EOF]
@@ -794,34 +794,34 @@ fn test_duplicate_insert_after() {
     let output = work_dir.run_jj(["duplicate", "a1", "b1", "--after", "c1", "--after", "d1"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Duplicated 5d93a4b8f4bd as muymlknp 7db83f0f a1
-    Duplicated 6a9343b8797a as snrzyvry d10bd4dd b1
+    Duplicated 94078b99a3ab as muymlknp f0516baa a1
+    Duplicated e7241b6b0079 as snrzyvry ca1f0f71 b1
     Rebased 2 commits onto duplicated commits
-    Working copy  (@) now at: nmzmmopx 57d2a947 d2 | d2
-    Parent commit (@-)      : muymlknp 7db83f0f a1
-    Parent commit (@-)      : snrzyvry d10bd4dd b1
+    Working copy  (@) now at: rmzmmopx 1a496e82 d2 | d2
+    Parent commit (@-)      : muymlknp f0516baa a1
+    Parent commit (@-)      : snrzyvry ca1f0f71 b1
     Added 3 files, modified 0 files, removed 0 files
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @    57d2a947c305   d2
+    @    1a496e82b224   d2
     ├─╮
-    │ │ ○  aca0050dbbc4   c2
+    │ │ ○  66899a31a50c   c2
     ╭─┬─╯
-    │ ○    d10bd4ddb880   b1
+    │ ○    ca1f0f71408c   b1
     │ ├─╮
-    ○ │ │  7db83f0f554b   a1
+    ○ │ │  f0516baaccf2   a1
     ╰─┬─╮
-      │ ○  ae61a031221a   d1
+      │ ○  8aae10eecc84   d1
       ○ │  9b24b49f717e   c1
       ├─╯
-    ○ │  65b6f1fe6b41   b2
-    ○ │  6a9343b8797a   b1
+    ○ │  06712178d528   b2
+    ○ │  e7241b6b0079   b1
     ├─╯
-    │ ○  e9b68b6313be   a4
-    │ ○  5fb83d2b58d6   a3
-    │ ○  7bfd9fbe959c   a2
-    │ ○  5d93a4b8f4bd   a1
+    │ ○  31f05d9b8a41   a4
+    │ ○  fb5b814db965   a3
+    │ ○  932fb7b4fc1e   a2
+    │ ○  94078b99a3ab   a1
     ├─╯
     ◆  000000000000
     [EOF]
@@ -833,31 +833,31 @@ fn test_duplicate_insert_after() {
     let output = work_dir.run_jj(["duplicate", "a3", "b1", "--after", "a1", "--after", "c1"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Warning: Duplicating commit 5fb83d2b58d6 as an ancestor of itself
-    Duplicated 5fb83d2b58d6 as vnqwxmpr 749e7782 a3
-    Duplicated 6a9343b8797a as pvqonzsn cdc6ab27 b1
+    Warning: Duplicating commit fb5b814db965 as an ancestor of itself
+    Duplicated fb5b814db965 as vnqwxmpr 616184ac a3
+    Duplicated e7241b6b0079 as pvqonzsn b260f09e b1
     Rebased 4 commits onto duplicated commits
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  3e122d6a4b70   d2
-    ○  ae61a031221a   d1
-    │ ○    77dbe4a4ab86   c2
+    @  d7fd293d0ee4   d2
+    ○  8aae10eecc84   d1
+    │ ○    0e5e70cb5c7d   c2
     │ ├─╮
-    │ │ │ ○  52a5fbe4cfe6   a4
-    │ │ │ ○  87a6779455c5   a3
-    │ │ │ ○  1df3435c91be   a2
+    │ │ │ ○  d20e1531fe79   a4
+    │ │ │ ○  c5c3cdb83d11   a3
+    │ │ │ ○  fba9171322f3   a2
     │ ╭─┬─╯
-    │ │ ○    cdc6ab279cb7   b1
+    │ │ ○    b260f09e49cb   b1
     │ │ ├─╮
-    │ ○ │ │  749e778247d3   a3
+    │ ○ │ │  616184ac420c   a3
     │ ╰─┬─╮
     │   │ ○  9b24b49f717e   c1
     ├─────╯
-    │   ○  5d93a4b8f4bd   a1
+    │   ○  94078b99a3ab   a1
     ├───╯
-    │ ○  65b6f1fe6b41   b2
-    │ ○  6a9343b8797a   b1
+    │ ○  06712178d528   b2
+    │ ○  e7241b6b0079   b1
     ├─╯
     ◆  000000000000
     [EOF]
@@ -869,30 +869,30 @@ fn test_duplicate_insert_after() {
     let output = work_dir.run_jj(["duplicate", "a1", "b1", "--after", "a3", "--after", "c2"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Warning: Duplicating commit 5d93a4b8f4bd as a descendant of itself
-    Duplicated 5d93a4b8f4bd as qtvkyytt e9ac46df (empty) a1
-    Duplicated 6a9343b8797a as ouvslmur bbf796e8 b1
+    Warning: Duplicating commit 94078b99a3ab as a descendant of itself
+    Duplicated 94078b99a3ab as qtvkyytt c2d9e172 (empty) a1
+    Duplicated e7241b6b0079 as ouvslmur d037ef3f b1
     Rebased 1 commits onto duplicated commits
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  3e122d6a4b70   d2
-    ○  ae61a031221a   d1
-    │ ○    ecaa1f7b16fb   a4
+    @  d7fd293d0ee4   d2
+    ○  8aae10eecc84   d1
+    │ ○    c56f22b44ec5   a4
     │ ├─╮
-    │ │ ○    bbf796e8f265   b1
+    │ │ ○    d037ef3fea72   b1
     │ │ ├─╮
-    │ ○ │ │  e9ac46df3691   a1
+    │ ○ │ │  c2d9e17233f9   a1
     │ ╰─┬─╮
-    │   │ ○  47a79ab4bbc6   c2
+    │   │ ○  10855af02fff   c2
     │   │ ○  9b24b49f717e   c1
     ├─────╯
-    │   ○  5fb83d2b58d6   a3
-    │   ○  7bfd9fbe959c   a2
-    │   ○  5d93a4b8f4bd   a1
+    │   ○  fb5b814db965   a3
+    │   ○  932fb7b4fc1e   a2
+    │   ○  94078b99a3ab   a1
     ├───╯
-    │ ○  65b6f1fe6b41   b2
-    │ ○  6a9343b8797a   b1
+    │ ○  06712178d528   b2
+    │ ○  e7241b6b0079   b1
     ├─╯
     ◆  000000000000
     [EOF]
@@ -904,25 +904,25 @@ fn test_duplicate_insert_after() {
     let output = work_dir.run_jj(["duplicate", "a1", "a3", "--after", "c2"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Duplicated 5d93a4b8f4bd as qowqnpnw 0478473b a1
-    Duplicated 5fb83d2b58d6 as mommxqln 6175d88f a3
+    Duplicated 94078b99a3ab as qowqnpnw 661c603f a1
+    Duplicated fb5b814db965 as mommxqln 526992a5 a3
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  3e122d6a4b70   d2
-    ○  ae61a031221a   d1
-    │ ○  6175d88f3848   a3
-    │ ○  0478473bfff3   a1
-    │ ○  47a79ab4bbc6   c2
+    @  d7fd293d0ee4   d2
+    ○  8aae10eecc84   d1
+    │ ○  526992a57e7f   a3
+    │ ○  661c603fdd94   a1
+    │ ○  10855af02fff   c2
     │ ○  9b24b49f717e   c1
     ├─╯
-    │ ○  65b6f1fe6b41   b2
-    │ ○  6a9343b8797a   b1
+    │ ○  06712178d528   b2
+    │ ○  e7241b6b0079   b1
     ├─╯
-    │ ○  e9b68b6313be   a4
-    │ ○  5fb83d2b58d6   a3
-    │ ○  7bfd9fbe959c   a2
-    │ ○  5d93a4b8f4bd   a1
+    │ ○  31f05d9b8a41   a4
+    │ ○  fb5b814db965   a3
+    │ ○  932fb7b4fc1e   a2
+    │ ○  94078b99a3ab   a1
     ├─╯
     ◆  000000000000
     [EOF]
@@ -934,28 +934,28 @@ fn test_duplicate_insert_after() {
     let output = work_dir.run_jj(["duplicate", "a2", "a3", "--after", "a1"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Warning: Duplicating commit 5fb83d2b58d6 as an ancestor of itself
-    Warning: Duplicating commit 7bfd9fbe959c as an ancestor of itself
-    Duplicated 7bfd9fbe959c as qzusktlu abac3b29 a2
-    Duplicated 5fb83d2b58d6 as zryotxso 0ac7bc72 a3
+    Warning: Duplicating commit fb5b814db965 as an ancestor of itself
+    Warning: Duplicating commit 932fb7b4fc1e as an ancestor of itself
+    Duplicated 932fb7b4fc1e as qzusktlu 302e8c8e a2
+    Duplicated fb5b814db965 as zryotxso 71b0f3f5 a3
     Rebased 3 commits onto duplicated commits
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  3e122d6a4b70   d2
-    ○  ae61a031221a   d1
-    │ ○  47a79ab4bbc6   c2
+    @  d7fd293d0ee4   d2
+    ○  8aae10eecc84   d1
+    │ ○  10855af02fff   c2
     │ ○  9b24b49f717e   c1
     ├─╯
-    │ ○  65b6f1fe6b41   b2
-    │ ○  6a9343b8797a   b1
+    │ ○  06712178d528   b2
+    │ ○  e7241b6b0079   b1
     ├─╯
-    │ ○  e6b5faccb8d6   a4
-    │ ○  1b0489e81cdf   a3
-    │ ○  91cc24eeda92   a2
-    │ ○  0ac7bc72e563   a3
-    │ ○  abac3b29eace   a2
-    │ ○  5d93a4b8f4bd   a1
+    │ ○  fcd4a84b877b   a4
+    │ ○  d9de6aceb55b   a3
+    │ ○  16282d473e5e   a2
+    │ ○  71b0f3f51789   a3
+    │ ○  302e8c8e1462   a2
+    │ ○  94078b99a3ab   a1
     ├─╯
     ◆  000000000000
     [EOF]
@@ -967,28 +967,28 @@ fn test_duplicate_insert_after() {
     let output = work_dir.run_jj(["duplicate", "a1", "a2", "--after", "a3"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Warning: Duplicating commit 7bfd9fbe959c as a descendant of itself
-    Warning: Duplicating commit 5d93a4b8f4bd as a descendant of itself
-    Duplicated 5d93a4b8f4bd as stzvpxow 607f49d4 (empty) a1
-    Duplicated 7bfd9fbe959c as zrzsnomp 802bec72 (empty) a2
+    Warning: Duplicating commit 932fb7b4fc1e as a descendant of itself
+    Warning: Duplicating commit 94078b99a3ab as a descendant of itself
+    Duplicated 94078b99a3ab as stzvpxow 4bb169c3 (empty) a1
+    Duplicated 932fb7b4fc1e as zrzsnomp 5d89a41f (empty) a2
     Rebased 1 commits onto duplicated commits
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  3e122d6a4b70   d2
-    ○  ae61a031221a   d1
-    │ ○  47a79ab4bbc6   c2
+    @  d7fd293d0ee4   d2
+    ○  8aae10eecc84   d1
+    │ ○  10855af02fff   c2
     │ ○  9b24b49f717e   c1
     ├─╯
-    │ ○  65b6f1fe6b41   b2
-    │ ○  6a9343b8797a   b1
+    │ ○  06712178d528   b2
+    │ ○  e7241b6b0079   b1
     ├─╯
-    │ ○  5968d4b950df   a4
-    │ ○  802bec723045   a2
-    │ ○  607f49d4e2dd   a1
-    │ ○  5fb83d2b58d6   a3
-    │ ○  7bfd9fbe959c   a2
-    │ ○  5d93a4b8f4bd   a1
+    │ ○  4fa1d0d8f99b   a4
+    │ ○  5d89a41f3267   a2
+    │ ○  4bb169c3ab82   a1
+    │ ○  fb5b814db965   a3
+    │ ○  932fb7b4fc1e   a2
+    │ ○  94078b99a3ab   a1
     ├─╯
     ◆  000000000000
     [EOF]
@@ -1000,26 +1000,26 @@ fn test_duplicate_insert_after() {
     let output = work_dir.run_jj(["duplicate", "a1", "a3", "--after", "c2", "--after", "d2"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Duplicated 5d93a4b8f4bd as ysllonyo 24a4e9f8 a1
-    Duplicated 5fb83d2b58d6 as kzxwzvzw 64d6f104 a3
+    Duplicated 94078b99a3ab as ysllonyo 697b40b2 a1
+    Duplicated fb5b814db965 as kzxwzvzw 53ca8429 a3
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    ○  64d6f1045b10   a3
-    ○    24a4e9f817c7   a1
+    ○  53ca8429c1ba   a3
+    ○    697b40b29246   a1
     ├─╮
-    │ @  3e122d6a4b70   d2
-    │ ○  ae61a031221a   d1
-    ○ │  47a79ab4bbc6   c2
+    │ @  d7fd293d0ee4   d2
+    │ ○  8aae10eecc84   d1
+    ○ │  10855af02fff   c2
     ○ │  9b24b49f717e   c1
     ├─╯
-    │ ○  65b6f1fe6b41   b2
-    │ ○  6a9343b8797a   b1
+    │ ○  06712178d528   b2
+    │ ○  e7241b6b0079   b1
     ├─╯
-    │ ○  e9b68b6313be   a4
-    │ ○  5fb83d2b58d6   a3
-    │ ○  7bfd9fbe959c   a2
-    │ ○  5d93a4b8f4bd   a1
+    │ ○  31f05d9b8a41   a4
+    │ ○  fb5b814db965   a3
+    │ ○  932fb7b4fc1e   a2
+    │ ○  94078b99a3ab   a1
     ├─╯
     ◆  000000000000
     [EOF]
@@ -1031,29 +1031,29 @@ fn test_duplicate_insert_after() {
     let output = work_dir.run_jj(["duplicate", "a3", "a4", "--after", "a2", "--after", "c2"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Warning: Duplicating commit e9b68b6313be as an ancestor of itself
-    Warning: Duplicating commit 5fb83d2b58d6 as an ancestor of itself
-    Duplicated 5fb83d2b58d6 as kvqpkqvl 59583d1b a3
-    Duplicated e9b68b6313be as zqztuxrl b327e326 a4
+    Warning: Duplicating commit 31f05d9b8a41 as an ancestor of itself
+    Warning: Duplicating commit fb5b814db965 as an ancestor of itself
+    Duplicated fb5b814db965 as kvqpkqvl 782345d2 a3
+    Duplicated 31f05d9b8a41 as zqztuxrl 8a9ab779 a4
     Rebased 2 commits onto duplicated commits
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  3e122d6a4b70   d2
-    ○  ae61a031221a   d1
-    │ ○  c6d033e3dbae   a4
-    │ ○  969593962a7c   a3
-    │ ○  b327e326e151   a4
-    │ ○    59583d1b591c   a3
+    @  d7fd293d0ee4   d2
+    ○  8aae10eecc84   d1
+    │ ○  22deba30c553   a4
+    │ ○  e46513e020a7   a3
+    │ ○  8a9ab779d9cc   a4
+    │ ○    782345d22a6a   a3
     │ ├─╮
-    │ │ ○  47a79ab4bbc6   c2
+    │ │ ○  10855af02fff   c2
     │ │ ○  9b24b49f717e   c1
     ├───╯
-    │ ○  7bfd9fbe959c   a2
-    │ ○  5d93a4b8f4bd   a1
+    │ ○  932fb7b4fc1e   a2
+    │ ○  94078b99a3ab   a1
     ├─╯
-    │ ○  65b6f1fe6b41   b2
-    │ ○  6a9343b8797a   b1
+    │ ○  06712178d528   b2
+    │ ○  e7241b6b0079   b1
     ├─╯
     ◆  000000000000
     [EOF]
@@ -1065,29 +1065,29 @@ fn test_duplicate_insert_after() {
     let output = work_dir.run_jj(["duplicate", "a1", "a2", "--after", "a3", "--after", "c2"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Warning: Duplicating commit 7bfd9fbe959c as a descendant of itself
-    Warning: Duplicating commit 5d93a4b8f4bd as a descendant of itself
-    Duplicated 5d93a4b8f4bd as xsvtwpuq 579fa109 (empty) a1
-    Duplicated 7bfd9fbe959c as tmzzmpyp 995ffc29 (empty) a2
+    Warning: Duplicating commit 932fb7b4fc1e as a descendant of itself
+    Warning: Duplicating commit 94078b99a3ab as a descendant of itself
+    Duplicated 94078b99a3ab as xsvtwpuq 03b391b5 (empty) a1
+    Duplicated 932fb7b4fc1e as tmzzmpyp c040997b (empty) a2
     Rebased 1 commits onto duplicated commits
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  3e122d6a4b70   d2
-    ○  ae61a031221a   d1
-    │ ○  a462f9946f62   a4
-    │ ○  995ffc29e76b   a2
-    │ ○    579fa1093ceb   a1
+    @  d7fd293d0ee4   d2
+    ○  8aae10eecc84   d1
+    │ ○  a7b61baf26cd   a4
+    │ ○  c040997b717e   a2
+    │ ○    03b391b59022   a1
     │ ├─╮
-    │ │ ○  47a79ab4bbc6   c2
+    │ │ ○  10855af02fff   c2
     │ │ ○  9b24b49f717e   c1
     ├───╯
-    │ ○  5fb83d2b58d6   a3
-    │ ○  7bfd9fbe959c   a2
-    │ ○  5d93a4b8f4bd   a1
+    │ ○  fb5b814db965   a3
+    │ ○  932fb7b4fc1e   a2
+    │ ○  94078b99a3ab   a1
     ├─╯
-    │ ○  65b6f1fe6b41   b2
-    │ ○  6a9343b8797a   b1
+    │ ○  06712178d528   b2
+    │ ○  e7241b6b0079   b1
     ├─╯
     ◆  000000000000
     [EOF]
@@ -1098,7 +1098,7 @@ fn test_duplicate_insert_after() {
     let output = work_dir.run_jj(["duplicate", "a1", "--after", "b1", "--after", "b2"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Error: Refusing to create a loop: commit 65b6f1fe6b41 would be both an ancestor and a descendant of the duplicated commits
+    Error: Refusing to create a loop: commit 06712178d528 would be both an ancestor and a descendant of the duplicated commits
     [EOF]
     [exit status: 1]
     ");
@@ -1124,18 +1124,18 @@ fn test_duplicate_insert_before() {
 
     // Test the setup
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  3e122d6a4b70   d2
-    ○  ae61a031221a   d1
-    │ ○  47a79ab4bbc6   c2
+    @  d7fd293d0ee4   d2
+    ○  8aae10eecc84   d1
+    │ ○  10855af02fff   c2
     │ ○  9b24b49f717e   c1
     ├─╯
-    │ ○  65b6f1fe6b41   b2
-    │ ○  6a9343b8797a   b1
+    │ ○  06712178d528   b2
+    │ ○  e7241b6b0079   b1
     ├─╯
-    │ ○  e9b68b6313be   a4
-    │ ○  5fb83d2b58d6   a3
-    │ ○  7bfd9fbe959c   a2
-    │ ○  5d93a4b8f4bd   a1
+    │ ○  31f05d9b8a41   a4
+    │ ○  fb5b814db965   a3
+    │ ○  932fb7b4fc1e   a2
+    │ ○  94078b99a3ab   a1
     ├─╯
     ◆  000000000000
     [EOF]
@@ -1145,24 +1145,24 @@ fn test_duplicate_insert_before() {
     let output = work_dir.run_jj(["duplicate", "a1", "--before", "b2"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Duplicated 5d93a4b8f4bd as nlrtlrxv 52959024 a1
+    Duplicated 94078b99a3ab as nlrtlrxv 403a87a9 a1
     Rebased 1 commits onto duplicated commits
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  3e122d6a4b70   d2
-    ○  ae61a031221a   d1
-    │ ○  47a79ab4bbc6   c2
+    @  d7fd293d0ee4   d2
+    ○  8aae10eecc84   d1
+    │ ○  10855af02fff   c2
     │ ○  9b24b49f717e   c1
     ├─╯
-    │ ○  8124402d0ebe   b2
-    │ ○  52959024d93a   a1
-    │ ○  6a9343b8797a   b1
+    │ ○  e03525446a4f   b2
+    │ ○  403a87a97264   a1
+    │ ○  e7241b6b0079   b1
     ├─╯
-    │ ○  e9b68b6313be   a4
-    │ ○  5fb83d2b58d6   a3
-    │ ○  7bfd9fbe959c   a2
-    │ ○  5d93a4b8f4bd   a1
+    │ ○  31f05d9b8a41   a4
+    │ ○  fb5b814db965   a3
+    │ ○  932fb7b4fc1e   a2
+    │ ○  94078b99a3ab   a1
     ├─╯
     ◆  000000000000
     [EOF]
@@ -1173,25 +1173,25 @@ fn test_duplicate_insert_before() {
     let output = work_dir.run_jj(["duplicate", "a3", "--before", "a1"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Warning: Duplicating commit 5fb83d2b58d6 as an ancestor of itself
-    Duplicated 5fb83d2b58d6 as uuuvxpvw cbb38dd4 a3
+    Warning: Duplicating commit fb5b814db965 as an ancestor of itself
+    Duplicated fb5b814db965 as uuuvxpvw cbb38dd4 a3
     Rebased 4 commits onto duplicated commits
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  3e122d6a4b70   d2
-    ○  ae61a031221a   d1
-    │ ○  6d36ca1b1215   a4
-    │ ○  ec479e2b5c1c   a3
-    │ ○  54f79ca85067   a2
-    │ ○  34db3229bbf9   a1
+    @  d7fd293d0ee4   d2
+    ○  8aae10eecc84   d1
+    │ ○  e85e551840d0   a4
+    │ ○  6976425a5e4e   a3
+    │ ○  01e4e43ca191   a2
+    │ ○  87cf0c9c25fb   a1
     │ ○  cbb38dd4f677   a3
     ├─╯
-    │ ○  47a79ab4bbc6   c2
+    │ ○  10855af02fff   c2
     │ ○  9b24b49f717e   c1
     ├─╯
-    │ ○  65b6f1fe6b41   b2
-    │ ○  6a9343b8797a   b1
+    │ ○  06712178d528   b2
+    │ ○  e7241b6b0079   b1
     ├─╯
     ◆  000000000000
     [EOF]
@@ -1202,25 +1202,25 @@ fn test_duplicate_insert_before() {
     let output = work_dir.run_jj(["duplicate", "a1", "--before", "a3"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Warning: Duplicating commit 5d93a4b8f4bd as a descendant of itself
-    Duplicated 5d93a4b8f4bd as pkstwlsy e6dcd064 (empty) a1
+    Warning: Duplicating commit 94078b99a3ab as a descendant of itself
+    Duplicated 94078b99a3ab as pkstwlsy 26ff671e (empty) a1
     Rebased 2 commits onto duplicated commits
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  3e122d6a4b70   d2
-    ○  ae61a031221a   d1
-    │ ○  47a79ab4bbc6   c2
+    @  d7fd293d0ee4   d2
+    ○  8aae10eecc84   d1
+    │ ○  10855af02fff   c2
     │ ○  9b24b49f717e   c1
     ├─╯
-    │ ○  65b6f1fe6b41   b2
-    │ ○  6a9343b8797a   b1
+    │ ○  06712178d528   b2
+    │ ○  e7241b6b0079   b1
     ├─╯
-    │ ○  88ed72c9e2cd   a4
-    │ ○  bf1cebc7b328   a3
-    │ ○  e6dcd064caba   a1
-    │ ○  7bfd9fbe959c   a2
-    │ ○  5d93a4b8f4bd   a1
+    │ ○  635ca6b60217   a4
+    │ ○  9eb3fccbc0fb   a3
+    │ ○  26ff671ef00d   a1
+    │ ○  932fb7b4fc1e   a2
+    │ ○  94078b99a3ab   a1
     ├─╯
     ◆  000000000000
     [EOF]
@@ -1232,26 +1232,26 @@ fn test_duplicate_insert_before() {
     let output = work_dir.run_jj(["duplicate", "a1", "--before", "b2", "--before", "c2"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Duplicated 5d93a4b8f4bd as zowrlwsv a78c25cc a1
+    Duplicated 94078b99a3ab as zowrlwsv 1c771e05 a1
     Rebased 2 commits onto duplicated commits
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  3e122d6a4b70   d2
-    ○  ae61a031221a   d1
-    │ ○  4150b5a5466e   c2
-    │ │ ○  4a1f33498a39   b2
+    @  d7fd293d0ee4   d2
+    ○  8aae10eecc84   d1
+    │ ○  71854ffefce7   c2
+    │ │ ○  0f42648eec8e   b2
     │ ├─╯
-    │ ○    a78c25cc7d58   a1
+    │ ○    1c771e05c0d3   a1
     │ ├─╮
     │ │ ○  9b24b49f717e   c1
     ├───╯
-    │ ○  6a9343b8797a   b1
+    │ ○  e7241b6b0079   b1
     ├─╯
-    │ ○  e9b68b6313be   a4
-    │ ○  5fb83d2b58d6   a3
-    │ ○  7bfd9fbe959c   a2
-    │ ○  5d93a4b8f4bd   a1
+    │ ○  31f05d9b8a41   a4
+    │ ○  fb5b814db965   a3
+    │ ○  932fb7b4fc1e   a2
+    │ ○  94078b99a3ab   a1
     ├─╯
     ◆  000000000000
     [EOF]
@@ -1262,27 +1262,27 @@ fn test_duplicate_insert_before() {
     let output = work_dir.run_jj(["duplicate", "a3", "--before", "a2", "--before", "b2"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Warning: Duplicating commit 5fb83d2b58d6 as an ancestor of itself
-    Duplicated 5fb83d2b58d6 as wvmqtotl 388c8d9d a3
+    Warning: Duplicating commit fb5b814db965 as an ancestor of itself
+    Duplicated fb5b814db965 as wvmqtotl 3aa4ac96 a3
     Rebased 4 commits onto duplicated commits
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  3e122d6a4b70   d2
-    ○  ae61a031221a   d1
-    │ ○  47a79ab4bbc6   c2
+    @  d7fd293d0ee4   d2
+    ○  8aae10eecc84   d1
+    │ ○  10855af02fff   c2
     │ ○  9b24b49f717e   c1
     ├─╯
-    │ ○  a7c33fa6bdd2   b2
-    │ │ ○  4a4c76b85974   a4
-    │ │ ○  6e519ad5a603   a3
-    │ │ ○  40bb4cf3aecf   a2
+    │ ○  388fd4668840   b2
+    │ │ ○  c822624aed5d   a4
+    │ │ ○  feaa49d43b8e   a3
+    │ │ ○  87f815dbcc15   a2
     │ ├─╯
-    │ ○    388c8d9d7b49   a3
+    │ ○    3aa4ac96c873   a3
     │ ├─╮
-    │ │ ○  6a9343b8797a   b1
+    │ │ ○  e7241b6b0079   b1
     ├───╯
-    │ ○  5d93a4b8f4bd   a1
+    │ ○  94078b99a3ab   a1
     ├─╯
     ◆  000000000000
     [EOF]
@@ -1293,27 +1293,27 @@ fn test_duplicate_insert_before() {
     let output = work_dir.run_jj(["duplicate", "a1", "--before", "a3", "--before", "b2"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Warning: Duplicating commit 5d93a4b8f4bd as a descendant of itself
-    Duplicated 5d93a4b8f4bd as opwsxtwu 644afaf1 (empty) a1
+    Warning: Duplicating commit 94078b99a3ab as a descendant of itself
+    Duplicated 94078b99a3ab as opwsxtwu e2dcaa9c (empty) a1
     Rebased 3 commits onto duplicated commits
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  3e122d6a4b70   d2
-    ○  ae61a031221a   d1
-    │ ○  47a79ab4bbc6   c2
+    @  d7fd293d0ee4   d2
+    ○  8aae10eecc84   d1
+    │ ○  10855af02fff   c2
     │ ○  9b24b49f717e   c1
     ├─╯
-    │ ○  00f96f926fd4   b2
-    │ │ ○  b0d1638032b2   a4
-    │ │ ○  f2d014886a49   a3
+    │ ○  55c7d5e620d1   b2
+    │ │ ○  e1478dae0b59   a4
+    │ │ ○  a1e7be94b5c9   a3
     │ ├─╯
-    │ ○    644afaf17a49   a1
+    │ ○    e2dcaa9c31d5   a1
     │ ├─╮
-    │ │ ○  6a9343b8797a   b1
+    │ │ ○  e7241b6b0079   b1
     ├───╯
-    │ ○  7bfd9fbe959c   a2
-    │ ○  5d93a4b8f4bd   a1
+    │ ○  932fb7b4fc1e   a2
+    │ ○  94078b99a3ab   a1
     ├─╯
     ◆  000000000000
     [EOF]
@@ -1325,28 +1325,28 @@ fn test_duplicate_insert_before() {
     let output = work_dir.run_jj(["duplicate", "a1", "b1", "--before", "c1"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Duplicated 5d93a4b8f4bd as ukwxllxp 3323f9c3 a1
-    Duplicated 6a9343b8797a as yrwmsomt a6ef0369 b1
+    Duplicated 94078b99a3ab as ukwxllxp 3323f9c3 a1
+    Duplicated e7241b6b0079 as yrwmsomt a6ef0369 b1
     Rebased 2 commits onto duplicated commits
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  3e122d6a4b70   d2
-    ○  ae61a031221a   d1
-    │ ○  a0d7984ef9ce   c2
+    @  d7fd293d0ee4   d2
+    ○  8aae10eecc84   d1
+    │ ○  5529d29f53bf   c2
     │ ○    2d5211a7d52f   c1
     │ ├─╮
     │ │ ○  a6ef03692b89   b1
     ├───╯
     │ ○  3323f9c396f8   a1
     ├─╯
-    │ ○  65b6f1fe6b41   b2
-    │ ○  6a9343b8797a   b1
+    │ ○  06712178d528   b2
+    │ ○  e7241b6b0079   b1
     ├─╯
-    │ ○  e9b68b6313be   a4
-    │ ○  5fb83d2b58d6   a3
-    │ ○  7bfd9fbe959c   a2
-    │ ○  5d93a4b8f4bd   a1
+    │ ○  31f05d9b8a41   a4
+    │ ○  fb5b814db965   a3
+    │ ○  932fb7b4fc1e   a2
+    │ ○  94078b99a3ab   a1
     ├─╯
     ◆  000000000000
     [EOF]
@@ -1358,29 +1358,29 @@ fn test_duplicate_insert_before() {
     let output = work_dir.run_jj(["duplicate", "a3", "b1", "--before", "a2"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Warning: Duplicating commit 5fb83d2b58d6 as an ancestor of itself
-    Duplicated 5fb83d2b58d6 as szrrkvty fa34ba15 a3
-    Duplicated 6a9343b8797a as wvmrymqu dd6d65a2 b1
+    Warning: Duplicating commit fb5b814db965 as an ancestor of itself
+    Duplicated fb5b814db965 as szrrkvty 872c3f20 a3
+    Duplicated e7241b6b0079 as wvmrymqu 340f6bb8 b1
     Rebased 3 commits onto duplicated commits
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  3e122d6a4b70   d2
-    ○  ae61a031221a   d1
-    │ ○  47a79ab4bbc6   c2
+    @  d7fd293d0ee4   d2
+    ○  8aae10eecc84   d1
+    │ ○  10855af02fff   c2
     │ ○  9b24b49f717e   c1
     ├─╯
-    │ ○  65b6f1fe6b41   b2
-    │ ○  6a9343b8797a   b1
+    │ ○  06712178d528   b2
+    │ ○  e7241b6b0079   b1
     ├─╯
-    │ ○  0f4182479035   a4
-    │ ○  2ce96f99ba9a   a3
-    │ ○    18eda16173aa   a2
+    │ ○  59c0b3ba82a7   a4
+    │ ○  954c28d0b37b   a3
+    │ ○    386c48637ff1   a2
     │ ├─╮
-    │ │ ○  dd6d65a2db44   b1
-    │ ○ │  fa34ba15a5cc   a3
+    │ │ ○  340f6bb8eba8   b1
+    │ ○ │  872c3f209e23   a3
     │ ├─╯
-    │ ○  5d93a4b8f4bd   a1
+    │ ○  94078b99a3ab   a1
     ├─╯
     ◆  000000000000
     [EOF]
@@ -1392,29 +1392,29 @@ fn test_duplicate_insert_before() {
     let output = work_dir.run_jj(["duplicate", "a1", "b1", "--before", "a3"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Warning: Duplicating commit 5d93a4b8f4bd as a descendant of itself
-    Duplicated 5d93a4b8f4bd as ztnvrxlv 4131a4c1 (empty) a1
-    Duplicated 6a9343b8797a as upuzqpxs 2a4ce4e3 b1
+    Warning: Duplicating commit 94078b99a3ab as a descendant of itself
+    Duplicated 94078b99a3ab as ztnvrxlv fa5a74fa (empty) a1
+    Duplicated e7241b6b0079 as upuzqpxs b3d7a96b b1
     Rebased 2 commits onto duplicated commits
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  3e122d6a4b70   d2
-    ○  ae61a031221a   d1
-    │ ○  47a79ab4bbc6   c2
+    @  d7fd293d0ee4   d2
+    ○  8aae10eecc84   d1
+    │ ○  10855af02fff   c2
     │ ○  9b24b49f717e   c1
     ├─╯
-    │ ○  65b6f1fe6b41   b2
-    │ ○  6a9343b8797a   b1
+    │ ○  06712178d528   b2
+    │ ○  e7241b6b0079   b1
     ├─╯
-    │ ○  cf945b2bc8af   a4
-    │ ○    6f86e945fda5   a3
+    │ ○  052d0b0c2edf   a4
+    │ ○    ffe51e55e530   a3
     │ ├─╮
-    │ │ ○  2a4ce4e3aebb   b1
-    │ ○ │  4131a4c1003c   a1
+    │ │ ○  b3d7a96b290f   b1
+    │ ○ │  fa5a74fac661   a1
     │ ├─╯
-    │ ○  7bfd9fbe959c   a2
-    │ ○  5d93a4b8f4bd   a1
+    │ ○  932fb7b4fc1e   a2
+    │ ○  94078b99a3ab   a1
     ├─╯
     ◆  000000000000
     [EOF]
@@ -1426,31 +1426,31 @@ fn test_duplicate_insert_before() {
     let output = work_dir.run_jj(["duplicate", "a1", "b1", "--before", "c1", "--before", "d1"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Duplicated 5d93a4b8f4bd as muymlknp 9add628e a1
-    Duplicated 6a9343b8797a as snrzyvry b63fdd54 b1
+    Duplicated 94078b99a3ab as muymlknp 9add628e a1
+    Duplicated e7241b6b0079 as snrzyvry b63fdd54 b1
     Rebased 4 commits onto duplicated commits
-    Working copy  (@) now at: nmzmmopx 1aec68e6 d2 | d2
-    Parent commit (@-)      : xznxytkn 3b2ee7ee d1 | d1
+    Working copy  (@) now at: rmzmmopx dec31ad0 d2 | d2
+    Parent commit (@-)      : mznxytkn 70b5dbc6 d1 | d1
     Added 2 files, modified 0 files, removed 0 files
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  1aec68e662c2   d2
-    ○    3b2ee7eeb0c0   d1
+    @  dec31ad0c0d5   d2
+    ○    70b5dbc66dc7   d1
     ├─╮
-    │ │ ○  a2adf9d2849d   c2
+    │ │ ○  8432e9329ed5   c2
     │ │ ○  fdc43aa17cf1   c1
     ╭─┬─╯
     │ ○  b63fdd54c3f9   b1
     ○ │  9add628e2f94   a1
     ├─╯
-    │ ○  65b6f1fe6b41   b2
-    │ ○  6a9343b8797a   b1
+    │ ○  06712178d528   b2
+    │ ○  e7241b6b0079   b1
     ├─╯
-    │ ○  e9b68b6313be   a4
-    │ ○  5fb83d2b58d6   a3
-    │ ○  7bfd9fbe959c   a2
-    │ ○  5d93a4b8f4bd   a1
+    │ ○  31f05d9b8a41   a4
+    │ ○  fb5b814db965   a3
+    │ ○  932fb7b4fc1e   a2
+    │ ○  94078b99a3ab   a1
     ├─╯
     ◆  000000000000
     [EOF]
@@ -1462,29 +1462,29 @@ fn test_duplicate_insert_before() {
     let output = work_dir.run_jj(["duplicate", "a3", "b1", "--before", "a1", "--before", "c1"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Warning: Duplicating commit 5fb83d2b58d6 as an ancestor of itself
-    Duplicated 5fb83d2b58d6 as vnqwxmpr 73f3594f a3
-    Duplicated 6a9343b8797a as pvqonzsn 67d4a940 b1
+    Warning: Duplicating commit fb5b814db965 as an ancestor of itself
+    Duplicated fb5b814db965 as vnqwxmpr 73f3594f a3
+    Duplicated e7241b6b0079 as pvqonzsn 67d4a940 b1
     Rebased 6 commits onto duplicated commits
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  3e122d6a4b70   d2
-    ○  ae61a031221a   d1
-    │ ○  12da11313262   c2
+    @  d7fd293d0ee4   d2
+    ○  8aae10eecc84   d1
+    │ ○  9fdad5c6c18c   c2
     │ ○    dbb8e01766cc   c1
     │ ├─╮
-    │ │ │ ○  622c81500218   a4
-    │ │ │ ○  ae205a70138e   a3
-    │ │ │ ○  9e97d48369cd   a2
-    │ │ │ ○  22afb4fd6d02   a1
+    │ │ │ ○  a8f5997056f0   a4
+    │ │ │ ○  2c140b15105f   a3
+    │ │ │ ○  efcfa3a910d7   a2
+    │ │ │ ○  559edec70334   a1
     │ ╭─┬─╯
     │ │ ○  67d4a9404b6b   b1
     ├───╯
     │ ○  73f3594f082f   a3
     ├─╯
-    │ ○  65b6f1fe6b41   b2
-    │ ○  6a9343b8797a   b1
+    │ ○  06712178d528   b2
+    │ ○  e7241b6b0079   b1
     ├─╯
     ◆  000000000000
     [EOF]
@@ -1496,31 +1496,31 @@ fn test_duplicate_insert_before() {
     let output = work_dir.run_jj(["duplicate", "a1", "b1", "--before", "a3", "--before", "c2"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Warning: Duplicating commit 5d93a4b8f4bd as a descendant of itself
-    Duplicated 5d93a4b8f4bd as qtvkyytt 2a37f838 (empty) a1
-    Duplicated 6a9343b8797a as ouvslmur f2337ef6 b1
+    Warning: Duplicating commit 94078b99a3ab as a descendant of itself
+    Duplicated 94078b99a3ab as qtvkyytt d6b68ab1 (empty) a1
+    Duplicated e7241b6b0079 as ouvslmur f9d630e5 b1
     Rebased 3 commits onto duplicated commits
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  3e122d6a4b70   d2
-    ○  ae61a031221a   d1
-    │ ○    7562404a5fe2   c2
+    @  d7fd293d0ee4   d2
+    ○  8aae10eecc84   d1
+    │ ○    3e00ce9e0b75   c2
     │ ├─╮
-    │ │ │ ○  116b92e839d4   a4
-    │ │ │ ○  b814e7dd0b6d   a3
+    │ │ │ ○  fc357110d6e0   a4
+    │ │ │ ○  d37ac4734b62   a3
     │ ╭─┬─╯
-    │ │ ○    f2337ef6d7af   b1
+    │ │ ○    f9d630e59922   b1
     │ │ ├─╮
-    │ ○ │ │  2a37f83808d9   a1
+    │ ○ │ │  d6b68ab125ee   a1
     │ ╰─┬─╮
     │   │ ○  9b24b49f717e   c1
     ├─────╯
-    │   ○  7bfd9fbe959c   a2
-    │   ○  5d93a4b8f4bd   a1
+    │   ○  932fb7b4fc1e   a2
+    │   ○  94078b99a3ab   a1
     ├───╯
-    │ ○  65b6f1fe6b41   b2
-    │ ○  6a9343b8797a   b1
+    │ ○  06712178d528   b2
+    │ ○  e7241b6b0079   b1
     ├─╯
     ◆  000000000000
     [EOF]
@@ -1532,26 +1532,26 @@ fn test_duplicate_insert_before() {
     let output = work_dir.run_jj(["duplicate", "a1", "a3", "--before", "c2"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Duplicated 5d93a4b8f4bd as qowqnpnw 1cd05f49 a1
-    Duplicated 5fb83d2b58d6 as mommxqln 51d00be6 a3
+    Duplicated 94078b99a3ab as qowqnpnw 1cd05f49 a1
+    Duplicated fb5b814db965 as mommxqln 51d00be6 a3
     Rebased 1 commits onto duplicated commits
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  3e122d6a4b70   d2
-    ○  ae61a031221a   d1
-    │ ○  7d22145dee97   c2
+    @  d7fd293d0ee4   d2
+    ○  8aae10eecc84   d1
+    │ ○  97207ca0668e   c2
     │ ○  51d00be616d6   a3
     │ ○  1cd05f491a63   a1
     │ ○  9b24b49f717e   c1
     ├─╯
-    │ ○  65b6f1fe6b41   b2
-    │ ○  6a9343b8797a   b1
+    │ ○  06712178d528   b2
+    │ ○  e7241b6b0079   b1
     ├─╯
-    │ ○  e9b68b6313be   a4
-    │ ○  5fb83d2b58d6   a3
-    │ ○  7bfd9fbe959c   a2
-    │ ○  5d93a4b8f4bd   a1
+    │ ○  31f05d9b8a41   a4
+    │ ○  fb5b814db965   a3
+    │ ○  932fb7b4fc1e   a2
+    │ ○  94078b99a3ab   a1
     ├─╯
     ◆  000000000000
     [EOF]
@@ -1563,28 +1563,28 @@ fn test_duplicate_insert_before() {
     let output = work_dir.run_jj(["duplicate", "a1", "a3", "--before", "a1"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Warning: Duplicating commit 5fb83d2b58d6 as an ancestor of itself
-    Warning: Duplicating commit 5d93a4b8f4bd as an ancestor of itself
-    Duplicated 5d93a4b8f4bd as qzusktlu d8aaed30 a1
-    Duplicated 5fb83d2b58d6 as zryotxso 701cf123 a3
+    Warning: Duplicating commit fb5b814db965 as an ancestor of itself
+    Warning: Duplicating commit 94078b99a3ab as an ancestor of itself
+    Duplicated 94078b99a3ab as qzusktlu d8aaed30 a1
+    Duplicated fb5b814db965 as zryotxso 701cf123 a3
     Rebased 4 commits onto duplicated commits
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  3e122d6a4b70   d2
-    ○  ae61a031221a   d1
-    │ ○  d44c70bd7777   a4
-    │ ○  4898b1b61699   a3
-    │ ○  c10b845b6926   a2
-    │ ○  848ddba9889a   a1
+    @  d7fd293d0ee4   d2
+    ○  8aae10eecc84   d1
+    │ ○  049b474c3237   a4
+    │ ○  55db825c3612   a3
+    │ ○  4676026aa09a   a2
+    │ ○  3333c388c9bb   a1
     │ ○  701cf1238e40   a3
     │ ○  d8aaed30e073   a1
     ├─╯
-    │ ○  47a79ab4bbc6   c2
+    │ ○  10855af02fff   c2
     │ ○  9b24b49f717e   c1
     ├─╯
-    │ ○  65b6f1fe6b41   b2
-    │ ○  6a9343b8797a   b1
+    │ ○  06712178d528   b2
+    │ ○  e7241b6b0079   b1
     ├─╯
     ◆  000000000000
     [EOF]
@@ -1596,28 +1596,28 @@ fn test_duplicate_insert_before() {
     let output = work_dir.run_jj(["duplicate", "a1", "a2", "--before", "a3"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Warning: Duplicating commit 7bfd9fbe959c as a descendant of itself
-    Warning: Duplicating commit 5d93a4b8f4bd as a descendant of itself
-    Duplicated 5d93a4b8f4bd as stzvpxow ced08d1e (empty) a1
-    Duplicated 7bfd9fbe959c as zrzsnomp fe7136d1 (empty) a2
+    Warning: Duplicating commit 932fb7b4fc1e as a descendant of itself
+    Warning: Duplicating commit 94078b99a3ab as a descendant of itself
+    Duplicated 94078b99a3ab as stzvpxow b30be90c (empty) a1
+    Duplicated 932fb7b4fc1e as zrzsnomp 9b00bd13 (empty) a2
     Rebased 2 commits onto duplicated commits
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  3e122d6a4b70   d2
-    ○  ae61a031221a   d1
-    │ ○  47a79ab4bbc6   c2
+    @  d7fd293d0ee4   d2
+    ○  8aae10eecc84   d1
+    │ ○  10855af02fff   c2
     │ ○  9b24b49f717e   c1
     ├─╯
-    │ ○  65b6f1fe6b41   b2
-    │ ○  6a9343b8797a   b1
+    │ ○  06712178d528   b2
+    │ ○  e7241b6b0079   b1
     ├─╯
-    │ ○  f83372ee5f96   a4
-    │ ○  aac435e6dffb   a3
-    │ ○  fe7136d10a72   a2
-    │ ○  ced08d1e6dd9   a1
-    │ ○  7bfd9fbe959c   a2
-    │ ○  5d93a4b8f4bd   a1
+    │ ○  4e3254a554d2   a4
+    │ ○  0c2c875c730c   a3
+    │ ○  9b00bd13027c   a2
+    │ ○  b30be90c574e   a1
+    │ ○  932fb7b4fc1e   a2
+    │ ○  94078b99a3ab   a1
     ├─╯
     ◆  000000000000
     [EOF]
@@ -1629,31 +1629,31 @@ fn test_duplicate_insert_before() {
     let output = work_dir.run_jj(["duplicate", "a1", "a3", "--before", "c2", "--before", "d2"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Duplicated 5d93a4b8f4bd as ysllonyo b9b23a94 a1
-    Duplicated 5fb83d2b58d6 as kzxwzvzw 22d5f430 a3
+    Duplicated 94078b99a3ab as ysllonyo 0744dd96 a1
+    Duplicated fb5b814db965 as kzxwzvzw a5eb90b5 a3
     Rebased 2 commits onto duplicated commits
-    Working copy  (@) now at: nmzmmopx b00d1c06 d2 | d2
-    Parent commit (@-)      : kzxwzvzw 22d5f430 a3
+    Working copy  (@) now at: rmzmmopx a395b8c4 d2 | d2
+    Parent commit (@-)      : kzxwzvzw a5eb90b5 a3
     Added 3 files, modified 0 files, removed 0 files
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  b00d1c0624f9   d2
-    │ ○  bbc756f1d839   c2
+    @  a395b8c4f9b8   d2
+    │ ○  2c33d86fcf48   c2
     ├─╯
-    ○  22d5f4304b47   a3
-    ○    b9b23a944c2a   a1
+    ○  a5eb90b55b73   a3
+    ○    0744dd965980   a1
     ├─╮
-    │ ○  ae61a031221a   d1
+    │ ○  8aae10eecc84   d1
     ○ │  9b24b49f717e   c1
     ├─╯
-    │ ○  65b6f1fe6b41   b2
-    │ ○  6a9343b8797a   b1
+    │ ○  06712178d528   b2
+    │ ○  e7241b6b0079   b1
     ├─╯
-    │ ○  e9b68b6313be   a4
-    │ ○  5fb83d2b58d6   a3
-    │ ○  7bfd9fbe959c   a2
-    │ ○  5d93a4b8f4bd   a1
+    │ ○  31f05d9b8a41   a4
+    │ ○  fb5b814db965   a3
+    │ ○  932fb7b4fc1e   a2
+    │ ○  94078b99a3ab   a1
     ├─╯
     ◆  000000000000
     [EOF]
@@ -1665,30 +1665,30 @@ fn test_duplicate_insert_before() {
     let output = work_dir.run_jj(["duplicate", "a3", "a4", "--before", "a2", "--before", "c2"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Warning: Duplicating commit e9b68b6313be as an ancestor of itself
-    Warning: Duplicating commit 5fb83d2b58d6 as an ancestor of itself
-    Duplicated 5fb83d2b58d6 as kvqpkqvl 469d73d0 a3
-    Duplicated e9b68b6313be as zqztuxrl 1146a57a a4
+    Warning: Duplicating commit 31f05d9b8a41 as an ancestor of itself
+    Warning: Duplicating commit fb5b814db965 as an ancestor of itself
+    Duplicated fb5b814db965 as kvqpkqvl 2af19233 a3
+    Duplicated 31f05d9b8a41 as zqztuxrl 0f8b723e a4
     Rebased 4 commits onto duplicated commits
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  3e122d6a4b70   d2
-    ○  ae61a031221a   d1
-    │ ○  93291babd184   c2
-    │ │ ○  83bce95a4e22   a4
-    │ │ ○  26314519c960   a3
-    │ │ ○  0d0144d0c427   a2
+    @  d7fd293d0ee4   d2
+    ○  8aae10eecc84   d1
+    │ ○  547066cdd064   c2
+    │ │ ○  d259a3385807   a4
+    │ │ ○  88e9b5424cdf   a3
+    │ │ ○  540df4eecd9a   a2
     │ ├─╯
-    │ ○  1146a57afb7c   a4
-    │ ○    469d73d08c1b   a3
+    │ ○  0f8b723eabf8   a4
+    │ ○    2af192339fec   a3
     │ ├─╮
     │ │ ○  9b24b49f717e   c1
     ├───╯
-    │ ○  5d93a4b8f4bd   a1
+    │ ○  94078b99a3ab   a1
     ├─╯
-    │ ○  65b6f1fe6b41   b2
-    │ ○  6a9343b8797a   b1
+    │ ○  06712178d528   b2
+    │ ○  e7241b6b0079   b1
     ├─╯
     ◆  000000000000
     [EOF]
@@ -1700,30 +1700,30 @@ fn test_duplicate_insert_before() {
     let output = work_dir.run_jj(["duplicate", "a1", "a2", "--before", "a3", "--before", "c2"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Warning: Duplicating commit 7bfd9fbe959c as a descendant of itself
-    Warning: Duplicating commit 5d93a4b8f4bd as a descendant of itself
-    Duplicated 5d93a4b8f4bd as xsvtwpuq b166c219 (empty) a1
-    Duplicated 7bfd9fbe959c as tmzzmpyp 111a9c6e (empty) a2
+    Warning: Duplicating commit 932fb7b4fc1e as a descendant of itself
+    Warning: Duplicating commit 94078b99a3ab as a descendant of itself
+    Duplicated 94078b99a3ab as xsvtwpuq 25e380ee (empty) a1
+    Duplicated 932fb7b4fc1e as tmzzmpyp 304eb3d9 (empty) a2
     Rebased 3 commits onto duplicated commits
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  3e122d6a4b70   d2
-    ○  ae61a031221a   d1
-    │ ○  f1c1d4b44d61   c2
-    │ │ ○  ffef7620a964   a4
-    │ │ ○  9b06af9a8d57   a3
+    @  d7fd293d0ee4   d2
+    ○  8aae10eecc84   d1
+    │ ○  34fad5173b7f   c2
+    │ │ ○  ce1cca82ac7c   a4
+    │ │ ○  e69839ebb5db   a3
     │ ├─╯
-    │ ○  111a9c6ec9da   a2
-    │ ○    b166c219ae16   a1
+    │ ○  304eb3d9d0c2   a2
+    │ ○    25e380ee496d   a1
     │ ├─╮
     │ │ ○  9b24b49f717e   c1
     ├───╯
-    │ ○  7bfd9fbe959c   a2
-    │ ○  5d93a4b8f4bd   a1
+    │ ○  932fb7b4fc1e   a2
+    │ ○  94078b99a3ab   a1
     ├─╯
-    │ ○  65b6f1fe6b41   b2
-    │ ○  6a9343b8797a   b1
+    │ ○  06712178d528   b2
+    │ ○  e7241b6b0079   b1
     ├─╯
     ◆  000000000000
     [EOF]
@@ -1734,7 +1734,7 @@ fn test_duplicate_insert_before() {
     let output = work_dir.run_jj(["duplicate", "a1", "--before", "b1", "--before", "b2"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Error: Refusing to create a loop: commit 6a9343b8797a would be both an ancestor and a descendant of the duplicated commits
+    Error: Refusing to create a loop: commit e7241b6b0079 would be both an ancestor and a descendant of the duplicated commits
     [EOF]
     [exit status: 1]
     ");
@@ -1760,18 +1760,18 @@ fn test_duplicate_insert_after_before() {
 
     // Test the setup
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  3e122d6a4b70   d2
-    ○  ae61a031221a   d1
-    │ ○  47a79ab4bbc6   c2
+    @  d7fd293d0ee4   d2
+    ○  8aae10eecc84   d1
+    │ ○  10855af02fff   c2
     │ ○  9b24b49f717e   c1
     ├─╯
-    │ ○  65b6f1fe6b41   b2
-    │ ○  6a9343b8797a   b1
+    │ ○  06712178d528   b2
+    │ ○  e7241b6b0079   b1
     ├─╯
-    │ ○  e9b68b6313be   a4
-    │ ○  5fb83d2b58d6   a3
-    │ ○  7bfd9fbe959c   a2
-    │ ○  5d93a4b8f4bd   a1
+    │ ○  31f05d9b8a41   a4
+    │ ○  fb5b814db965   a3
+    │ ○  932fb7b4fc1e   a2
+    │ ○  94078b99a3ab   a1
     ├─╯
     ◆  000000000000
     [EOF]
@@ -1781,25 +1781,25 @@ fn test_duplicate_insert_after_before() {
     let output = work_dir.run_jj(["duplicate", "a1", "--before", "b2", "--after", "c2"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Duplicated 5d93a4b8f4bd as nlrtlrxv 16aac4ae a1
+    Duplicated 94078b99a3ab as nlrtlrxv 9d768b2f a1
     Rebased 1 commits onto duplicated commits
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  3e122d6a4b70   d2
-    ○  ae61a031221a   d1
-    │ ○    b0611efaa0d5   b2
+    @  d7fd293d0ee4   d2
+    ○  8aae10eecc84   d1
+    │ ○    d181500bbf1e   b2
     │ ├─╮
-    │ │ ○  16aac4aec6de   a1
-    │ │ ○  47a79ab4bbc6   c2
+    │ │ ○  9d768b2f99bf   a1
+    │ │ ○  10855af02fff   c2
     │ │ ○  9b24b49f717e   c1
     ├───╯
-    │ ○  6a9343b8797a   b1
+    │ ○  e7241b6b0079   b1
     ├─╯
-    │ ○  e9b68b6313be   a4
-    │ ○  5fb83d2b58d6   a3
-    │ ○  7bfd9fbe959c   a2
-    │ ○  5d93a4b8f4bd   a1
+    │ ○  31f05d9b8a41   a4
+    │ ○  fb5b814db965   a3
+    │ ○  932fb7b4fc1e   a2
+    │ ○  94078b99a3ab   a1
     ├─╯
     ◆  000000000000
     [EOF]
@@ -1810,25 +1810,25 @@ fn test_duplicate_insert_after_before() {
     let output = work_dir.run_jj(["duplicate", "a3", "--before", "a2", "--after", "a1"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Warning: Duplicating commit 5fb83d2b58d6 as an ancestor of itself
-    Duplicated 5fb83d2b58d6 as uuuvxpvw f626655e a3
+    Warning: Duplicating commit fb5b814db965 as an ancestor of itself
+    Duplicated fb5b814db965 as uuuvxpvw 82ae0465 a3
     Rebased 3 commits onto duplicated commits
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  3e122d6a4b70   d2
-    ○  ae61a031221a   d1
-    │ ○  47a79ab4bbc6   c2
+    @  d7fd293d0ee4   d2
+    ○  8aae10eecc84   d1
+    │ ○  10855af02fff   c2
     │ ○  9b24b49f717e   c1
     ├─╯
-    │ ○  65b6f1fe6b41   b2
-    │ ○  6a9343b8797a   b1
+    │ ○  06712178d528   b2
+    │ ○  e7241b6b0079   b1
     ├─╯
-    │ ○  cfea8bb13adf   a4
-    │ ○  3a595c648b6d   a3
-    │ ○  307ab42af890   a2
-    │ ○  f626655ef3dd   a3
-    │ ○  5d93a4b8f4bd   a1
+    │ ○  8767667a6595   a4
+    │ ○  a6238b8a4ee7   a3
+    │ ○  e50feabdd2c0   a2
+    │ ○  82ae04656204   a3
+    │ ○  94078b99a3ab   a1
     ├─╯
     ◆  000000000000
     [EOF]
@@ -1840,26 +1840,26 @@ fn test_duplicate_insert_after_before() {
     let output = work_dir.run_jj(["duplicate", "a3", "--before", "a2", "--after", "b2"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Warning: Duplicating commit 5fb83d2b58d6 as an ancestor of itself
-    Duplicated 5fb83d2b58d6 as pkstwlsy 99b4ea10 a3
+    Warning: Duplicating commit fb5b814db965 as an ancestor of itself
+    Duplicated fb5b814db965 as pkstwlsy ce36a444 a3
     Rebased 3 commits onto duplicated commits
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  3e122d6a4b70   d2
-    ○  ae61a031221a   d1
-    │ ○  47a79ab4bbc6   c2
+    @  d7fd293d0ee4   d2
+    ○  8aae10eecc84   d1
+    │ ○  10855af02fff   c2
     │ ○  9b24b49f717e   c1
     ├─╯
-    │ ○  8671cfa6437d   a4
-    │ ○  b7e2ccc4ab64   a3
-    │ ○    44b6be52de17   a2
+    │ ○  ee6e2d96b7b7   a4
+    │ ○  9ad0ab3dfd07   a3
+    │ ○    afe639bdac35   a2
     │ ├─╮
-    │ │ ○  99b4ea109aff   a3
-    │ │ ○  65b6f1fe6b41   b2
-    │ │ ○  6a9343b8797a   b1
+    │ │ ○  ce36a4449e02   a3
+    │ │ ○  06712178d528   b2
+    │ │ ○  e7241b6b0079   b1
     ├───╯
-    │ ○  5d93a4b8f4bd   a1
+    │ ○  94078b99a3ab   a1
     ├─╯
     ◆  000000000000
     [EOF]
@@ -1870,25 +1870,25 @@ fn test_duplicate_insert_after_before() {
     let output = work_dir.run_jj(["duplicate", "a1", "--after", "a3", "--before", "a4"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Warning: Duplicating commit 5d93a4b8f4bd as a descendant of itself
-    Duplicated 5d93a4b8f4bd as zowrlwsv 5ba52649 (empty) a1
+    Warning: Duplicating commit 94078b99a3ab as a descendant of itself
+    Duplicated 94078b99a3ab as zowrlwsv b3121b8b (empty) a1
     Rebased 1 commits onto duplicated commits
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  3e122d6a4b70   d2
-    ○  ae61a031221a   d1
-    │ ○  47a79ab4bbc6   c2
+    @  d7fd293d0ee4   d2
+    ○  8aae10eecc84   d1
+    │ ○  10855af02fff   c2
     │ ○  9b24b49f717e   c1
     ├─╯
-    │ ○  65b6f1fe6b41   b2
-    │ ○  6a9343b8797a   b1
+    │ ○  06712178d528   b2
+    │ ○  e7241b6b0079   b1
     ├─╯
-    │ ○  2ad2abd6ed40   a4
-    │ ○  5ba52649f9f6   a1
-    │ ○  5fb83d2b58d6   a3
-    │ ○  7bfd9fbe959c   a2
-    │ ○  5d93a4b8f4bd   a1
+    │ ○  8a60dca460aa   a4
+    │ ○  b3121b8b5955   a1
+    │ ○  fb5b814db965   a3
+    │ ○  932fb7b4fc1e   a2
+    │ ○  94078b99a3ab   a1
     ├─╯
     ◆  000000000000
     [EOF]
@@ -1900,27 +1900,27 @@ fn test_duplicate_insert_after_before() {
     let output = work_dir.run_jj(["duplicate", "a1", "--after", "a3", "--before", "b2"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Warning: Duplicating commit 5d93a4b8f4bd as a descendant of itself
-    Duplicated 5d93a4b8f4bd as wvmqtotl ef1e2f46 (empty) a1
+    Warning: Duplicating commit 94078b99a3ab as a descendant of itself
+    Duplicated 94078b99a3ab as wvmqtotl 907f4e68 (empty) a1
     Rebased 1 commits onto duplicated commits
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  3e122d6a4b70   d2
-    ○  ae61a031221a   d1
-    │ ○  47a79ab4bbc6   c2
+    @  d7fd293d0ee4   d2
+    ○  8aae10eecc84   d1
+    │ ○  10855af02fff   c2
     │ ○  9b24b49f717e   c1
     ├─╯
-    │ ○    e9701b5153e5   b2
+    │ ○    53db1227a0ba   b2
     │ ├─╮
-    │ │ ○  ef1e2f461427   a1
-    │ ○ │  6a9343b8797a   b1
+    │ │ ○  907f4e687807   a1
+    │ ○ │  e7241b6b0079   b1
     ├─╯ │
-    │ ○ │  e9b68b6313be   a4
+    │ ○ │  31f05d9b8a41   a4
     │ ├─╯
-    │ ○  5fb83d2b58d6   a3
-    │ ○  7bfd9fbe959c   a2
-    │ ○  5d93a4b8f4bd   a1
+    │ ○  fb5b814db965   a3
+    │ ○  932fb7b4fc1e   a2
+    │ ○  94078b99a3ab   a1
     ├─╯
     ◆  000000000000
     [EOF]
@@ -1932,26 +1932,26 @@ fn test_duplicate_insert_after_before() {
     let output = work_dir.run_jj(["duplicate", "a2", "--after", "a1", "--before", "a4"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Duplicated 7bfd9fbe959c as opwsxtwu c9d7dee9 a2
+    Duplicated 932fb7b4fc1e as opwsxtwu fb042846 a2
     Rebased 1 commits onto duplicated commits
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  3e122d6a4b70   d2
-    ○  ae61a031221a   d1
-    │ ○  47a79ab4bbc6   c2
+    @  d7fd293d0ee4   d2
+    ○  8aae10eecc84   d1
+    │ ○  10855af02fff   c2
     │ ○  9b24b49f717e   c1
     ├─╯
-    │ ○  65b6f1fe6b41   b2
-    │ ○  6a9343b8797a   b1
+    │ ○  06712178d528   b2
+    │ ○  e7241b6b0079   b1
     ├─╯
-    │ ○    5249308b5df2   a4
+    │ ○    38f9a19a55b2   a4
     │ ├─╮
-    │ │ ○  c9d7dee9b730   a2
-    │ ○ │  5fb83d2b58d6   a3
-    │ ○ │  7bfd9fbe959c   a2
+    │ │ ○  fb042846b520   a2
+    │ ○ │  fb5b814db965   a3
+    │ ○ │  932fb7b4fc1e   a2
     │ ├─╯
-    │ ○  5d93a4b8f4bd   a1
+    │ ○  94078b99a3ab   a1
     ├─╯
     ◆  000000000000
     [EOF]
@@ -1963,34 +1963,34 @@ fn test_duplicate_insert_after_before() {
     let output = work_dir.run_jj(["duplicate", "a1", "b1", "--after", "c1", "--before", "d2"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Duplicated 5d93a4b8f4bd as ukwxllxp 0cedc1c7 a1
-    Duplicated 6a9343b8797a as yrwmsomt 0d18a4ba b1
+    Duplicated 94078b99a3ab as ukwxllxp 0cedc1c7 a1
+    Duplicated e7241b6b0079 as yrwmsomt 0d18a4ba b1
     Rebased 1 commits onto duplicated commits
-    Working copy  (@) now at: nmzmmopx 4aafd744 d2 | d2
-    Parent commit (@-)      : xznxytkn ae61a031 d1 | d1
+    Working copy  (@) now at: rmzmmopx 0f64dfec d2 | d2
+    Parent commit (@-)      : mznxytkn 8aae10ee d1 | d1
     Parent commit (@-)      : ukwxllxp 0cedc1c7 a1
     Parent commit (@-)      : yrwmsomt 0d18a4ba b1
     Added 3 files, modified 0 files, removed 0 files
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @      4aafd7445a66   d2
+    @      0f64dfec719e   d2
     ├─┬─╮
     │ │ ○  0d18a4ba8860   b1
     │ ○ │  0cedc1c7f5dc   a1
     │ ├─╯
-    ○ │  ae61a031221a   d1
-    │ │ ○  47a79ab4bbc6   c2
+    ○ │  8aae10eecc84   d1
+    │ │ ○  10855af02fff   c2
     │ ├─╯
     │ ○  9b24b49f717e   c1
     ├─╯
-    │ ○  65b6f1fe6b41   b2
-    │ ○  6a9343b8797a   b1
+    │ ○  06712178d528   b2
+    │ ○  e7241b6b0079   b1
     ├─╯
-    │ ○  e9b68b6313be   a4
-    │ ○  5fb83d2b58d6   a3
-    │ ○  7bfd9fbe959c   a2
-    │ ○  5d93a4b8f4bd   a1
+    │ ○  31f05d9b8a41   a4
+    │ ○  fb5b814db965   a3
+    │ ○  932fb7b4fc1e   a2
+    │ ○  94078b99a3ab   a1
     ├─╯
     ◆  000000000000
     [EOF]
@@ -2003,29 +2003,29 @@ fn test_duplicate_insert_after_before() {
     let output = work_dir.run_jj(["duplicate", "a3", "b1", "--after", "a2", "--before", "c2"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Duplicated 5fb83d2b58d6 as szrrkvty 5ea1ddf1 a3
-    Duplicated 6a9343b8797a as wvmrymqu 8081d164 b1
+    Duplicated fb5b814db965 as szrrkvty d914610f a3
+    Duplicated e7241b6b0079 as wvmrymqu e07aeee7 b1
     Rebased 1 commits onto duplicated commits
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  3e122d6a4b70   d2
-    ○  ae61a031221a   d1
-    │ ○      410b365b142e   c2
+    @  d7fd293d0ee4   d2
+    ○  8aae10eecc84   d1
+    │ ○      9cc20a631b4d   c2
     │ ├─┬─╮
-    │ │ │ ○  8081d1648811   b1
-    │ │ ○ │  5ea1ddf11f02   a3
+    │ │ │ ○  e07aeee7dc3d   b1
+    │ │ ○ │  d914610fbc0d   a3
     │ │ ├─╯
     │ ○ │  9b24b49f717e   c1
     ├─╯ │
-    │ ○ │  65b6f1fe6b41   b2
-    │ ○ │  6a9343b8797a   b1
+    │ ○ │  06712178d528   b2
+    │ ○ │  e7241b6b0079   b1
     ├─╯ │
-    │ ○ │  e9b68b6313be   a4
-    │ ○ │  5fb83d2b58d6   a3
+    │ ○ │  31f05d9b8a41   a4
+    │ ○ │  fb5b814db965   a3
     │ ├─╯
-    │ ○  7bfd9fbe959c   a2
-    │ ○  5d93a4b8f4bd   a1
+    │ ○  932fb7b4fc1e   a2
+    │ ○  94078b99a3ab   a1
     ├─╯
     ◆  000000000000
     [EOF]
@@ -2038,30 +2038,30 @@ fn test_duplicate_insert_after_before() {
     let output = work_dir.run_jj(["duplicate", "a1", "b1", "--after", "a3", "--before", "c2"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Warning: Duplicating commit 5d93a4b8f4bd as a descendant of itself
-    Duplicated 5d93a4b8f4bd as ztnvrxlv 896deede (empty) a1
-    Duplicated 6a9343b8797a as upuzqpxs ad048f81 b1
+    Warning: Duplicating commit 94078b99a3ab as a descendant of itself
+    Duplicated 94078b99a3ab as ztnvrxlv 650404f6 (empty) a1
+    Duplicated e7241b6b0079 as upuzqpxs a76583cc b1
     Rebased 1 commits onto duplicated commits
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  3e122d6a4b70   d2
-    ○  ae61a031221a   d1
-    │ ○      e5e35bfebdf4   c2
+    @  d7fd293d0ee4   d2
+    ○  8aae10eecc84   d1
+    │ ○      e7c3f5420501   c2
     │ ├─┬─╮
-    │ │ │ ○  ad048f810d3c   b1
-    │ │ ○ │  896deede3c03   a1
+    │ │ │ ○  a76583cc72f4   b1
+    │ │ ○ │  650404f6e8b5   a1
     │ │ ├─╯
     │ ○ │  9b24b49f717e   c1
     ├─╯ │
-    │ ○ │  65b6f1fe6b41   b2
-    │ ○ │  6a9343b8797a   b1
+    │ ○ │  06712178d528   b2
+    │ ○ │  e7241b6b0079   b1
     ├─╯ │
-    │ ○ │  e9b68b6313be   a4
+    │ ○ │  31f05d9b8a41   a4
     │ ├─╯
-    │ ○  5fb83d2b58d6   a3
-    │ ○  7bfd9fbe959c   a2
-    │ ○  5d93a4b8f4bd   a1
+    │ ○  fb5b814db965   a3
+    │ ○  932fb7b4fc1e   a2
+    │ ○  94078b99a3ab   a1
     ├─╯
     ◆  000000000000
     [EOF]
@@ -2073,34 +2073,34 @@ fn test_duplicate_insert_after_before() {
     let output = work_dir.run_jj(["duplicate", "a1", "b1", "--after", "c1", "--before", "d2"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Duplicated 5d93a4b8f4bd as muymlknp e3890eb5 a1
-    Duplicated 6a9343b8797a as snrzyvry d3066453 b1
+    Duplicated 94078b99a3ab as muymlknp e3890eb5 a1
+    Duplicated e7241b6b0079 as snrzyvry d3066453 b1
     Rebased 1 commits onto duplicated commits
-    Working copy  (@) now at: nmzmmopx 12e787a7 d2 | d2
-    Parent commit (@-)      : xznxytkn ae61a031 d1 | d1
+    Working copy  (@) now at: rmzmmopx 292325b5 d2 | d2
+    Parent commit (@-)      : mznxytkn 8aae10ee d1 | d1
     Parent commit (@-)      : muymlknp e3890eb5 a1
     Parent commit (@-)      : snrzyvry d3066453 b1
     Added 3 files, modified 0 files, removed 0 files
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @      12e787a7acb9   d2
+    @      292325b5e23e   d2
     ├─┬─╮
     │ │ ○  d30664539118   b1
     │ ○ │  e3890eb5520e   a1
     │ ├─╯
-    ○ │  ae61a031221a   d1
-    │ │ ○  47a79ab4bbc6   c2
+    ○ │  8aae10eecc84   d1
+    │ │ ○  10855af02fff   c2
     │ ├─╯
     │ ○  9b24b49f717e   c1
     ├─╯
-    │ ○  65b6f1fe6b41   b2
-    │ ○  6a9343b8797a   b1
+    │ ○  06712178d528   b2
+    │ ○  e7241b6b0079   b1
     ├─╯
-    │ ○  e9b68b6313be   a4
-    │ ○  5fb83d2b58d6   a3
-    │ ○  7bfd9fbe959c   a2
-    │ ○  5d93a4b8f4bd   a1
+    │ ○  31f05d9b8a41   a4
+    │ ○  fb5b814db965   a3
+    │ ○  932fb7b4fc1e   a2
+    │ ○  94078b99a3ab   a1
     ├─╯
     ◆  000000000000
     [EOF]
@@ -2112,32 +2112,32 @@ fn test_duplicate_insert_after_before() {
     let output = work_dir.run_jj(["duplicate", "a1", "a3", "--after", "c1", "--before", "d2"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Duplicated 5d93a4b8f4bd as vnqwxmpr 0a6ab30c a1
-    Duplicated 5fb83d2b58d6 as pvqonzsn eb5c8329 a3
+    Duplicated 94078b99a3ab as vnqwxmpr 0a6ab30c a1
+    Duplicated fb5b814db965 as pvqonzsn eb5c8329 a3
     Rebased 1 commits onto duplicated commits
-    Working copy  (@) now at: nmzmmopx e3fab709 d2 | d2
-    Parent commit (@-)      : xznxytkn ae61a031 d1 | d1
+    Working copy  (@) now at: rmzmmopx f667599d d2 | d2
+    Parent commit (@-)      : mznxytkn 8aae10ee d1 | d1
     Parent commit (@-)      : pvqonzsn eb5c8329 a3
     Added 3 files, modified 0 files, removed 0 files
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @    e3fab7093036   d2
+    @    f667599dc50c   d2
     ├─╮
     │ ○  eb5c832980d2   a3
     │ ○  0a6ab30c6a03   a1
-    ○ │  ae61a031221a   d1
-    │ │ ○  47a79ab4bbc6   c2
+    ○ │  8aae10eecc84   d1
+    │ │ ○  10855af02fff   c2
     │ ├─╯
     │ ○  9b24b49f717e   c1
     ├─╯
-    │ ○  65b6f1fe6b41   b2
-    │ ○  6a9343b8797a   b1
+    │ ○  06712178d528   b2
+    │ ○  e7241b6b0079   b1
     ├─╯
-    │ ○  e9b68b6313be   a4
-    │ ○  5fb83d2b58d6   a3
-    │ ○  7bfd9fbe959c   a2
-    │ ○  5d93a4b8f4bd   a1
+    │ ○  31f05d9b8a41   a4
+    │ ○  fb5b814db965   a3
+    │ ○  932fb7b4fc1e   a2
+    │ ○  94078b99a3ab   a1
     ├─╯
     ◆  000000000000
     [EOF]
@@ -2150,28 +2150,28 @@ fn test_duplicate_insert_after_before() {
     let output = work_dir.run_jj(["duplicate", "a3", "a4", "--after", "a2", "--before", "c2"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Duplicated 5fb83d2b58d6 as qtvkyytt 92720226 a3
-    Duplicated e9b68b6313be as ouvslmur c565fb9e a4
+    Duplicated fb5b814db965 as qtvkyytt 63062e2d a3
+    Duplicated 31f05d9b8a41 as ouvslmur 08ed9574 a4
     Rebased 1 commits onto duplicated commits
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  3e122d6a4b70   d2
-    ○  ae61a031221a   d1
-    │ ○    45da82514fef   c2
+    @  d7fd293d0ee4   d2
+    ○  8aae10eecc84   d1
+    │ ○    4657b371268e   c2
     │ ├─╮
-    │ │ ○  c565fb9eec0b   a4
-    │ │ ○  927202268f69   a3
+    │ │ ○  08ed957425b3   a4
+    │ │ ○  63062e2d8b3f   a3
     │ ○ │  9b24b49f717e   c1
     ├─╯ │
-    │ ○ │  65b6f1fe6b41   b2
-    │ ○ │  6a9343b8797a   b1
+    │ ○ │  06712178d528   b2
+    │ ○ │  e7241b6b0079   b1
     ├─╯ │
-    │ ○ │  e9b68b6313be   a4
-    │ ○ │  5fb83d2b58d6   a3
+    │ ○ │  31f05d9b8a41   a4
+    │ ○ │  fb5b814db965   a3
     │ ├─╯
-    │ ○  7bfd9fbe959c   a2
-    │ ○  5d93a4b8f4bd   a1
+    │ ○  932fb7b4fc1e   a2
+    │ ○  94078b99a3ab   a1
     ├─╯
     ◆  000000000000
     [EOF]
@@ -2184,27 +2184,27 @@ fn test_duplicate_insert_after_before() {
     let output = work_dir.run_jj(["duplicate", "a1", "a2", "--before", "a3", "--after", "c2"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Duplicated 5d93a4b8f4bd as qowqnpnw 0478473b a1
-    Duplicated 7bfd9fbe959c as mommxqln fd58dece a2
+    Duplicated 94078b99a3ab as qowqnpnw 661c603f a1
+    Duplicated 932fb7b4fc1e as mommxqln 0f27a04e a2
     Rebased 2 commits onto duplicated commits
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  3e122d6a4b70   d2
-    ○  ae61a031221a   d1
-    │ ○  58ed94dc9684   a4
-    │ ○    678cebe68e8a   a3
+    @  d7fd293d0ee4   d2
+    ○  8aae10eecc84   d1
+    │ ○  e5c598b73191   a4
+    │ ○    bbba043083dd   a3
     │ ├─╮
-    │ │ ○  fd58dece7c4f   a2
-    │ │ ○  0478473bfff3   a1
-    │ │ ○  47a79ab4bbc6   c2
+    │ │ ○  0f27a04e3aeb   a2
+    │ │ ○  661c603fdd94   a1
+    │ │ ○  10855af02fff   c2
     │ │ ○  9b24b49f717e   c1
     ├───╯
-    │ ○  7bfd9fbe959c   a2
-    │ ○  5d93a4b8f4bd   a1
+    │ ○  932fb7b4fc1e   a2
+    │ ○  94078b99a3ab   a1
     ├─╯
-    │ ○  65b6f1fe6b41   b2
-    │ ○  6a9343b8797a   b1
+    │ ○  06712178d528   b2
+    │ ○  e7241b6b0079   b1
     ├─╯
     ◆  000000000000
     [EOF]
@@ -2216,28 +2216,28 @@ fn test_duplicate_insert_after_before() {
     let output = work_dir.run_jj(["duplicate", "a3", "a4", "--after", "a1", "--before", "a2"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Warning: Duplicating commit e9b68b6313be as an ancestor of itself
-    Warning: Duplicating commit 5fb83d2b58d6 as an ancestor of itself
-    Duplicated 5fb83d2b58d6 as qzusktlu bfad21d4 a3
-    Duplicated e9b68b6313be as zryotxso a83e9a5d a4
+    Warning: Duplicating commit 31f05d9b8a41 as an ancestor of itself
+    Warning: Duplicating commit fb5b814db965 as an ancestor of itself
+    Duplicated fb5b814db965 as qzusktlu 27c7398b a3
+    Duplicated 31f05d9b8a41 as zryotxso 48becebd a4
     Rebased 3 commits onto duplicated commits
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  3e122d6a4b70   d2
-    ○  ae61a031221a   d1
-    │ ○  47a79ab4bbc6   c2
+    @  d7fd293d0ee4   d2
+    ○  8aae10eecc84   d1
+    │ ○  10855af02fff   c2
     │ ○  9b24b49f717e   c1
     ├─╯
-    │ ○  65b6f1fe6b41   b2
-    │ ○  6a9343b8797a   b1
+    │ ○  06712178d528   b2
+    │ ○  e7241b6b0079   b1
     ├─╯
-    │ ○  b88510005789   a4
-    │ ○  55fd608caaf7   a3
-    │ ○  d375a67f0929   a2
-    │ ○  a83e9a5d4771   a4
-    │ ○  bfad21d45a87   a3
-    │ ○  5d93a4b8f4bd   a1
+    │ ○  2049bb0c1213   a4
+    │ ○  3b847034bd03   a3
+    │ ○  37c590c83d22   a2
+    │ ○  48becebd34bf   a4
+    │ ○  27c7398b920d   a3
+    │ ○  94078b99a3ab   a1
     ├─╯
     ◆  000000000000
     [EOF]
@@ -2249,28 +2249,28 @@ fn test_duplicate_insert_after_before() {
     let output = work_dir.run_jj(["duplicate", "a1", "a2", "--after", "a3", "--before", "a4"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Warning: Duplicating commit 7bfd9fbe959c as a descendant of itself
-    Warning: Duplicating commit 5d93a4b8f4bd as a descendant of itself
-    Duplicated 5d93a4b8f4bd as stzvpxow 607f49d4 (empty) a1
-    Duplicated 7bfd9fbe959c as zrzsnomp 802bec72 (empty) a2
+    Warning: Duplicating commit 932fb7b4fc1e as a descendant of itself
+    Warning: Duplicating commit 94078b99a3ab as a descendant of itself
+    Duplicated 94078b99a3ab as stzvpxow 4bb169c3 (empty) a1
+    Duplicated 932fb7b4fc1e as zrzsnomp 5d89a41f (empty) a2
     Rebased 1 commits onto duplicated commits
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  3e122d6a4b70   d2
-    ○  ae61a031221a   d1
-    │ ○  47a79ab4bbc6   c2
+    @  d7fd293d0ee4   d2
+    ○  8aae10eecc84   d1
+    │ ○  10855af02fff   c2
     │ ○  9b24b49f717e   c1
     ├─╯
-    │ ○  65b6f1fe6b41   b2
-    │ ○  6a9343b8797a   b1
+    │ ○  06712178d528   b2
+    │ ○  e7241b6b0079   b1
     ├─╯
-    │ ○  5968d4b950df   a4
-    │ ○  802bec723045   a2
-    │ ○  607f49d4e2dd   a1
-    │ ○  5fb83d2b58d6   a3
-    │ ○  7bfd9fbe959c   a2
-    │ ○  5d93a4b8f4bd   a1
+    │ ○  4fa1d0d8f99b   a4
+    │ ○  5d89a41f3267   a2
+    │ ○  4bb169c3ab82   a1
+    │ ○  fb5b814db965   a3
+    │ ○  932fb7b4fc1e   a2
+    │ ○  94078b99a3ab   a1
     ├─╯
     ◆  000000000000
     [EOF]
@@ -2282,28 +2282,28 @@ fn test_duplicate_insert_after_before() {
     let output = work_dir.run_jj(["duplicate", "a2", "a3", "--after", "a1", "--before", "a4"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Duplicated 7bfd9fbe959c as ysllonyo b3b3e9e3 a2
-    Duplicated 5fb83d2b58d6 as kzxwzvzw b5e1d0bf a3
+    Duplicated 932fb7b4fc1e as ysllonyo 646ba07b a2
+    Duplicated fb5b814db965 as kzxwzvzw b761c9da a3
     Rebased 1 commits onto duplicated commits
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  3e122d6a4b70   d2
-    ○  ae61a031221a   d1
-    │ ○  47a79ab4bbc6   c2
+    @  d7fd293d0ee4   d2
+    ○  8aae10eecc84   d1
+    │ ○  10855af02fff   c2
     │ ○  9b24b49f717e   c1
     ├─╯
-    │ ○  65b6f1fe6b41   b2
-    │ ○  6a9343b8797a   b1
+    │ ○  06712178d528   b2
+    │ ○  e7241b6b0079   b1
     ├─╯
-    │ ○    90e48c697af8   a4
+    │ ○    c8ea4f3f2dde   a4
     │ ├─╮
-    │ │ ○  b5e1d0bf2f7a   a3
-    │ │ ○  b3b3e9e342b9   a2
-    │ ○ │  5fb83d2b58d6   a3
-    │ ○ │  7bfd9fbe959c   a2
+    │ │ ○  b761c9dacf4d   a3
+    │ │ ○  646ba07be1da   a2
+    │ ○ │  fb5b814db965   a3
+    │ ○ │  932fb7b4fc1e   a2
     │ ├─╯
-    │ ○  5d93a4b8f4bd   a1
+    │ ○  94078b99a3ab   a1
     ├─╯
     ◆  000000000000
     [EOF]
@@ -2314,7 +2314,7 @@ fn test_duplicate_insert_after_before() {
     let output = work_dir.run_jj(["duplicate", "a1", "--after", "b2", "--before", "b1"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Error: Refusing to create a loop: commit 65b6f1fe6b41 would be both an ancestor and a descendant of the duplicated commits
+    Error: Refusing to create a loop: commit 06712178d528 would be both an ancestor and a descendant of the duplicated commits
     [EOF]
     [exit status: 1]
     ");
@@ -2329,7 +2329,7 @@ fn test_undo_after_duplicate() {
 
     create_commit(&work_dir, "a", &[]);
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  7d980be7a1d4   a
+    @  a1afb5834d8e   a
     ◆  000000000000
     [EOF]
     ");
@@ -2338,7 +2338,7 @@ fn test_undo_after_duplicate() {
     let output = work_dir.run_jj(["duplicate", "a", "--quiet"]);
     insta::assert_snapshot!(output, @"");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  7d980be7a1d4   a
+    @  a1afb5834d8e   a
     │ ○  346a7abed73c   a
     ├─╯
     ◆  000000000000
@@ -2348,12 +2348,12 @@ fn test_undo_after_duplicate() {
     let output = work_dir.run_jj(["undo"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Undid operation: 9466a30ad115 (2001-02-03 08:05:11) duplicate 1 commit(s)
-    Restored to operation: 276a53f19d12 (2001-02-03 08:05:09) create bookmark a pointing to commit 7d980be7a1d499e4d316ab4c01242885032f7eaf
+    Undid operation: 7508dc2c713d (2001-02-03 08:05:11) duplicate 1 commit(s)
+    Restored to operation: 5852f7bcda39 (2001-02-03 08:05:09) create bookmark a pointing to commit a1afb5834d8ee4dcb61b59db0f682c7a53f96f53
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  7d980be7a1d4   a
+    @  a1afb5834d8e   a
     ◆  000000000000
     [EOF]
     ");
@@ -2371,9 +2371,9 @@ fn test_rebase_duplicates() {
     create_commit(&work_dir, "c", &["b"]);
     // Test the setup
     insta::assert_snapshot!(get_log_output_with_ts(&work_dir), @"
-    @  dffaa0d4dacc   c @ 2001-02-03 04:05:13.000 +07:00
-    ○  123b4d91f6e5   b @ 2001-02-03 04:05:11.000 +07:00
-    ○  7d980be7a1d4   a @ 2001-02-03 04:05:09.000 +07:00
+    @  26c624f4f2a7   c @ 2001-02-03 04:05:13.000 +07:00
+    ○  dd148a1be8f0   b @ 2001-02-03 04:05:11.000 +07:00
+    ○  a1afb5834d8e   a @ 2001-02-03 04:05:09.000 +07:00
     ◆  000000000000    @ 1970-01-01 00:00:00.000 +00:00
     [EOF]
     ");
@@ -2381,23 +2381,23 @@ fn test_rebase_duplicates() {
     let output = work_dir.run_jj(["duplicate", "c"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Duplicated dffaa0d4dacc as yostqsxw fc2e8dc2 c
+    Duplicated 26c624f4f2a7 as yostqsxw 851ae923 c
     [EOF]
     ");
     let output = work_dir.run_jj(["duplicate", "c"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Duplicated dffaa0d4dacc as znkkpsqq 14e2803a c
+    Duplicated 26c624f4f2a7 as znkkpsqq 75642066 c
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output_with_ts(&work_dir), @"
-    @  dffaa0d4dacc   c @ 2001-02-03 04:05:13.000 +07:00
-    │ ○  14e2803a4b0e   c @ 2001-02-03 04:05:16.000 +07:00
+    @  26c624f4f2a7   c @ 2001-02-03 04:05:13.000 +07:00
+    │ ○  75642066eb4e   c @ 2001-02-03 04:05:16.000 +07:00
     ├─╯
-    │ ○  fc2e8dc218ab   c @ 2001-02-03 04:05:15.000 +07:00
+    │ ○  851ae9234e09   c @ 2001-02-03 04:05:15.000 +07:00
     ├─╯
-    ○  123b4d91f6e5   b @ 2001-02-03 04:05:11.000 +07:00
-    ○  7d980be7a1d4   a @ 2001-02-03 04:05:09.000 +07:00
+    ○  dd148a1be8f0   b @ 2001-02-03 04:05:11.000 +07:00
+    ○  a1afb5834d8e   a @ 2001-02-03 04:05:09.000 +07:00
     ◆  000000000000    @ 1970-01-01 00:00:00.000 +00:00
     [EOF]
     ");
@@ -2406,21 +2406,21 @@ fn test_rebase_duplicates() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Rebased 4 commits to destination
-    Working copy  (@) now at: royxmykx fa60711d c | c
-    Parent commit (@-)      : zsuskuln 594e9d32 b | b
+    Working copy  (@) now at: ooyxmykx 84f86707 c | c
+    Parent commit (@-)      : psuskuln ab040f78 b | b
     Added 0 files, modified 0 files, removed 1 files
     [EOF]
     ");
     // Some of the duplicate commits' timestamps were changed a little to make them
     // have distinct commit ids.
     insta::assert_snapshot!(get_log_output_with_ts(&work_dir), @"
-    @  fa60711d6bd1   c @ 2001-02-03 04:05:18.000 +07:00
-    │ ○  e320e3d23be0   c @ 2001-02-03 04:05:18.000 +07:00
+    @  84f867077804   c @ 2001-02-03 04:05:18.000 +07:00
+    │ ○  c5e49011b9aa   c @ 2001-02-03 04:05:18.000 +07:00
     ├─╯
-    │ ○  f9c10a3b2cfd   c @ 2001-02-03 04:05:18.000 +07:00
+    │ ○  78b763f2ae89   c @ 2001-02-03 04:05:18.000 +07:00
     ├─╯
-    ○  594e9d322230   b @ 2001-02-03 04:05:18.000 +07:00
-    │ ○  7d980be7a1d4   a @ 2001-02-03 04:05:09.000 +07:00
+    ○  ab040f786d0b   b @ 2001-02-03 04:05:18.000 +07:00
+    │ ○  a1afb5834d8e   a @ 2001-02-03 04:05:09.000 +07:00
     ├─╯
     ◆  000000000000    @ 1970-01-01 00:00:00.000 +00:00
     [EOF]
@@ -2439,9 +2439,9 @@ fn test_duplicate_description_template() {
 
     // Test the setup
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  dffaa0d4dacc   c
-    ○  123b4d91f6e5   b
-    ○  7d980be7a1d4   a
+    @  26c624f4f2a7   c
+    ○  dd148a1be8f0   b
+    ○  a1afb5834d8e   a
     ◆  000000000000
     [EOF]
     ");
@@ -2451,7 +2451,7 @@ fn test_duplicate_description_template() {
     let output = work_dir.run_jj(["duplicate", "a"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Duplicated 7d980be7a1d4 as yostqsxw f73017d9 a
+    Duplicated a1afb5834d8e as yostqsxw 937cc4bf a
     [EOF]
     ");
 
@@ -2459,11 +2459,11 @@ fn test_duplicate_description_template() {
     let output = work_dir.run_jj(["duplicate", "a", "-B", "b"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Warning: Duplicating commit 7d980be7a1d4 as a descendant of itself
-    Duplicated 7d980be7a1d4 as znkkpsqq fdd77a5e (empty) a
+    Warning: Duplicating commit a1afb5834d8e as a descendant of itself
+    Duplicated a1afb5834d8e as znkkpsqq 319a3bbb (empty) a
     Rebased 2 commits onto duplicated commits
-    Working copy  (@) now at: royxmykx 5679a60a c | c
-    Parent commit (@-)      : zsuskuln cb58e31e b | b
+    Working copy  (@) now at: ooyxmykx c1a62298 c | c
+    Parent commit (@-)      : psuskuln 0847a3bb b | b
     [EOF]
     ");
 
@@ -2472,7 +2472,7 @@ fn test_duplicate_description_template() {
     let output = work_dir.run_jj(["duplicate", "b", "-o", "root()"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Duplicated cb58e31ed5d4 as kpqxywon 33044659 (no description set)
+    Duplicated 0847a3bb3e92 as kpqxywon 33044659 (no description set)
     [EOF]
     ");
 
@@ -2490,25 +2490,25 @@ fn test_duplicate_description_template() {
     ]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Duplicated 5679a60ab86b as kmkuslsw e36bebd2 alias
+    Duplicated c1a622989f46 as kmkuslsw e36bebd2 alias
     [EOF]
     ");
 
     let template = r#"commit_id.short() ++ "\n" ++ description ++ "[END]\n""#;
     let output = work_dir.run_jj(["log", "-T", template]);
     insta::assert_snapshot!(output, @"
-    @  5679a60ab86b
+    @  c1a622989f46
     │  c
     │  [END]
-    ○  cb58e31ed5d4
+    ○  0847a3bb3e92
     │  b
     │  [END]
-    ○  fdd77a5e11d5
+    ○  319a3bbbc606
     │  a
     │
-    │  (cherry picked from commit 7d980be7a1d499e4d316ab4c01242885032f7eaf)
+    │  (cherry picked from commit a1afb5834d8ee4dcb61b59db0f682c7a53f96f53)
     │  [END]
-    ○  7d980be7a1d4
+    ○  a1afb5834d8e
     │  a
     │  [END]
     │ ○  e36bebd28ab6
@@ -2516,10 +2516,10 @@ fn test_duplicate_description_template() {
     │    [END]
     │ ○  33044659b895
     ├─╯  [END]
-    │ ○  f73017d958e7
+    │ ○  937cc4bf468a
     ├─╯  a
     │
-    │    (cherry picked from commit 7d980be7a1d499e4d316ab4c01242885032f7eaf)
+    │    (cherry picked from commit a1afb5834d8ee4dcb61b59db0f682c7a53f96f53)
     │    [END]
     ◆  000000000000
        [END]

--- a/cli/tests/test_evolog_command.rs
+++ b/cli/tests/test_evolog_command.rs
@@ -32,36 +32,36 @@ fn test_evolog_with_or_without_diff() {
 
     let output = work_dir.run_jj(["evolog"]);
     insta::assert_snapshot!(output, @"
-    @  rlvkpnrz test.user@example.com 2001-02-03 08:05:10 33c10ace
+    @  ylvkpnrz test.user@example.com 2001-02-03 08:05:10 12504201
     │  my description
-    │  -- operation 2c9e19859343 snapshot working copy
-    ×  rlvkpnrz/1 test.user@example.com 2001-02-03 08:05:09 cdf175ef (hidden) (conflict)
+    │  -- operation 57a20c8c552b snapshot working copy
+    ×  ylvkpnrz/1 test.user@example.com 2001-02-03 08:05:09 fd2bf88d (hidden) (conflict)
     │  my description
-    │  -- operation 449a03ec4824 rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
-    ○  rlvkpnrz/2 test.user@example.com 2001-02-03 08:05:09 51e08f95 (hidden)
+    │  -- operation c59083acfa5c rebase commit 31130ed362f21618d994b44d66bddf72b8ead5be
+    ○  ylvkpnrz/2 test.user@example.com 2001-02-03 08:05:09 31130ed3 (hidden)
     │  my description
-    │  -- operation fff45c7cf767 snapshot working copy
-    ○  rlvkpnrz/3 test.user@example.com 2001-02-03 08:05:08 b955b72e (hidden)
+    │  -- operation 410bf8901bee snapshot working copy
+    ○  ylvkpnrz/3 test.user@example.com 2001-02-03 08:05:08 6b58dc6c (hidden)
        (empty) my description
-       -- operation c5d06fd4ff51 new empty commit
+       -- operation 4177036ae819 new empty commit
     [EOF]
     ");
 
     // Color
     let output = work_dir.run_jj(["--color=always", "evolog"]);
     insta::assert_snapshot!(output, @"
-    [1m[38;5;2m@[0m  [1m[38;5;13mr[38;5;8mlvkpnrz[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 08:05:10[39m [38;5;12m3[38;5;8m3c10ace[39m[0m
+    [1m[38;5;2m@[0m  [1m[38;5;13my[38;5;8mlvkpnrz[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 08:05:10[39m [38;5;12m1[38;5;8m2504201[39m[0m
     │  [1mmy description[0m
-    │  [38;5;8m--[39m operation [38;5;4m2c9e19859343[39m snapshot working copy
-    [1m[38;5;1m×[0m  [1m[39mr[0m[38;5;8mlvkpnrz[1m[39m/1[0m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:09[39m [1m[38;5;4mcd[0m[38;5;8mf175ef[39m (hidden) [38;5;1m(conflict)[39m
+    │  [38;5;8m--[39m operation [38;5;4m57a20c8c552b[39m snapshot working copy
+    [1m[38;5;1m×[0m  [1m[39my[0m[38;5;8mlvkpnrz[1m[39m/1[0m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:09[39m [1m[38;5;4mf[0m[38;5;8md2bf88d[39m (hidden) [38;5;1m(conflict)[39m
     │  my description
-    │  [38;5;8m--[39m operation [38;5;4m449a03ec4824[39m rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
-    ○  [1m[39mr[0m[38;5;8mlvkpnrz[1m[39m/2[0m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:09[39m [1m[38;5;4m5[0m[38;5;8m1e08f95[39m (hidden)
+    │  [38;5;8m--[39m operation [38;5;4mc59083acfa5c[39m rebase commit 31130ed362f21618d994b44d66bddf72b8ead5be
+    ○  [1m[39my[0m[38;5;8mlvkpnrz[1m[39m/2[0m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:09[39m [1m[38;5;4m3[0m[38;5;8m1130ed3[39m (hidden)
     │  my description
-    │  [38;5;8m--[39m operation [38;5;4mfff45c7cf767[39m snapshot working copy
-    ○  [1m[39mr[0m[38;5;8mlvkpnrz[1m[39m/3[0m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:08[39m [1m[38;5;4mb[0m[38;5;8m955b72e[39m (hidden)
+    │  [38;5;8m--[39m operation [38;5;4m410bf8901bee[39m snapshot working copy
+    ○  [1m[39my[0m[38;5;8mlvkpnrz[1m[39m/3[0m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:08[39m [1m[38;5;4m6[0m[38;5;8mb58dc6c[39m (hidden)
        [38;5;2m(empty)[39m my description
-       [38;5;8m--[39m operation [38;5;4mc5d06fd4ff51[39m new empty commit
+       [38;5;8m--[39m operation [38;5;4m4177036ae819[39m new empty commit
     [EOF]
     ");
 
@@ -69,33 +69,33 @@ fn test_evolog_with_or_without_diff() {
     // (even even though it resulted in a conflict).
     let output = work_dir.run_jj(["evolog", "-p"]);
     insta::assert_snapshot!(output, @r#"
-    @  rlvkpnrz test.user@example.com 2001-02-03 08:05:10 33c10ace
+    @  ylvkpnrz test.user@example.com 2001-02-03 08:05:10 12504201
     │  my description
-    │  -- operation 2c9e19859343 snapshot working copy
+    │  -- operation 57a20c8c552b snapshot working copy
     │  Resolved conflict in file1:
     │     1     : <<<<<<< conflict 1 of 1
     │     2     : %%%%%%% diff from: qpvuntsm c664a51b (parents of rebased revision)
     │     3     : \\\\\\\        to: zzzzzzzz 00000000 (rebase destination)
     │     4     : -foo
-    │     5     : +++++++ rlvkpnrz 51e08f95 "my description" (rebased revision)
+    │     5     : +++++++ ylvkpnrz 31130ed3 "my description" (rebased revision)
     │     6     : foo
     │     7     : bar
     │     8     : >>>>>>> conflict 1 of 1 ends
     │          1: resolved
-    ×  rlvkpnrz/1 test.user@example.com 2001-02-03 08:05:09 cdf175ef (hidden) (conflict)
+    ×  ylvkpnrz/1 test.user@example.com 2001-02-03 08:05:09 fd2bf88d (hidden) (conflict)
     │  my description
-    │  -- operation 449a03ec4824 rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
-    ○  rlvkpnrz/2 test.user@example.com 2001-02-03 08:05:09 51e08f95 (hidden)
+    │  -- operation c59083acfa5c rebase commit 31130ed362f21618d994b44d66bddf72b8ead5be
+    ○  ylvkpnrz/2 test.user@example.com 2001-02-03 08:05:09 31130ed3 (hidden)
     │  my description
-    │  -- operation fff45c7cf767 snapshot working copy
+    │  -- operation 410bf8901bee snapshot working copy
     │  Modified regular file file1:
     │     1    1: foo
     │          2: bar
     │  Added regular file file2:
     │          1: foo
-    ○  rlvkpnrz/3 test.user@example.com 2001-02-03 08:05:08 b955b72e (hidden)
+    ○  ylvkpnrz/3 test.user@example.com 2001-02-03 08:05:08 6b58dc6c (hidden)
        (empty) my description
-       -- operation c5d06fd4ff51 new empty commit
+       -- operation 4177036ae819 new empty commit
        Modified commit description:
                1: my description
     [EOF]
@@ -104,18 +104,18 @@ fn test_evolog_with_or_without_diff() {
     // Multiple starting revisions
     let output = work_dir.run_jj(["evolog", "-r.."]);
     insta::assert_snapshot!(output, @"
-    @  rlvkpnrz test.user@example.com 2001-02-03 08:05:10 33c10ace
+    @  ylvkpnrz test.user@example.com 2001-02-03 08:05:10 12504201
     │  my description
-    │  -- operation 2c9e19859343 snapshot working copy
-    ×  rlvkpnrz/1 test.user@example.com 2001-02-03 08:05:09 cdf175ef (hidden) (conflict)
+    │  -- operation 57a20c8c552b snapshot working copy
+    ×  ylvkpnrz/1 test.user@example.com 2001-02-03 08:05:09 fd2bf88d (hidden) (conflict)
     │  my description
-    │  -- operation 449a03ec4824 rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
-    ○  rlvkpnrz/2 test.user@example.com 2001-02-03 08:05:09 51e08f95 (hidden)
+    │  -- operation c59083acfa5c rebase commit 31130ed362f21618d994b44d66bddf72b8ead5be
+    ○  ylvkpnrz/2 test.user@example.com 2001-02-03 08:05:09 31130ed3 (hidden)
     │  my description
-    │  -- operation fff45c7cf767 snapshot working copy
-    ○  rlvkpnrz/3 test.user@example.com 2001-02-03 08:05:08 b955b72e (hidden)
+    │  -- operation 410bf8901bee snapshot working copy
+    ○  ylvkpnrz/3 test.user@example.com 2001-02-03 08:05:08 6b58dc6c (hidden)
        (empty) my description
-       -- operation c5d06fd4ff51 new empty commit
+       -- operation 4177036ae819 new empty commit
     ○  qpvuntsm test.user@example.com 2001-02-03 08:05:08 c664a51b
     │  (no description set)
     │  -- operation b243f4039fc9 snapshot working copy
@@ -128,39 +128,39 @@ fn test_evolog_with_or_without_diff() {
     // Test `--limit`
     let output = work_dir.run_jj(["evolog", "--limit=2"]);
     insta::assert_snapshot!(output, @"
-    @  rlvkpnrz test.user@example.com 2001-02-03 08:05:10 33c10ace
+    @  ylvkpnrz test.user@example.com 2001-02-03 08:05:10 12504201
     │  my description
-    │  -- operation 2c9e19859343 snapshot working copy
-    ×  rlvkpnrz/1 test.user@example.com 2001-02-03 08:05:09 cdf175ef (hidden) (conflict)
+    │  -- operation 57a20c8c552b snapshot working copy
+    ×  ylvkpnrz/1 test.user@example.com 2001-02-03 08:05:09 fd2bf88d (hidden) (conflict)
     │  my description
-    │  -- operation 449a03ec4824 rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
+    │  -- operation c59083acfa5c rebase commit 31130ed362f21618d994b44d66bddf72b8ead5be
     [EOF]
     ");
 
     // Test `--no-graph`
     let output = work_dir.run_jj(["evolog", "--no-graph"]);
     insta::assert_snapshot!(output, @"
-    rlvkpnrz test.user@example.com 2001-02-03 08:05:10 33c10ace
+    ylvkpnrz test.user@example.com 2001-02-03 08:05:10 12504201
     my description
-    -- operation 2c9e19859343 snapshot working copy
-    rlvkpnrz/1 test.user@example.com 2001-02-03 08:05:09 cdf175ef (hidden) (conflict)
+    -- operation 57a20c8c552b snapshot working copy
+    ylvkpnrz/1 test.user@example.com 2001-02-03 08:05:09 fd2bf88d (hidden) (conflict)
     my description
-    -- operation 449a03ec4824 rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
-    rlvkpnrz/2 test.user@example.com 2001-02-03 08:05:09 51e08f95 (hidden)
+    -- operation c59083acfa5c rebase commit 31130ed362f21618d994b44d66bddf72b8ead5be
+    ylvkpnrz/2 test.user@example.com 2001-02-03 08:05:09 31130ed3 (hidden)
     my description
-    -- operation fff45c7cf767 snapshot working copy
-    rlvkpnrz/3 test.user@example.com 2001-02-03 08:05:08 b955b72e (hidden)
+    -- operation 410bf8901bee snapshot working copy
+    ylvkpnrz/3 test.user@example.com 2001-02-03 08:05:08 6b58dc6c (hidden)
     (empty) my description
-    -- operation c5d06fd4ff51 new empty commit
+    -- operation 4177036ae819 new empty commit
     [EOF]
     ");
 
     // Test `--git` format, and that it implies `-p`
     let output = work_dir.run_jj(["evolog", "--no-graph", "--git"]);
     insta::assert_snapshot!(output, @r#"
-    rlvkpnrz test.user@example.com 2001-02-03 08:05:10 33c10ace
+    ylvkpnrz test.user@example.com 2001-02-03 08:05:10 12504201
     my description
-    -- operation 2c9e19859343 snapshot working copy
+    -- operation 57a20c8c552b snapshot working copy
     diff --git a/file1 b/file1
     index 0000000000..2ab19ae607 100644
     --- a/file1
@@ -170,17 +170,17 @@ fn test_evolog_with_or_without_diff() {
     -%%%%%%% diff from: qpvuntsm c664a51b (parents of rebased revision)
     -\\\\\\\        to: zzzzzzzz 00000000 (rebase destination)
     --foo
-    -+++++++ rlvkpnrz 51e08f95 "my description" (rebased revision)
+    -+++++++ ylvkpnrz 31130ed3 "my description" (rebased revision)
     -foo
     -bar
     ->>>>>>> conflict 1 of 1 ends
     +resolved
-    rlvkpnrz/1 test.user@example.com 2001-02-03 08:05:09 cdf175ef (hidden) (conflict)
+    ylvkpnrz/1 test.user@example.com 2001-02-03 08:05:09 fd2bf88d (hidden) (conflict)
     my description
-    -- operation 449a03ec4824 rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
-    rlvkpnrz/2 test.user@example.com 2001-02-03 08:05:09 51e08f95 (hidden)
+    -- operation c59083acfa5c rebase commit 31130ed362f21618d994b44d66bddf72b8ead5be
+    ylvkpnrz/2 test.user@example.com 2001-02-03 08:05:09 31130ed3 (hidden)
     my description
-    -- operation fff45c7cf767 snapshot working copy
+    -- operation 410bf8901bee snapshot working copy
     diff --git a/file1 b/file1
     index 257cc5642c..3bd1f0e297 100644
     --- a/file1
@@ -195,9 +195,9 @@ fn test_evolog_with_or_without_diff() {
     +++ b/file2
     @@ -0,0 +1,1 @@
     +foo
-    rlvkpnrz/3 test.user@example.com 2001-02-03 08:05:08 b955b72e (hidden)
+    ylvkpnrz/3 test.user@example.com 2001-02-03 08:05:08 6b58dc6c (hidden)
     (empty) my description
-    -- operation c5d06fd4ff51 new empty commit
+    -- operation 4177036ae819 new empty commit
     diff --git a/JJ-COMMIT-DESCRIPTION b/JJ-COMMIT-DESCRIPTION
     --- JJ-COMMIT-DESCRIPTION
     +++ JJ-COMMIT-DESCRIPTION
@@ -294,18 +294,18 @@ fn test_evolog_with_custom_symbols() {
     let output = work_dir.run_jj(["evolog", "--config", config]);
 
     insta::assert_snapshot!(output, @"
-    $  rlvkpnrz test.user@example.com 2001-02-03 08:05:10 33c10ace
+    $  ylvkpnrz test.user@example.com 2001-02-03 08:05:10 12504201
     │  my description
-    │  -- operation 1684911914c1 snapshot working copy
-    ┝  rlvkpnrz/1 test.user@example.com 2001-02-03 08:05:09 cdf175ef (hidden) (conflict)
+    │  -- operation 06e3c4671ce6 snapshot working copy
+    ┝  ylvkpnrz/1 test.user@example.com 2001-02-03 08:05:09 fd2bf88d (hidden) (conflict)
     │  my description
-    │  -- operation 449a03ec4824 rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
-    ┝  rlvkpnrz/2 test.user@example.com 2001-02-03 08:05:09 51e08f95 (hidden)
+    │  -- operation c59083acfa5c rebase commit 31130ed362f21618d994b44d66bddf72b8ead5be
+    ┝  ylvkpnrz/2 test.user@example.com 2001-02-03 08:05:09 31130ed3 (hidden)
     │  my description
-    │  -- operation fff45c7cf767 snapshot working copy
-    ┝  rlvkpnrz/3 test.user@example.com 2001-02-03 08:05:08 b955b72e (hidden)
+    │  -- operation 410bf8901bee snapshot working copy
+    ┝  ylvkpnrz/3 test.user@example.com 2001-02-03 08:05:08 6b58dc6c (hidden)
        (empty) my description
-       -- operation c5d06fd4ff51 new empty commit
+       -- operation 4177036ae819 new empty commit
     [EOF]
     ");
 }
@@ -419,7 +419,7 @@ fn test_evolog_squash() {
     insta::assert_snapshot!(output, @r"
     ○      qpvuntsm test.user@example.com 2001-02-03 08:05:15 5f3281c6
     ├─┬─╮  squashed 3
-    │ │ │  -- operation 834dc47a2691 squash commits into 5ec0619af5cb4f7707a556a71a6f96af0bc294d2
+    │ │ │  -- operation a66188771e8a squash commits into 5ec0619af5cb4f7707a556a71a6f96af0bc294d2
     │ │ │  Modified commit description:
     │ │ │     1     : <<<<<<< conflict 1 of 1
     │ │ │     2     : +++++++ side #1
@@ -432,29 +432,29 @@ fn test_evolog_squash() {
     │ │ │     9     : +fifth
     │ │ │    10     : >>>>>>> conflict 1 of 1 ends
     │ │ │          1: squashed 3
-    │ │ ○  vruxwmqv/0 test.user@example.com 2001-02-03 08:05:15 770795d0 (hidden)
+    │ │ ○  uruxwmqv/0 test.user@example.com 2001-02-03 08:05:15 a966bf31 (hidden)
     │ │ │  fifth
-    │ │ │  -- operation d727647433c1 snapshot working copy
+    │ │ │  -- operation 3cc2b4580e39 snapshot working copy
     │ │ │  Added regular file file5:
     │ │ │          1: foo5
-    │ │ ○  vruxwmqv/1 test.user@example.com 2001-02-03 08:05:14 2e0123d1 (hidden)
+    │ │ ○  uruxwmqv/1 test.user@example.com 2001-02-03 08:05:14 e7ebd7ac (hidden)
     │ │    (empty) fifth
-    │ │    -- operation 9b66a7792e7b new empty commit
+    │ │    -- operation 63f30b056cbc new empty commit
     │ │    Modified commit description:
     │ │            1: fifth
-    │ ○  yqosqzyt/0 test.user@example.com 2001-02-03 08:05:14 ea8161b6 (hidden)
+    │ ○  oqosqzyt/0 test.user@example.com 2001-02-03 08:05:14 a4f8e01d (hidden)
     │ │  fourth
-    │ │  -- operation e9387215360e snapshot working copy
+    │ │  -- operation ca0f89644a78 snapshot working copy
     │ │  Added regular file file4:
     │ │          1: foo4
-    │ ○  yqosqzyt/1 test.user@example.com 2001-02-03 08:05:13 1de5fdb6 (hidden)
+    │ ○  oqosqzyt/1 test.user@example.com 2001-02-03 08:05:13 903b1e90 (hidden)
     │    (empty) fourth
-    │    -- operation 4746e5b93ebb new empty commit
+    │    -- operation e56aee7332f8 new empty commit
     │    Modified commit description:
     │            1: fourth
     ○    qpvuntsm/1 test.user@example.com 2001-02-03 08:05:12 5ec0619a (hidden)
     ├─╮  squashed 2
-    │ │  -- operation 47521583d5c7 squash commits into 690858846504af0e42fde980fdacf9851559ebb8
+    │ │  -- operation 3dc370ff4040 squash commits into 690858846504af0e42fde980fdacf9851559ebb8
     │ │  Modified commit description:
     │ │     1     : <<<<<<< conflict 1 of 1
     │ │     2     : +++++++ side #1
@@ -470,7 +470,7 @@ fn test_evolog_squash() {
     │ │     1     : foo3
     │ ○  zsuskuln/3 test.user@example.com 2001-02-03 08:05:12 cce957f1 (hidden)
     │ │  third
-    │ │  -- operation 4406238f2235 snapshot working copy
+    │ │  -- operation 3aa705a02061 snapshot working copy
     │ │  Modified regular file file1:
     │ │     1    1: foo
     │ │     2    2: bar
@@ -481,15 +481,15 @@ fn test_evolog_squash() {
     │ │          1: foo3
     │ ○  zsuskuln/4 test.user@example.com 2001-02-03 08:05:11 3a2a4253 (hidden)
     │ │  (empty) third
-    │ │  -- operation 1ef878808235 describe commit ebec10f449ad7ab92c7293efab5e3db2d8e9fea1
+    │ │  -- operation f5681f0a9180 describe commit ebec10f449ad7ab92c7293efab5e3db2d8e9fea1
     │ │  Modified commit description:
     │ │          1: third
     │ ○  zsuskuln/5 test.user@example.com 2001-02-03 08:05:10 ebec10f4 (hidden)
     │    (empty) (no description set)
-    │    -- operation c6c228cfffd1 squash commits into 5878cbe03cdf599c9353e5a1a52a01f4c5e0e0fa
+    │    -- operation 9c24a37a8cc9 squash commits into 5878cbe03cdf599c9353e5a1a52a01f4c5e0e0fa
     ○    qpvuntsm/2 test.user@example.com 2001-02-03 08:05:10 69085884 (hidden)
     ├─╮  squashed 1
-    │ │  -- operation c6c228cfffd1 squash commits into 5878cbe03cdf599c9353e5a1a52a01f4c5e0e0fa
+    │ │  -- operation 9c24a37a8cc9 squash commits into 5878cbe03cdf599c9353e5a1a52a01f4c5e0e0fa
     │ │  Modified commit description:
     │ │     1     : <<<<<<< conflict 1 of 1
     │ │     2     : %%%%%%% diff from: base
@@ -499,15 +499,15 @@ fn test_evolog_squash() {
     │ │     6     : second
     │ │     7     : >>>>>>> conflict 1 of 1 ends
     │ │          1: squashed 1
-    │ ○  kkmpptxz/0 test.user@example.com 2001-02-03 08:05:10 a3759c9d (hidden)
+    │ ○  nkmpptxz/0 test.user@example.com 2001-02-03 08:05:10 049b4155 (hidden)
     │ │  second
-    │ │  -- operation d7409e8bb16e snapshot working copy
+    │ │  -- operation a4702428554e snapshot working copy
     │ │  Modified regular file file1:
     │ │     1    1: foo
     │ │          2: bar
-    │ ○  kkmpptxz/1 test.user@example.com 2001-02-03 08:05:09 a5b2f625 (hidden)
+    │ ○  nkmpptxz/1 test.user@example.com 2001-02-03 08:05:09 e40881fd (hidden)
     │    (empty) second
-    │    -- operation 3882a27a689e new empty commit
+    │    -- operation 2cbcc4a6a7d5 new empty commit
     │    Modified commit description:
     │            1: second
     ○  qpvuntsm/3 test.user@example.com 2001-02-03 08:05:09 5878cbe0 (hidden)
@@ -696,29 +696,29 @@ fn test_evolog_reverse_with_graph() {
     ○  qpvuntsm/1 test.user@example.com 2001-02-03 08:05:10 b28cda4b (hidden)
     │  (empty) c
     │  -- operation 63b6e96eb14e describe commit 9f43967b1cdbce4ab322cb7b4636fc0362c38373
-    │ ○  mzvwutvl/0 test.user@example.com 2001-02-03 08:05:11 6a4ff8aa (hidden)
+    │ ○  pzvwutvl/0 test.user@example.com 2001-02-03 08:05:11 ffe3b88b (hidden)
     ├─╯  (empty) d
-    │    -- operation 834d3c2b578c new empty commit
-    │ ○  royxmykx/0 test.user@example.com 2001-02-03 08:05:12 7dea2d1d (hidden)
+    │    -- operation a217bb82b4cd new empty commit
+    │ ○  ooyxmykx/0 test.user@example.com 2001-02-03 08:05:12 cad3f546 (hidden)
     ├─╯  (empty) e
-    │    -- operation 303ac509f441 new empty commit
+    │    -- operation bf0ab50f535e new empty commit
     ○  qpvuntsm test.user@example.com 2001-02-03 08:05:13 78fdd026
        (empty) c+d+e
-       -- operation 10809bce2b20 squash commits into b28cda4b118fc50495ca34a24f030abc078d032e
+       -- operation 254bf0dbbdb5 squash commits into b28cda4b118fc50495ca34a24f030abc078d032e
     [EOF]
     ");
 
     let output = work_dir.run_jj(["evolog", "-rsubject(c+d+e)", "--limit=3", "--reversed"]);
     insta::assert_snapshot!(output, @"
-    ○  mzvwutvl/0 test.user@example.com 2001-02-03 08:05:11 6a4ff8aa (hidden)
+    ○  pzvwutvl/0 test.user@example.com 2001-02-03 08:05:11 ffe3b88b (hidden)
     │  (empty) d
-    │  -- operation 834d3c2b578c new empty commit
-    │ ○  royxmykx/0 test.user@example.com 2001-02-03 08:05:12 7dea2d1d (hidden)
+    │  -- operation a217bb82b4cd new empty commit
+    │ ○  ooyxmykx/0 test.user@example.com 2001-02-03 08:05:12 cad3f546 (hidden)
     ├─╯  (empty) e
-    │    -- operation 303ac509f441 new empty commit
+    │    -- operation bf0ab50f535e new empty commit
     ○  qpvuntsm test.user@example.com 2001-02-03 08:05:13 78fdd026
        (empty) c+d+e
-       -- operation 10809bce2b20 squash commits into b28cda4b118fc50495ca34a24f030abc078d032e
+       -- operation 254bf0dbbdb5 squash commits into b28cda4b118fc50495ca34a24f030abc078d032e
     [EOF]
     ");
 }
@@ -748,9 +748,9 @@ fn test_evolog_template_predecessors_and_inter_diff() {
         ])
         .success();
     insta::assert_snapshot!(output, @"
-    @  kkmpptxz test.user@example.com 2001-02-03 08:05:10 c6106cde
+    @  nkmpptxz test.user@example.com 2001-02-03 08:05:10 05458575
     │  d
-    │  -- operation d23cb3c75003 snapshot working copy
+    │  -- operation 6c57873a2081 snapshot working copy
     │  diff --git a/file1 b/file1
     │  new file mode 100644
     │  index 0000000000..4bcfe98e64
@@ -758,9 +758,9 @@ fn test_evolog_template_predecessors_and_inter_diff() {
     │  +++ b/file1
     │  @@ -0,0 +1,1 @@
     │  +d
-    ○  kkmpptxz/1 test.user@example.com 2001-02-03 08:05:09 780d27be (hidden)
+    ○  nkmpptxz/1 test.user@example.com 2001-02-03 08:05:09 f47fb146 (hidden)
        (empty) d
-       -- operation 442a733fd961 new empty commit
+       -- operation f57bd00829f3 new empty commit
     [EOF]
     ");
 
@@ -794,26 +794,26 @@ fn test_evolog_template_predecessors_and_inter_diff() {
     insta::assert_snapshot!(output, @"
     ○      qpvuntsm test.user@example.com 2001-02-03 08:05:12 92850c35
     ├─┬─╮  c+d+e
-    │ │ │  -- operation a0d2f98ffe2f squash commits into e3ce68f48b53d16111a1310c7f417a39c2934931
-    │ │ │  predecessors: e3ce68f4,c6106cde,870e49d7
-    │ │ ○  mzvwutvl/0 test.user@example.com 2001-02-03 08:05:12 870e49d7 (hidden)
+    │ │ │  -- operation 44984942c5fc squash commits into e3ce68f48b53d16111a1310c7f417a39c2934931
+    │ │ │  predecessors: e3ce68f4,05458575,0ffad200
+    │ │ ○  pzvwutvl/0 test.user@example.com 2001-02-03 08:05:12 0ffad200 (hidden)
     │ │ │  e
-    │ │ │  -- operation 3e23aa680b92 snapshot working copy
-    │ │ │  predecessors: 3345e308
+    │ │ │  -- operation 1bea6e647f00 snapshot working copy
+    │ │ │  predecessors: a1d0bb3f
     │ │ │  A file3
-    │ │ ○  mzvwutvl/1 test.user@example.com 2001-02-03 08:05:11 3345e308 (hidden)
+    │ │ ○  pzvwutvl/1 test.user@example.com 2001-02-03 08:05:11 a1d0bb3f (hidden)
     │ │    (empty) e
-    │ │    -- operation d61bdfd0cb90 new empty commit
+    │ │    -- operation bb3ffad2177d new empty commit
     │ │    predecessors:
-    │ ○  kkmpptxz/0 test.user@example.com 2001-02-03 08:05:10 c6106cde (hidden)
+    │ ○  nkmpptxz/0 test.user@example.com 2001-02-03 08:05:10 05458575 (hidden)
     │ │  d
-    │ │  -- operation d23cb3c75003 snapshot working copy
-    │ │  predecessors: 780d27be
+    │ │  -- operation 6c57873a2081 snapshot working copy
+    │ │  predecessors: f47fb146
     │ │  A file1
     │ │  A file2
-    │ ○  kkmpptxz/1 test.user@example.com 2001-02-03 08:05:09 780d27be (hidden)
+    │ ○  nkmpptxz/1 test.user@example.com 2001-02-03 08:05:09 f47fb146 (hidden)
     │    (empty) d
-    │    -- operation 442a733fd961 new empty commit
+    │    -- operation f57bd00829f3 new empty commit
     │    predecessors:
     ○  qpvuntsm/1 test.user@example.com 2001-02-03 08:05:08 e3ce68f4 (hidden)
     │  (empty) c

--- a/cli/tests/test_file_annotate_command.rs
+++ b/cli/tests/test_file_annotate_command.rs
@@ -49,7 +49,7 @@ fn test_annotate_linear() {
     let output = work_dir.run_jj(["file", "annotate", "file.txt"]);
     insta::assert_snapshot!(output, @"
     qpvuntsm foo      2001-02-03 08:05:08    1: line1
-    kkmpptxz test.use 2001-02-03 08:05:10    2: new text from new commit
+    nkmpptxz test.use 2001-02-03 08:05:10    2: new text from new commit
     [EOF]
     ");
 }
@@ -133,8 +133,8 @@ fn test_annotate_merge() {
     let output = work_dir.run_jj(["file", "annotate", "file.txt"]);
     insta::assert_snapshot!(output, @"
     qpvuntsm test.use 2001-02-03 08:05:08    1: line1
-    zsuskuln test.use 2001-02-03 08:05:11    2: new text from new commit 1
-    royxmykx test.use 2001-02-03 08:05:13    3: new text from new commit 2
+    psuskuln test.use 2001-02-03 08:05:11    2: new text from new commit 1
+    ooyxmykx test.use 2001-02-03 08:05:13    3: new text from new commit 2
     [EOF]
     ");
 }
@@ -178,13 +178,13 @@ fn test_annotate_conflicted() {
     let output = work_dir.run_jj(["file", "annotate", "file.txt"]);
     insta::assert_snapshot!(output, @r#"
     qpvuntsm test.use 2001-02-03 08:05:08    1: line1
-    yostqsxw test.use 2001-02-03 08:05:15    2: <<<<<<< conflict 1 of 1
-    yostqsxw test.use 2001-02-03 08:05:15    3: %%%%%%% diff from: qpvuntsm a5daff01 "initial"
-    yostqsxw test.use 2001-02-03 08:05:15    4: \\\\\\\        to: zsuskuln 30cd4478 "commit1"
-    yostqsxw test.use 2001-02-03 08:05:15    5: +new text from new commit 1
-    yostqsxw test.use 2001-02-03 08:05:15    6: +++++++ royxmykx ad312256 "commit2"
-    royxmykx test.use 2001-02-03 08:05:13    7: new text from new commit 2
-    yostqsxw test.use 2001-02-03 08:05:15    8: >>>>>>> conflict 1 of 1 ends
+    sostqsxw test.use 2001-02-03 08:05:15    2: <<<<<<< conflict 1 of 1
+    sostqsxw test.use 2001-02-03 08:05:15    3: %%%%%%% diff from: qpvuntsm a5daff01 "initial"
+    sostqsxw test.use 2001-02-03 08:05:15    4: \\\\\\\        to: psuskuln 8a01997e "commit1"
+    sostqsxw test.use 2001-02-03 08:05:15    5: +new text from new commit 1
+    sostqsxw test.use 2001-02-03 08:05:15    6: +++++++ ooyxmykx e0d3719d "commit2"
+    ooyxmykx test.use 2001-02-03 08:05:13    7: new text from new commit 2
+    sostqsxw test.use 2001-02-03 08:05:15    8: >>>>>>> conflict 1 of 1 ends
     [EOF]
     "#);
 }
@@ -229,7 +229,7 @@ fn test_annotate_merge_one_sided_conflict_resolution() {
     let output = work_dir.run_jj(["file", "annotate", "file.txt"]);
     insta::assert_snapshot!(output, @"
     qpvuntsm test.use 2001-02-03 08:05:08    1: line1
-    zsuskuln test.use 2001-02-03 08:05:11    2: new text from new commit 1
+    psuskuln test.use 2001-02-03 08:05:11    2: new text from new commit 1
     [EOF]
     ");
 }
@@ -248,7 +248,7 @@ fn test_annotate_abandoned() {
     let output = work_dir.run_jj(["file", "annotate", "-rat_operation(@-, @)", "file.txt"]);
     insta::assert_snapshot!(output, @"
     qpvuntsm test.use 2001-02-03 08:05:08    1: line1
-    rlvkpnrz test.use 2001-02-03 08:05:09    2: line2
+    ylvkpnrz test.use 2001-02-03 08:05:09    2: line2
     [EOF]
     ");
 }

--- a/cli/tests/test_file_chmod_command.rs
+++ b/cli/tests/test_file_chmod_command.rs
@@ -87,11 +87,11 @@ fn test_chmod_regular_conflict() {
     let output = work_dir.run_jj(["file", "show", "file"]);
     insta::assert_snapshot!(output, @r#"
     <<<<<<< conflict 1 of 1
-    %%%%%%% diff from: rlvkpnrz 1792382a "base"
-    \\\\\\\        to: royxmykx 02247291 "x"
+    %%%%%%% diff from: ylvkpnrz b3d9a894 "base"
+    \\\\\\\        to: ooyxmykx 81bb4f98 "x"
     -base
     +x
-    +++++++ zsuskuln eb0ba805 "n"
+    +++++++ psuskuln 8ba0373a "n"
     n
     >>>>>>> conflict 1 of 1 ends
     [EOF]
@@ -107,11 +107,11 @@ fn test_chmod_regular_conflict() {
     let output = work_dir.run_jj(["file", "show", "file"]);
     insta::assert_snapshot!(output, @r#"
     <<<<<<< conflict 1 of 1
-    %%%%%%% diff from: rlvkpnrz 1792382a "base"
-    \\\\\\\        to: royxmykx 02247291 "x"
+    %%%%%%% diff from: ylvkpnrz b3d9a894 "base"
+    \\\\\\\        to: ooyxmykx 81bb4f98 "x"
     -base
     +x
-    +++++++ zsuskuln eb0ba805 "n"
+    +++++++ psuskuln 8ba0373a "n"
     n
     >>>>>>> conflict 1 of 1 ends
     [EOF]
@@ -125,11 +125,11 @@ fn test_chmod_regular_conflict() {
     let output = work_dir.run_jj(["file", "show", "file"]);
     insta::assert_snapshot!(output, @r#"
     <<<<<<< conflict 1 of 1
-    %%%%%%% diff from: rlvkpnrz 1792382a "base"
-    \\\\\\\        to: royxmykx 02247291 "x"
+    %%%%%%% diff from: ylvkpnrz b3d9a894 "base"
+    \\\\\\\        to: ooyxmykx 81bb4f98 "x"
     -base
     +x
-    +++++++ zsuskuln eb0ba805 "n"
+    +++++++ psuskuln 8ba0373a "n"
     n
     >>>>>>> conflict 1 of 1 ends
     [EOF]
@@ -140,9 +140,9 @@ fn test_chmod_regular_conflict() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Warning: No matching entries for paths: nonexistent
-    Working copy  (@) now at: yostqsxw a1b4dce4 conflict | (conflict) conflict
-    Parent commit (@-)      : royxmykx 02247291 x | x
-    Parent commit (@-)      : zsuskuln eb0ba805 n | n
+    Working copy  (@) now at: rostqsxw 8ef83c2e conflict | (conflict) conflict
+    Parent commit (@-)      : ooyxmykx 81bb4f98 x | x
+    Parent commit (@-)      : psuskuln 8ba0373a n | n
     Added 0 files, modified 1 files, removed 0 files
     Warning: There are unresolved conflicts at these paths:
     file    2-sided conflict including an executable
@@ -234,9 +234,9 @@ fn test_chmod_file_dir_deletion_conflicts() {
     let output = work_dir.run_jj(["file", "show", "-r=file_dir", "file"]);
     insta::assert_snapshot!(output, @r#"
     Conflict:
-      Removing file with id df967b96a579e45a18b8251732d16804b2e56a55 (rlvkpnrz 1792382a "base")
-      Adding file with id 78981922613b2afb6025042ff6bd878ac1994e85 (zsuskuln bc9cdea1 "file")
-      Adding tree with id 133bb38fc4e4bf6b551f1f04db7e48f04cac2877 (vruxwmqv 223cb383 "dir")
+      Removing file with id df967b96a579e45a18b8251732d16804b2e56a55 (ylvkpnrz b3d9a894 "base")
+      Adding file with id 78981922613b2afb6025042ff6bd878ac1994e85 (psuskuln fab75a90 "file")
+      Adding tree with id 133bb38fc4e4bf6b551f1f04db7e48f04cac2877 (truxwmqv c553e0f1 "dir")
     [EOF]
     "#);
     let output = work_dir.run_jj(["file", "chmod", "x", "file", "-r=file_dir"]);
@@ -256,10 +256,10 @@ fn test_chmod_file_dir_deletion_conflicts() {
     let output = work_dir.run_jj(["file", "show", "-r=file_deletion", "file"]);
     insta::assert_snapshot!(output, @r#"
     <<<<<<< conflict 1 of 1
-    +++++++ zsuskuln bc9cdea1 "file"
+    +++++++ psuskuln fab75a90 "file"
     a
-    %%%%%%% diff from: rlvkpnrz 1792382a "base"
-    \\\\\\\        to: royxmykx d7d39332 "deletion"
+    %%%%%%% diff from: ylvkpnrz b3d9a894 "base"
+    \\\\\\\        to: ooyxmykx 01e5f18a "deletion"
     -base
     >>>>>>> conflict 1 of 1 ends
     [EOF]
@@ -267,17 +267,17 @@ fn test_chmod_file_dir_deletion_conflicts() {
     let output = work_dir.run_jj(["file", "chmod", "x", "file", "-r=file_deletion"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: kmkuslsw b468931e file_deletion | (conflict) file_deletion
-    Parent commit (@-)      : zsuskuln bc9cdea1 file | file
-    Parent commit (@-)      : royxmykx d7d39332 deletion | deletion
+    Working copy  (@) now at: wmkuslsw 6be4fbe3 file_deletion | (conflict) file_deletion
+    Parent commit (@-)      : psuskuln fab75a90 file | file
+    Parent commit (@-)      : ooyxmykx 01e5f18a deletion | deletion
     Added 0 files, modified 1 files, removed 0 files
     Warning: There are unresolved conflicts at these paths:
     file    2-sided conflict including 1 deletion and an executable
     New conflicts appeared in 1 commits:
-      kmkuslsw b468931e file_deletion | (conflict) file_deletion
+      wmkuslsw 6be4fbe3 file_deletion | (conflict) file_deletion
     Hint: To resolve the conflicts, start by creating a commit on top of
     the conflicted commit:
-      jj new kmkuslsw
+      jj new wmkuslsw
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you can inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
@@ -291,10 +291,10 @@ fn test_chmod_file_dir_deletion_conflicts() {
     let output = work_dir.run_jj(["file", "show", "-r=file_deletion", "file"]);
     insta::assert_snapshot!(output, @r#"
     <<<<<<< conflict 1 of 1
-    +++++++ zsuskuln bc9cdea1 "file"
+    +++++++ psuskuln fab75a90 "file"
     a
-    %%%%%%% diff from: rlvkpnrz 1792382a "base"
-    \\\\\\\        to: royxmykx d7d39332 "deletion"
+    %%%%%%% diff from: ylvkpnrz b3d9a894 "base"
+    \\\\\\\        to: ooyxmykx 01e5f18a "deletion"
     -base
     >>>>>>> conflict 1 of 1 ends
     [EOF]
@@ -323,7 +323,7 @@ fn test_chmod_exec_bit_settings() -> TestResult {
 
     let output = work_dir.run_jj(["debug", "local-working-copy"]);
     insta::assert_snapshot!(output.normalize_stdout_with(redact_timestamp), @r#"
-    Current operation: OperationId("c213f276df4f2ac12ede4d6e1b7f386311c02049195b5db39a476b1785fe052e21b816b82ad41a2833296c04e27eab5a981f1744fa511581e32d405e0f8370b2")
+    Current operation: OperationId("51633f27a15684d79b6d45aa51f6a4849e9c932eab2ca15b735fc85aa5210b9e0399ffb7e745143c503efdfff6d72f4aedc666024bcd9cabb721367bc7a618b5")
     Current tree: MergedTree { tree_ids: Resolved(TreeId("6d5f482d15035cdd7733b1b551d1fead28d22592")), labels: Unlabeled, .. }
     Normal { exec_bit: ExecBit(false) }             5 <timestamp> None "file"
     [EOF]
@@ -336,7 +336,7 @@ fn test_chmod_exec_bit_settings() -> TestResult {
     set_file_executable(path, true);
     let output = work_dir.run_jj(["debug", "local-working-copy"]);
     insta::assert_snapshot!(output.normalize_stdout_with(redact_timestamp), @r#"
-    Current operation: OperationId("60ebc37d4d08925da7d4d50b21ebd4395dfd71180cd3694cc288bce2145e8d601ca38ecdf2ce1abbba7368d678f154688b0f0c855e874757bfb8ec2d54c46c18")
+    Current operation: OperationId("77756b2b5471c2fb6e41dc7eb54dd6196725e6dc726b4599bf323f763b9601b280680c8e86dbf1b31b27e92cad2d9d4317a2bce75b6d703312b394cc1fef2ca6")
     Current tree: MergedTree { tree_ids: Resolved(TreeId("5201dbafb66dc1b28b029a262e1b206f6f93df1e")), labels: Unlabeled, .. }
     Normal { exec_bit: ExecBit(true) }             5 <timestamp> None "file"
     [EOF]
@@ -358,7 +358,7 @@ fn test_chmod_exec_bit_settings() -> TestResult {
     assert_file_executable(path, true);
     let output = work_dir.run_jj(["debug", "local-working-copy"]);
     insta::assert_snapshot!(output.normalize_stdout_with(redact_timestamp), @r#"
-    Current operation: OperationId("2b128dc13ea9967d7a233535a8ea1f70b2f9a5e713d17097507fe9f0d986c9852377aa578fdd49959bcd60692ebd4cfd6c6f02d8e86a67ce631bf39ecf48cc2c")
+    Current operation: OperationId("78fa37e0db1c07c94894718c159d01fb2d71a43e3ae3913247b55a8cbd7fed8383bb655e1799150e827ca2d738b9a9704f64ae4c426bee34d2a11a529fddbe6c")
     Current tree: MergedTree { tree_ids: Resolved(TreeId("6d5f482d15035cdd7733b1b551d1fead28d22592")), labels: Unlabeled, .. }
     Normal { exec_bit: ExecBit(true) }             5 <timestamp> None "file"
     [EOF]
@@ -369,7 +369,7 @@ fn test_chmod_exec_bit_settings() -> TestResult {
     assert_file_executable(path, false);
     let output = work_dir.run_jj(["debug", "local-working-copy"]);
     insta::assert_snapshot!(output.normalize_stdout_with(redact_timestamp), @r#"
-    Current operation: OperationId("73ee76ab06de88c3a43feefd313883127562f28cacd52e41408b6a1769294731d7a7fd90313e6324db6e501ea6602c5c83cd647a4d750728889688b5dc7178a2")
+    Current operation: OperationId("9272ffeee7f3eadad2ccf55414904119b6f8767ac7c3b431edfe5f8d4d2bb858c91ba02f72eea1e34122b750610a64cb01981d7ac04c0417b9c1cba2fa7e482b")
     Current tree: MergedTree { tree_ids: Resolved(TreeId("5201dbafb66dc1b28b029a262e1b206f6f93df1e")), labels: Unlabeled, .. }
     Normal { exec_bit: ExecBit(false) }             5 <timestamp> None "file"
     [EOF]
@@ -384,15 +384,15 @@ fn test_chmod_exec_bit_settings() -> TestResult {
     insta::assert_snapshot!(output, @"
     Working copy changes:
     M file
-    Working copy  (@) : znkkpsqq 71681768 ignore | ignore
-    Parent commit (@-): rlvkpnrz 1792382a base | base
+    Working copy  (@) : onkkpsqq 3e5d6ee6 ignore | ignore
+    Parent commit (@-): ylvkpnrz b3d9a894 base | base
     [EOF]
     ");
     let output = work_dir.run_jj(["file", "chmod", "x", "file"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: znkkpsqq ef0a25b6 ignore | ignore
-    Parent commit (@-)      : rlvkpnrz 1792382a base | base
+    Working copy  (@) now at: onkkpsqq 0eed64c8 ignore | ignore
+    Parent commit (@-)      : ylvkpnrz b3d9a894 base | base
     Added 0 files, modified 1 files, removed 0 files
     [EOF]
     ");
@@ -402,7 +402,7 @@ fn test_chmod_exec_bit_settings() -> TestResult {
     set_file_executable(path, true);
     let output = work_dir.run_jj(["debug", "local-working-copy"]);
     insta::assert_snapshot!(output.normalize_stdout_with(redact_timestamp), @r#"
-    Current operation: OperationId("8ab66b017c52976aaa389ea0a5f4f6fd6a0267525b44303a8882d6ed2d5ac507fd661fcde9f466efa51f09d82c826bbff2af236b68502cbb991877e609d4858b")
+    Current operation: OperationId("40c84a2f7af0f995a03d3308a3493bdff4587e02018e4355e94219f891988d8a816fb235fb7608f80c2339543de161da99cd6b5e6ea7951fc7c19eeb0568ca04")
     Current tree: MergedTree { tree_ids: Resolved(TreeId("5201dbafb66dc1b28b029a262e1b206f6f93df1e")), labels: Unlabeled, .. }
     Normal { exec_bit: ExecBit(true) }             5 <timestamp> None "file"
     [EOF]
@@ -465,7 +465,7 @@ fn test_chmod_exec_bit_ignore_then_respect() {
     let output = work_dir.run_jj(["file", "chmod", "x", "file"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: rlvkpnrz cb3f99cb base | base
+    Working copy  (@) now at: ylvkpnrz eb47640c base | base
     Parent commit (@-)      : zzzzzzzz 00000000 (empty) (no description set)
     Added 0 files, modified 1 files, removed 0 files
     [EOF]
@@ -479,7 +479,7 @@ fn test_chmod_exec_bit_ignore_then_respect() {
     let output = work_dir.run_jj(["file", "chmod", "x", "file"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: rlvkpnrz 96872a96 base | base
+    Working copy  (@) now at: ylvkpnrz 3ea377d2 base | base
     Parent commit (@-)      : zzzzzzzz 00000000 (empty) (no description set)
     Added 0 files, modified 1 files, removed 0 files
     [EOF]

--- a/cli/tests/test_file_search_command.rs
+++ b/cli/tests/test_file_search_command.rs
@@ -106,11 +106,11 @@ fn test_file_search_conflicts() {
     // Test the setup
     insta::assert_snapshot!(work_dir.read_file("file1"), @r"
     <<<<<<< conflict 1 of 1
-    %%%%%%% diff from: rlvkpnrz 60901f47 (parents of rebased revision)
+    %%%%%%% diff from: ylvkpnrz ea1d17fc (parents of rebased revision)
     \\\\\\\        to: qpvuntsm fae24a95 (rebase destination)
     --bar-
     +-foo-
-    +++++++ kkmpptxz 51957a05 (rebased revision)
+    +++++++ nkmpptxz c589d6cf (rebased revision)
     -baz-
     >>>>>>> conflict 1 of 1 ends
     ");

--- a/cli/tests/test_file_show_command.rs
+++ b/cli/tests/test_file_show_command.rs
@@ -122,11 +122,11 @@ fn test_show() {
     let output = work_dir.run_jj(["file", "show", "file1"]);
     insta::assert_snapshot!(output, @r"
     <<<<<<< conflict 1 of 1
-    %%%%%%% diff from: rlvkpnrz fc7b369e (parents of rebased revision)
+    %%%%%%% diff from: ylvkpnrz cd1eb6f7 (parents of rebased revision)
     \\\\\\\        to: qpvuntsm eb7b8a1f (rebase destination)
     -b
     +a
-    +++++++ kmkuslsw f74f80c5 (rebased revision)
+    +++++++ wmkuslsw 51bb08e1 (rebased revision)
     c
     >>>>>>> conflict 1 of 1 ends
     [EOF]

--- a/cli/tests/test_fix_command.rs
+++ b/cli/tests/test_fix_command.rs
@@ -656,7 +656,7 @@ fn test_fix_leaf_commit() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Fixed 1 commits of 1 checked.
-    Working copy  (@) now at: rlvkpnrz f5c11961 (no description set)
+    Working copy  (@) now at: ylvkpnrz f22e4dd3 (no description set)
     Parent commit (@-)      : qpvuntsm b37955c0 (no description set)
     Added 0 files, modified 1 files, removed 0 files
     [EOF]
@@ -693,7 +693,7 @@ fn test_fix_parent_commit() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Fixed 3 commits of 3 checked.
-    Working copy  (@) now at: mzvwutvl e7ba6d31 child2 | (no description set)
+    Working copy  (@) now at: pzvwutvl b7e40097 child2 | (no description set)
     Parent commit (@-)      : qpvuntsm 49f1ddd5 parent | (no description set)
     Added 0 files, modified 1 files, removed 0 files
     [EOF]
@@ -767,7 +767,7 @@ fn test_fix_descendant_commits() {
     ------- stderr -------
     Warning: No matching entries for paths: nonexistent
     Fixed 2 commits of 3 checked.
-    Working copy  (@) now at: mzvwutvl afe0ade0 child2 | (no description set)
+    Working copy  (@) now at: pzvwutvl bf27c07a child2 | (no description set)
     Parent commit (@-)      : qpvuntsm c9cb6288 parent | (no description set)
     Added 0 files, modified 1 files, removed 0 files
     [EOF]
@@ -825,8 +825,8 @@ fn test_default_revset() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Fixed 3 commits of 3 checked.
-    Working copy  (@) now at: yostqsxw 932b950d bar2 | (no description set)
-    Parent commit (@-)      : yqosqzyt 8a37ed67 bar1 | (no description set)
+    Working copy  (@) now at: tostqsxw 51c536d7 bar2 | (no description set)
+    Parent commit (@-)      : oqosqzyt 10a5c9a0 bar1 | (no description set)
     Added 0 files, modified 1 files, removed 0 files
     [EOF]
     ");
@@ -1070,8 +1070,8 @@ fn test_deduplication() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Fixed 4 commits of 4 checked.
-    Working copy  (@) now at: yqosqzyt 9849a250 d | (no description set)
-    Parent commit (@-)      : mzvwutvl 9544f381 c | (empty) (no description set)
+    Working copy  (@) now at: oqosqzyt b07cb12c d | (no description set)
+    Parent commit (@-)      : pzvwutvl 5c2db4b6 c | (empty) (no description set)
     Added 0 files, modified 1 files, removed 0 files
     [EOF]
     ");
@@ -1372,9 +1372,9 @@ fn test_fix_adding_merge_commit() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Fixed 1 commits of 1 checked.
-    Working copy  (@) now at: mzvwutvl 9f580aac (no description set)
+    Working copy  (@) now at: pzvwutvl 74cb2f47 (no description set)
     Parent commit (@-)      : qpvuntsm 93f04460 a | (no description set)
-    Parent commit (@-)      : kkmpptxz ad4fc36c b | (no description set)
+    Parent commit (@-)      : nkmpptxz a676f3bc b | (no description set)
     Added 0 files, modified 4 files, removed 0 files
     [EOF]
     ");
@@ -1411,9 +1411,9 @@ fn test_fix_both_sides_of_conflict() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Fixed 3 commits of 3 checked.
-    Working copy  (@) now at: mzvwutvl 1bfa5dc3 (conflict) (empty) (no description set)
+    Working copy  (@) now at: pzvwutvl e9432438 (conflict) (empty) (no description set)
     Parent commit (@-)      : qpvuntsm 0eae0dae a | (no description set)
-    Parent commit (@-)      : kkmpptxz eb61ba8d b | (no description set)
+    Parent commit (@-)      : nkmpptxz 0d02dac6 b | (no description set)
     Added 0 files, modified 1 files, removed 0 files
     Warning: There are unresolved conflicts at these paths:
     file    2-sided conflict
@@ -1435,7 +1435,7 @@ fn test_fix_both_sides_of_conflict() {
     %%%%%%% diff from: zzzzzzzz 00000000
     \\\\\\\        to: qpvuntsm c8346c1c
     +CONTENT A
-    +++++++ kkmpptxz 7c4518cb
+    +++++++ nkmpptxz 3cc6acba
     CONTENT B
     >>>>>>> conflict 1 of 1 ends
     [EOF]
@@ -1467,9 +1467,9 @@ fn test_fix_resolve_conflict() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Fixed 3 commits of 3 checked.
-    Working copy  (@) now at: mzvwutvl c4e4665e (empty) (no description set)
+    Working copy  (@) now at: pzvwutvl d22c4bc8 (empty) (no description set)
     Parent commit (@-)      : qpvuntsm 7a0dbb95 a | (no description set)
-    Parent commit (@-)      : kkmpptxz 5d9510ab b | (no description set)
+    Parent commit (@-)      : nkmpptxz 024d5d36 b | (no description set)
     Added 0 files, modified 1 files, removed 0 files
     [EOF]
     ");
@@ -1688,8 +1688,8 @@ fn test_fix_with_line_ranges() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Fixed 2 commits of 2 checked.
-    Working copy  (@) now at: mzvwutvl 7d52a6e8 c3 | (no description set)
-    Parent commit (@-)      : kkmpptxz a8e4c2e8 c2 | (no description set)
+    Working copy  (@) now at: pzvwutvl b1d8c52d c3 | (no description set)
+    Parent commit (@-)      : nkmpptxz 6fc6e8b9 c2 | (no description set)
     Added 0 files, modified 2 files, removed 0 files
     [EOF]
     ");
@@ -1808,7 +1808,7 @@ fn test_fix_with_run_tool_if_zero_line_ranges() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Fixed 1 commits of 1 checked.
-    Working copy  (@) now at: kkmpptxz 4613d090 c2 | (no description set)
+    Working copy  (@) now at: nkmpptxz 7961775b c2 | (no description set)
     Parent commit (@-)      : qpvuntsm 074c5dba c1 | (no description set)
     Added 0 files, modified 1 files, removed 0 files
     [EOF]
@@ -1944,7 +1944,7 @@ fn test_fix_with_all_lines_arg() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Fixed 1 commits of 1 checked.
-    Working copy  (@) now at: kkmpptxz d875fd1f c2 | (no description set)
+    Working copy  (@) now at: nkmpptxz 239d4d81 c2 | (no description set)
     Parent commit (@-)      : qpvuntsm 81234495 c1 | (no description set)
     Added 0 files, modified 3 files, removed 0 files
     [EOF]
@@ -2041,7 +2041,7 @@ fn test_fix_with_line_ranges_multiple_formatters() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Fixed 1 commits of 1 checked.
-    Working copy  (@) now at: kkmpptxz 4c5f12f5 c2 | (no description set)
+    Working copy  (@) now at: nkmpptxz 2ebdab4f c2 | (no description set)
     Parent commit (@-)      : qpvuntsm 37f1e5c6 c1 | (no description set)
     Added 0 files, modified 2 files, removed 0 files
     [EOF]
@@ -2124,7 +2124,7 @@ fn test_fix_with_line_ranges_and_include_unchanged_files_all_lines() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Fixed 1 commits of 1 checked.
-    Working copy  (@) now at: kkmpptxz 1fb2bf8f c2 | (no description set)
+    Working copy  (@) now at: nkmpptxz 3e1ed2bf c2 | (no description set)
     Parent commit (@-)      : qpvuntsm 42db21c2 c1 | (no description set)
     Added 0 files, modified 3 files, removed 0 files
     [EOF]

--- a/cli/tests/test_gerrit_upload.rs
+++ b/cli/tests/test_gerrit_upload.rs
@@ -74,7 +74,7 @@ fn test_gerrit_upload_dryrun() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Found 1 heads to push to Gerrit (remote 'origin'), target branch 'main'
-    Dry-run: Would push zsuskuln 123b4d91 b | b
+    Dry-run: Would push psuskuln dd148a1b b | b
     [EOF]
     ");
 
@@ -82,7 +82,7 @@ fn test_gerrit_upload_dryrun() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Found 1 heads to push to Gerrit (remote 'origin'), target branch 'other'
-    Dry-run: Would push zsuskuln 123b4d91 b | b
+    Dry-run: Would push psuskuln dd148a1b b | b
     [EOF]
     ");
 }
@@ -114,7 +114,7 @@ fn test_gerrit_upload_default_revision() {
     ------- stderr -------
     No revision provided. Defaulting to @
     Found 1 heads to push to Gerrit (remote 'origin'), target branch 'main'
-    Dry-run: Would push kkmpptxz a41ea4e9 parent
+    Dry-run: Would push nkmpptxz f7f633c0 parent
     [EOF]
     ");
 
@@ -124,7 +124,7 @@ fn test_gerrit_upload_default_revision() {
     ------- stderr -------
     No revision provided and @ has no description. Defaulting to @-
     Found 1 heads to push to Gerrit (remote 'origin'), target branch 'main'
-    Dry-run: Would push kkmpptxz a41ea4e9 parent
+    Dry-run: Would push nkmpptxz f7f633c0 parent
     [EOF]
     ");
 
@@ -171,19 +171,19 @@ fn test_gerrit_upload_default_revision_already_in_trunk() {
     local_dir.run_jj(["describe", "-m="]).success();
 
     let output = local_dir.run_jj(["gerrit", "upload", "--dry-run"]);
-    insta::assert_snapshot!(output, @"
+    insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     No revision provided and @ has no description. Defaulting to @-
-    Error: Commit 57df4838fd85 is immutable
-    Hint: Could not modify commit: rlvkpnrz 57df4838 main@origin | main
+    Error: Commit 86be1db760f2 is immutable
+    Hint: Could not modify commit: ylvkpnrz 86be1db7 main@origin | main
     Hint: Immutable commits are used to protect shared history.
     Hint: For more information, see:
           - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
-          - `jj help -k config`, \"Set of immutable commits\"
+          - `jj help -k config`, "Set of immutable commits"
     Hint: This operation would rewrite 1 immutable commits.
     [EOF]
     [exit status: 1]
-    ");
+    "#);
 }
 
 #[test]
@@ -271,7 +271,7 @@ fn test_gerrit_upload_failure() {
     let output = local_dir.run_jj(["gerrit", "upload", "-r", "b", "--remote-branch=main"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Error: Refusing to upload revision mzvwutvlkqwt because it is empty
+    Error: Refusing to upload revision pzvwutvlkqwt because it is empty
     Hint: Perhaps you squashed then ran upload? Maybe you meant to upload the parent commit instead (eg. @-)
     [EOF]
     [exit status: 1]
@@ -281,7 +281,7 @@ fn test_gerrit_upload_failure() {
     let output = local_dir.run_jj(["gerrit", "upload", "-r", "c", "--remote-branch=main"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Error: Refusing to upload revision yqosqzytrlsw because it is has no description
+    Error: Refusing to upload revision nqosqzytrlsw because it is has no description
     Hint: Maybe you meant to upload the parent commit instead (eg. @-)
     [EOF]
     [exit status: 1]
@@ -295,7 +295,7 @@ fn test_gerrit_upload_failure() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Found 1 heads to push to Gerrit (remote 'origin'), target branch 'main'
-    Pushing znkkpsqq 47f1f88c d | d
+    Pushing qnkkpsqq 50f9c1c1 d | d
     Error: Internal git error while pushing to gerrit
     Caused by: Could not find repository at '$TEST_ENV/local/nonexistent'
     [EOF]
@@ -333,11 +333,11 @@ fn test_gerrit_upload_local_implicit_change_ids() {
     // temporary commits)
     let output = local_dir.run_jj(["log", "-r", "all()"]);
     insta::assert_snapshot!(output, @"
-    @  yqosqzyt test.user@example.com 2001-02-03 08:05:15 c f6e97ced
+    @  nqosqzyt test.user@example.com 2001-02-03 08:05:15 c 06dc682a
     │  c
-    ○  mzvwutvl test.user@example.com 2001-02-03 08:05:12 b 3bcb28c4
+    ○  pzvwutvl test.user@example.com 2001-02-03 08:05:12 b bd2773ca
     │  b
-    ◆  rlvkpnrz test.user@example.com 2001-02-03 08:05:09 a@origin 7d980be7
+    ◆  ylvkpnrz test.user@example.com 2001-02-03 08:05:09 a@origin a1afb583
     │  a
     ◆  zzzzzzzz root() 00000000
     [EOF]
@@ -347,7 +347,7 @@ fn test_gerrit_upload_local_implicit_change_ids() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Found 1 heads to push to Gerrit (remote 'origin'), target branch 'main'
-    Pushing yqosqzyt f6e97ced c | c
+    Pushing nqosqzyt 06dc682a c | c
     [EOF]
     ");
 
@@ -355,11 +355,11 @@ fn test_gerrit_upload_local_implicit_change_ids() {
     // transiently
     let output = local_dir.run_jj(["log", "-r", "all()"]);
     insta::assert_snapshot!(output, @"
-    @  yqosqzyt test.user@example.com 2001-02-03 08:05:15 c f6e97ced
+    @  nqosqzyt test.user@example.com 2001-02-03 08:05:15 c 06dc682a
     │  c
-    ○  mzvwutvl test.user@example.com 2001-02-03 08:05:12 b 3bcb28c4
+    ○  pzvwutvl test.user@example.com 2001-02-03 08:05:12 b bd2773ca
     │  b
-    ◆  rlvkpnrz test.user@example.com 2001-02-03 08:05:09 a@origin 7d980be7
+    ◆  ylvkpnrz test.user@example.com 2001-02-03 08:05:09 a@origin a1afb583
     │  a
     ◆  zzzzzzzz root() 00000000
     [EOF]
@@ -368,25 +368,25 @@ fn test_gerrit_upload_local_implicit_change_ids() {
     // There's no particular reason to run this with jj util exec, it's just that
     // the infra makes it easier to run this way.
     let output = remote_dir.run_jj(["util", "exec", "--", "git", "log", "refs/for/main"]);
-    insta::assert_snapshot!(output, @"
-    commit 68b986d2eb820643b767ae219fb48128dcc2fc03
+    insta::assert_snapshot!(output, @r"
+    commit d8b9cbe0b3ee36981d2d55050589d2d07fb05045
     Author: Test User <test.user@example.com>
     Date:   Sat Feb 3 04:05:13 2001 +0700
 
         c
         
         Signed-off-by: Lucky K Maintainer <lucky@maintainer.example.org>
-        Change-Id: I19b790168e73f7a73a98deae21e807c06a6a6964
+        Change-Id: Ic9b790168e73f7a73a98deae21e807c06a6a6964
 
-    commit 81b723522d1c1a583a045eab5bfb323e45e6198d
+    commit 166a6cec7b25f3206d67e661b5b354b60ae29998
     Author: Test User <test.user@example.com>
     Date:   Sat Feb 3 04:05:11 2001 +0700
 
         b
         
-        Change-Id: Id043564ef93650b06a70f92f9d91912b6a6a6964
+        Change-Id: Ia043564ef93650b06a70f92f9d91912b6a6a6964
 
-    commit 7d980be7a1d499e4d316ab4c01242885032f7eaf
+    commit a1afb5834d8ee4dcb61b59db0f682c7a53f96f53
     Author: Test User <test.user@example.com>
     Date:   Sat Feb 3 04:05:08 2001 +0700
 
@@ -431,11 +431,11 @@ review-url = "https://gerrit.example.com/"
     // temporary commits)
     let output = local_dir.run_jj(["log", "-r", "all()"]);
     insta::assert_snapshot!(output, @"
-    @  yqosqzyt test.user@example.com 2001-02-03 08:05:15 c f6e97ced
+    @  nqosqzyt test.user@example.com 2001-02-03 08:05:15 c 06dc682a
     │  c
-    ○  mzvwutvl test.user@example.com 2001-02-03 08:05:12 b 3bcb28c4
+    ○  pzvwutvl test.user@example.com 2001-02-03 08:05:12 b bd2773ca
     │  b
-    ◆  rlvkpnrz test.user@example.com 2001-02-03 08:05:09 a@origin 7d980be7
+    ◆  ylvkpnrz test.user@example.com 2001-02-03 08:05:09 a@origin a1afb583
     │  a
     ◆  zzzzzzzz root() 00000000
     [EOF]
@@ -445,7 +445,7 @@ review-url = "https://gerrit.example.com/"
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Found 1 heads to push to Gerrit (remote 'origin'), target branch 'main'
-    Pushing yqosqzyt f6e97ced c | c
+    Pushing nqosqzyt 06dc682a c | c
     [EOF]
     ");
 
@@ -453,11 +453,11 @@ review-url = "https://gerrit.example.com/"
     // transiently
     let output = local_dir.run_jj(["log", "-r", "all()"]);
     insta::assert_snapshot!(output, @"
-    @  yqosqzyt test.user@example.com 2001-02-03 08:05:15 c f6e97ced
+    @  nqosqzyt test.user@example.com 2001-02-03 08:05:15 c 06dc682a
     │  c
-    ○  mzvwutvl test.user@example.com 2001-02-03 08:05:12 b 3bcb28c4
+    ○  pzvwutvl test.user@example.com 2001-02-03 08:05:12 b bd2773ca
     │  b
-    ◆  rlvkpnrz test.user@example.com 2001-02-03 08:05:09 a@origin 7d980be7
+    ◆  ylvkpnrz test.user@example.com 2001-02-03 08:05:09 a@origin a1afb583
     │  a
     ◆  zzzzzzzz root() 00000000
     [EOF]
@@ -467,24 +467,24 @@ review-url = "https://gerrit.example.com/"
     // the infra makes it easier to run this way.
     let output = remote_dir.run_jj(["util", "exec", "--", "git", "log", "refs/for/main"]);
     insta::assert_snapshot!(output, @r"
-    commit b2731737e530be944c12679a86dacca2a3d3c6ad
+    commit f4f2cd7de12a02296bbe8b2aeadf0abda9fc5e58
     Author: Test User <test.user@example.com>
     Date:   Sat Feb 3 04:05:13 2001 +0700
 
         c
         
         Signed-off-by: Lucky K Maintainer <lucky@maintainer.example.org>
-        Link: https://gerrit.example.com/id/I19b790168e73f7a73a98deae21e807c06a6a6964
+        Link: https://gerrit.example.com/id/Ic9b790168e73f7a73a98deae21e807c06a6a6964
 
-    commit 9bc0339b54de4f3bcf241f8d68daf75bd6501cff
+    commit 0137efaa46414aac8f664eb33f5a7739b3372bda
     Author: Test User <test.user@example.com>
     Date:   Sat Feb 3 04:05:11 2001 +0700
 
         b
         
-        Link: https://gerrit.example.com/id/Id043564ef93650b06a70f92f9d91912b6a6a6964
+        Link: https://gerrit.example.com/id/Ia043564ef93650b06a70f92f9d91912b6a6a6964
 
-    commit 7d980be7a1d499e4d316ab4c01242885032f7eaf
+    commit a1afb5834d8ee4dcb61b59db0f682c7a53f96f53
     Author: Test User <test.user@example.com>
     Date:   Sat Feb 3 04:05:08 2001 +0700
 
@@ -517,8 +517,8 @@ fn test_gerrit_upload_local_explicit_change_ids() {
     ]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: mzvwutvl 887a7016 b | b
-    Parent commit (@-)      : rlvkpnrz 7d980be7 a@origin | a
+    Working copy  (@) now at: pzvwutvl a92f28f1 b | b
+    Parent commit (@-)      : ylvkpnrz a1afb583 a@origin | a
     [EOF]
     ");
 
@@ -533,8 +533,8 @@ fn test_gerrit_upload_local_explicit_change_ids() {
     ]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: vruxwmqv b4124fc9 c | c
-    Parent commit (@-)      : mzvwutvl 887a7016 b | b
+    Working copy  (@) now at: truxwmqv e5c39e2f c | c
+    Parent commit (@-)      : pzvwutvl a92f28f1 b | b
     [EOF]
     ");
 
@@ -542,11 +542,11 @@ fn test_gerrit_upload_local_explicit_change_ids() {
     // temporary commits)
     let output = local_dir.run_jj(["log", "-r", "all()"]);
     insta::assert_snapshot!(output, @"
-    @  vruxwmqv test.user@example.com 2001-02-03 08:05:16 c b4124fc9
+    @  truxwmqv test.user@example.com 2001-02-03 08:05:16 c e5c39e2f
     │  c
-    ○  mzvwutvl test.user@example.com 2001-02-03 08:05:13 b 887a7016
+    ○  pzvwutvl test.user@example.com 2001-02-03 08:05:13 b a92f28f1
     │  b
-    ◆  rlvkpnrz test.user@example.com 2001-02-03 08:05:09 a@origin 7d980be7
+    ◆  ylvkpnrz test.user@example.com 2001-02-03 08:05:09 a@origin a1afb583
     │  a
     ◆  zzzzzzzz root() 00000000
     [EOF]
@@ -556,7 +556,7 @@ fn test_gerrit_upload_local_explicit_change_ids() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Found 1 heads to push to Gerrit (remote 'origin'), target branch 'main'
-    Pushing vruxwmqv b4124fc9 c | c
+    Pushing truxwmqv e5c39e2f c | c
     [EOF]
     ");
 
@@ -564,11 +564,11 @@ fn test_gerrit_upload_local_explicit_change_ids() {
     // been created
     let output = local_dir.run_jj(["log", "-r", "all()"]);
     insta::assert_snapshot!(output, @"
-    @  vruxwmqv test.user@example.com 2001-02-03 08:05:16 c b4124fc9
+    @  truxwmqv test.user@example.com 2001-02-03 08:05:16 c e5c39e2f
     │  c
-    ○  mzvwutvl test.user@example.com 2001-02-03 08:05:13 b 887a7016
+    ○  pzvwutvl test.user@example.com 2001-02-03 08:05:13 b a92f28f1
     │  b
-    ◆  rlvkpnrz test.user@example.com 2001-02-03 08:05:09 a@origin 7d980be7
+    ◆  ylvkpnrz test.user@example.com 2001-02-03 08:05:09 a@origin a1afb583
     │  a
     ◆  zzzzzzzz root() 00000000
     [EOF]
@@ -578,7 +578,7 @@ fn test_gerrit_upload_local_explicit_change_ids() {
     // the infra makes it easier to run this way.
     let output = remote_dir.run_jj(["util", "exec", "--", "git", "log", "refs/for/main"]);
     insta::assert_snapshot!(output, @"
-    commit b4124fc9d4694eecb4d9938cf4874cd13f1252b6
+    commit e5c39e2fe97d0c6db908e0bfe8487814cc04fa3d
     Author: Test User <test.user@example.com>
     Date:   Sat Feb 3 04:05:14 2001 +0700
 
@@ -586,7 +586,7 @@ fn test_gerrit_upload_local_explicit_change_ids() {
         
         Link: https://gerrit.example.com/id/Idfac1e8c149efddf5c7a286f787b43886a6a6964
 
-    commit 887a7016ec03a904835da1059543d8cc34b6ba76
+    commit a92f28f1118f62b6b8c85eb7252e5a3c63720005
     Author: Test User <test.user@example.com>
     Date:   Sat Feb 3 04:05:11 2001 +0700
 
@@ -594,7 +594,7 @@ fn test_gerrit_upload_local_explicit_change_ids() {
         
         Change-Id: Id39b308212fe7e0b746d16c13355f3a90712d7f9
 
-    commit 7d980be7a1d499e4d316ab4c01242885032f7eaf
+    commit a1afb5834d8ee4dcb61b59db0f682c7a53f96f53
     Author: Test User <test.user@example.com>
     Date:   Sat Feb 3 04:05:08 2001 +0700
 
@@ -628,8 +628,8 @@ fn test_gerrit_upload_local_mixed_change_ids() {
     ]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: yqosqzyt 8d46d915 c | c
-    Parent commit (@-)      : mzvwutvl 3bcb28c4 b | b
+    Working copy  (@) now at: nqosqzyt a030199b c | c
+    Parent commit (@-)      : pzvwutvl bd2773ca b | b
     [EOF]
     ");
 
@@ -637,11 +637,11 @@ fn test_gerrit_upload_local_mixed_change_ids() {
     // temporary commits)
     let output = local_dir.run_jj(["log", "-r", "all()"]);
     insta::assert_snapshot!(output, @"
-    @  yqosqzyt test.user@example.com 2001-02-03 08:05:15 c 8d46d915
+    @  nqosqzyt test.user@example.com 2001-02-03 08:05:15 c a030199b
     │  c
-    ○  mzvwutvl test.user@example.com 2001-02-03 08:05:12 b 3bcb28c4
+    ○  pzvwutvl test.user@example.com 2001-02-03 08:05:12 b bd2773ca
     │  b
-    ◆  rlvkpnrz test.user@example.com 2001-02-03 08:05:09 a@origin 7d980be7
+    ◆  ylvkpnrz test.user@example.com 2001-02-03 08:05:09 a@origin a1afb583
     │  a
     ◆  zzzzzzzz root() 00000000
     [EOF]
@@ -651,7 +651,7 @@ fn test_gerrit_upload_local_mixed_change_ids() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Found 1 heads to push to Gerrit (remote 'origin'), target branch 'main'
-    Pushing yqosqzyt 8d46d915 c | c
+    Pushing nqosqzyt a030199b c | c
     [EOF]
     ");
 
@@ -659,11 +659,11 @@ fn test_gerrit_upload_local_mixed_change_ids() {
     // should all be temporary
     let output = local_dir.run_jj(["log", "-r", "all()"]);
     insta::assert_snapshot!(output, @"
-    @  yqosqzyt test.user@example.com 2001-02-03 08:05:15 c 8d46d915
+    @  nqosqzyt test.user@example.com 2001-02-03 08:05:15 c a030199b
     │  c
-    ○  mzvwutvl test.user@example.com 2001-02-03 08:05:12 b 3bcb28c4
+    ○  pzvwutvl test.user@example.com 2001-02-03 08:05:12 b bd2773ca
     │  b
-    ◆  rlvkpnrz test.user@example.com 2001-02-03 08:05:09 a@origin 7d980be7
+    ◆  ylvkpnrz test.user@example.com 2001-02-03 08:05:09 a@origin a1afb583
     │  a
     ◆  zzzzzzzz root() 00000000
     [EOF]
@@ -673,7 +673,7 @@ fn test_gerrit_upload_local_mixed_change_ids() {
     // the infra makes it easier to run this way.
     let output = remote_dir.run_jj(["util", "exec", "--", "git", "log", "refs/for/main"]);
     insta::assert_snapshot!(output, @"
-    commit 015df2b1d38bdc71ae7ef24c2889100e39d34ef8
+    commit 1fad1dc37e6e6c0b2afc98f5103a7f912537110c
     Author: Test User <test.user@example.com>
     Date:   Sat Feb 3 04:05:13 2001 +0700
 
@@ -681,15 +681,15 @@ fn test_gerrit_upload_local_mixed_change_ids() {
         
         Change-Id: Id39b308212fe7e0b746d16c13355f3a90712d7f9
 
-    commit 81b723522d1c1a583a045eab5bfb323e45e6198d
+    commit 166a6cec7b25f3206d67e661b5b354b60ae29998
     Author: Test User <test.user@example.com>
     Date:   Sat Feb 3 04:05:11 2001 +0700
 
         b
         
-        Change-Id: Id043564ef93650b06a70f92f9d91912b6a6a6964
+        Change-Id: Ia043564ef93650b06a70f92f9d91912b6a6a6964
 
-    commit 7d980be7a1d499e4d316ab4c01242885032f7eaf
+    commit a1afb5834d8ee4dcb61b59db0f682c7a53f96f53
     Author: Test User <test.user@example.com>
     Date:   Sat Feb 3 04:05:08 2001 +0700
 
@@ -779,21 +779,21 @@ fn test_gerrit_upload_bad_change_ids() {
     let output = local_dir.run_jj(["gerrit", "upload", "-rc", "--remote-branch=main"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Error: Multiple Change-Id footers in revision wqnwkozpkust
+    Error: Multiple Change-Id footers in revision vqnwkozpkust
     [EOF]
     [exit status: 1]
     ");
     let output = local_dir.run_jj(["gerrit", "upload", "-rd", "--remote-branch=main"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Error: Multiple Change-Id footers in revision kxryzmorwvtz
+    Error: Multiple Change-Id footers in revision uxryzmorwvtz
     [EOF]
     [exit status: 1]
     ");
     let output = local_dir.run_jj(["gerrit", "upload", "-re", "--remote-branch=main"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Error: Multiple Change-Id footers in revision uyznsvlquzzm
+    Error: Multiple Change-Id footers in revision wyznsvlquzzm
     [EOF]
     [exit status: 1]
     ");
@@ -802,12 +802,12 @@ fn test_gerrit_upload_bad_change_ids() {
     let output = local_dir.run_jj(["gerrit", "upload", "-rb4", "--remote-branch=main"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Warning: Invalid Change-Id footer in revision mzvwutvlkqwt
-    Warning: Invalid Change-Id footer in revision yqosqzytrlsw
-    Warning: Invalid Link footer in revision yostqsxwqrlt
+    Warning: Invalid Change-Id footer in revision pzvwutvlkqwt
+    Warning: Invalid Change-Id footer in revision nqosqzytrlsw
+    Warning: Invalid Link footer in revision rostqsxwqrlt
     Warning: Invalid Link footer in revision kpqxywonksrl
     Found 1 heads to push to Gerrit (remote 'origin'), target branch 'main'
-    Pushing kpqxywon 69536ef3 b4
+    Pushing kpqxywon 45cdd32b b4
     [EOF]
     ");
 }
@@ -852,8 +852,8 @@ fn test_gerrit_upload_rejected_by_remote() -> TestResult {
     ]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: mzvwutvl 887a7016 b | b
-    Parent commit (@-)      : rlvkpnrz 7d980be7 a@origin | a
+    Working copy  (@) now at: pzvwutvl a92f28f1 b | b
+    Parent commit (@-)      : ylvkpnrz a1afb583 a@origin | a
     [EOF]
     ");
 
@@ -861,7 +861,7 @@ fn test_gerrit_upload_rejected_by_remote() -> TestResult {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Found 1 heads to push to Gerrit (remote 'origin'), target branch 'main'
-    Pushing mzvwutvl 887a7016 b | b
+    Pushing pzvwutvl a92f28f1 b | b
     remote: error: hook declined to update refs/for/main        
     Warning: The remote rejected the following updates:
       refs/for/main (reason: hook declined)

--- a/cli/tests/test_git_clone.rs
+++ b/cli/tests/test_git_clone.rs
@@ -1191,7 +1191,7 @@ fn test_git_clone_malformed() {
     let output = clone_dir.run_jj(["status"]);
     insta::assert_snapshot!(output, @"
     The working copy has no changes.
-    Working copy  (@) : zsuskuln c2934cfb (empty) (no description set)
+    Working copy  (@) : psuskuln 78fad9fc (empty) (no description set)
     Parent commit (@-): zzzzzzzz 00000000 (empty) (no description set)
     [EOF]
     ");

--- a/cli/tests/test_git_colocated.rs
+++ b/cli/tests/test_git_colocated.rs
@@ -87,7 +87,7 @@ fn test_git_colocated() -> TestResult {
     // Create a new change from jj and check that it's reflected in Git
     work_dir.run_jj(["new"]).success();
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  4ddddef596e9d68f729f1be9e1b2cdaaf45bef08
+    @  83f7a30bd92ed65a71d8394e9a617a10a7c205c2
     ○  9dfe8c7005c8dff6078ecdfd953c6bfddc633c90
     ○  97358f54806c7cd005ed5ade68a779595efbae7e master initial
     ◆  0000000000000000000000000000000000000000
@@ -226,7 +226,7 @@ fn test_git_colocated_unborn_bookmark() -> TestResult {
     let output = work_dir.run_jj(["new", "root()"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: zsuskuln c2934cfb (empty) (no description set)
+    Working copy  (@) now at: psuskuln 78fad9fc (empty) (no description set)
     Parent commit (@-)      : zzzzzzzz 00000000 (empty) (no description set)
     Added 0 files, modified 0 files, removed 1 files
     [EOF]
@@ -237,7 +237,7 @@ fn test_git_colocated_unborn_bookmark() -> TestResult {
         b"refs/heads/master"
     );
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  c2934cfbfb196d2c473959667beffcc19e71e5e8
+    @  78fad9fc172edf4d55cf6d090ffb45c9d477a421
     │ ○  e6669bb3438ef218fa618e1047a1911d2b3410dd
     ├─╯
     ◆  0000000000000000000000000000000000000000
@@ -252,7 +252,7 @@ fn test_git_colocated_unborn_bookmark() -> TestResult {
     checkout_index();
     insta::assert_snapshot!(work_dir.run_jj(["status"]), @"
     The working copy has no changes.
-    Working copy  (@) : zsuskuln c2934cfb (empty) (no description set)
+    Working copy  (@) : psuskuln 78fad9fc (empty) (no description set)
     Parent commit (@-): zzzzzzzz 00000000 (empty) (no description set)
     [EOF]
     ");
@@ -263,18 +263,18 @@ fn test_git_colocated_unborn_bookmark() -> TestResult {
     let output = work_dir.run_jj(["new"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: vruxwmqv 2d7a8abb (empty) (no description set)
-    Parent commit (@-)      : zsuskuln ff536684 (no description set)
+    Working copy  (@) now at: uruxwmqv 404c464d (empty) (no description set)
+    Parent commit (@-)      : psuskuln 13f22618 (no description set)
     [EOF]
     ");
     assert!(git_repo.head()?.is_detached());
     insta::assert_snapshot!(
         git_repo.head_id()?.to_string(),
-        @"ff5366846b039b25c6c4998fa74dca821c246243"
+        @"13f22618dd6530ad1909b1081c63b6974b206c0f"
     );
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  2d7a8abb601ebf559df4037279e9f2e851a75e63
-    ○  ff5366846b039b25c6c4998fa74dca821c246243
+    @  404c464d074a10abfbdf0173e5f8aa010727f7f4
+    ○  13f22618dd6530ad1909b1081c63b6974b206c0f
     │ ○  e6669bb3438ef218fa618e1047a1911d2b3410dd
     ├─╯
     ◆  0000000000000000000000000000000000000000
@@ -282,15 +282,15 @@ fn test_git_colocated_unborn_bookmark() -> TestResult {
     ");
     insta::assert_snapshot!(get_colocation_status(&work_dir), @"
     Workspace is currently colocated with Git.
-    Last imported/exported Git HEAD: ff5366846b039b25c6c4998fa74dca821c246243
+    Last imported/exported Git HEAD: 13f22618dd6530ad1909b1081c63b6974b206c0f
     [EOF]
     ");
     // Staged change shouldn't persist.
     checkout_index();
     insta::assert_snapshot!(work_dir.run_jj(["status"]), @"
     The working copy has no changes.
-    Working copy  (@) : vruxwmqv 2d7a8abb (empty) (no description set)
-    Parent commit (@-): zsuskuln ff536684 (no description set)
+    Working copy  (@) : uruxwmqv 404c464d (empty) (no description set)
+    Parent commit (@-): psuskuln 13f22618 (no description set)
     [EOF]
     ");
 
@@ -313,8 +313,8 @@ fn test_git_colocated_unborn_bookmark() -> TestResult {
     assert!(git_repo.head()?.is_unborn());
     insta::assert_snapshot!(get_log_output(&work_dir), @"
     @  88e8407a4f0a5e6f40a7c6c494106764adc00fed
-    │ ○  2dd7385602e703388fd266b939bba6f57a1439d3
-    │ ○  ff5366846b039b25c6c4998fa74dca821c246243 master
+    │ ○  94a99b37620f5bb3c2960dbffbf65a6e5cfa1214
+    │ ○  13f22618dd6530ad1909b1081c63b6974b206c0f master
     ├─╯
     │ ○  e6669bb3438ef218fa618e1047a1911d2b3410dd
     ├─╯
@@ -340,15 +340,15 @@ fn test_git_colocated_unborn_bookmark() -> TestResult {
     let output = work_dir.run_jj(["new"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: uyznsvlq 2fb16499 (empty) (no description set)
+    Working copy  (@) now at: vyznsvlq 73cf66f6 (empty) (no description set)
     Parent commit (@-)      : wqnwkozp bb21bc2d (no description set)
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  2fb16499a987e632407402e38976ed250c939c42
+    @  73cf66f69f26cbe791026d59a1867e6b47275b7d
     ○  bb21bc2dce2af92973fdd6d42686d77bd16bc466
-    │ ○  2dd7385602e703388fd266b939bba6f57a1439d3
-    │ ○  ff5366846b039b25c6c4998fa74dca821c246243 master
+    │ ○  94a99b37620f5bb3c2960dbffbf65a6e5cfa1214
+    │ ○  13f22618dd6530ad1909b1081c63b6974b206c0f master
     ├─╯
     │ ○  e6669bb3438ef218fa618e1047a1911d2b3410dd
     ├─╯
@@ -465,8 +465,8 @@ fn test_git_colocated_bookmarks() -> TestResult {
     work_dir.run_jj(["new", "-m", "foo"]).success();
     work_dir.run_jj(["new", "@-", "-m", "bar"]).success();
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  95e79774f8e7c785fc36da2b798ecfe0dc864e02 bar
-    │ ○  b51ab2e2c88fe2d38bd7ca6946c4d87f281ce7e2 foo
+    @  029c37b5d34cb575cd6b3e33ace2335e0cc66610 bar
+    │ ○  74f128eafed036ef5507e302b24ccd5131c09665 foo
     ├─╯
     ○  e8849ae12c709f2321908879bc724fdb2ab8a781
     ◆  0000000000000000000000000000000000000000
@@ -480,7 +480,7 @@ fn test_git_colocated_bookmarks() -> TestResult {
         .success();
     insta::assert_snapshot!(
         git_repo.find_reference("refs/heads/master")?.target().id().to_string(),
-        @"95e79774f8e7c785fc36da2b798ecfe0dc864e02"
+        @"029c37b5d34cb575cd6b3e33ace2335e0cc66610"
     );
     assert!(git_repo.head()?.is_detached());
     insta::assert_snapshot!(
@@ -502,7 +502,7 @@ fn test_git_colocated_bookmarks() -> TestResult {
     )?;
     insta::assert_snapshot!(get_log_output(&work_dir), @"
     @  507c0edcfc028f714f3c7a3027cb141f6610e867
-    │ ○  b51ab2e2c88fe2d38bd7ca6946c4d87f281ce7e2 master foo
+    │ ○  74f128eafed036ef5507e302b24ccd5131c09665 master foo
     ├─╯
     ○  e8849ae12c709f2321908879bc724fdb2ab8a781
     ◆  0000000000000000000000000000000000000000
@@ -531,14 +531,14 @@ fn test_git_colocated_bookmark_forget() -> TestResult {
         .run_jj(["bookmark", "create", "-r@", "foo"])
         .success();
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  43444d88b0096888ebfd664c0cf792c9d15e3f14 foo
+    @  e521ae80c3d70ec4b6dab193c8915c8de7cb7311 foo
     ○  e8849ae12c709f2321908879bc724fdb2ab8a781
     ◆  0000000000000000000000000000000000000000
     [EOF]
     ");
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @"
-    foo: rlvkpnrz 43444d88 (empty) (no description set)
-      @git: rlvkpnrz 43444d88 (empty) (no description set)
+    foo: ylvkpnrz e521ae80 (empty) (no description set)
+      @git: ylvkpnrz e521ae80 (empty) (no description set)
     [EOF]
     ");
 
@@ -665,7 +665,7 @@ fn test_git_colocated_checkout_non_empty_working_copy() -> TestResult {
     let output = work_dir.run_jj(["describe", "-m", "new"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: kkmpptxz 986aa548 (empty) new
+    Working copy  (@) now at: nkmpptxz a2527ce8 (empty) new
     Parent commit (@-)      : slsumksp 97358f54 master | initial
     [EOF]
     ");
@@ -676,7 +676,7 @@ fn test_git_colocated_checkout_non_empty_working_copy() -> TestResult {
     );
 
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  986aa548466ed43b48c059854720e70d8ec2bf71 new
+    @  a2527ce855aecd5dd1e8af71d39873edb6e04212 new
     │ ○  6b0f7d59e0749d3a6ff2ecf686d5fa48023b7b93 two
     ├─╯
     ○  97358f54806c7cd005ed5ade68a779595efbae7e master initial
@@ -717,10 +717,10 @@ fn test_git_colocated_fetch_deleted_or_moved_bookmark() -> TestResult {
     clone_dir.run_jj(["git", "init", "--git-repo=."]).success();
     clone_dir.run_jj(["new", "A"]).success();
     insta::assert_snapshot!(get_log_output(&clone_dir), @"
-    @  0060713e4c7c46c4ce0d69a43ac16451582eda79
-    │ ○  dd905babf5b4ad4689f2da1350fd4f0ac5568209 C_to_move original C
+    @  b982f42f97d7191ab84657935e2fe1f24916e6f3
+    │ ○  082bd179562bd973fa0355ee827b555bad397d88 C_to_move original C
     ├─╯
-    │ ○  b2ea51c027e11c0f2871cce2a52e648e194df771 B_to_delete B_to_delete
+    │ ○  6def29fe5d0be7c497e6e6c757365376d961ff9d B_to_delete B_to_delete
     ├─╯
     ◆  8777db25171cace71ad014598663d5ffc4fae6b1 A A
     ◆  0000000000000000000000000000000000000000
@@ -740,15 +740,15 @@ fn test_git_colocated_fetch_deleted_or_moved_bookmark() -> TestResult {
     bookmark: B_to_delete@origin [deleted] untracked
     bookmark: C_to_move@origin   [updated] tracked
     Abandoned 1 commits that are no longer reachable:
-      zsuskuln b2ea51c0 B_to_delete@git | (empty) B_to_delete
+      psuskuln 6def29fe B_to_delete@git | (empty) B_to_delete
     Updated 1 rewritten commits.
     [EOF]
     ");
     // "original C" and "B_to_delete" are abandoned, as the corresponding bookmarks
     // were deleted or moved on the remote (#864)
     insta::assert_snapshot!(get_log_output(&clone_dir), @"
-    @  0060713e4c7c46c4ce0d69a43ac16451582eda79
-    │ ○  fb297975e4ef98dc057f65b761aed2cdb0386598 C_to_move moved C
+    @  b982f42f97d7191ab84657935e2fe1f24916e6f3
+    │ ○  f121e99940c996eb2f117e214d44937a963e34d3 C_to_move moved C
     ├─╯
     ◆  8777db25171cace71ad014598663d5ffc4fae6b1 A A
     ◆  0000000000000000000000000000000000000000
@@ -782,7 +782,7 @@ fn test_git_colocated_rebase_dirty_working_copy() -> TestResult {
     insta::assert_snapshot!(output, @"
     Working copy changes:
     M file
-    Working copy  (@) : rlvkpnrz e23559e3 feature?? | (no description set)
+    Working copy  (@) : ylvkpnrz 6282fedc feature?? | (no description set)
     Parent commit (@-): qpvuntsm f99015d7 (no description set)
     Warning: These bookmarks have conflicts:
       feature
@@ -795,7 +795,7 @@ fn test_git_colocated_rebase_dirty_working_copy() -> TestResult {
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  e23559e3bc6f22a5562297696fc357e2c581df77 feature??
+    @  6282fedc66bd0409f6e0b372890d9c013b9882ea feature??
     ○  f99015d7d9b82a5912ec4d96a18d2a4afbd8dd49
     ◆  0000000000000000000000000000000000000000
     [EOF]
@@ -831,8 +831,8 @@ fn test_git_colocated_external_checkout() -> TestResult {
 
     // Checked out anonymous bookmark
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  6f8612f0e7f6d52efd8a72615796df06f8d64cdc
-    ○  319eaafc8fd04c763a0683a000bba5452082feb3 B
+    @  e9d967013a147358e51843d0f8872dbb5a2de3b3
+    ○  5febc7be568fde865c28f77dc4052b72c62b816e B
     │ ○  8777db25171cace71ad014598663d5ffc4fae6b1 master A
     ├─╯
     ◆  0000000000000000000000000000000000000000
@@ -847,7 +847,7 @@ fn test_git_colocated_external_checkout() -> TestResult {
     insta::assert_snapshot!(get_log_output(&work_dir), @"
     @  7ceeaaae54c8ac99ad34eeed7fe1e896f535be99
     ○  8777db25171cace71ad014598663d5ffc4fae6b1 master A
-    │ ○  319eaafc8fd04c763a0683a000bba5452082feb3 B
+    │ ○  5febc7be568fde865c28f77dc4052b72c62b816e B
     ├─╯
     ◆  0000000000000000000000000000000000000000
     [EOF]
@@ -860,9 +860,9 @@ fn test_git_colocated_external_checkout() -> TestResult {
     work_dir.run_jj(["new", "subject(B)"]).success();
     work_dir.run_jj(["new", "-m=C", "--no-edit"]).success();
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    ○  823204bc895aad19d46b895bc510fb3e9d0c97c7 C
-    @  c6abf242550b7c4116d3821b69c79326889aeba0
-    ○  319eaafc8fd04c763a0683a000bba5452082feb3 B
+    ○  0890c7d45b6b6323fc99dca7a43af28c2c0e2347 C
+    @  5be1f497ea0b178008cc945971568f4b631a62ce
+    ○  5febc7be568fde865c28f77dc4052b72c62b816e B
     │ ○  8777db25171cace71ad014598663d5ffc4fae6b1 master A
     ├─╯
     ◆  0000000000000000000000000000000000000000
@@ -876,9 +876,9 @@ fn test_git_colocated_external_checkout() -> TestResult {
     insta::assert_snapshot!(get_log_output(&work_dir), @"
     @  277b693c61dcdea59ac26d6982370f78751f6ef5
     ○  8777db25171cace71ad014598663d5ffc4fae6b1 master A
-    │ ○  823204bc895aad19d46b895bc510fb3e9d0c97c7 C
-    │ ○  c6abf242550b7c4116d3821b69c79326889aeba0
-    │ ○  319eaafc8fd04c763a0683a000bba5452082feb3 B
+    │ ○  0890c7d45b6b6323fc99dca7a43af28c2c0e2347 C
+    │ ○  5be1f497ea0b178008cc945971568f4b631a62ce
+    │ ○  5febc7be568fde865c28f77dc4052b72c62b816e B
     ├─╯
     ◆  0000000000000000000000000000000000000000
     [EOF]
@@ -898,7 +898,7 @@ fn test_git_colocated_external_checkout() -> TestResult {
     [EOF]
     ------- stderr -------
     Reset the working copy parent to the new Git HEAD.
-    Operation left uncommitted because --no-integrate-operation was requested: 4dd0ee71039d
+    Operation left uncommitted because --no-integrate-operation was requested: 4e66050b9947
     [EOF]
     ");
     let output = work_dir.run_jj(["status", "--no-integrate-operation"]);
@@ -909,7 +909,7 @@ fn test_git_colocated_external_checkout() -> TestResult {
     [EOF]
     ------- stderr -------
     Reset the working copy parent to the new Git HEAD.
-    Operation left uncommitted because --no-integrate-operation was requested: 1c501b6939b3
+    Operation left uncommitted because --no-integrate-operation was requested: e74d2bcb6913
     [EOF]
     ");
 
@@ -939,22 +939,22 @@ fn test_git_colocated_concurrent_checkout() -> TestResult {
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Warning: Failed to update Git HEAD ref
-    Caused by: The reference "HEAD" should have content dc0b92dfa0af129b2929fa1789fc896b075782b2, actual content was 091e39feb0aba632ab9a9503ceb1dddeac4dd496
-    Working copy  (@) now at: mzvwutvl cf0ddbb4 (empty) (no description set)
-    Parent commit (@-)      : zsuskuln b6786455 (empty) commit3
+    Caused by: The reference "HEAD" should have content 646030fc00319f9b3a778b8c8d60c8ff02413713, actual content was 211c1ba69e5581709c911f9810112b8e5b0ee497
+    Working copy  (@) now at: mzvwutvl c41c6649 (empty) (no description set)
+    Parent commit (@-)      : psuskuln e6d5793c (empty) commit3
     [EOF]
     "#);
 
     // git_head() isn't updated because the export failed
     insta::assert_snapshot!(work_dir.run_jj(["log", "--summary", "--ignore-working-copy"]), @"
-    @  mzvwutvl test.user@example.com 2001-02-03 08:05:11 cf0ddbb4
+    @  mzvwutvl test.user@example.com 2001-02-03 08:05:11 c41c6649
     │  (empty) (no description set)
-    ○  zsuskuln test.user@example.com 2001-02-03 08:05:11 b6786455
+    ○  psuskuln test.user@example.com 2001-02-03 08:05:11 e6d5793c
     │  (empty) commit3
-    ○  kkmpptxz test.user@example.com 2001-02-03 08:05:10 dc0b92df
+    ○  nkmpptxz test.user@example.com 2001-02-03 08:05:10 646030fc
     │  commit2
     │  A file2
-    ○  rlvkpnrz test.user@example.com 2001-02-03 08:05:09 091e39fe
+    ○  ylvkpnrz test.user@example.com 2001-02-03 08:05:09 211c1ba6
     │  commit1
     │  A file1
     ○  qpvuntsm test.user@example.com 2001-02-03 08:05:07 e8849ae1
@@ -965,14 +965,14 @@ fn test_git_colocated_concurrent_checkout() -> TestResult {
 
     // The current Git HEAD is imported on the next jj invocation
     insta::assert_snapshot!(work_dir.run_jj(["log", "--summary"]), @"
-    @  yqosqzyt test.user@example.com 2001-02-03 08:05:13 9529e8f5
+    @  yqosqzyt test.user@example.com 2001-02-03 08:05:13 105eea93
     │  (empty) (no description set)
-    │ ○  zsuskuln test.user@example.com 2001-02-03 08:05:11 b6786455
+    │ ○  psuskuln test.user@example.com 2001-02-03 08:05:11 e6d5793c
     │ │  (empty) commit3
-    │ ○  kkmpptxz test.user@example.com 2001-02-03 08:05:10 dc0b92df
+    │ ○  nkmpptxz test.user@example.com 2001-02-03 08:05:10 646030fc
     ├─╯  commit2
     │    A file2
-    ○  rlvkpnrz test.user@example.com 2001-02-03 08:05:09 091e39fe
+    ○  ylvkpnrz test.user@example.com 2001-02-03 08:05:09 211c1ba6
     │  commit1
     │  A file1
     ○  qpvuntsm test.user@example.com 2001-02-03 08:05:07 e8849ae1
@@ -1035,7 +1035,7 @@ fn test_git_colocated_undo_head_move() -> TestResult {
         git_repo.head_id()?.to_string(),
         @"e8849ae12c709f2321908879bc724fdb2ab8a781");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  43444d88b0096888ebfd664c0cf792c9d15e3f14
+    @  e521ae80c3d70ec4b6dab193c8915c8de7cb7311
     ○  e8849ae12c709f2321908879bc724fdb2ab8a781
     ◆  0000000000000000000000000000000000000000
     [EOF]
@@ -1064,29 +1064,29 @@ fn test_git_colocated_undo_head_move() -> TestResult {
     work_dir.run_jj(["new"]).success();
     work_dir.run_jj(["new"]).success();
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  5e37f1b8313299eb1b62221eefcf32881b0dc4c6
-    ○  23e6e06a7471634da3567ef975fadf883082658f
+    @  3f0378f662f827e0e4f4ee78c505dda5ffca22a2
+    ○  fa8ebb809983154839420ad3fc22b504f3b7972e
     ○  e8849ae12c709f2321908879bc724fdb2ab8a781
     ◆  0000000000000000000000000000000000000000
     [EOF]
     ");
     insta::assert_snapshot!(get_colocation_status(&work_dir), @"
     Workspace is currently colocated with Git.
-    Last imported/exported Git HEAD: 23e6e06a7471634da3567ef975fadf883082658f
+    Last imported/exported Git HEAD: fa8ebb809983154839420ad3fc22b504f3b7972e
     [EOF]
     ");
     assert!(git_repo.head()?.is_detached());
     insta::assert_snapshot!(
         git_repo.head_id()?.to_string(),
-        @"23e6e06a7471634da3567ef975fadf883082658f");
+        @"fa8ebb809983154839420ad3fc22b504f3b7972e");
 
     // HEAD should be moved back
     let output = work_dir.run_jj(["undo"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Undid operation: 370aaac5a54d (2001-02-03 08:05:15) new empty commit
-    Restored to operation: f4eb73ce02a5 (2001-02-03 08:05:14) new empty commit
-    Working copy  (@) now at: vruxwmqv 23e6e06a (empty) (no description set)
+    Undid operation: 02eb4e1d35d7 (2001-02-03 08:05:15) new empty commit
+    Restored to operation: e93edf58e767 (2001-02-03 08:05:14) new empty commit
+    Working copy  (@) now at: truxwmqv fa8ebb80 (empty) (no description set)
     Parent commit (@-)      : qpvuntsm e8849ae1 (empty) (no description set)
     [EOF]
     ");
@@ -1095,7 +1095,7 @@ fn test_git_colocated_undo_head_move() -> TestResult {
         git_repo.head_id()?.to_string(),
         @"e8849ae12c709f2321908879bc724fdb2ab8a781");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  23e6e06a7471634da3567ef975fadf883082658f
+    @  fa8ebb809983154839420ad3fc22b504f3b7972e
     ○  e8849ae12c709f2321908879bc724fdb2ab8a781
     ◆  0000000000000000000000000000000000000000
     [EOF]
@@ -1136,8 +1136,8 @@ fn test_git_colocated_update_index_preserves_timestamps() -> TestResult {
     work_dir.run_jj(["new"]).success();
 
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  a1886a45815f0dcca5cefcc334d11ffb908a1eb8
-    ○  8b0c962ef1fea901fb16f8a484e692a1f0dcbc59 commit2
+    @  cef9c4d8a5a7fbab004b7abe4b4f8f215d38bb3e
+    ○  b4dd73903ef9ac426dd35a019692c0eb7d2eedef commit2
     ○  d37eac5eea00fa74a41c1512839711f42aca2c35 commit1
     ◆  0000000000000000000000000000000000000000
     [EOF]
@@ -1165,7 +1165,7 @@ fn test_git_colocated_update_index_preserves_timestamps() -> TestResult {
     work_dir.run_jj(["edit", "commit2"]).success();
 
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  8b0c962ef1fea901fb16f8a484e692a1f0dcbc59 commit2
+    @  b4dd73903ef9ac426dd35a019692c0eb7d2eedef commit2
     ○  d37eac5eea00fa74a41c1512839711f42aca2c35 commit1
     ◆  0000000000000000000000000000000000000000
     [EOF]
@@ -1183,8 +1183,8 @@ fn test_git_colocated_update_index_preserves_timestamps() -> TestResult {
     work_dir.run_jj(["new", "commit1"]).success();
 
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  d9c7f1932e1135856d5905f1a0fc194ce2657065
-    │ ○  8b0c962ef1fea901fb16f8a484e692a1f0dcbc59 commit2
+    @  2690256ebae7884d564a55640f07fbe889289f9a
+    │ ○  b4dd73903ef9ac426dd35a019692c0eb7d2eedef commit2
     ├─╯
     ○  d37eac5eea00fa74a41c1512839711f42aca2c35 commit1
     ◆  0000000000000000000000000000000000000000
@@ -1249,10 +1249,10 @@ fn test_git_colocated_update_index_merge_conflict() -> TestResult {
     work_dir.run_jj(["new", "left", "right"]).success();
 
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @    3b7a70e06827787d9b89cb2943eb56c1fc01b199
+    @    27ab0d254a9693167a9940cc5424231dae69c96e
     ├─╮
-    │ ○  620e15db9fcd05fff912c52d2cafd36c9e01523c right
-    ○ │  d0f55ffafa1e0e72980202c349af23d093f825be left
+    │ ○  35530dae260329267e22c23a97897dd43005bd7c right
+    ○ │  1f13710f6a46af7b2949b90e52654dd96f559704 left
     ├─╯
     ○  1861378a9167e6561bf8ce4a6fef2d7c0897dd87 base
     ◆  0000000000000000000000000000000000000000
@@ -1273,11 +1273,11 @@ fn test_git_colocated_update_index_merge_conflict() -> TestResult {
     work_dir.run_jj(["new"]).success();
 
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  0e393df829aba628f38c7cea10ed084c01c4f8dc
-    ×    3b7a70e06827787d9b89cb2943eb56c1fc01b199
+    @  7457e29b8deab4fcaafd35ad138a96dad9375518
+    ×    27ab0d254a9693167a9940cc5424231dae69c96e
     ├─╮
-    │ ○  620e15db9fcd05fff912c52d2cafd36c9e01523c right
-    ○ │  d0f55ffafa1e0e72980202c349af23d093f825be left
+    │ ○  35530dae260329267e22c23a97897dd43005bd7c right
+    ○ │  1f13710f6a46af7b2949b90e52654dd96f559704 left
     ├─╯
     ○  1861378a9167e6561bf8ce4a6fef2d7c0897dd87 base
     ◆  0000000000000000000000000000000000000000
@@ -1329,8 +1329,8 @@ fn test_git_colocated_update_index_rebase_conflict() -> TestResult {
     work_dir.run_jj(["edit", "left"]).success();
 
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  d0f55ffafa1e0e72980202c349af23d093f825be left
-    │ ○  620e15db9fcd05fff912c52d2cafd36c9e01523c right
+    @  1f13710f6a46af7b2949b90e52654dd96f559704 left
+    │ ○  35530dae260329267e22c23a97897dd43005bd7c right
     ├─╯
     ○  1861378a9167e6561bf8ce4a6fef2d7c0897dd87 base
     ◆  0000000000000000000000000000000000000000
@@ -1358,8 +1358,8 @@ fn test_git_colocated_update_index_rebase_conflict() -> TestResult {
         .success();
 
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  4f7465da96352c91b5ef51c7b6339cfac762ddd4 left
-    ○  620e15db9fcd05fff912c52d2cafd36c9e01523c right
+    @  b0e2e0c4fdc8111581d218509bf0e9d64550e7fb left
+    ○  35530dae260329267e22c23a97897dd43005bd7c right
     ○  1861378a9167e6561bf8ce4a6fef2d7c0897dd87 base
     ◆  0000000000000000000000000000000000000000
     [EOF]
@@ -1377,9 +1377,9 @@ fn test_git_colocated_update_index_rebase_conflict() -> TestResult {
     work_dir.run_jj(["new"]).success();
 
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  e4522a78bd213fdb32fdc85b3ba270efeaba058b
-    ×  4f7465da96352c91b5ef51c7b6339cfac762ddd4 left
-    ○  620e15db9fcd05fff912c52d2cafd36c9e01523c right
+    @  fd0ec12b8148f2851efaf23d2ca7b471eeaab4f7
+    ×  b0e2e0c4fdc8111581d218509bf0e9d64550e7fb left
+    ○  35530dae260329267e22c23a97897dd43005bd7c right
     ○  1861378a9167e6561bf8ce4a6fef2d7c0897dd87 base
     ◆  0000000000000000000000000000000000000000
     [EOF]
@@ -1456,12 +1456,12 @@ fn test_git_colocated_update_index_3_sided_conflict() -> TestResult {
         .success();
 
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @      2d396332267d4158d0554a636343498ad74b1555
+    @      be1155a2aee8f49a6132d0cb5d4dcb8e71281420
     ├─┬─╮
-    │ │ ○  5008c8807feaa955d02e96cb1b0dcf51536fefb8 side-3
-    │ ○ │  da6e0a03f8b72f6868a9ea33836123fe965c0cb4 side-2
+    │ │ ○  8e557c4fa56ee8713b44769e7a20b413d922931e side-3
+    │ ○ │  13a224f2ddfb75582340c5a0d58c195d4314b798 side-2
     │ ├─╯
-    ○ │  ad7eaf61b769dce99884d2ceb0ddf48fc4eac463 side-1
+    ○ │  5b2fc6e007973fa56221fed78fa33aab06b4f386 side-1
     ├─╯
     ○  1861378a9167e6561bf8ce4a6fef2d7c0897dd87 base
     ◆  0000000000000000000000000000000000000000
@@ -1482,13 +1482,13 @@ fn test_git_colocated_update_index_3_sided_conflict() -> TestResult {
     work_dir.run_jj(["new"]).success();
 
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  05c0d46f4f8e6fee4b1ee268242bc11a71745739
-    ×      2d396332267d4158d0554a636343498ad74b1555
+    @  78e326a70f68a8909dc18978620796005ec9bf31
+    ×      be1155a2aee8f49a6132d0cb5d4dcb8e71281420
     ├─┬─╮
-    │ │ ○  5008c8807feaa955d02e96cb1b0dcf51536fefb8 side-3
-    │ ○ │  da6e0a03f8b72f6868a9ea33836123fe965c0cb4 side-2
+    │ │ ○  8e557c4fa56ee8713b44769e7a20b413d922931e side-3
+    │ ○ │  13a224f2ddfb75582340c5a0d58c195d4314b798 side-2
     │ ├─╯
-    ○ │  ad7eaf61b769dce99884d2ceb0ddf48fc4eac463 side-1
+    ○ │  5b2fc6e007973fa56221fed78fa33aab06b4f386 side-1
     ├─╯
     ○  1861378a9167e6561bf8ce4a6fef2d7c0897dd87 base
     ◆  0000000000000000000000000000000000000000
@@ -1693,9 +1693,9 @@ fn test_git_colocated_operation_cleanup() -> TestResult {
     work_dir.run_jj(["new"]).success();
 
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  40638ce20b8b74e94460e95709cb077f4307ad7c
-    ○  a50e55141dcd5f8f8d549acd2232ce4839eaa798 feature 3
-    │ ○  cf3bb116ded416d9b202e71303f260e504c2eeb9 main 2
+    @  91b09a48325e050be83835a3c817485385d60538
+    ○  b774c9f6118536f3855a2970b465dd2d34377cdd feature 3
+    │ ○  60476fc631a3c4602eb8b9a64b6b3d0951ed2837 main 2
     ├─╯
     ○  87f64775047d7ce62b7ee81412b8e4cc07aea40a 1
     ◆  0000000000000000000000000000000000000000
@@ -1720,9 +1720,9 @@ fn test_git_colocated_operation_cleanup() -> TestResult {
     assert!(output.status.success());
     insta::assert_snapshot!(String::from_utf8(output.stdout)?, @"UU file");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  588c505e689d116180684778b29c540fe7180268
-    ○  cf3bb116ded416d9b202e71303f260e504c2eeb9 main 2
-    │ ○  a50e55141dcd5f8f8d549acd2232ce4839eaa798 feature 3
+    @  9b52e6dfe5200f47ca82cf6cf522f0186005c4eb
+    ○  60476fc631a3c4602eb8b9a64b6b3d0951ed2837 main 2
+    │ ○  b774c9f6118536f3855a2970b465dd2d34377cdd feature 3
     ├─╯
     ○  87f64775047d7ce62b7ee81412b8e4cc07aea40a 1
     ◆  0000000000000000000000000000000000000000
@@ -1736,17 +1736,17 @@ fn test_git_colocated_operation_cleanup() -> TestResult {
     let output = work_dir.run_jj(["new", "main"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: kmkuslsw aa14563c (empty) (no description set)
-    Parent commit (@-)      : kkmpptxz cf3bb116 main | 2
+    Working copy  (@) now at: xmkuslsw b25e19a9 (empty) (no description set)
+    Parent commit (@-)      : nkmpptxz 60476fc6 main | 2
     Added 0 files, modified 1 files, removed 0 files
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  aa14563cf5d892238f1e60260c5c284627d76e7c
-    │ ○  588c505e689d116180684778b29c540fe7180268
+    @  b25e19a9f57508b66d1c0137e3d0a08ae4eb4031
+    │ ○  9b52e6dfe5200f47ca82cf6cf522f0186005c4eb
     ├─╯
-    ○  cf3bb116ded416d9b202e71303f260e504c2eeb9 main 2
-    │ ○  a50e55141dcd5f8f8d549acd2232ce4839eaa798 feature 3
+    ○  60476fc631a3c4602eb8b9a64b6b3d0951ed2837 main 2
+    │ ○  b774c9f6118536f3855a2970b465dd2d34377cdd feature 3
     ├─╯
     ○  87f64775047d7ce62b7ee81412b8e4cc07aea40a 1
     ◆  0000000000000000000000000000000000000000
@@ -1754,7 +1754,7 @@ fn test_git_colocated_operation_cleanup() -> TestResult {
     ");
     insta::assert_snapshot!(get_colocation_status(&work_dir), @"
     Workspace is currently colocated with Git.
-    Last imported/exported Git HEAD: cf3bb116ded416d9b202e71303f260e504c2eeb9
+    Last imported/exported Git HEAD: 60476fc631a3c4602eb8b9a64b6b3d0951ed2837
     [EOF]
     ");
 

--- a/cli/tests/test_git_fetch.rs
+++ b/cli/tests/test_git_fetch.rs
@@ -725,7 +725,7 @@ fn test_git_fetch_conflicting_bookmarks() {
         .run_jj(["bookmark", "create", "-r@", "rem1"])
         .success();
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @"
-    rem1: kkmpptxz 2b17ac71 (empty) (no description set)
+    rem1: nkmpptxz ae68e36f (empty) (no description set)
       @rem1 (not created yet)
     [EOF]
     ");
@@ -736,7 +736,7 @@ fn test_git_fetch_conflicting_bookmarks() {
     // This should result in a CONFLICTED bookmark
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @"
     rem1 (conflicted):
-      + kkmpptxz 2b17ac71 (empty) (no description set)
+      + nkmpptxz ae68e36f (empty) (no description set)
       + ppspxspk 4acd0343 message
       @rem1 (behind by 1 commits): ppspxspk 4acd0343 message
     [EOF]
@@ -762,8 +762,8 @@ fn test_git_fetch_conflicting_bookmarks_colocated() {
         .run_jj(["bookmark", "create", "-r@", "rem1"])
         .success();
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @"
-    rem1: zsuskuln c2934cfb (empty) (no description set)
-      @git: zsuskuln c2934cfb (empty) (no description set)
+    rem1: psuskuln 78fad9fc (empty) (no description set)
+      @git: psuskuln 78fad9fc (empty) (no description set)
       @rem1 (not created yet)
     [EOF]
     ");
@@ -775,9 +775,9 @@ fn test_git_fetch_conflicting_bookmarks_colocated() {
     // See https://github.com/jj-vcs/jj/pull/1146#discussion_r1112372340 for the bug this tests for.
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @"
     rem1 (conflicted):
-      + zsuskuln c2934cfb (empty) (no description set)
+      + psuskuln 78fad9fc (empty) (no description set)
       + ppspxspk 4acd0343 message
-      @git (behind by 1 commits): zsuskuln c2934cfb (empty) (no description set)
+      @git (behind by 1 commits): psuskuln 78fad9fc (empty) (no description set)
       @rem1 (behind by 1 commits): ppspxspk 4acd0343 message
     [EOF]
     ");
@@ -919,12 +919,12 @@ fn test_git_fetch_all() {
     let source_log = create_colocated_repo_and_bookmarks_from_trunk1(&source_dir);
     insta::assert_snapshot!(source_log, @r#"
        ===== Source git repo contents =====
-    @  bc83465a3090 "b" b
-    │ ○  d4d535f1d579 "a2" a2
+    @  4ed9450fe936 "b" b
+    │ ○  0c30cbbbd5c0 "a2" a2
     ├─╯
-    │ ○  c8303692b8e2 "a1" a1
+    │ ○  72ab9ad275fb "a1" a1
     ├─╯
-    ○  382881770501 "trunk1" trunk1
+    ○  7fe1c25a9714 "trunk1" trunk1
     ◆  000000000000 ""
     [EOF]
     "#);
@@ -946,24 +946,24 @@ fn test_git_fetch_all() {
     [EOF]
     ");
     insta::assert_snapshot!(get_bookmark_output(&target_dir), @"
-    a1: mzvwutvl c8303692 a1
-      @origin: mzvwutvl c8303692 a1
-    a2: yqosqzyt d4d535f1 a2
-      @origin: yqosqzyt d4d535f1 a2
-    b: yostqsxw bc83465a b
-      @origin: yostqsxw bc83465a b
-    trunk1: kkmpptxz 38288177 trunk1
-      @origin: kkmpptxz 38288177 trunk1
+    a1: qzvwutvl 72ab9ad2 a1
+      @origin: qzvwutvl 72ab9ad2 a1
+    a2: oqosqzyt 0c30cbbb a2
+      @origin: oqosqzyt 0c30cbbb a2
+    b: sostqsxw 4ed9450f b
+      @origin: sostqsxw 4ed9450f b
+    trunk1: nkmpptxz 7fe1c25a trunk1
+      @origin: nkmpptxz 7fe1c25a trunk1
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&target_dir), @r#"
     @  e8849ae12c70 ""
-    │ ○  bc83465a3090 "b" b
-    │ │ ○  d4d535f1d579 "a2" a2
+    │ ○  4ed9450fe936 "b" b
+    │ │ ○  0c30cbbbd5c0 "a2" a2
     │ ├─╯
-    │ │ ○  c8303692b8e2 "a1" a1
+    │ │ ○  72ab9ad275fb "a1" a1
     │ ├─╯
-    │ ○  382881770501 "trunk1" trunk1
+    │ ○  7fe1c25a9714 "trunk1" trunk1
     ├─╯
     ◆  000000000000 ""
     [EOF]
@@ -974,13 +974,13 @@ fn test_git_fetch_all() {
     let source_log = create_trunk2_and_rebase_bookmarks(&source_dir);
     insta::assert_snapshot!(source_log, @r#"
        ===== Source git repo contents =====
-    ○  6fc6fe17dbee "b" b
-    │ ○  baad96fead6c "a2" a2
+    ○  ee10b1522303 "b" b
+    │ ○  1d78aa48e073 "a2" a2
     ├─╯
-    │ ○  798c5e2435e1 "a1" a1
+    │ ○  26d7f7cef75a "a1" a1
     ├─╯
-    @  e80d998ab04b "trunk2" trunk2
-    ○  382881770501 "trunk1" trunk1
+    @  7405313c740d "trunk2" trunk2
+    ○  7fe1c25a9714 "trunk1" trunk1
     ◆  000000000000 ""
     [EOF]
     "#);
@@ -992,25 +992,25 @@ fn test_git_fetch_all() {
     // Our repo before and after fetch
     insta::assert_snapshot!(get_log_output(&target_dir), @r#"
     @  e8849ae12c70 ""
-    │ ○  0fbbc495357c "new_descr_for_b_to_create_conflict" b*
-    │ │ ○  d4d535f1d579 "a2" a2
+    │ ○  5387be87c57f "new_descr_for_b_to_create_conflict" b*
+    │ │ ○  0c30cbbbd5c0 "a2" a2
     │ ├─╯
-    │ │ ○  c8303692b8e2 "a1" a1
+    │ │ ○  72ab9ad275fb "a1" a1
     │ ├─╯
-    │ ○  382881770501 "trunk1" trunk1
+    │ ○  7fe1c25a9714 "trunk1" trunk1
     ├─╯
     ◆  000000000000 ""
     [EOF]
     "#);
     insta::assert_snapshot!(get_bookmark_output(&target_dir), @"
-    a1: mzvwutvl c8303692 a1
-      @origin: mzvwutvl c8303692 a1
-    a2: yqosqzyt d4d535f1 a2
-      @origin: yqosqzyt d4d535f1 a2
-    b: yostqsxw 0fbbc495 new_descr_for_b_to_create_conflict
-      @origin (ahead by 1 commits, behind by 1 commits): yostqsxw/1 bc83465a (hidden) b
-    trunk1: kkmpptxz 38288177 trunk1
-      @origin: kkmpptxz 38288177 trunk1
+    a1: qzvwutvl 72ab9ad2 a1
+      @origin: qzvwutvl 72ab9ad2 a1
+    a2: oqosqzyt 0c30cbbb a2
+      @origin: oqosqzyt 0c30cbbb a2
+    b: sostqsxw 5387be87 new_descr_for_b_to_create_conflict
+      @origin (ahead by 1 commits, behind by 1 commits): sostqsxw/1 4ed9450f (hidden) b
+    trunk1: nkmpptxz 7fe1c25a trunk1
+      @origin: nkmpptxz 7fe1c25a trunk1
     [EOF]
     ");
     let output = target_dir.run_jj(["git", "fetch"]);
@@ -1024,32 +1024,32 @@ fn test_git_fetch_all() {
     [EOF]
     ");
     insta::assert_snapshot!(get_bookmark_output(&target_dir), @"
-    a1: mzvwutvl 798c5e24 a1
-      @origin: mzvwutvl 798c5e24 a1
-    a2: yqosqzyt baad96fe a2
-      @origin: yqosqzyt baad96fe a2
+    a1: qzvwutvl 26d7f7ce a1
+      @origin: qzvwutvl 26d7f7ce a1
+    a2: oqosqzyt 1d78aa48 a2
+      @origin: oqosqzyt 1d78aa48 a2
     b (conflicted):
-      - yostqsxw/2 bc83465a (hidden) b
-      + yostqsxw/1 0fbbc495 (divergent) new_descr_for_b_to_create_conflict
-      + yostqsxw/0 6fc6fe17 (divergent) b
-      @origin (behind by 1 commits): yostqsxw/0 6fc6fe17 (divergent) b
-    trunk1: kkmpptxz 38288177 trunk1
-      @origin: kkmpptxz 38288177 trunk1
-    trunk2: uyznsvlq e80d998a trunk2
-      @origin: uyznsvlq e80d998a trunk2
+      - sostqsxw/2 4ed9450f (hidden) b
+      + sostqsxw/1 5387be87 (divergent) new_descr_for_b_to_create_conflict
+      + sostqsxw/0 ee10b152 (divergent) b
+      @origin (behind by 1 commits): sostqsxw/0 ee10b152 (divergent) b
+    trunk1: nkmpptxz 7fe1c25a trunk1
+      @origin: nkmpptxz 7fe1c25a trunk1
+    trunk2: wyznsvlq 7405313c trunk2
+      @origin: wyznsvlq 7405313c trunk2
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&target_dir), @r#"
     @  e8849ae12c70 ""
-    │ ○  6fc6fe17dbee "b" b?? b@origin
-    │ │ ○  baad96fead6c "a2" a2
+    │ ○  ee10b1522303 "b" b?? b@origin
+    │ │ ○  1d78aa48e073 "a2" a2
     │ ├─╯
-    │ │ ○  798c5e2435e1 "a1" a1
+    │ │ ○  26d7f7cef75a "a1" a1
     │ ├─╯
-    │ ○  e80d998ab04b "trunk2" trunk2
-    │ │ ○  0fbbc495357c "new_descr_for_b_to_create_conflict" b??
+    │ ○  7405313c740d "trunk2" trunk2
+    │ │ ○  5387be87c57f "new_descr_for_b_to_create_conflict" b??
     │ ├─╯
-    │ ○  382881770501 "trunk1" trunk1
+    │ ○  7fe1c25a9714 "trunk1" trunk1
     ├─╯
     ◆  000000000000 ""
     [EOF]
@@ -1077,12 +1077,12 @@ fn test_git_fetch_some_of_many_bookmarks() {
     let source_log = create_colocated_repo_and_bookmarks_from_trunk1(&source_dir);
     insta::assert_snapshot!(source_log, @r#"
        ===== Source git repo contents =====
-    @  bc83465a3090 "b" b
-    │ ○  d4d535f1d579 "a2" a2
+    @  4ed9450fe936 "b" b
+    │ ○  0c30cbbbd5c0 "a2" a2
     ├─╯
-    │ ○  c8303692b8e2 "a1" a1
+    │ ○  72ab9ad275fb "a1" a1
     ├─╯
-    ○  382881770501 "trunk1" trunk1
+    ○  7fe1c25a9714 "trunk1" trunk1
     ◆  000000000000 ""
     [EOF]
     "#);
@@ -1118,16 +1118,16 @@ fn test_git_fetch_some_of_many_bookmarks() {
     ");
     insta::assert_snapshot!(get_log_output(&target_dir), @r#"
     @  e8849ae12c70 ""
-    │ ○  bc83465a3090 "b" b
-    │ ○  382881770501 "trunk1"
+    │ ○  4ed9450fe936 "b" b
+    │ ○  7fe1c25a9714 "trunk1"
     ├─╯
     ◆  000000000000 ""
     [EOF]
     "#);
     // ...check what the intermediate state looks like...
     insta::assert_snapshot!(get_bookmark_output(&target_dir), @"
-    b: yostqsxw bc83465a b
-      @origin: yostqsxw bc83465a b
+    b: sostqsxw 4ed9450f b
+      @origin: sostqsxw 4ed9450f b
     [EOF]
     ");
     // ...then fetch two others with a glob.
@@ -1140,12 +1140,12 @@ fn test_git_fetch_some_of_many_bookmarks() {
     ");
     insta::assert_snapshot!(get_log_output(&target_dir), @r#"
     @  e8849ae12c70 ""
-    │ ○  d4d535f1d579 "a2" a2
-    │ │ ○  c8303692b8e2 "a1" a1
+    │ ○  0c30cbbbd5c0 "a2" a2
+    │ │ ○  72ab9ad275fb "a1" a1
     │ ├─╯
-    │ │ ○  bc83465a3090 "b" b
+    │ │ ○  4ed9450fe936 "b" b
     │ ├─╯
-    │ ○  382881770501 "trunk1"
+    │ ○  7fe1c25a9714 "trunk1"
     ├─╯
     ◆  000000000000 ""
     [EOF]
@@ -1159,12 +1159,12 @@ fn test_git_fetch_some_of_many_bookmarks() {
     ");
     insta::assert_snapshot!(get_log_output(&target_dir), @r#"
     @  e8849ae12c70 ""
-    │ ○  d4d535f1d579 "a2" a2
-    │ │ ○  c8303692b8e2 "a1" a1
+    │ ○  0c30cbbbd5c0 "a2" a2
+    │ │ ○  72ab9ad275fb "a1" a1
     │ ├─╯
-    │ │ ○  bc83465a3090 "b" b
+    │ │ ○  4ed9450fe936 "b" b
     │ ├─╯
-    │ ○  382881770501 "trunk1"
+    │ ○  7fe1c25a9714 "trunk1"
     ├─╯
     ◆  000000000000 ""
     [EOF]
@@ -1175,13 +1175,13 @@ fn test_git_fetch_some_of_many_bookmarks() {
     let source_log = create_trunk2_and_rebase_bookmarks(&source_dir);
     insta::assert_snapshot!(source_log, @r#"
        ===== Source git repo contents =====
-    ○  2b30dbc93959 "b" b
-    │ ○  841140b152fc "a2" a2
+    ○  ca0f169df838 "b" b
+    │ ○  c09fd70f366c "a2" a2
     ├─╯
-    │ ○  bc7e74c21d43 "a1" a1
+    │ ○  f651f6d40b51 "a1" a1
     ├─╯
-    @  756be1d31c41 "trunk2" trunk2
-    ○  382881770501 "trunk1" trunk1
+    @  bedc6362fa60 "trunk2" trunk2
+    ○  7fe1c25a9714 "trunk1" trunk1
     ◆  000000000000 ""
     [EOF]
     "#);
@@ -1193,12 +1193,12 @@ fn test_git_fetch_some_of_many_bookmarks() {
     // Our repo before and after fetch of two bookmarks
     insta::assert_snapshot!(get_log_output(&target_dir), @r#"
     @  e8849ae12c70 ""
-    │ ○  c62db3119722 "new_descr_for_b_to_create_conflict" b*
-    │ │ ○  d4d535f1d579 "a2" a2
+    │ ○  dfb5c595294f "new_descr_for_b_to_create_conflict" b*
+    │ │ ○  0c30cbbbd5c0 "a2" a2
     │ ├─╯
-    │ │ ○  c8303692b8e2 "a1" a1
+    │ │ ○  72ab9ad275fb "a1" a1
     │ ├─╯
-    │ ○  382881770501 "trunk1"
+    │ ○  7fe1c25a9714 "trunk1"
     ├─╯
     ◆  000000000000 ""
     [EOF]
@@ -1213,15 +1213,15 @@ fn test_git_fetch_some_of_many_bookmarks() {
     ");
     insta::assert_snapshot!(get_log_output(&target_dir), @r#"
     @  e8849ae12c70 ""
-    │ ○  2b30dbc93959 "b" b?? b@origin
-    │ │ ○  bc7e74c21d43 "a1" a1
+    │ ○  ca0f169df838 "b" b?? b@origin
+    │ │ ○  f651f6d40b51 "a1" a1
     │ ├─╯
-    │ ○  756be1d31c41 "trunk2"
-    │ │ ○  c62db3119722 "new_descr_for_b_to_create_conflict" b??
+    │ ○  bedc6362fa60 "trunk2"
+    │ │ ○  dfb5c595294f "new_descr_for_b_to_create_conflict" b??
     │ ├─╯
-    │ │ ○  d4d535f1d579 "a2" a2
+    │ │ ○  0c30cbbbd5c0 "a2" a2
     │ ├─╯
-    │ ○  382881770501 "trunk1"
+    │ ○  7fe1c25a9714 "trunk1"
     ├─╯
     ◆  000000000000 ""
     [EOF]
@@ -1229,15 +1229,15 @@ fn test_git_fetch_some_of_many_bookmarks() {
 
     // We left a2 where it was before, let's see how `jj bookmark list` sees this.
     insta::assert_snapshot!(get_bookmark_output(&target_dir), @"
-    a1: mzvwutvl bc7e74c2 a1
-      @origin: mzvwutvl bc7e74c2 a1
-    a2: yqosqzyt d4d535f1 a2
-      @origin: yqosqzyt d4d535f1 a2
+    a1: qzvwutvl f651f6d4 a1
+      @origin: qzvwutvl f651f6d4 a1
+    a2: oqosqzyt 0c30cbbb a2
+      @origin: oqosqzyt 0c30cbbb a2
     b (conflicted):
-      - yostqsxw/2 bc83465a (hidden) b
-      + yostqsxw/1 c62db311 (divergent) new_descr_for_b_to_create_conflict
-      + yostqsxw/0 2b30dbc9 (divergent) b
-      @origin (behind by 1 commits): yostqsxw/0 2b30dbc9 (divergent) b
+      - sostqsxw/2 4ed9450f (hidden) b
+      + sostqsxw/1 dfb5c595 (divergent) new_descr_for_b_to_create_conflict
+      + sostqsxw/0 ca0f169d (divergent) b
+      @origin (behind by 1 commits): sostqsxw/0 ca0f169d (divergent) b
     [EOF]
     ");
     // Now, let's fetch a2 and double-check that fetching a1 and b again doesn't do
@@ -1251,29 +1251,29 @@ fn test_git_fetch_some_of_many_bookmarks() {
     ");
     insta::assert_snapshot!(get_log_output(&target_dir), @r#"
     @  e8849ae12c70 ""
-    │ ○  841140b152fc "a2" a2
-    │ │ ○  2b30dbc93959 "b" b?? b@origin
+    │ ○  c09fd70f366c "a2" a2
+    │ │ ○  ca0f169df838 "b" b?? b@origin
     │ ├─╯
-    │ │ ○  bc7e74c21d43 "a1" a1
+    │ │ ○  f651f6d40b51 "a1" a1
     │ ├─╯
-    │ ○  756be1d31c41 "trunk2"
-    │ │ ○  c62db3119722 "new_descr_for_b_to_create_conflict" b??
+    │ ○  bedc6362fa60 "trunk2"
+    │ │ ○  dfb5c595294f "new_descr_for_b_to_create_conflict" b??
     │ ├─╯
-    │ ○  382881770501 "trunk1"
+    │ ○  7fe1c25a9714 "trunk1"
     ├─╯
     ◆  000000000000 ""
     [EOF]
     "#);
     insta::assert_snapshot!(get_bookmark_output(&target_dir), @"
-    a1: mzvwutvl bc7e74c2 a1
-      @origin: mzvwutvl bc7e74c2 a1
-    a2: yqosqzyt 841140b1 a2
-      @origin: yqosqzyt 841140b1 a2
+    a1: qzvwutvl f651f6d4 a1
+      @origin: qzvwutvl f651f6d4 a1
+    a2: oqosqzyt c09fd70f a2
+      @origin: oqosqzyt c09fd70f a2
     b (conflicted):
-      - yostqsxw/2 bc83465a (hidden) b
-      + yostqsxw/1 c62db311 (divergent) new_descr_for_b_to_create_conflict
-      + yostqsxw/0 2b30dbc9 (divergent) b
-      @origin (behind by 1 commits): yostqsxw/0 2b30dbc9 (divergent) b
+      - sostqsxw/2 4ed9450f (hidden) b
+      + sostqsxw/1 dfb5c595 (divergent) new_descr_for_b_to_create_conflict
+      + sostqsxw/0 ca0f169d (divergent) b
+      @origin (behind by 1 commits): sostqsxw/0 ca0f169d (divergent) b
     [EOF]
     ");
 }
@@ -1452,12 +1452,12 @@ fn test_git_fetch_undo() {
         .run_jj(["tag", "set", "-rtrunk1", "tag1"])
         .success();
     insta::assert_snapshot!(get_log_output(&source_dir), @r#"
-    @  bc83465a3090 "b" b
-    │ ○  d4d535f1d579 "a2" a2
+    @  4ed9450fe936 "b" b
+    │ ○  0c30cbbbd5c0 "a2" a2
     ├─╯
-    │ ○  c8303692b8e2 "a1" a1
+    │ ○  72ab9ad275fb "a1" a1
     ├─╯
-    ◆  382881770501 "trunk1" trunk1 tag1
+    ◆  7fe1c25a9714 "trunk1" trunk1 tag1
     ◆  000000000000 ""
     [EOF]
     "#);
@@ -1473,10 +1473,10 @@ fn test_git_fetch_undo() {
     ");
     insta::assert_snapshot!(get_log_output(&target_dir), @r#"
     @  e8849ae12c70 ""
-    │ ○  bc83465a3090 "b" b
-    │ │ ○  c8303692b8e2 "a1" a1
+    │ ○  4ed9450fe936 "b" b
+    │ │ ○  72ab9ad275fb "a1" a1
     │ ├─╯
-    │ ◆  382881770501 "trunk1" tag1
+    │ ◆  7fe1c25a9714 "trunk1" tag1
     ├─╯
     ◆  000000000000 ""
     [EOF]
@@ -1484,7 +1484,7 @@ fn test_git_fetch_undo() {
     let output = target_dir.run_jj(["undo"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Undid operation: 353367639195 (2001-02-03 08:05:20) fetch from git remote(s) origin
+    Undid operation: 5439e275337f (2001-02-03 08:05:20) fetch from git remote(s) origin
     Restored to operation: abd709a7b737 (2001-02-03 08:05:07) add git remote origin
     [EOF]
     ");
@@ -1504,8 +1504,8 @@ fn test_git_fetch_undo() {
     ");
     insta::assert_snapshot!(get_log_output(&target_dir), @r#"
     @  e8849ae12c70 ""
-    │ ○  bc83465a3090 "b" b
-    │ ◆  382881770501 "trunk1" tag1
+    │ ○  4ed9450fe936 "b" b
+    │ ◆  7fe1c25a9714 "trunk1" tag1
     ├─╯
     ◆  000000000000 ""
     [EOF]
@@ -1534,12 +1534,12 @@ fn test_fetch_undo_what() {
     let source_log = create_colocated_repo_and_bookmarks_from_trunk1(&source_dir);
     insta::assert_snapshot!(source_log, @r#"
        ===== Source git repo contents =====
-    @  bc83465a3090 "b" b
-    │ ○  d4d535f1d579 "a2" a2
+    @  4ed9450fe936 "b" b
+    │ ○  0c30cbbbd5c0 "a2" a2
     ├─╯
-    │ ○  c8303692b8e2 "a1" a1
+    │ ○  72ab9ad275fb "a1" a1
     ├─╯
-    ○  382881770501 "trunk1" trunk1
+    ○  7fe1c25a9714 "trunk1" trunk1
     ◆  000000000000 ""
     [EOF]
     "#);
@@ -1558,15 +1558,15 @@ fn test_fetch_undo_what() {
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @r#"
     @  e8849ae12c70 ""
-    │ ○  bc83465a3090 "b" b
-    │ ○  382881770501 "trunk1"
+    │ ○  4ed9450fe936 "b" b
+    │ ○  7fe1c25a9714 "trunk1"
     ├─╯
     ◆  000000000000 ""
     [EOF]
     "#);
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @"
-    b: yostqsxw bc83465a b
-      @origin: yostqsxw bc83465a b
+    b: sostqsxw 4ed9450f b
+      @origin: sostqsxw 4ed9450f b
     [EOF]
     ");
 
@@ -1580,7 +1580,7 @@ fn test_fetch_undo_what() {
     ");
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @"
     b (deleted)
-      @origin: yostqsxw/0 bc83465a (hidden) b
+      @origin: sostqsxw/0 4ed9450f (hidden) b
     [EOF]
     ");
 
@@ -1591,7 +1591,7 @@ fn test_fetch_undo_what() {
         .success();
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @"
     b (deleted)
-      @origin: yostqsxw/0 bc83465a (hidden) b
+      @origin: sostqsxw/0 4ed9450f (hidden) b
     newbookmark: qpvuntsm e8849ae1 (empty) (no description set)
       @origin (not created yet)
     [EOF]
@@ -1738,12 +1738,12 @@ fn test_git_fetch_removed_bookmark() {
     let source_log = create_colocated_repo_and_bookmarks_from_trunk1(&source_dir);
     insta::assert_snapshot!(source_log, @r#"
        ===== Source git repo contents =====
-    @  bc83465a3090 "b" b
-    │ ○  d4d535f1d579 "a2" a2
+    @  4ed9450fe936 "b" b
+    │ ○  0c30cbbbd5c0 "a2" a2
     ├─╯
-    │ ○  c8303692b8e2 "a1" a1
+    │ ○  72ab9ad275fb "a1" a1
     ├─╯
-    ○  382881770501 "trunk1" trunk1
+    ○  7fe1c25a9714 "trunk1" trunk1
     ◆  000000000000 ""
     [EOF]
     "#);
@@ -1760,12 +1760,12 @@ fn test_git_fetch_removed_bookmark() {
     ");
     insta::assert_snapshot!(get_log_output(&target_dir), @r#"
     @  e8849ae12c70 ""
-    │ ○  bc83465a3090 "b" b
-    │ │ ○  d4d535f1d579 "a2" a2
+    │ ○  4ed9450fe936 "b" b
+    │ │ ○  0c30cbbbd5c0 "a2" a2
     │ ├─╯
-    │ │ ○  c8303692b8e2 "a1" a1
+    │ │ ○  72ab9ad275fb "a1" a1
     │ ├─╯
-    │ ○  382881770501 "trunk1" trunk1
+    │ ○  7fe1c25a9714 "trunk1" trunk1
     ├─╯
     ◆  000000000000 ""
     [EOF]
@@ -1785,12 +1785,12 @@ fn test_git_fetch_removed_bookmark() {
     ");
     insta::assert_snapshot!(get_log_output(&target_dir), @r#"
     @  e8849ae12c70 ""
-    │ ○  bc83465a3090 "b" b
-    │ │ ○  d4d535f1d579 "a2" a2
+    │ ○  4ed9450fe936 "b" b
+    │ │ ○  0c30cbbbd5c0 "a2" a2
     │ ├─╯
-    │ │ ○  c8303692b8e2 "a1" a1
+    │ │ ○  72ab9ad275fb "a1" a1
     │ ├─╯
-    │ ○  382881770501 "trunk1" trunk1
+    │ ○  7fe1c25a9714 "trunk1" trunk1
     ├─╯
     ◆  000000000000 ""
     [EOF]
@@ -1802,15 +1802,15 @@ fn test_git_fetch_removed_bookmark() {
     ------- stderr -------
     bookmark: a2@origin [deleted] untracked
     Abandoned 1 commits that are no longer reachable:
-      yqosqzyt d4d535f1 a2
+      oqosqzyt 0c30cbbb a2
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&target_dir), @r#"
     @  e8849ae12c70 ""
-    │ ○  bc83465a3090 "b" b
-    │ │ ○  c8303692b8e2 "a1" a1
+    │ ○  4ed9450fe936 "b" b
+    │ │ ○  72ab9ad275fb "a1" a1
     │ ├─╯
-    │ ○  382881770501 "trunk1" trunk1
+    │ ○  7fe1c25a9714 "trunk1" trunk1
     ├─╯
     ◆  000000000000 ""
     [EOF]
@@ -1837,12 +1837,12 @@ fn test_git_fetch_removed_parent_bookmark() {
     let source_log = create_colocated_repo_and_bookmarks_from_trunk1(&source_dir);
     insta::assert_snapshot!(source_log, @r#"
        ===== Source git repo contents =====
-    @  bc83465a3090 "b" b
-    │ ○  d4d535f1d579 "a2" a2
+    @  4ed9450fe936 "b" b
+    │ ○  0c30cbbbd5c0 "a2" a2
     ├─╯
-    │ ○  c8303692b8e2 "a1" a1
+    │ ○  72ab9ad275fb "a1" a1
     ├─╯
-    ○  382881770501 "trunk1" trunk1
+    ○  7fe1c25a9714 "trunk1" trunk1
     ◆  000000000000 ""
     [EOF]
     "#);
@@ -1859,12 +1859,12 @@ fn test_git_fetch_removed_parent_bookmark() {
     ");
     insta::assert_snapshot!(get_log_output(&target_dir), @r#"
     @  e8849ae12c70 ""
-    │ ○  bc83465a3090 "b" b
-    │ │ ○  d4d535f1d579 "a2" a2
+    │ ○  4ed9450fe936 "b" b
+    │ │ ○  0c30cbbbd5c0 "a2" a2
     │ ├─╯
-    │ │ ○  c8303692b8e2 "a1" a1
+    │ │ ○  72ab9ad275fb "a1" a1
     │ ├─╯
-    │ ○  382881770501 "trunk1" trunk1
+    │ ○  7fe1c25a9714 "trunk1" trunk1
     ├─╯
     ◆  000000000000 ""
     [EOF]
@@ -1886,16 +1886,16 @@ fn test_git_fetch_removed_parent_bookmark() {
     bookmark: a1@origin     [deleted] untracked
     bookmark: trunk1@origin [deleted] untracked
     Abandoned 1 commits that are no longer reachable:
-      mzvwutvl c8303692 a1
+      qzvwutvl 72ab9ad2 a1
     Warning: No matching branches found on any specified/configured remote: master
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&target_dir), @r#"
     @  e8849ae12c70 ""
-    │ ○  bc83465a3090 "b" b
-    │ │ ○  d4d535f1d579 "a2" a2
+    │ ○  4ed9450fe936 "b" b
+    │ │ ○  0c30cbbbd5c0 "a2" a2
     │ ├─╯
-    │ ○  382881770501 "trunk1"
+    │ ○  7fe1c25a9714 "trunk1"
     ├─╯
     ◆  000000000000 ""
     [EOF]
@@ -2076,8 +2076,8 @@ fn test_git_fetch_remotely_rewritten() {
     let local_dir = test_env.work_dir("local");
     local_dir.run_jj(["new", "book@origin"]).success();
     insta::assert_snapshot!(get_log_output(&local_dir), @r#"
-    @  257ea01fb9d0 ""
-    ◆  eedc27091311 "bookmarked" book@origin
+    @  51ec5c776adb ""
+    ◆  b82d3d8ad87d "bookmarked" book@origin
     ◆  97604bbedb48 "original"
     ◆  000000000000 ""
     [EOF]
@@ -2096,15 +2096,15 @@ fn test_git_fetch_remotely_rewritten() {
     bookmark: book@origin [updated] untracked
     Updated 2 rewritten commits.
     Rebased 1 descendant commits
-    Working copy  (@) now at: royxmykx 0818b176 (empty) (no description set)
-    Parent commit (@-)      : kkmpptxz 3ee37bc8 book@origin | (empty) bookmarked
+    Working copy  (@) now at: qoyxmykx c305b4ee (empty) (no description set)
+    Parent commit (@-)      : nkmpptxz 3250f5bf book@origin | (empty) bookmarked
     [EOF]
     ");
 
     // The working copy should be rebased onto the modified revision
     insta::assert_snapshot!(get_log_output(&local_dir), @r#"
-    @  0818b17602ee ""
-    ◆  3ee37bc82bb0 "bookmarked" book@origin
+    @  c305b4ee5cb3 ""
+    ◆  3250f5bfbf4c "bookmarked" book@origin
     ◆  f30445f7806d "modified"
     ◆  000000000000 ""
     [EOF]
@@ -2113,14 +2113,14 @@ fn test_git_fetch_remotely_rewritten() {
     // Evolution history should point to the "git fetch" operation
     let output = local_dir.run_jj(["evolog", "-r..book@origin"]);
     insta::assert_snapshot!(output, @"
-    ◆  kkmpptxz test.user@example.com 2001-02-03 08:05:14 book@origin 3ee37bc8
+    ◆  nkmpptxz test.user@example.com 2001-02-03 08:05:14 book@origin 3250f5bf
     │  (empty) bookmarked
-    │  -- operation 747e22d526e2 fetch from git remote(s) origin
-    ○  kkmpptxz/1 test.user@example.com 2001-02-03 08:05:09 eedc2709 (hidden)
+    │  -- operation 93e7cbcdf8eb fetch from git remote(s) origin
+    ○  nkmpptxz/1 test.user@example.com 2001-02-03 08:05:09 b82d3d8a (hidden)
        (empty) bookmarked
     ◆  qpvuntsm test.user@example.com 2001-02-03 08:05:14 f30445f7
     │  (empty) modified
-    │  -- operation 747e22d526e2 fetch from git remote(s) origin
+    │  -- operation 93e7cbcdf8eb fetch from git remote(s) origin
     ○  qpvuntsm/1 test.user@example.com 2001-02-03 08:05:08 97604bbe (hidden)
        (empty) original
     [EOF]
@@ -2134,15 +2134,15 @@ fn test_git_fetch_remotely_rewritten() {
     bookmark: book@origin [updated] untracked
     Updated 2 rewritten commits.
     Rebased 1 descendant commits
-    Working copy  (@) now at: royxmykx 3eb3f040 (empty) (no description set)
-    Parent commit (@-)      : kkmpptxz 3ee37bc8 book@origin | (empty) bookmarked
+    Working copy  (@) now at: qoyxmykx 727a0bb1 (empty) (no description set)
+    Parent commit (@-)      : nkmpptxz 3250f5bf book@origin | (empty) bookmarked
     [EOF]
     ");
 
     // The working copy should be rebased again onto the modified revision
     insta::assert_snapshot!(get_log_output(&local_dir), @r#"
-    @  3eb3f0409f47 ""
-    ◆  3ee37bc82bb0 "bookmarked" book@origin
+    @  727a0bb10154 ""
+    ◆  3250f5bfbf4c "bookmarked" book@origin
     ◆  f30445f7806d "modified"
     ◆  000000000000 ""
     [EOF]
@@ -2152,14 +2152,14 @@ fn test_git_fetch_remotely_rewritten() {
     // evolution history points to the first operation
     let output = local_dir.run_jj(["evolog", "-r..book@origin"]);
     insta::assert_snapshot!(output, @"
-    ◆  kkmpptxz test.user@example.com 2001-02-03 08:05:14 book@origin 3ee37bc8
+    ◆  nkmpptxz test.user@example.com 2001-02-03 08:05:14 book@origin 3250f5bf
     │  (empty) bookmarked
-    │  -- operation 747e22d526e2 fetch from git remote(s) origin
-    ○  kkmpptxz/1 test.user@example.com 2001-02-03 08:05:09 eedc2709 (hidden)
+    │  -- operation 93e7cbcdf8eb fetch from git remote(s) origin
+    ○  nkmpptxz/1 test.user@example.com 2001-02-03 08:05:09 b82d3d8a (hidden)
        (empty) bookmarked
     ◆  qpvuntsm test.user@example.com 2001-02-03 08:05:14 f30445f7
     │  (empty) modified
-    │  -- operation 747e22d526e2 fetch from git remote(s) origin
+    │  -- operation 93e7cbcdf8eb fetch from git remote(s) origin
     ○  qpvuntsm/1 test.user@example.com 2001-02-03 08:05:08 97604bbe (hidden)
        (empty) original
     [EOF]
@@ -2187,8 +2187,8 @@ fn test_git_fetch_remotely_rewritten_no_synthetic_predecessors() {
     let local_dir = test_env.work_dir("local");
     local_dir.run_jj(["new", "book@origin"]).success();
     insta::assert_snapshot!(get_log_output(&local_dir), @r#"
-    @  257ea01fb9d0 ""
-    ◆  eedc27091311 "bookmarked" book@origin
+    @  51ec5c776adb ""
+    ◆  b82d3d8ad87d "bookmarked" book@origin
     ◆  97604bbedb48 "original"
     ◆  000000000000 ""
     [EOF]
@@ -2205,18 +2205,18 @@ fn test_git_fetch_remotely_rewritten_no_synthetic_predecessors() {
     ------- stderr -------
     bookmark: book@origin [updated] untracked
     Abandoned 2 commits that are no longer reachable:
-      kkmpptxz/1 eedc2709 (divergent) (empty) bookmarked
+      nkmpptxz/1 b82d3d8a (divergent) (empty) bookmarked
       qpvuntsm/1 97604bbe (divergent) (empty) original
     Rebased 1 descendant commits
-    Working copy  (@) now at: royxmykx caf224f7 (empty) (no description set)
+    Working copy  (@) now at: qoyxmykx 5e157b82 (empty) (no description set)
     Parent commit (@-)      : zzzzzzzz 00000000 (empty) (no description set)
     [EOF]
     ");
 
     // The working copy should be rebased onto the root
     insta::assert_snapshot!(get_log_output(&local_dir), @r#"
-    @  caf224f7e640 ""
-    │ ◆  3ee37bc82bb0 "bookmarked" book@origin
+    @  5e157b826e45 ""
+    │ ◆  3250f5bfbf4c "bookmarked" book@origin
     │ ◆  f30445f7806d "modified"
     ├─╯
     ◆  000000000000 ""
@@ -2226,7 +2226,7 @@ fn test_git_fetch_remotely_rewritten_no_synthetic_predecessors() {
     // Evolution history should not point to the "git fetch" operation
     let output = local_dir.run_jj(["evolog", "-r..book@origin"]);
     insta::assert_snapshot!(output, @"
-    ◆  kkmpptxz test.user@example.com 2001-02-03 08:05:14 book@origin 3ee37bc8
+    ◆  nkmpptxz test.user@example.com 2001-02-03 08:05:14 book@origin 3250f5bf
        (empty) bookmarked
     ◆  qpvuntsm test.user@example.com 2001-02-03 08:05:14 f30445f7
        (empty) modified
@@ -2258,10 +2258,10 @@ fn test_git_fetch_remotely_rewritten_descendants() {
         .run_jj(["new", "subject(original)", "-mlocal"])
         .success();
     insta::assert_snapshot!(get_log_output(&local_dir), @r#"
-    @  b4adc7786cf0 "local"
-    │ ◆  cce448c253e0 "bookmarked 2" book2@origin
+    @  7c99a6ba737a "local"
+    │ ◆  b88abf3cde94 "bookmarked 2" book2@origin
     ├─╯
-    │ ◆  2a6bbeb458de "bookmarked 1" book1@origin
+    │ ◆  d1ffc35bede3 "bookmarked 1" book1@origin
     ├─╯
     ◆  97604bbedb48 "original"
     ◆  000000000000 ""
@@ -2280,7 +2280,7 @@ fn test_git_fetch_remotely_rewritten_descendants() {
     bookmark: book1@origin [updated] untracked
     Updated 2 rewritten commits.
     Rebased 2 descendant commits
-    Working copy  (@) now at: vruxwmqv a1d01244 (empty) local
+    Working copy  (@) now at: sruxwmqv b0f05409 (empty) local
     Parent commit (@-)      : qpvuntsm a843bfad (empty) modified
     [EOF]
     ");
@@ -2288,10 +2288,10 @@ fn test_git_fetch_remotely_rewritten_descendants() {
     // The working copy should be rebased onto the modified revision
     // FIXME: the other remote branch shouldn't be rebased
     insta::assert_snapshot!(get_log_output(&local_dir), @r#"
-    @  a1d01244a4ec "local"
-    │ ○  8e6c17fa9e2e "bookmarked 2"
+    @  b0f05409b4ba "local"
+    │ ○  fd397000bdd3 "bookmarked 2"
     ├─╯
-    │ ◆  ad5c5f3c59a7 "bookmarked 1" book1@origin
+    │ ◆  ac47030a7a6f "bookmarked 1" book1@origin
     ├─╯
     ◆  a843bfad2abb "modified"
     ◆  000000000000 ""
@@ -2301,17 +2301,17 @@ fn test_git_fetch_remotely_rewritten_descendants() {
     // Evolution history should point to the "git fetch" operation
     let output = local_dir.run_jj(["evolog", "-r..remote_bookmarks()"]);
     insta::assert_snapshot!(output, @"
-    ◆  kkmpptxz test.user@example.com 2001-02-03 08:05:16 book1@origin ad5c5f3c
+    ◆  nkmpptxz test.user@example.com 2001-02-03 08:05:16 book1@origin ac47030a
     │  (empty) bookmarked 1
-    │  -- operation ac34b601b3a2 fetch from git remote(s) origin
-    ○  kkmpptxz/1 test.user@example.com 2001-02-03 08:05:09 2a6bbeb4 (hidden)
+    │  -- operation ddb9381d4e22 fetch from git remote(s) origin
+    ○  nkmpptxz/1 test.user@example.com 2001-02-03 08:05:09 d1ffc35b (hidden)
        (empty) bookmarked 1
     ◆  qpvuntsm test.user@example.com 2001-02-03 08:05:16 a843bfad
     │  (empty) modified
-    │  -- operation ac34b601b3a2 fetch from git remote(s) origin
+    │  -- operation ddb9381d4e22 fetch from git remote(s) origin
     ◆  qpvuntsm/1 test.user@example.com 2001-02-03 08:05:08 97604bbe (hidden)
        (empty) original
-    ◆  mzvwutvl/1 test.user@example.com 2001-02-03 08:05:11 book2@origin cce448c2 (hidden)
+    ◆  pzvwutvl/1 test.user@example.com 2001-02-03 08:05:11 book2@origin b88abf3c (hidden)
        (empty) bookmarked 2
     ◆  qpvuntsm/1 test.user@example.com 2001-02-03 08:05:08 97604bbe (hidden)
        (empty) original

--- a/cli/tests/test_git_import_export.rs
+++ b/cli/tests/test_git_import_export.rs
@@ -259,15 +259,15 @@ fn test_git_import_move_export_with_default_undo() -> TestResult {
         .run_jj(["bookmark", "set", "a", "--to=@"])
         .success();
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @"
-    a: royxmykx e7d0d5fd (empty) (no description set)
+    a: poyxmykx 201a61cf (empty) (no description set)
       @git (behind by 1 commits): qpvuntsm e8849ae1 (empty) (no description set)
     [EOF]
     ");
     let output = work_dir.run_jj(["git", "export"]);
     insta::assert_snapshot!(output, @"");
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @"
-    a: royxmykx e7d0d5fd (empty) (no description set)
-      @git: royxmykx e7d0d5fd (empty) (no description set)
+    a: poyxmykx 201a61cf (empty) (no description set)
+      @git: poyxmykx 201a61cf (empty) (no description set)
     [EOF]
     ");
 
@@ -288,7 +288,7 @@ fn test_git_import_move_export_with_default_undo() -> TestResult {
         (
             "refs/heads/a",
             CommitId(
-                "e7d0d5fdaf96051d0dacec1e74d9413d64a15822",
+                "201a61cfa7b2f86564cfa517af7ef85ffae07b76",
             ),
         ),
     ]
@@ -303,8 +303,8 @@ fn test_git_import_move_export_with_default_undo() -> TestResult {
     [EOF]
     ");
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @"
-    a: royxmykx e7d0d5fd (empty) (no description set)
-      @git: royxmykx e7d0d5fd (empty) (no description set)
+    a: poyxmykx 201a61cf (empty) (no description set)
+      @git: poyxmykx 201a61cf (empty) (no description set)
     [EOF]
     ");
     Ok(())

--- a/cli/tests/test_git_init.rs
+++ b/cli/tests/test_git_init.rs
@@ -486,7 +486,7 @@ fn test_git_init_colocated_via_git_repo_path() {
     // Check that the Git repo's HEAD moves
     work_dir.run_jj(["new"]).success();
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  bacc067e7740
+    @  960b062f8bb7
     ○  f3fe58bc88cc
     ○  e80a42cccd06 my-bookmark My commit message
     ◆  000000000000
@@ -535,7 +535,7 @@ fn test_git_init_colocated_via_git_repo_path_gitlink() {
     // Check that the Git repo's HEAD moves
     jj_work_dir.run_jj(["new"]).success();
     insta::assert_snapshot!(get_log_output(&jj_work_dir), @"
-    @  bacc067e7740
+    @  960b062f8bb7
     ○  f3fe58bc88cc
     ○  e80a42cccd06 my-bookmark My commit message
     ◆  000000000000
@@ -583,7 +583,7 @@ fn test_git_init_colocated_via_git_repo_path_symlink_directory() -> TestResult {
     // Check that the Git repo's HEAD moves
     jj_work_dir.run_jj(["new"]).success();
     insta::assert_snapshot!(get_log_output(&jj_work_dir), @"
-    @  bacc067e7740
+    @  960b062f8bb7
     ○  f3fe58bc88cc
     ○  e80a42cccd06 my-bookmark My commit message
     ◆  000000000000
@@ -637,7 +637,7 @@ fn test_git_init_colocated_via_git_repo_path_symlink_directory_without_bare_conf
     // Check that the Git repo's HEAD moves
     jj_work_dir.run_jj(["new"]).success();
     insta::assert_snapshot!(get_log_output(&jj_work_dir), @"
-    @  bacc067e7740
+    @  960b062f8bb7
     ○  f3fe58bc88cc
     ○  e80a42cccd06 my-bookmark My commit message
     ◆  000000000000
@@ -693,7 +693,7 @@ fn test_git_init_colocated_via_git_repo_path_symlink_gitlink() -> TestResult {
     // Check that the Git repo's HEAD moves
     jj_work_dir.run_jj(["new"]).success();
     insta::assert_snapshot!(get_log_output(&jj_work_dir), @"
-    @  bacc067e7740
+    @  960b062f8bb7
     ○  f3fe58bc88cc
     ○  e80a42cccd06 my-bookmark My commit message
     ◆  000000000000
@@ -921,7 +921,7 @@ fn test_git_init_external_but_git_dir_exists() {
     // Check that Git HEAD is not set because this isn't a colocated workspace
     work_dir.run_jj(["new"]).success();
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  1c1c95df80e5
+    @  3babb3519b29
     ○  e8849ae12c70
     ◆  000000000000
     [EOF]
@@ -964,7 +964,7 @@ fn test_git_init_colocated_via_flag_git_dir_exists() {
     // Check that the Git repo's HEAD moves
     work_dir.run_jj(["new"]).success();
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  bacc067e7740
+    @  960b062f8bb7
     ○  f3fe58bc88cc
     ○  e80a42cccd06 my-bookmark My commit message
     ◆  000000000000
@@ -1009,7 +1009,7 @@ fn test_git_init_colocated_via_config_git_dir_exists() {
     // Check that the Git repo's HEAD moves
     work_dir.run_jj(["new"]).success();
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  bacc067e7740
+    @  960b062f8bb7
     ○  f3fe58bc88cc
     ○  e80a42cccd06 my-bookmark My commit message
     ◆  000000000000

--- a/cli/tests/test_git_private_commits.rs
+++ b/cli/tests/test_git_private_commits.rs
@@ -102,8 +102,8 @@ fn test_git_private_commits_block_pushing() {
     let output = work_dir.run_jj(["git", "push", "--all"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Warning: Won't push bookmark main: commit 469f044473ed is private
-      znkkpsqq 469f0444 main* | (empty) private 1
+    Warning: Won't push bookmark main: commit f4a25aaf3e1f is private
+      pnkkpsqq f4a25aaf main* | (empty) private 1
     Hint: Configured git.private-commits: 'description('private*')'
     Warning: Won't push tag alpha: commit 69b30fdbc569 is private
       wqnwkozp 69b30fdb (empty) private 2
@@ -114,8 +114,8 @@ fn test_git_private_commits_block_pushing() {
     let output = work_dir.run_jj(["git", "push", "--tracked"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Warning: Won't push bookmark main: commit 469f044473ed is private
-      znkkpsqq 469f0444 main* | (empty) private 1
+    Warning: Won't push bookmark main: commit f4a25aaf3e1f is private
+      pnkkpsqq f4a25aaf main* | (empty) private 1
     Hint: Configured git.private-commits: 'description('private*')'
     Warning: Won't push tag alpha: commit 69b30fdbc569 is private
       wqnwkozp 69b30fdb (empty) private 2
@@ -126,8 +126,8 @@ fn test_git_private_commits_block_pushing() {
     let output = work_dir.run_jj(["git", "push", "-rall()"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Warning: Won't push bookmark main: commit 469f044473ed is private
-      znkkpsqq 469f0444 main* | (empty) private 1
+    Warning: Won't push bookmark main: commit f4a25aaf3e1f is private
+      pnkkpsqq f4a25aaf main* | (empty) private 1
     Hint: Configured git.private-commits: 'description('private*')'
     Warning: Won't push tag alpha: commit 69b30fdbc569 is private
       wqnwkozp 69b30fdb (empty) private 2
@@ -148,8 +148,8 @@ fn test_git_private_commits_block_pushing() {
     let output = work_dir.run_jj(["git", "push", "--bookmark=*"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Error: Won't push commit 469f044473ed since it is private
-    Hint: Rejected commit: znkkpsqq 469f0444 main* | (empty) private 1
+    Error: Won't push commit f4a25aaf3e1f since it is private
+    Hint: Rejected commit: pnkkpsqq f4a25aaf main* | (empty) private 1
     Hint: Configured git.private-commits: 'description('private*')'
     [EOF]
     [exit status: 1]
@@ -170,8 +170,8 @@ fn test_git_private_commits_block_pushing() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Changes to push to origin:
-      bookmark: main [move forward from 95cc152cd086 to 469f044473ed]
-      tag: alpha [move sideways from 95cc152cd086 to 69b30fdbc569]
+      bookmark: main [move forward from f9aeb61c0c99 to f4a25aaf3e1f]
+      tag: alpha [move sideways from f9aeb61c0c99 to 69b30fdbc569]
     [EOF]
     ");
 }
@@ -192,8 +192,8 @@ fn test_git_private_commits_can_be_overridden() {
     let output = work_dir.run_jj(["git", "push", "--all"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Warning: Won't push bookmark main: commit 7f665ca27d4e is private
-      yqosqzyt 7f665ca2 main* | (empty) private 1
+    Warning: Won't push bookmark main: commit 89761bbdecdd is private
+      oqosqzyt 89761bbd main* | (empty) private 1
     Hint: Configured git.private-commits: 'description('private*')'
     Nothing changed.
     [EOF]
@@ -204,7 +204,7 @@ fn test_git_private_commits_can_be_overridden() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Changes to push to origin:
-      bookmark: main [move forward from 95cc152cd086 to 7f665ca27d4e]
+      bookmark: main [move forward from f9aeb61c0c99 to 89761bbdecdd]
     [EOF]
     ");
 }
@@ -226,7 +226,7 @@ fn test_git_private_commits_are_not_checked_if_immutable() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Changes to push to origin:
-      bookmark: main [move forward from 95cc152cd086 to 7f665ca27d4e]
+      bookmark: main [move forward from f9aeb61c0c99 to 89761bbdecdd]
     [EOF]
     ");
 }
@@ -252,8 +252,8 @@ fn test_git_private_commits_not_directly_in_line_block_pushing() {
     let output = work_dir.run_jj(["git", "push", "-b=bookmark1"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Error: Won't push commit 613114f44bdd since it is private
-    Hint: Rejected commit: yqosqzyt 613114f4 (empty) private 1
+    Error: Won't push commit 9aa1d878c426 since it is private
+    Hint: Rejected commit: oqosqzyt 9aa1d878 (empty) private 1
     Hint: Configured git.private-commits: 'description('private*')'
     [EOF]
     [exit status: 1]
@@ -279,14 +279,14 @@ fn test_git_private_commits_descending_from_commits_pushed_do_not_block_pushing(
     let output = work_dir.run_jj(["git", "push", "--all"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Warning: Won't push bookmark wip1: commit c3ad06b3e0ea is private
-      yostqsxw c3ad06b3 wip1 wip2 | (empty) private 1
+    Warning: Won't push bookmark wip1: commit 4416d66d320c is private
+      sostqsxw 4416d66d wip1 wip2 | (empty) private 1
     Hint: Configured git.private-commits: 'description('private*')'
-    Warning: Won't push bookmark wip2: commit c3ad06b3e0ea is private
-      yostqsxw c3ad06b3 wip1 wip2 | (empty) private 1
+    Warning: Won't push bookmark wip2: commit 4416d66d320c is private
+      sostqsxw 4416d66d wip1 wip2 | (empty) private 1
     Hint: Configured git.private-commits: 'description('private*')'
     Changes to push to origin:
-      bookmark: main [move forward from 95cc152cd086 to f0291dea729d]
+      bookmark: main [move forward from f9aeb61c0c99 to a774e9588ffe]
     [EOF]
     ");
 }
@@ -314,8 +314,8 @@ fn test_git_private_commits_already_on_the_remote_do_not_block_push() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Changes to push to origin:
-      bookmark: bookmark1 [add to 95cc152cd086]
-      bookmark: main [move forward from 95cc152cd086 to 03bc2bf271e0]
+      bookmark: bookmark1 [add to f9aeb61c0c99]
+      bookmark: main [move forward from f9aeb61c0c99 to 557549a012fb]
     [EOF]
     ");
 
@@ -329,7 +329,7 @@ fn test_git_private_commits_already_on_the_remote_do_not_block_push() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Changes to push to origin:
-      bookmark: bookmark1 [move forward from 95cc152cd086 to 03bc2bf271e0]
+      bookmark: bookmark1 [move forward from f9aeb61c0c99 to 557549a012fb]
     [EOF]
     ");
 
@@ -345,7 +345,7 @@ fn test_git_private_commits_already_on_the_remote_do_not_block_push() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Changes to push to origin:
-      bookmark: bookmark2 [add to 987ee765174d]
+      bookmark: bookmark2 [add to 5c477def4472]
     [EOF]
     ");
 }
@@ -369,7 +369,7 @@ fn test_git_private_commits_are_evaluated_separately_for_each_remote() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Changes to push to origin:
-      bookmark: main [move forward from 95cc152cd086 to efa3666d00e4]
+      bookmark: main [move forward from f9aeb61c0c99 to 7b767b50ea89]
     [EOF]
     ");
 
@@ -380,8 +380,8 @@ fn test_git_private_commits_are_evaluated_separately_for_each_remote() {
     let output = work_dir.run_jj(["git", "push", "--remote=other", "-b=main"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Error: Won't push commit a714fa972186 since it is private
-    Hint: Rejected commit: kpqxywon a714fa97 (empty) private 1
+    Error: Won't push commit cfdafd8c8d16 since it is private
+    Hint: Rejected commit: kpqxywon cfdafd8c (empty) private 1
     Hint: Configured git.private-commits: 'description('private*')'
     [EOF]
     [exit status: 1]

--- a/cli/tests/test_git_push.rs
+++ b/cli/tests/test_git_push.rs
@@ -72,8 +72,8 @@ fn test_git_push_nothing() {
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @"
     bookmark1: qpvuntsm 9b2e76de (empty) description 1
       @origin: qpvuntsm 9b2e76de (empty) description 1
-    bookmark2: zsuskuln 38a20473 (empty) description 2
-      @origin: zsuskuln 38a20473 (empty) description 2
+    bookmark2: psuskuln 7ac95915 (empty) description 2
+      @origin: psuskuln 7ac95915 (empty) description 2
     [EOF]
     ");
 
@@ -169,9 +169,9 @@ fn test_git_push_current_bookmark() {
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @"
     bookmark1: qpvuntsm e5ce6d9a (empty) modified bookmark1 commit
       @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm/1 9b2e76de (hidden) (empty) description 1
-    bookmark2: yostqsxw 88ca14a7 (empty) foo
-      @origin (behind by 1 commits): zsuskuln 38a20473 (empty) description 2
-    my-bookmark: yostqsxw 88ca14a7 (empty) foo
+    bookmark2: rostqsxw b1fc3a6f (empty) foo
+      @origin (behind by 1 commits): psuskuln 7ac95915 (empty) description 2
+    my-bookmark: rostqsxw b1fc3a6f (empty) foo
       @origin (not created yet)
     [EOF]
     ");
@@ -180,8 +180,8 @@ fn test_git_push_current_bookmark() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Changes to push to origin:
-      bookmark: bookmark2 [move forward from 38a204733702 to 88ca14a7d46f]
-      bookmark: my-bookmark [add to 88ca14a7d46f]
+      bookmark: bookmark2 [move forward from 7ac95915695d to b1fc3a6f6cd9]
+      bookmark: my-bookmark [add to b1fc3a6f6cd9]
     Dry-run requested, not pushing.
     [EOF]
     ");
@@ -189,17 +189,17 @@ fn test_git_push_current_bookmark() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Changes to push to origin:
-      bookmark: bookmark2 [move forward from 38a204733702 to 88ca14a7d46f]
-      bookmark: my-bookmark [add to 88ca14a7d46f]
+      bookmark: bookmark2 [move forward from 7ac95915695d to b1fc3a6f6cd9]
+      bookmark: my-bookmark [add to b1fc3a6f6cd9]
     [EOF]
     ");
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @"
     bookmark1: qpvuntsm e5ce6d9a (empty) modified bookmark1 commit
       @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm/1 9b2e76de (hidden) (empty) description 1
-    bookmark2: yostqsxw 88ca14a7 (empty) foo
-      @origin: yostqsxw 88ca14a7 (empty) foo
-    my-bookmark: yostqsxw 88ca14a7 (empty) foo
-      @origin: yostqsxw 88ca14a7 (empty) foo
+    bookmark2: rostqsxw b1fc3a6f (empty) foo
+      @origin: rostqsxw b1fc3a6f (empty) foo
+    my-bookmark: rostqsxw b1fc3a6f (empty) foo
+      @origin: rostqsxw b1fc3a6f (empty) foo
     [EOF]
     ");
 
@@ -227,7 +227,7 @@ fn test_git_push_current_bookmark() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Changes to push to origin:
-      bookmark: bookmark2 [move backward from 88ca14a7d46f to 38a204733702]
+      bookmark: bookmark2 [move backward from b1fc3a6f6cd9 to 7ac95915695d]
     [EOF]
     ");
 }
@@ -445,10 +445,10 @@ fn test_git_push_sideways_unexpectedly_moved() {
         .run_jj(["bookmark", "set", "bookmark1", "-r@"])
         .success();
     insta::assert_snapshot!(get_bookmark_output(&origin_dir), @"
-    bookmark1: vruxwmqv 7ce4029e remote
+    bookmark1: uruxwmqv 9ab45f12 remote
       @git (behind by 1 commits): qpvuntsm 9b2e76de (empty) description 1
-    bookmark2: zsuskuln 38a20473 (empty) description 2
-      @git: zsuskuln 38a20473 (empty) description 2
+    bookmark2: psuskuln 7ac95915 (empty) description 2
+      @git: psuskuln 7ac95915 (empty) description 2
     [EOF]
     ");
     origin_dir.run_jj(["git", "export"]).success();
@@ -460,10 +460,10 @@ fn test_git_push_sideways_unexpectedly_moved() {
         .run_jj(["bookmark", "set", "bookmark1", "--allow-backwards", "-r@"])
         .success();
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @"
-    bookmark1: kmkuslsw 827b8a38 local
+    bookmark1: wmkuslsw db695c28 local
       @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm 9b2e76de (empty) description 1
-    bookmark2: zsuskuln 38a20473 (empty) description 2
-      @origin: zsuskuln 38a20473 (empty) description 2
+    bookmark2: psuskuln 7ac95915 (empty) description 2
+      @origin: psuskuln 7ac95915 (empty) description 2
     [EOF]
     ");
 
@@ -471,7 +471,7 @@ fn test_git_push_sideways_unexpectedly_moved() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Changes to push to origin:
-      bookmark: bookmark1 [move sideways from 9b2e76de3920 to 827b8a385853]
+      bookmark: bookmark1 [move sideways from 9b2e76de3920 to db695c2833a1]
     Warning: The following references unexpectedly moved on the remote:
       refs/heads/bookmark1 (reason: stale info)
     Hint: Try fetching from the remote, then make the bookmark point to where you want it to be, and push again.
@@ -485,7 +485,7 @@ fn test_git_push_sideways_unexpectedly_moved() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Changes to push to origin:
-      bookmark: bookmark1 [move sideways from 9b2e76de3920 to 827b8a385853]
+      bookmark: bookmark1 [move sideways from 9b2e76de3920 to db695c2833a1]
     [1m[38;5;3mWarning: [39mThe following references unexpectedly moved on the remote:[0m
       [38;5;2mrefs/heads/bookmark1[39m (reason: stale info)
     [1m[38;5;6mHint: [0m[39mTry fetching from the remote, then make the bookmark point to where you want it to be, and push again.[39m
@@ -513,10 +513,10 @@ fn test_git_push_deletion_unexpectedly_moved() {
         .run_jj(["bookmark", "set", "bookmark1", "-r@"])
         .success();
     insta::assert_snapshot!(get_bookmark_output(&origin_dir), @"
-    bookmark1: vruxwmqv 7ce4029e remote
+    bookmark1: uruxwmqv 9ab45f12 remote
       @git (behind by 1 commits): qpvuntsm 9b2e76de (empty) description 1
-    bookmark2: zsuskuln 38a20473 (empty) description 2
-      @git: zsuskuln 38a20473 (empty) description 2
+    bookmark2: psuskuln 7ac95915 (empty) description 2
+      @git: psuskuln 7ac95915 (empty) description 2
     [EOF]
     ");
     origin_dir.run_jj(["git", "export"]).success();
@@ -528,8 +528,8 @@ fn test_git_push_deletion_unexpectedly_moved() {
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @"
     bookmark1 (deleted)
       @origin: qpvuntsm 9b2e76de (empty) description 1
-    bookmark2: zsuskuln 38a20473 (empty) description 2
-      @origin: zsuskuln 38a20473 (empty) description 2
+    bookmark2: psuskuln 7ac95915 (empty) description 2
+      @origin: psuskuln 7ac95915 (empty) description 2
     [EOF]
     ");
 
@@ -561,8 +561,8 @@ fn test_git_push_unexpectedly_deleted() {
     insta::assert_snapshot!(get_bookmark_output(&origin_dir), @"
     bookmark1 (deleted)
       @git: qpvuntsm 9b2e76de (empty) description 1
-    bookmark2: zsuskuln 38a20473 (empty) description 2
-      @git: zsuskuln 38a20473 (empty) description 2
+    bookmark2: psuskuln 7ac95915 (empty) description 2
+      @git: psuskuln 7ac95915 (empty) description 2
     [EOF]
     ");
     origin_dir.run_jj(["git", "export"]).success();
@@ -576,8 +576,8 @@ fn test_git_push_unexpectedly_deleted() {
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @"
     bookmark1: kpqxywon 09919fb0 local
       @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm 9b2e76de (empty) description 1
-    bookmark2: zsuskuln 38a20473 (empty) description 2
-      @origin: zsuskuln 38a20473 (empty) description 2
+    bookmark2: psuskuln 7ac95915 (empty) description 2
+      @origin: psuskuln 7ac95915 (empty) description 2
     [EOF]
     ");
 
@@ -601,8 +601,8 @@ fn test_git_push_unexpectedly_deleted() {
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @"
     bookmark1 (deleted)
       @origin: qpvuntsm 9b2e76de (empty) description 1
-    bookmark2: zsuskuln 38a20473 (empty) description 2
-      @origin: zsuskuln 38a20473 (empty) description 2
+    bookmark2: psuskuln 7ac95915 (empty) description 2
+      @origin: psuskuln 7ac95915 (empty) description 2
     [EOF]
     ");
 
@@ -643,10 +643,10 @@ fn test_git_push_creation_unexpectedly_already_exists() {
         .run_jj(["bookmark", "create", "-r@", "bookmark1"])
         .success();
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @"
-    bookmark1: yostqsxw a43cb801 new bookmark1
+    bookmark1: rostqsxw 132d1b1b new bookmark1
       @origin (not created yet)
-    bookmark2: zsuskuln 38a20473 (empty) description 2
-      @origin: zsuskuln 38a20473 (empty) description 2
+    bookmark2: psuskuln 7ac95915 (empty) description 2
+      @origin: psuskuln 7ac95915 (empty) description 2
     [EOF]
     ");
 
@@ -654,7 +654,7 @@ fn test_git_push_creation_unexpectedly_already_exists() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Changes to push to origin:
-      bookmark: bookmark1 [add to a43cb8011c85]
+      bookmark: bookmark1 [add to 132d1b1b45fd]
     Warning: The following references unexpectedly moved on the remote:
       refs/heads/bookmark1 (reason: stale info)
     Hint: Try fetching from the remote, then make the bookmark point to where you want it to be, and push again.
@@ -693,7 +693,7 @@ fn test_git_push_locally_created_and_rewritten() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Changes to push to origin:
-      bookmark: my [add to e0cba5e497ee]
+      bookmark: my [add to 2901efb0a58e]
     [EOF]
     ");
 
@@ -703,17 +703,17 @@ fn test_git_push_locally_created_and_rewritten() {
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @"
     bookmark1: qpvuntsm 9b2e76de (empty) description 1
       @origin: qpvuntsm 9b2e76de (empty) description 1
-    bookmark2: zsuskuln 38a20473 (empty) description 2
-      @origin: zsuskuln 38a20473 (empty) description 2
-    my: vruxwmqv 5eb416c1 (empty) local 2
-      @origin (ahead by 1 commits, behind by 1 commits): vruxwmqv/1 e0cba5e4 (hidden) (empty) local 1
+    bookmark2: psuskuln 7ac95915 (empty) description 2
+      @origin: psuskuln 7ac95915 (empty) description 2
+    my: truxwmqv 9de3639a (empty) local 2
+      @origin (ahead by 1 commits, behind by 1 commits): truxwmqv/1 2901efb0 (hidden) (empty) local 1
     [EOF]
     ");
     let output = work_dir.run_jj(["git", "push"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Changes to push to origin:
-      bookmark: my [move sideways from e0cba5e497ee to 5eb416c1ff97]
+      bookmark: my [move sideways from 2901efb0a58e to 9de3639a5039]
     [EOF]
     ");
 }
@@ -760,7 +760,7 @@ fn test_git_push_multiple() {
     bookmark1 (deleted)
       @origin: qpvuntsm 9b2e76de (empty) description 1
     bookmark2: yqosqzyt 0cb91ecd (empty) foo
-      @origin (ahead by 1 commits, behind by 1 commits): zsuskuln 38a20473 (empty) description 2
+      @origin (ahead by 1 commits, behind by 1 commits): psuskuln 7ac95915 (empty) description 2
     bookmark3: yqosqzyt 0cb91ecd (empty) foo
       @origin (not created yet)
     my-bookmark: yqosqzyt 0cb91ecd (empty) foo
@@ -782,7 +782,7 @@ fn test_git_push_multiple() {
     Warning: Refusing to create new remote tag tag2@origin
     Changes to push to origin:
       bookmark: bookmark1 [delete from 9b2e76de3920]
-      bookmark: bookmark2 [move sideways from 38a204733702 to 0cb91ecd4965]
+      bookmark: bookmark2 [move sideways from 7ac95915695d to 0cb91ecd4965]
       bookmark: bookmark3 [add to 0cb91ecd4965]
       bookmark: my-bookmark [add to 0cb91ecd4965]
       tag: tag1 [move sideways from 9b2e76de3920 to 0cb91ecd4965]
@@ -830,7 +830,7 @@ fn test_git_push_multiple() {
     ------- stderr -------
     Changes to push to origin:
       bookmark: bookmark1 [delete from 9b2e76de3920]
-      bookmark: bookmark2 [move sideways from 38a204733702 to 0cb91ecd4965]
+      bookmark: bookmark2 [move sideways from 7ac95915695d to 0cb91ecd4965]
       bookmark: bookmark3 [add to 0cb91ecd4965]
     Dry-run requested, not pushing.
     [EOF]
@@ -861,7 +861,7 @@ fn test_git_push_multiple() {
     Hint: Push deleted bookmarks with --deleted or forget the bookmark to suppress this warning.
     Warning: Refusing to create new remote tag tag2@origin
     Changes to push to origin:
-      bookmark: bookmark2 [move sideways from 38a204733702 to 0cb91ecd4965]
+      bookmark: bookmark2 [move sideways from 7ac95915695d to 0cb91ecd4965]
       bookmark: bookmark3 [add to 0cb91ecd4965]
       bookmark: my-bookmark [add to 0cb91ecd4965]
       tag: tag1 [move sideways from 9b2e76de3920 to 0cb91ecd4965]
@@ -874,7 +874,7 @@ fn test_git_push_multiple() {
     Warning: Refusing to create new remote tag tag2@origin
     Changes to push to origin:
       bookmark: bookmark1 [delete from 9b2e76de3920]
-      bookmark: bookmark2 [move sideways from 38a204733702 to 0cb91ecd4965]
+      bookmark: bookmark2 [move sideways from 7ac95915695d to 0cb91ecd4965]
       bookmark: bookmark3 [add to 0cb91ecd4965]
       bookmark: my-bookmark [add to 0cb91ecd4965]
       tag: tag1 [move sideways from 9b2e76de3920 to 0cb91ecd4965]
@@ -890,7 +890,7 @@ fn test_git_push_multiple() {
     Warning: Refusing to create new remote tag tag2@origin
     Changes to push to origin:
       bookmark: bookmark1 [delete from 9b2e76de3920]
-      bookmark: bookmark2 [move sideways from 38a204733702 to 0cb91ecd4965]
+      bookmark: bookmark2 [move sideways from 7ac95915695d to 0cb91ecd4965]
       bookmark: bookmark3 [add to 0cb91ecd4965]
       bookmark: my-bookmark [add to 0cb91ecd4965]
       tag: tag1 [move sideways from 9b2e76de3920 to 0cb91ecd4965]
@@ -926,7 +926,7 @@ fn test_git_push_multiple() {
     insta::assert_snapshot!(output, @"
     @  yqosqzyt test.user@example.com 2001-02-03 08:05:20 bookmark2 bookmark3* my-bookmark tag1 tag2 0cb91ecd
     │  (empty) foo
-    │ ○  zsuskuln test.user@example.com 2001-02-03 08:05:10 38a20473
+    │ ○  psuskuln test.user@example.com 2001-02-03 08:05:10 7ac95915
     ├─╯  (empty) description 2
     │ ○  qpvuntsm test.user@example.com 2001-02-03 08:05:08 9b2e76de
     ├─╯  (empty) description 1
@@ -957,9 +957,9 @@ fn test_git_push_changes() {
     let output = work_dir.run_jj(["git", "push", "--change", "@"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Creating bookmark push-yostqsxwqrlt for revision yostqsxwqrlt
+    Creating bookmark push-rostqsxwqrlt for revision rostqsxwqrlt
     Changes to push to origin:
-      bookmark: push-yostqsxwqrlt [add to 916414184c47]
+      bookmark: push-rostqsxwqrlt [add to bf0ba55ca017]
     [EOF]
     ");
 
@@ -967,7 +967,7 @@ fn test_git_push_changes() {
     let output = work_dir.run_jj(["git", "push", "--change", "@"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Bookmark push-yostqsxwqrlt@origin already matches push-yostqsxwqrlt
+    Bookmark push-rostqsxwqrlt@origin already matches push-rostqsxwqrlt
     Nothing changed.
     [EOF]
     ");
@@ -979,7 +979,7 @@ fn test_git_push_changes() {
     ------- stderr -------
     Creating bookmark push-yqosqzytrlsw for revision yqosqzytrlsw
     Changes to push to origin:
-      bookmark: push-yostqsxwqrlt [move sideways from 916414184c47 to 107f11285524]
+      bookmark: push-rostqsxwqrlt [move sideways from bf0ba55ca017 to a8cf969f69c3]
       bookmark: push-yqosqzytrlsw [add to 0f8164cd580b]
     [EOF]
     ");
@@ -990,17 +990,17 @@ fn test_git_push_changes() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Changes to push to origin:
-      bookmark: push-yostqsxwqrlt [move sideways from 107f11285524 to 7436a8a600a4]
+      bookmark: push-rostqsxwqrlt [move sideways from a8cf969f69c3 to 141495e3e47f]
     [EOF]
     ");
 
     // specifying the same bookmark with --change/--bookmark doesn't break things
     work_dir.write_file("file", "modified4");
-    let output = work_dir.run_jj(["git", "push", "-c=@", "-b=push-yostqsxwqrlt"]);
+    let output = work_dir.run_jj(["git", "push", "-c=@", "-b=push-rostqsxwqrlt"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Changes to push to origin:
-      bookmark: push-yostqsxwqrlt [move sideways from 7436a8a600a4 to a8b93bdd0f68]
+      bookmark: push-rostqsxwqrlt [move sideways from 141495e3e47f to c5c0eb67f8fc]
     [EOF]
     ");
 
@@ -1012,22 +1012,22 @@ fn test_git_push_changes() {
             "set",
             "-r=@-",
             "--allow-backwards",
-            "push-yostqsxwqrlt",
+            "push-rostqsxwqrlt",
         ])
         .success();
     let output = work_dir.run_jj(["status"]);
     insta::assert_snapshot!(output, @"
     Working copy changes:
     M file
-    Working copy  (@) : yostqsxw 4b18f5ea bar
-    Parent commit (@-): yqosqzyt 0f8164cd push-yostqsxwqrlt* push-yqosqzytrlsw | foo
+    Working copy  (@) : rostqsxw cabf33c8 bar
+    Parent commit (@-): yqosqzyt 0f8164cd push-rostqsxwqrlt* push-yqosqzytrlsw | foo
     [EOF]
     ");
-    let output = work_dir.run_jj(["git", "push", "-c=@", "-b=push-yostqsxwqrlt"]);
+    let output = work_dir.run_jj(["git", "push", "-c=@", "-b=push-rostqsxwqrlt"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Error: Bookmark already exists: push-yostqsxwqrlt
-    Hint: Use 'jj bookmark move' to move it, and 'jj git push -b push-yostqsxwqrlt' to push it
+    Error: Bookmark already exists: push-rostqsxwqrlt
+    Hint: Use 'jj bookmark move' to move it, and 'jj git push -b push-rostqsxwqrlt' to push it
     [EOF]
     [exit status: 1]
     ");
@@ -1035,8 +1035,8 @@ fn test_git_push_changes() {
     insta::assert_snapshot!(output, @"
     Working copy changes:
     M file
-    Working copy  (@) : yostqsxw 4b18f5ea bar
-    Parent commit (@-): yqosqzyt 0f8164cd push-yostqsxwqrlt* push-yqosqzytrlsw | foo
+    Working copy  (@) : rostqsxw cabf33c8 bar
+    Parent commit (@-): yqosqzyt 0f8164cd push-rostqsxwqrlt* push-yqosqzytrlsw | foo
     [EOF]
     ");
 
@@ -1052,9 +1052,9 @@ fn test_git_push_changes() {
     ]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Creating bookmark test-yostqsxwqrlt for revision yostqsxwqrlt
+    Creating bookmark test-rostqsxwqrlt for revision rostqsxwqrlt
     Changes to push to origin:
-      bookmark: test-yostqsxwqrlt [add to 4b18f5ea2994]
+      bookmark: test-rostqsxwqrlt [add to cabf33c82fed]
     [EOF]
     ");
 
@@ -1067,7 +1067,7 @@ fn test_git_push_changes() {
     ]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Creating bookmark dupe-bookmark for revision yostqsxwqrlt
+    Creating bookmark dupe-bookmark for revision rostqsxwqrlt
     Error: Bookmark already exists: dupe-bookmark
     Hint: Use 'jj bookmark move' to move it, and 'jj git push -b dupe-bookmark' to push it
     [EOF]
@@ -1120,7 +1120,7 @@ fn test_git_push_changes_with_name() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Changes to push to origin:
-      bookmark: b1 [add to 5f4f9a466c96]
+      bookmark: b1 [add to 89ea5ca5f04c]
     [EOF]
     ");
     // Spaces before the = sign are treated like part of the bookmark name and such
@@ -1202,7 +1202,7 @@ fn test_git_push_changes_with_name() {
     ------- stderr -------
     Error: Revset `(@|@-)` resolved to more than one revision
     Hint: The revset `(@|@-)` resolved to these revisions:
-      yostqsxw 1b2bd869 b1* | pushed
+      rostqsxw 34bd1e21 b1* | pushed
       yqosqzyt 0f8164cd foo
     [EOF]
     [exit status: 1]
@@ -1214,7 +1214,7 @@ fn test_git_push_changes_with_name() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Changes to push to origin:
-      bookmark: b2 [add to 95ba7bdacb38]
+      bookmark: b2 [add to 5317293e9031]
     [EOF]
     ");
 }
@@ -1349,8 +1349,8 @@ fn test_git_push_changes_with_name_untracked_or_forgotten() {
         ])
         .success();
     insta::assert_snapshot!(output, @"
-    ○  9a0 child
-    @  767 b1@origin pushed_to_remote
+    ○  366 child
+    @  9e0 b1@origin pushed_to_remote
     ○  aa9 parent
     ◆  000
     [EOF]
@@ -1359,7 +1359,7 @@ fn test_git_push_changes_with_name_untracked_or_forgotten() {
         .run_jj(["bookmark", "list", "--all", "b1"])
         .success();
     insta::assert_snapshot!(output, @"
-    b1@origin: yostqsxw 767b63a5 pushed_to_remote
+    b1@origin: rostqsxw 9e0f2255 pushed_to_remote
     [EOF]
     ");
 
@@ -1421,7 +1421,7 @@ fn test_git_push_changes_with_name_untracked_or_forgotten() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Changes to push to origin:
-      bookmark: b1 [add to 9a0f76645905]
+      bookmark: b1 [add to 3668cedee47a]
     Warning: The following references unexpectedly moved on the remote:
       refs/heads/b1 (reason: stale info)
     Hint: Try fetching from the remote, then make the bookmark point to where you want it to be, and push again.
@@ -1436,7 +1436,7 @@ fn test_git_push_changes_with_name_untracked_or_forgotten() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Changes to push to origin:
-      bookmark: b1 [add to 767b63a598e1]
+      bookmark: b1 [add to 9e0f22551b20]
     [EOF]
     ");
 }
@@ -1481,15 +1481,15 @@ fn test_git_push_revisions() {
         .run_jj(["tag", "set", "--allow-move", "-rsubject(new3)", "tag-3"])
         .success();
     insta::assert_snapshot!(work_dir.run_jj(["log"]), @"
-    @  lylxulpl test.user@example.com 2001-02-03 08:05:23 bookmark-2a* bookmark-2b* tag-2* 6bc5860f
+    @  mylxulpl test.user@example.com 2001-02-03 08:05:23 bookmark-2a* bookmark-2b* tag-2* 11142838
     │  baz
-    ○  kmkuslsw test.user@example.com 2001-02-03 08:05:20 bookmark-1* 3c179a96
+    ○  wmkuslsw test.user@example.com 2001-02-03 08:05:20 bookmark-1* 2b2c6c07
     │  bar
     ○  yqosqzyt test.user@example.com 2001-02-03 08:05:18 33b167f8
     │  foo
-    │ ○  xznxytkn test.user@example.com 2001-02-03 08:05:24 tag-3* 14504d39
+    │ ○  lznxytkn test.user@example.com 2001-02-03 08:05:24 tag-3* 44ea9da4
     ├─╯  (empty) new3
-    │ ○  zsuskuln test.user@example.com 2001-02-03 08:05:10 bookmark2 38a20473
+    │ ○  psuskuln test.user@example.com 2001-02-03 08:05:10 bookmark2 7ac95915
     ├─╯  (empty) description 2
     │ ○  qpvuntsm test.user@example.com 2001-02-03 08:05:08 bookmark1 tag-1 tag-2@origin tag-3@origin 9b2e76de
     ├─╯  (empty) description 1
@@ -1525,7 +1525,7 @@ fn test_git_push_revisions() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Changes to push to origin:
-      bookmark: bookmark-1 [add to 3c179a96c972]
+      bookmark: bookmark-1 [add to 2b2c6c07cdf3]
     Dry-run requested, not pushing.
     [EOF]
     ");
@@ -1534,7 +1534,7 @@ fn test_git_push_revisions() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Changes to push to origin:
-      tag: tag-3 [move sideways from 9b2e76de3920 to 14504d39da71]
+      tag: tag-3 [move sideways from 9b2e76de3920 to 44ea9da46261]
     Dry-run requested, not pushing.
     [EOF]
     ");
@@ -1544,7 +1544,7 @@ fn test_git_push_revisions() {
     ------- stderr -------
     Warning: No bookmarks/tags point to the specified revisions: @--
     Changes to push to origin:
-      bookmark: bookmark-1 [add to 3c179a96c972]
+      bookmark: bookmark-1 [add to 2b2c6c07cdf3]
     Dry-run requested, not pushing.
     [EOF]
     ");
@@ -1553,9 +1553,9 @@ fn test_git_push_revisions() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Changes to push to origin:
-      bookmark: bookmark-2a [add to 6bc5860f95fb]
-      bookmark: bookmark-2b [add to 6bc5860f95fb]
-      tag: tag-2 [move sideways from 9b2e76de3920 to 6bc5860f95fb]
+      bookmark: bookmark-2a [add to 111428387a8b]
+      bookmark: bookmark-2b [add to 111428387a8b]
+      tag: tag-2 [move sideways from 9b2e76de3920 to 111428387a8b]
     Dry-run requested, not pushing.
     [EOF]
     ");
@@ -1564,7 +1564,7 @@ fn test_git_push_revisions() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Changes to push to origin:
-      bookmark: bookmark-1 [add to 3c179a96c972]
+      bookmark: bookmark-1 [add to 2b2c6c07cdf3]
     Dry-run requested, not pushing.
     [EOF]
     ");
@@ -1573,7 +1573,7 @@ fn test_git_push_revisions() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Changes to push to origin:
-      bookmark: bookmark-1 [add to 3c179a96c972]
+      bookmark: bookmark-1 [add to 2b2c6c07cdf3]
     Dry-run requested, not pushing.
     [EOF]
     ");
@@ -1620,8 +1620,8 @@ fn test_git_push_mixed() {
     Hint: Run `jj bookmark track bookmark-2b --remote=origin` and try again.
     Changes to push to origin:
       bookmark: push-yqosqzytrlsw [add to 0f8164cd580b]
-      bookmark: bookmark-1 [add to bc7f5ebae839]
-      tag: tag-1 [add to 9b467a2a0cdf]
+      bookmark: bookmark-1 [add to 27bd1dbb5995]
+      tag: tag-1 [add to 78f71024a5c3]
     [EOF]
     ");
 }
@@ -1660,16 +1660,16 @@ fn test_git_push_bookmarks_and_tags_of_same_name() {
         .run_jj(["tag", "set", "-r@-", "--allow-move", "foo", "bar"])
         .success();
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @"
-    bar: vruxwmqv 5058996c (empty) local
+    bar: truxwmqv 0163b9ed (empty) local
       @origin (behind by 1 commits): qpvuntsm 110db8ed (empty) origin
-    foo: vruxwmqv 5058996c (empty) local
+    foo: truxwmqv 0163b9ed (empty) local
       @origin (behind by 1 commits): qpvuntsm 110db8ed (empty) origin
     [EOF]
     ");
     insta::assert_snapshot!(get_tag_output(&work_dir), @"
-    bar: vruxwmqv 5058996c (empty) local
+    bar: truxwmqv 0163b9ed (empty) local
       @origin (behind by 1 commits): qpvuntsm 110db8ed (empty) origin
-    foo: vruxwmqv 5058996c (empty) local
+    foo: truxwmqv 0163b9ed (empty) local
       @origin (behind by 1 commits): qpvuntsm 110db8ed (empty) origin
     [EOF]
     ");
@@ -1679,8 +1679,8 @@ fn test_git_push_bookmarks_and_tags_of_same_name() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Changes to push to origin:
-      bookmark: foo [move forward from 110db8edfa5f to 5058996c52e2]
-      tag: foo [move forward from 110db8edfa5f to 5058996c52e2]
+      bookmark: foo [move forward from 110db8edfa5f to 0163b9ed8732]
+      tag: foo [move forward from 110db8edfa5f to 0163b9ed8732]
     Dry-run requested, not pushing.
     [EOF]
     ");
@@ -1688,10 +1688,10 @@ fn test_git_push_bookmarks_and_tags_of_same_name() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Changes to push to origin:
-      bookmark: bar [move forward from 110db8edfa5f to 5058996c52e2]
-      bookmark: foo [move forward from 110db8edfa5f to 5058996c52e2]
-      tag: bar [move forward from 110db8edfa5f to 5058996c52e2]
-      tag: foo [move forward from 110db8edfa5f to 5058996c52e2]
+      bookmark: bar [move forward from 110db8edfa5f to 0163b9ed8732]
+      bookmark: foo [move forward from 110db8edfa5f to 0163b9ed8732]
+      tag: bar [move forward from 110db8edfa5f to 0163b9ed8732]
+      tag: foo [move forward from 110db8edfa5f to 0163b9ed8732]
     Dry-run requested, not pushing.
     [EOF]
     ");
@@ -1701,8 +1701,8 @@ fn test_git_push_bookmarks_and_tags_of_same_name() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Changes to push to origin:
-      bookmark: foo [move forward from 110db8edfa5f to 5058996c52e2]
-      tag: bar [move forward from 110db8edfa5f to 5058996c52e2]
+      bookmark: foo [move forward from 110db8edfa5f to 0163b9ed8732]
+      tag: bar [move forward from 110db8edfa5f to 0163b9ed8732]
     Dry-run requested, not pushing.
     [EOF]
     ");
@@ -1878,7 +1878,7 @@ fn test_git_push_no_description_in_immutable() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Changes to push to origin:
-      bookmark: my-bookmark [add to 240e2e89abb2]
+      bookmark: my-bookmark [add to aed7f818ab04]
     Dry-run requested, not pushing.
     [EOF]
     ");
@@ -1900,8 +1900,8 @@ fn test_git_push_missing_author() {
     let output = work_dir.run_jj(["git", "push", "--bookmark", "missing-name"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Error: Won't push commit 613adaba9d49 since it has no author and/or committer set
-    Hint: Rejected commit: vruxwmqv 613adaba missing-name* | (empty) initial
+    Error: Won't push commit 14c3571c4153 since it has no author and/or committer set
+    Hint: Rejected commit: truxwmqv 14c3571c missing-name* | (empty) initial
     [EOF]
     [exit status: 1]
     ");
@@ -1942,8 +1942,8 @@ fn test_git_push_missing_author_in_immutable() {
     let output = work_dir.run_jj(["git", "push", "--bookmark=my-bookmark", "--dry-run"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Error: Won't push commit 5c3cc711907f since it has no author and/or committer set
-    Hint: Rejected commit: yostqsxw 5c3cc711 imm* | (empty) no author email
+    Error: Won't push commit 0f6d496a6e33 since it has no author and/or committer set
+    Hint: Rejected commit: rostqsxw 0f6d496a imm* | (empty) no author email
     [EOF]
     [exit status: 1]
     ");
@@ -1953,7 +1953,7 @@ fn test_git_push_missing_author_in_immutable() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Changes to push to origin:
-      bookmark: my-bookmark [add to 96080b93b4ce]
+      bookmark: my-bookmark [add to 1e056846da20]
     Dry-run requested, not pushing.
     [EOF]
     ");
@@ -2035,8 +2035,8 @@ fn test_git_push_missing_committer_in_immutable() {
     let output = work_dir.run_jj(["git", "push", "--bookmark=my-bookmark", "--dry-run"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Error: Won't push commit ab230f98c812 since it has no author and/or committer set
-    Hint: Rejected commit: yostqsxw ab230f98 imm* | (empty) no committer email
+    Error: Won't push commit 8356575dda50 since it has no author and/or committer set
+    Hint: Rejected commit: rostqsxw 8356575d imm* | (empty) no committer email
     [EOF]
     [exit status: 1]
     ");
@@ -2046,7 +2046,7 @@ fn test_git_push_missing_committer_in_immutable() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Changes to push to origin:
-      bookmark: my-bookmark [add to e0dff9c29479]
+      bookmark: my-bookmark [add to 274d0f582429]
     Dry-run requested, not pushing.
     [EOF]
     ");
@@ -2081,7 +2081,7 @@ fn test_git_push_deleted() {
     insta::assert_snapshot!(output, @"
     @  yqosqzyt test.user@example.com 2001-02-03 08:05:13 8d23abdd
     │  (empty) (no description set)
-    │ ○  zsuskuln test.user@example.com 2001-02-03 08:05:10 bookmark2 38a20473
+    │ ○  psuskuln test.user@example.com 2001-02-03 08:05:10 bookmark2 7ac95915
     ├─╯  (empty) description 2
     │ ○  qpvuntsm test.user@example.com 2001-02-03 08:05:08 9b2e76de
     ├─╯  (empty) description 1
@@ -2124,9 +2124,9 @@ fn test_git_push_conflicting_bookmarks() -> TestResult {
     bookmark1: qpvuntsm 9b2e76de (empty) description 1
       @origin: qpvuntsm 9b2e76de (empty) description 1
     bookmark2 (conflicted):
-      + yostqsxw ebedbe63 (empty) description 3
-      + zsuskuln 38a20473 (empty) description 2
-      @origin (behind by 1 commits): zsuskuln 38a20473 (empty) description 2
+      + postqsxw 602aa604 (empty) description 3
+      + psuskuln 7ac95915 (empty) description 2
+      @origin (behind by 1 commits): psuskuln 7ac95915 (empty) description 2
     [EOF]
     ");
 
@@ -2165,7 +2165,7 @@ fn test_git_push_conflicting_bookmarks() -> TestResult {
     Warning: Bookmark bookmark2 is conflicted
     Hint: Run `jj bookmark list` to inspect, and use `jj bookmark set` to fix it up.
     Changes to push to origin:
-      bookmark: bookmark1 [move forward from 9b2e76de3920 to 749c2e6d999f]
+      bookmark: bookmark1 [move forward from 9b2e76de3920 to 2eb9ca9d923e]
     [EOF]
     ");
 
@@ -2177,7 +2177,7 @@ fn test_git_push_conflicting_bookmarks() -> TestResult {
     Warning: Bookmark bookmark2 is conflicted
     Hint: Run `jj bookmark list` to inspect, and use `jj bookmark set` to fix it up.
     Changes to push to origin:
-      bookmark: bookmark1 [move forward from 749c2e6d999f to 9bb0f427b517]
+      bookmark: bookmark1 [move forward from 2eb9ca9d923e to 7b78a524086f]
     [EOF]
     ");
     Ok(())
@@ -2274,12 +2274,12 @@ fn test_git_push_deleted_remote_conflict() {
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @"
     my-bookmark (conflicted):
       - qpvuntsm/0 9b2e76de (hidden) (empty) description 1
-      + royxmykx d7d20286 (empty) description 2
-      + znkkpsqq 7b393945 (empty) description 3
+      + poyxmykx fe007030 (empty) description 2
+      + onkkpsqq 110b71ca (empty) description 3
       @origin (ahead by 2 commits, behind by 1 commits) (conflicted):
       - qpvuntsm/0 9b2e76de (hidden) (empty) description 1
-      + royxmykx/1 8a615f93 (hidden) (empty) description 2
-      + znkkpsqq 7b393945 (empty) description 3
+      + poyxmykx/1 a37f5af9 (hidden) (empty) description 2
+      + onkkpsqq 110b71ca (empty) description 3
     [EOF]
     ");
 
@@ -2291,8 +2291,8 @@ fn test_git_push_deleted_remote_conflict() {
     my-bookmark (deleted)
       @origin (conflicted):
       - qpvuntsm/0 9b2e76de (hidden) (empty) description 1
-      + royxmykx/1 8a615f93 (hidden) (empty) description 2
-      + znkkpsqq 7b393945 (empty) description 3
+      + poyxmykx/1 a37f5af9 (hidden) (empty) description 2
+      + onkkpsqq 110b71ca (empty) description 3
     [EOF]
     ");
     let output = work_dir.run_jj(["git", "push", "--deleted"]);
@@ -2343,19 +2343,19 @@ fn test_git_push_tracked_vs_all() {
         .success();
     work_dir.run_jj(["tag", "set", "-r@", "tag3"]).success();
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @"
-    bookmark1: kmkuslsw f8cde667 (empty) moved bookmark1
+    bookmark1: wmkuslsw 36714d46 (empty) moved bookmark1
     bookmark1@origin: qpvuntsm 9b2e76de (empty) description 1
     bookmark2 (deleted)
-      @origin: zsuskuln 38a20473 (empty) description 2
-    bookmark3: lylxulpl db4b9518 (empty) moved bookmark2
+      @origin: psuskuln 7ac95915 (empty) description 2
+    bookmark3: mylxulpl 844b3f91 (empty) moved bookmark2
     [EOF]
     ");
     insta::assert_snapshot!(get_tag_output(&work_dir), @"
     tag1: qpvuntsm 9b2e76de (empty) description 1
       @origin: qpvuntsm 9b2e76de (empty) description 1
     tag2 (deleted)
-      @origin: zsuskuln 38a20473 (empty) description 2
-    tag3: lylxulpl db4b9518 (empty) moved bookmark2
+      @origin: psuskuln 7ac95915 (empty) description 2
+    tag3: mylxulpl 844b3f91 (empty) moved bookmark2
     [EOF]
     ");
 
@@ -2376,8 +2376,8 @@ fn test_git_push_tracked_vs_all() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Changes to push to origin:
-      bookmark: bookmark2 [delete from 38a204733702]
-      tag: tag2 [delete from 38a204733702]
+      bookmark: bookmark2 [delete from 7ac95915695d]
+      tag: tag2 [delete from 7ac95915695d]
     Dry-run requested, not pushing.
     [EOF]
     ");
@@ -2387,10 +2387,10 @@ fn test_git_push_tracked_vs_all() {
         .run_jj(["bookmark", "untrack", "bookmark2"])
         .success();
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @"
-    bookmark1: kmkuslsw f8cde667 (empty) moved bookmark1
+    bookmark1: wmkuslsw 36714d46 (empty) moved bookmark1
     bookmark1@origin: qpvuntsm 9b2e76de (empty) description 1
-    bookmark2@origin: zsuskuln 38a20473 (empty) description 2
-    bookmark3: lylxulpl db4b9518 (empty) moved bookmark2
+    bookmark2@origin: psuskuln 7ac95915 (empty) description 2
+    bookmark3: mylxulpl 844b3f91 (empty) moved bookmark2
     [EOF]
     ");
 
@@ -2429,7 +2429,7 @@ fn test_git_push_tracked_vs_all() {
     Hint: Push deleted tags with --deleted.
     Warning: Refusing to create new remote tag tag3@origin
     Changes to push to origin:
-      bookmark: bookmark3 [add to db4b95184aca]
+      bookmark: bookmark3 [add to 844b3f914c63]
     [EOF]
     ");
 }
@@ -2501,7 +2501,7 @@ fn test_git_push_to_remote_named_git() {
     ------- stderr -------
     Changes to push to git:
       bookmark: bookmark1 [add to 9b2e76de3920]
-      bookmark: bookmark2 [add to 38a204733702]
+      bookmark: bookmark2 [add to 7ac95915695d]
     Error: Git remote named 'git' is reserved for local Git repository
     Hint: Run `jj git remote rename` to give a different name.
     [EOF]
@@ -2526,7 +2526,7 @@ fn test_git_push_to_remote_with_slashes() {
     ------- stderr -------
     Changes to push to slash/origin:
       bookmark: bookmark1 [add to 9b2e76de3920]
-      bookmark: bookmark2 [add to 38a204733702]
+      bookmark: bookmark2 [add to 7ac95915695d]
     Error: Git remotes with slashes are incompatible with jj: slash/origin
     Hint: Run `jj git remote rename` to give a different name.
     [EOF]
@@ -2551,7 +2551,7 @@ fn test_git_push_commits_not_ready() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Changes to push to origin:
-      bookmark: bookmark2 [move forward from 38a204733702 to 9e7e2853b980]
+      bookmark: bookmark2 [move forward from 7ac95915695d to e1f429e5205e]
     Dry-run requested, not pushing.
     [EOF]
     ");
@@ -2566,8 +2566,8 @@ fn test_git_push_commits_not_ready() {
     let output = work_dir.run_jj(["git", "push"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Warning: Won't push bookmark bookmark2: commit b63db0e60f60 has no author and/or committer set
-      vruxwmqv b63db0e6 bookmark2* | (empty) commit not suitable
+    Warning: Won't push bookmark bookmark2: commit 744d067f0b2d has no author and/or committer set
+      truxwmqv 744d067f bookmark2* | (empty) commit not suitable
     Nothing changed.
     [EOF]
     ");
@@ -2576,8 +2576,8 @@ fn test_git_push_commits_not_ready() {
     let output = work_dir.run_jj(["git", "push", "--config", "git.private-commits=all()"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Warning: Won't push bookmark bookmark2: commit b63db0e60f60 has no author and/or committer set and is private
-      vruxwmqv b63db0e6 bookmark2* | (empty) commit not suitable
+    Warning: Won't push bookmark bookmark2: commit 744d067f0b2d has no author and/or committer set and is private
+      truxwmqv 744d067f bookmark2* | (empty) commit not suitable
     Hint: Configured git.private-commits: 'all()'
     Nothing changed.
     [EOF]
@@ -2593,8 +2593,8 @@ fn test_git_push_commits_not_ready() {
     ]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Warning: Won't push bookmark bookmark2: commit b63db0e60f60 has no author and/or committer set
-      vruxwmqv b63db0e6 bookmark2* | (empty) commit not suitable
+    Warning: Won't push bookmark bookmark2: commit 744d067f0b2d has no author and/or committer set
+      truxwmqv 744d067f bookmark2* | (empty) commit not suitable
     Nothing changed.
     [EOF]
     ");
@@ -2656,7 +2656,7 @@ fn test_git_push_sign_on_push() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Changes to push to origin:
-      bookmark: bookmark2 [move forward from 38a204733702 to 3779ed7f18df]
+      bookmark: bookmark2 [move forward from 7ac95915695d to ab23dfb46418]
     Dry-run requested, not pushing.
     [EOF]
     ");
@@ -2679,9 +2679,9 @@ fn test_git_push_sign_on_push() {
     Updated signatures of 2 commits
     Rebased 2 descendant commits
     Changes to push to origin:
-      bookmark: bookmark2 [move forward from 38a204733702 to d45e2adce0ad]
-    Working copy  (@) now at: kmkuslsw 3d5a9465 (empty) commit which should not be signed 2
-    Parent commit (@-)      : kpqxywon 48ea83e9 (empty) commit which should not be signed 1
+      bookmark: bookmark2 [move forward from 7ac95915695d to adc71fb1a763]
+    Working copy  (@) now at: xmkuslsw f36ecefd (empty) commit which should not be signed 2
+    Parent commit (@-)      : kpqxywon a7a9ae6e (empty) commit which should not be signed 1
     [EOF]
     ");
     // Only commits which are being pushed should be signed
@@ -2704,7 +2704,7 @@ fn test_git_push_sign_on_push() {
     let output = work_dir.run_jj(["bookmark", "move", "bookmark2", "--to", "@-"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Moved 1 bookmarks to kpqxywon 48ea83e9 bookmark2* | (empty) commit which should not be signed 1
+    Moved 1 bookmarks to kpqxywon a7a9ae6e bookmark2* | (empty) commit which should not be signed 1
     [EOF]
     ");
     test_env.add_config(r#"revset-aliases."immutable_heads()" = "bookmark2""#);
@@ -2712,7 +2712,7 @@ fn test_git_push_sign_on_push() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Changes to push to origin:
-      bookmark: bookmark2 [move forward from d45e2adce0ad to 48ea83e9499c]
+      bookmark: bookmark2 [move forward from adc71fb1a763 to a7a9ae6eb373]
     [EOF]
     ");
     let output = work_dir.run_jj(["log", "-T", template, "-r", "::"]);
@@ -2766,9 +2766,9 @@ fn test_git_push_sign_on_push() {
     ------- stderr -------
     Updated signatures of 1 commits
     Changes to push to origin:
-      bookmark: bookmark1 [move sideways from 9b2e76de3920 to 0617b6813c01]
-    Working copy  (@) now at: pzsxstzt 0617b681 bookmark1 | (empty) commit to be signed 3
-    Parent commit (@-)      : kmkuslsw 5114df95 (empty) commit which should not be signed 2
+      bookmark: bookmark1 [move sideways from 9b2e76de3920 to 0f0dc241548c]
+    Working copy  (@) now at: mzsxstzt 0f0dc241 bookmark1 | (empty) commit to be signed 3
+    Parent commit (@-)      : xmkuslsw da79958d (empty) commit which should not be signed 2
     [EOF]
     ");
     let output = work_dir.run_jj(["log", "-T", template]);
@@ -2796,8 +2796,8 @@ fn test_git_push_rejected_by_remote() -> TestResult {
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @"
     bookmark1: qpvuntsm 9b2e76de (empty) description 1
       @origin: qpvuntsm 9b2e76de (empty) description 1
-    bookmark2: zsuskuln 38a20473 (empty) description 2
-      @origin: zsuskuln 38a20473 (empty) description 2
+    bookmark2: psuskuln 7ac95915 (empty) description 2
+      @origin: psuskuln 7ac95915 (empty) description 2
     [EOF]
     ");
 
@@ -2845,7 +2845,7 @@ fn test_git_push_rejected_by_remote() -> TestResult {
         insta::assert_snapshot!(output, @"
         ------- stderr -------
         Changes to push to origin:
-          bookmark: bookmark1 [move forward from 9b2e76de3920 to 0fc4cf312e83]
+          bookmark: bookmark1 [move forward from 9b2e76de3920 to e88165908698]
         remote: error: hook declined to update refs/heads/bookmark1
         Warning: The remote rejected the following updates:
           refs/heads/bookmark1 (reason: hook declined)

--- a/cli/tests/test_global_opts.rs
+++ b/cli/tests/test_global_opts.rs
@@ -36,7 +36,7 @@ fn test_non_utf8_arg() {
         OsString::from_wide(&[0x0066, 0x006f, 0xD800, 0x006f])
     };
     let output = test_env.run_jj_in(".", [&invalid_utf]);
-    insta::assert_snapshot!(output, @"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Error: Non-UTF-8 argument
     [EOF]
@@ -135,8 +135,8 @@ fn test_no_subcommand() {
     let output = work_dir.run_jj([""; 0]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: kxryzmor 8db1ba9a (empty) (no description set)
-    Parent commit (@-)      : lylxulpl 19f3adb2 foo
+    Working copy  (@) now at: kxryzmor 71882475 (empty) (no description set)
+    Parent commit (@-)      : mylxulpl 884f83df foo
     [EOF]
     ");
 
@@ -192,8 +192,8 @@ fn test_no_subcommand() {
     let output = work_dir.run_jj(["status"]);
     insta::assert_snapshot!(output, @r"
     The working copy has no changes.
-    Working copy  (@) : kxryzmor 8db1ba9a (empty) (no description set)
-    Parent commit (@-): lylxulpl 19f3adb2 foo
+    Working copy  (@) : kxryzmor 71882475 (empty) (no description set)
+    Parent commit (@-): mylxulpl 884f83df foo
     [EOF]
     ");
 }
@@ -808,7 +808,7 @@ fn test_color_ui_messages() {
         "-Tdescription",
     ]);
     insta::assert_snapshot!(output, @"
-    [38;5;4m8afc18ff677d32e40043e1bc8c1683c2f9c2e916[39m
+    [38;5;4me6d583051789456eab14846c97cc5a7763cb9c64[39m
     [1m[39m<[38;5;1mError: [39mNo Commit available>[0m  [38;5;8m(elided revisions)[39m
     [38;5;4m0000000000000000000000000000000000000000[39m
     [EOF]
@@ -820,8 +820,8 @@ fn test_color_ui_messages() {
     ------- stderr -------
     [1m[38;5;1mError: [39mRevset `..` resolved to more than one revision[0m
     [1m[38;5;6mHint: [0m[39mThe revset `..` resolved to these revisions:[39m
-    [39m  [1m[38;5;13mm[38;5;8mzvwutvl[39m [38;5;12m8[38;5;8mafc18ff[39m [38;5;10m(empty)[39m [38;5;10m(no description set)[0m[39m[39m
-    [39m  [1m[38;5;5mq[0m[38;5;8mpvuntsm[39m [1m[38;5;4me[0m[38;5;8m8849ae1[39m [38;5;2m(empty)[39m [38;5;2m(no description set)[39m[39m
+    [39m  [1m[38;5;13mp[38;5;8mzvwutvl[39m [38;5;12me6[38;5;8md58305[39m [38;5;10m(empty)[39m [38;5;10m(no description set)[0m[39m[39m
+    [39m  [1m[38;5;5mq[0m[38;5;8mpvuntsm[39m [1m[38;5;4me8[0m[38;5;8m849ae1[39m [38;5;2m(empty)[39m [38;5;2m(no description set)[39m[39m
     [EOF]
     [exit status: 1]
     ");
@@ -830,8 +830,8 @@ fn test_color_ui_messages() {
     let output = work_dir.run_jj(["st", "--color", "debug"]);
     insta::assert_snapshot!(output, @"
     The working copy has no changes.
-    Working copy  (@) : [1m[38;5;13m<<commit working_copy change_id shortest prefix::m>>[38;5;8m<<commit working_copy change_id shortest rest::zvwutvl>>[39m<<commit working_copy:: >>[38;5;12m<<commit working_copy commit_id shortest prefix::8>>[38;5;8m<<commit working_copy commit_id shortest rest::afc18ff>>[39m<<commit working_copy:: >>[38;5;10m<<commit working_copy empty::(empty)>>[39m<<commit working_copy:: >>[38;5;10m<<commit working_copy empty description placeholder::(no description set)>>[0m
-    Parent commit (@-): [1m[38;5;5m<<commit change_id shortest prefix::q>>[0m[38;5;8m<<commit change_id shortest rest::pvuntsm>>[39m<<commit:: >>[1m[38;5;4m<<commit commit_id shortest prefix::e>>[0m[38;5;8m<<commit commit_id shortest rest::8849ae1>>[39m<<commit:: >>[38;5;2m<<commit empty::(empty)>>[39m<<commit:: >>[38;5;2m<<commit empty description placeholder::(no description set)>>[39m
+    Working copy  (@) : [1m[38;5;13m<<commit working_copy change_id shortest prefix::p>>[38;5;8m<<commit working_copy change_id shortest rest::zvwutvl>>[39m<<commit working_copy:: >>[38;5;12m<<commit working_copy commit_id shortest prefix::e6>>[38;5;8m<<commit working_copy commit_id shortest rest::d58305>>[39m<<commit working_copy:: >>[38;5;10m<<commit working_copy empty::(empty)>>[39m<<commit working_copy:: >>[38;5;10m<<commit working_copy empty description placeholder::(no description set)>>[0m
+    Parent commit (@-): [1m[38;5;5m<<commit change_id shortest prefix::q>>[0m[38;5;8m<<commit change_id shortest rest::pvuntsm>>[39m<<commit:: >>[1m[38;5;4m<<commit commit_id shortest prefix::e8>>[0m[38;5;8m<<commit commit_id shortest rest::849ae1>>[39m<<commit:: >>[38;5;2m<<commit empty::(empty)>>[39m<<commit:: >>[38;5;2m<<commit empty description placeholder::(no description set)>>[39m
     [EOF]
     ");
 
@@ -840,7 +840,7 @@ fn test_color_ui_messages() {
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Reverted 1 commits as follows:
-      [1m[38;5;5m<<commit change_id shortest prefix::y>>[0m[38;5;8m<<commit change_id shortest rest::ostqsxw>>[39m<<commit:: >>[1m[38;5;4m<<commit commit_id shortest prefix::8b>>[0m[38;5;8m<<commit commit_id shortest rest::f82eec>>[39m<<commit:: >>[38;5;2m<<commit empty::(empty)>>[39m<<commit:: >><<commit description first_line::Revert "">>
+      [1m[38;5;5m<<commit change_id shortest prefix::y>>[0m[38;5;8m<<commit change_id shortest rest::ostqsxw>>[39m<<commit:: >>[1m[38;5;4m<<commit commit_id shortest prefix::3>>[0m[38;5;8m<<commit commit_id shortest rest::38a1abf>>[39m<<commit:: >>[38;5;2m<<commit empty::(empty)>>[39m<<commit:: >><<commit description first_line::Revert "">>
     [EOF]
     "#);
 }
@@ -1088,14 +1088,14 @@ fn test_conditional_config() {
     let output = test_env.run_jj_in(&test_env.home_dir().join("repo1"), ["foo"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: royxmykx 7c486962 (empty) repo1
+    Working copy  (@) now at: poyxmykx e9100761 (empty) repo1
     Parent commit (@-)      : zzzzzzzz 00000000 (empty) (no description set)
     [EOF]
     ");
     let output = test_env.run_jj_in(&test_env.home_dir().join("repo2"), ["foo"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: yqosqzyt 072741b8 (empty) home
+    Working copy  (@) now at: oqosqzyt aebc7697 (empty) home
     Parent commit (@-)      : zzzzzzzz 00000000 (empty) (no description set)
     [EOF]
     ");

--- a/cli/tests/test_identical_commits.rs
+++ b/cli/tests/test_identical_commits.rs
@@ -34,14 +34,15 @@ fn test_identical_commits() {
     // TODO: Should not fail
     insta::assert_snapshot!(work_dir.run_jj(["new", "root()", "-m=test"]), @"
     ------- stderr -------
-    Internal error: Unexpected error from backend
-    Caused by: Newly-created commit e94ed463cbb0776612e308eba2ecaae74a7f8a73 already exists
+    Working copy  (@) now at: xxmtprsl dfb66bee (empty) test
+    Parent commit (@-)      : zzzzzzzz 00000000 (empty) (no description set)
     [EOF]
-    [exit status: 255]
     ");
     // There should be a single "test" commit
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  e94ed463cbb0 test
+    @  dfb66bee7ef3 test
+    │ ○  271040159836 test
+    ├─╯
     ◆  000000000000
     [EOF]
     ");
@@ -62,7 +63,7 @@ fn test_identical_commits_concurrently() {
         .success();
     // There should be a single "test2" commit
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  c5abd2256ac0 test2
+    @  36c77e6a69f6 test2
     ◆  000000000000
     [EOF]
     ------- stderr -------
@@ -85,17 +86,17 @@ fn test_identical_commits_by_cycling_rewrite() {
     insta::assert_snapshot!(work_dir.run_jj(["describe", "-m=test1"]), @"
     ------- stderr -------
     Internal error: Unexpected error from backend
-    Caused by: Newly-created commit 053222c21fa06b9492e22346f8f70e732231ad4f already exists
+    Caused by: Newly-created commit da532833b539c03f7bc6043cdbbe7e74e17f4031 already exists
     [EOF]
     [exit status: 255]
     ");
     insta::assert_snapshot!(work_dir.run_jj(["evolog"]), @"
-    @  oxmtprsl test.user@example.com 2001-01-01 11:00:00 c5abd225
+    @  yxmtprsl test.user@example.com 2001-01-01 11:00:00 36c77e6a
     │  (empty) test2
-    │  -- operation f0e7f7b1629b describe commit 053222c21fa06b9492e22346f8f70e732231ad4f
-    ○  oxmtprsl/1 test.user@example.com 2001-01-01 11:00:00 053222c2 (hidden)
+    │  -- operation 4b462ee5d71e describe commit da532833b539c03f7bc6043cdbbe7e74e17f4031
+    ○  yxmtprsl/1 test.user@example.com 2001-01-01 11:00:00 da532833 (hidden)
        (empty) test1
-       -- operation 72d9ec4ca389 new empty commit
+       -- operation 161e6444330b new empty commit
     [EOF]
     ");
     // TODO: Test `jj op diff --from @--`
@@ -117,17 +118,19 @@ fn test_identical_commits_by_convergent_rewrite() {
     // TODO: Should not fail
     insta::assert_snapshot!(work_dir.run_jj(["describe", "-m=test3", "subject(test2)"]), @"
     ------- stderr -------
-    Internal error: Unexpected error from backend
-    Caused by: Newly-created commit 460733f1f6f9283d5a810b231dd3f846fd3a6f04 already exists
+    Working copy  (@) now at: xxmtprsl 50c2fa20 (empty) test3
+    Parent commit (@-)      : zzzzzzzz 00000000 (empty) (no description set)
     [EOF]
-    [exit status: 255]
     ");
     // TODO: The "test3" commit should have either "test1" or "test2" as predecessor
     // (or both?)
     insta::assert_snapshot!(work_dir.run_jj(["evolog"]), @"
-    @  oxmtprsl/1 test.user@example.com 2001-01-01 11:00:00 c5abd225 (divergent)
+    @  xxmtprsl test.user@example.com 2001-01-01 11:00:00 50c2fa20
+    │  (empty) test3
+    │  -- operation d9f8db473dd0 describe commit 51ca84bd62397818d82ae3c9906094e5800c78bd
+    ○  xxmtprsl/1 test.user@example.com 2001-01-01 11:00:00 51ca84bd (hidden)
        (empty) test2
-       -- operation 2c0ac8f6dfb7 new empty commit
+       -- operation 1937456f2199 new empty commit
     [EOF]
     ");
 }
@@ -145,15 +148,15 @@ fn test_identical_commits_by_convergent_rewrite_one_operation() {
     // TODO: Should not fail
     insta::assert_snapshot!(work_dir.run_jj(["describe", "-m=test3", "root()+"]), @"
     ------- stderr -------
-    Internal error: Unexpected error from backend
-    Caused by: Newly-created commit 460733f1f6f9283d5a810b231dd3f846fd3a6f04 already exists
+    Updated 2 commits
+    Working copy  (@) now at: xxmtprsl 50c2fa20 (empty) test3
+    Parent commit (@-)      : zzzzzzzz 00000000 (empty) (no description set)
     [EOF]
-    [exit status: 255]
     ");
     // TODO: There should be a single "test3" commit
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  c5abd2256ac0 test2
-    │ ○  053222c21fa0 test1
+    @  50c2fa209245 test3
+    │ ○  68dcc29a6927 test3
     ├─╯
     ◆  000000000000
     [EOF]
@@ -161,9 +164,12 @@ fn test_identical_commits_by_convergent_rewrite_one_operation() {
     // TODO: The "test3" commit should have either "test1" or "test2" as predecessor
     // (or both?)
     insta::assert_snapshot!(work_dir.run_jj(["evolog"]), @"
-    @  oxmtprsl/0 test.user@example.com 2001-01-01 11:00:00 c5abd225 (divergent)
+    @  xxmtprsl test.user@example.com 2001-01-01 11:00:00 50c2fa20
+    │  (empty) test3
+    │  -- operation be5088ecda76 describe commit 51ca84bd62397818d82ae3c9906094e5800c78bd and 1 more
+    ○  xxmtprsl/1 test.user@example.com 2001-01-01 11:00:00 51ca84bd (hidden)
        (empty) test2
-       -- operation 2c0ac8f6dfb7 new empty commit
+       -- operation 1937456f2199 new empty commit
     [EOF]
     ");
 }
@@ -180,37 +186,39 @@ fn test_identical_commits_swap_by_reordering() {
     work_dir.run_jj(["new", "-m=test"]).success();
     // Test the setup
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  5bae90c9b34d test
-    ○  e94ed463cbb0 test
+    @  10877c9de412 test
+    ○  271040159836 test
     ◆  000000000000
     [EOF]
     ");
     // TODO: Should not fail
     insta::assert_snapshot!(work_dir.run_jj(["rebase", "-r=@", "-B=@-"]), @"
     ------- stderr -------
-    Internal error: Unexpected error from backend
-    Caused by: Newly-created commit e94ed463cbb0776612e308eba2ecaae74a7f8a73 already exists
+    Rebased 1 commits to destination
+    Rebased 1 descendant commits
+    Working copy  (@) now at: xxmtprsl dfb66bee (empty) test
+    Parent commit (@-)      : zzzzzzzz 00000000 (empty) (no description set)
     [EOF]
-    [exit status: 255]
     ");
     // There same two commits should still be visible
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  5bae90c9b34d test
-    ○  e94ed463cbb0 test
+    ○  852ad760b5c4 test
+    @  dfb66bee7ef3 test
     ◆  000000000000
     [EOF]
     ");
     // TODO: Each commit should be a predecessor of the other
     insta::assert_snapshot!(work_dir.run_jj(["evolog", "-r=@"]), @"
-    @  oxmtprsl/0 test.user@example.com 2001-01-01 11:00:00 5bae90c9 (divergent)
+    @  xxmtprsl test.user@example.com 2001-01-01 11:00:00 dfb66bee
+    │  (empty) test
+    │  -- operation aa3cbe1cfd92 rebase commit 10877c9de412e62ba46641a702034170210162a0
+    ○  xxmtprsl/1 test.user@example.com 2001-01-01 11:00:00 10877c9d (hidden)
        (empty) test
-       -- operation 51fb079a7e7c new empty commit
+       -- operation 5b46434cebfd new empty commit
     [EOF]
     ");
     insta::assert_snapshot!(work_dir.run_jj(["evolog", "-r=@-"]), @"
-    ○  oxmtprsl/1 test.user@example.com 2001-01-01 11:00:00 e94ed463 (divergent)
-       (empty) test
-       -- operation 03fecb732164 new empty commit
+    ◆  zzzzzzzz root() 00000000
     [EOF]
     ");
     // TODO: Test that `jj op show` displays something reasonable

--- a/cli/tests/test_immutable_commits.rs
+++ b/cli/tests/test_immutable_commits.rs
@@ -30,9 +30,9 @@ fn test_rewrite_immutable_generic() {
     work_dir.write_file("file", "c");
     let output = work_dir.run_jj(["log"]);
     insta::assert_snapshot!(output, @"
-    @  mzvwutvl test.user@example.com 2001-02-03 08:05:12 a6923629
+    @  pzvwutvl test.user@example.com 2001-02-03 08:05:12 eba3614a
     │  c
-    │ ○  kkmpptxz test.user@example.com 2001-02-03 08:05:10 main 9d190342
+    │ ○  nkmpptxz test.user@example.com 2001-02-03 08:05:10 main f74ff8bc
     ├─╯  b
     ○  qpvuntsm test.user@example.com 2001-02-03 08:05:08 c8c8515a
     │  a
@@ -45,8 +45,8 @@ fn test_rewrite_immutable_generic() {
     let output = work_dir.run_jj(["edit", "main"]);
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
-    Error: Commit 9d190342454d is immutable
-    Hint: Could not modify commit: kkmpptxz 9d190342 main | b
+    Error: Commit f74ff8bc3414 is immutable
+    Hint: Could not modify commit: nkmpptxz f74ff8bc main | b
     Hint: Immutable commits are used to protect shared history.
     Hint: For more information, see:
           - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
@@ -98,7 +98,7 @@ fn test_rewrite_immutable_generic() {
     let output = work_dir.run_jj(["--ignore-immutable", "edit", "main"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: kkmpptxz 9d190342 main | b
+    Working copy  (@) now at: nkmpptxz f74ff8bc main | b
     Parent commit (@-)      : qpvuntsm c8c8515a a
     Added 0 files, modified 1 files, removed 0 files
     [EOF]
@@ -119,8 +119,8 @@ fn test_rewrite_immutable_generic() {
     let output = work_dir.run_jj(["new", "main"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: wqnwkozp 8fc35e6e (empty) (no description set)
-    Parent commit (@-)      : kkmpptxz 9d190342 main | b
+    Working copy  (@) now at: wqnwkozp c04df56f (empty) (no description set)
+    Parent commit (@-)      : nkmpptxz f74ff8bc main | b
     [EOF]
     ");
 
@@ -148,15 +148,15 @@ fn test_new_wc_commit_when_wc_immutable() {
     let output = work_dir.run_jj(["bookmark", "set", "main", "-r@"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Moved 1 bookmarks to kkmpptxz e1cb4cf3 main | (empty) a
+    Moved 1 bookmarks to nkmpptxz 74d94dab main | (empty) a
     [EOF]
     ");
     work_dir.write_file("file", "a");
     let output = work_dir.run_jj(["log", "-r.."]);
     insta::assert_snapshot!(output, @"
-    @  mzvwutvl test.user@example.com 2001-02-03 08:05:11 49ad4c46
+    @  mzvwutvl test.user@example.com 2001-02-03 08:05:11 c9fda3f5
     │  (no description set)
-    ◆  kkmpptxz test.user@example.com 2001-02-03 08:05:09 main e1cb4cf3
+    ◆  nkmpptxz test.user@example.com 2001-02-03 08:05:09 main 74d94dab
     │  (empty) a
     ◆  qpvuntsm test.user@example.com 2001-02-03 08:05:07 e8849ae1
     │  (empty) (no description set)
@@ -180,16 +180,16 @@ fn test_immutable_heads_set_to_working_copy() {
     let output = work_dir.run_jj(["new", "-m=a"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: kkmpptxz e1cb4cf3 (empty) a
+    Working copy  (@) now at: nkmpptxz 74d94dab (empty) a
     Parent commit (@-)      : qpvuntsm e8849ae1 main | (empty) (no description set)
     [EOF]
     ");
     work_dir.write_file("file", "a");
     let output = work_dir.run_jj(["log", "-r.."]);
     insta::assert_snapshot!(output, @"
-    @  zsuskuln test.user@example.com 2001-02-03 08:05:10 aa4d78a2
+    @  zsuskuln test.user@example.com 2001-02-03 08:05:10 f5414d57
     │  (no description set)
-    ◆  kkmpptxz test.user@example.com 2001-02-03 08:05:09 e1cb4cf3
+    ◆  nkmpptxz test.user@example.com 2001-02-03 08:05:09 74d94dab
     │  (empty) a
     ◆  qpvuntsm test.user@example.com 2001-02-03 08:05:07 main e8849ae1
     │  (empty) (no description set)
@@ -220,15 +220,15 @@ fn test_new_wc_commit_when_wc_immutable_multi_workspace() {
     let output = work_dir.run_jj(["bookmark", "set", "main", "-r@"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Moved 1 bookmarks to kkmpptxz e1cb4cf3 main | (empty) a
+    Moved 1 bookmarks to nkmpptxz 74d94dab main | (empty) a
     [EOF]
     ");
     work_dir.write_file("file", "a");
     let output = work_dir.run_jj(["log", "-r.."]);
     insta::assert_snapshot!(output, @"
-    @  yqosqzyt test.user@example.com 2001-02-03 08:05:13 default@ 3386b5c7
+    @  yqosqzyt test.user@example.com 2001-02-03 08:05:13 default@ facdee7d
     │  (no description set)
-    ◆  kkmpptxz test.user@example.com 2001-02-03 08:05:09 main workspace1@ e1cb4cf3
+    ◆  nkmpptxz test.user@example.com 2001-02-03 08:05:09 main workspace1@ 74d94dab
     │  (empty) a
     ◆  qpvuntsm test.user@example.com 2001-02-03 08:05:07 e8849ae1
     │  (empty) (no description set)
@@ -242,11 +242,11 @@ fn test_new_wc_commit_when_wc_immutable_multi_workspace() {
     workspace1_dir.write_file("file", "a");
     let output = workspace1_dir.run_jj(["log", "-r.."]);
     insta::assert_snapshot!(output, @"
-    @  vruxwmqv test.user@example.com 2001-02-03 08:05:14 workspace1@ bbc55980
+    @  vruxwmqv test.user@example.com 2001-02-03 08:05:14 workspace1@ 43478bb7
     │  (no description set)
-    │ ○  yqosqzyt test.user@example.com 2001-02-03 08:05:13 default@ 3386b5c7
+    │ ○  yqosqzyt test.user@example.com 2001-02-03 08:05:13 default@ facdee7d
     ├─╯  (no description set)
-    ◆  kkmpptxz test.user@example.com 2001-02-03 08:05:09 main e1cb4cf3
+    ◆  nkmpptxz test.user@example.com 2001-02-03 08:05:09 main 74d94dab
     │  (empty) a
     ◆  qpvuntsm test.user@example.com 2001-02-03 08:05:07 e8849ae1
     │  (empty) (no description set)
@@ -280,7 +280,7 @@ fn test_new_wc_commit_when_wc_immutable_multi_workspace_already_immutable() {
     "#);
     let output = work_dir.run_jj(["log", "-r=::"]);
     insta::assert_snapshot!(output, @"
-    @  rlvkpnrz test.user@example.com 2001-02-03 08:05:08 default@ 167b8dbf
+    @  ylvkpnrz test.user@example.com 2001-02-03 08:05:08 default@ f8fe431e
     │  (empty) a
     │ ◆  pmmvwywv test.user@example.com 2001-02-03 08:05:09 workspace1@ 1cd27236
     ├─╯  (empty) (no description set)
@@ -294,8 +294,8 @@ fn test_new_wc_commit_when_wc_immutable_multi_workspace_already_immutable() {
     let output = work_dir.run_jj(["new"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: mzvwutvl b6d970c6 (empty) (no description set)
-    Parent commit (@-)      : rlvkpnrz 167b8dbf (empty) a
+    Working copy  (@) now at: ozvwutvl a3a2f368 (empty) (no description set)
+    Parent commit (@-)      : ylvkpnrz f8fe431e (empty) a
     [EOF]
     ");
 }
@@ -328,14 +328,14 @@ fn test_rewrite_immutable_commands() {
     // Log shows mutable commits, their parents, and trunk() by default
     let output = work_dir.run_jj(["log"]);
     insta::assert_snapshot!(output, @"
-    @  yqosqzyt test.user@example.com 2001-02-03 08:05:14 55c97dc7
+    @  oqosqzyt test.user@example.com 2001-02-03 08:05:14 d9893cbe
     │  (no description set)
-    │ ◆  mzvwutvl test.user@example.com 2001-02-03 08:05:12 main 1ca17106 (conflict)
+    │ ◆  rzvwutvl test.user@example.com 2001-02-03 08:05:12 main 050a0608 (conflict)
     ╭─┤  merge
     │ │
     │ ~
     │
-    ◆  kkmpptxz test.user@example.com 2001-02-03 08:05:10 9d190342
+    ◆  nkmpptxz test.user@example.com 2001-02-03 08:05:10 f74ff8bc
     │  b
     ~
     [EOF]
@@ -345,8 +345,8 @@ fn test_rewrite_immutable_commands() {
     let output = work_dir.run_jj(["abandon", "main"]);
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
-    Error: Commit 1ca17106e94f is immutable
-    Hint: Could not modify commit: mzvwutvl 1ca17106 main | (conflict) merge
+    Error: Commit 050a0608f6f5 is immutable
+    Hint: Could not modify commit: rzvwutvl 050a0608 main | (conflict) merge
     Hint: Immutable commits are used to protect shared history.
     Hint: For more information, see:
           - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
@@ -359,8 +359,8 @@ fn test_rewrite_immutable_commands() {
     let output = work_dir.run_jj(["absorb", "--into=::@-"]);
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
-    Error: Commit 9d190342454d is immutable
-    Hint: Could not modify commit: kkmpptxz 9d190342 b
+    Error: Commit f74ff8bc3414 is immutable
+    Hint: Could not modify commit: nkmpptxz f74ff8bc b
     Hint: Immutable commits are used to protect shared history.
     Hint: For more information, see:
           - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
@@ -373,8 +373,8 @@ fn test_rewrite_immutable_commands() {
     let output = work_dir.run_jj(["arrange", "-r=main"]);
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
-    Error: Commit 1ca17106e94f is immutable
-    Hint: Could not modify commit: mzvwutvl 1ca17106 main | (conflict) merge
+    Error: Commit 050a0608f6f5 is immutable
+    Hint: Could not modify commit: rzvwutvl 050a0608 main | (conflict) merge
     Hint: Immutable commits are used to protect shared history.
     Hint: For more information, see:
           - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
@@ -387,8 +387,8 @@ fn test_rewrite_immutable_commands() {
     let output = work_dir.run_jj(["file", "chmod", "-r=main", "x", "file"]);
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
-    Error: Commit 1ca17106e94f is immutable
-    Hint: Could not modify commit: mzvwutvl 1ca17106 main | (conflict) merge
+    Error: Commit 050a0608f6f5 is immutable
+    Hint: Could not modify commit: rzvwutvl 050a0608 main | (conflict) merge
     Hint: Immutable commits are used to protect shared history.
     Hint: For more information, see:
           - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
@@ -401,8 +401,8 @@ fn test_rewrite_immutable_commands() {
     let output = work_dir.run_jj(["describe", "main"]);
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
-    Error: Commit 1ca17106e94f is immutable
-    Hint: Could not modify commit: mzvwutvl 1ca17106 main | (conflict) merge
+    Error: Commit 050a0608f6f5 is immutable
+    Hint: Could not modify commit: rzvwutvl 050a0608 main | (conflict) merge
     Hint: Immutable commits are used to protect shared history.
     Hint: For more information, see:
           - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
@@ -415,8 +415,8 @@ fn test_rewrite_immutable_commands() {
     let output = work_dir.run_jj(["diffedit", "-r=main"]);
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
-    Error: Commit 1ca17106e94f is immutable
-    Hint: Could not modify commit: mzvwutvl 1ca17106 main | (conflict) merge
+    Error: Commit 050a0608f6f5 is immutable
+    Hint: Could not modify commit: rzvwutvl 050a0608 main | (conflict) merge
     Hint: Immutable commits are used to protect shared history.
     Hint: For more information, see:
           - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
@@ -429,8 +429,8 @@ fn test_rewrite_immutable_commands() {
     let output = work_dir.run_jj(["edit", "main"]);
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
-    Error: Commit 1ca17106e94f is immutable
-    Hint: Could not modify commit: mzvwutvl 1ca17106 main | (conflict) merge
+    Error: Commit 050a0608f6f5 is immutable
+    Hint: Could not modify commit: rzvwutvl 050a0608 main | (conflict) merge
     Hint: Immutable commits are used to protect shared history.
     Hint: For more information, see:
           - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
@@ -443,8 +443,8 @@ fn test_rewrite_immutable_commands() {
     let output = work_dir.run_jj(["metaedit", "-r=main"]);
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
-    Error: Commit 1ca17106e94f is immutable
-    Hint: Could not modify commit: mzvwutvl 1ca17106 main | (conflict) merge
+    Error: Commit 050a0608f6f5 is immutable
+    Hint: Could not modify commit: rzvwutvl 050a0608 main | (conflict) merge
     Hint: Immutable commits are used to protect shared history.
     Hint: For more information, see:
           - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
@@ -457,8 +457,8 @@ fn test_rewrite_immutable_commands() {
     let output = work_dir.run_jj(["new", "--insert-before", "main"]);
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
-    Error: Commit 1ca17106e94f is immutable
-    Hint: Could not modify commit: mzvwutvl 1ca17106 main | (conflict) merge
+    Error: Commit 050a0608f6f5 is immutable
+    Hint: Could not modify commit: rzvwutvl 050a0608 main | (conflict) merge
     Hint: Immutable commits are used to protect shared history.
     Hint: For more information, see:
           - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
@@ -471,8 +471,8 @@ fn test_rewrite_immutable_commands() {
     let output = work_dir.run_jj(["new", "--insert-after", "subject(b)"]);
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
-    Error: Commit 1ca17106e94f is immutable
-    Hint: Could not modify commit: mzvwutvl 1ca17106 main | (conflict) merge
+    Error: Commit 050a0608f6f5 is immutable
+    Hint: Could not modify commit: rzvwutvl 050a0608 main | (conflict) merge
     Hint: Immutable commits are used to protect shared history.
     Hint: For more information, see:
           - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
@@ -485,8 +485,8 @@ fn test_rewrite_immutable_commands() {
     let output = work_dir.run_jj(["parallelize", "subject(b)", "main"]);
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
-    Error: Commit 1ca17106e94f is immutable
-    Hint: Could not modify commit: mzvwutvl 1ca17106 main | (conflict) merge
+    Error: Commit 050a0608f6f5 is immutable
+    Hint: Could not modify commit: rzvwutvl 050a0608 main | (conflict) merge
     Hint: Immutable commits are used to protect shared history.
     Hint: For more information, see:
           - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
@@ -499,8 +499,8 @@ fn test_rewrite_immutable_commands() {
     let output = work_dir.run_jj(["rebase", "-s=main", "-d=@"]);
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
-    Error: Commit 1ca17106e94f is immutable
-    Hint: Could not modify commit: mzvwutvl 1ca17106 main | (conflict) merge
+    Error: Commit 050a0608f6f5 is immutable
+    Hint: Could not modify commit: rzvwutvl 050a0608 main | (conflict) merge
     Hint: Immutable commits are used to protect shared history.
     Hint: For more information, see:
           - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
@@ -513,8 +513,8 @@ fn test_rewrite_immutable_commands() {
     let output = work_dir.run_jj(["rebase", "-b=main", "-d=@"]);
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
-    Error: Commit dfa21421ac56 is immutable
-    Hint: Could not modify commit: zsuskuln dfa21421 c
+    Error: Commit da5638f8d7d0 is immutable
+    Hint: Could not modify commit: psuskuln da5638f8 c
     Hint: Immutable commits are used to protect shared history.
     Hint: For more information, see:
           - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
@@ -527,8 +527,8 @@ fn test_rewrite_immutable_commands() {
     let output = work_dir.run_jj(["rebase", "-r=main", "-d=@"]);
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
-    Error: Commit 1ca17106e94f is immutable
-    Hint: Could not modify commit: mzvwutvl 1ca17106 main | (conflict) merge
+    Error: Commit 050a0608f6f5 is immutable
+    Hint: Could not modify commit: rzvwutvl 050a0608 main | (conflict) merge
     Hint: Immutable commits are used to protect shared history.
     Hint: For more information, see:
           - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
@@ -541,8 +541,8 @@ fn test_rewrite_immutable_commands() {
     let output = work_dir.run_jj(["resolve", "-r=subject(merge)", "file"]);
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
-    Error: Commit 1ca17106e94f is immutable
-    Hint: Could not modify commit: mzvwutvl 1ca17106 main | (conflict) merge
+    Error: Commit 050a0608f6f5 is immutable
+    Hint: Could not modify commit: rzvwutvl 050a0608 main | (conflict) merge
     Hint: Immutable commits are used to protect shared history.
     Hint: For more information, see:
           - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
@@ -555,8 +555,8 @@ fn test_rewrite_immutable_commands() {
     let output = work_dir.run_jj(["restore", "-c=main"]);
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
-    Error: Commit 1ca17106e94f is immutable
-    Hint: Could not modify commit: mzvwutvl 1ca17106 main | (conflict) merge
+    Error: Commit 050a0608f6f5 is immutable
+    Hint: Could not modify commit: rzvwutvl 050a0608 main | (conflict) merge
     Hint: Immutable commits are used to protect shared history.
     Hint: For more information, see:
           - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
@@ -569,8 +569,8 @@ fn test_rewrite_immutable_commands() {
     let output = work_dir.run_jj(["restore", "--into=main"]);
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
-    Error: Commit 1ca17106e94f is immutable
-    Hint: Could not modify commit: mzvwutvl 1ca17106 main | (conflict) merge
+    Error: Commit 050a0608f6f5 is immutable
+    Hint: Could not modify commit: rzvwutvl 050a0608 main | (conflict) merge
     Hint: Immutable commits are used to protect shared history.
     Hint: For more information, see:
           - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
@@ -583,8 +583,8 @@ fn test_rewrite_immutable_commands() {
     let output = work_dir.run_jj(["split", "-r=main"]);
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
-    Error: Commit 1ca17106e94f is immutable
-    Hint: Could not modify commit: mzvwutvl 1ca17106 main | (conflict) merge
+    Error: Commit 050a0608f6f5 is immutable
+    Hint: Could not modify commit: rzvwutvl 050a0608 main | (conflict) merge
     Hint: Immutable commits are used to protect shared history.
     Hint: For more information, see:
           - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
@@ -597,8 +597,8 @@ fn test_rewrite_immutable_commands() {
     let output = work_dir.run_jj(["split", "-B=main", "-m", "will fail", "file"]);
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
-    Error: Commit 1ca17106e94f is immutable
-    Hint: Could not modify commit: mzvwutvl 1ca17106 main | (conflict) merge
+    Error: Commit 050a0608f6f5 is immutable
+    Hint: Could not modify commit: rzvwutvl 050a0608 main | (conflict) merge
     Hint: Immutable commits are used to protect shared history.
     Hint: For more information, see:
           - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
@@ -611,8 +611,8 @@ fn test_rewrite_immutable_commands() {
     let output = work_dir.run_jj(["squash", "-r=subject(b)"]);
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
-    Error: Commit 9d190342454d is immutable
-    Hint: Could not modify commit: kkmpptxz 9d190342 b
+    Error: Commit f74ff8bc3414 is immutable
+    Hint: Could not modify commit: nkmpptxz f74ff8bc b
     Hint: Immutable commits are used to protect shared history.
     Hint: For more information, see:
           - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
@@ -625,8 +625,8 @@ fn test_rewrite_immutable_commands() {
     let output = work_dir.run_jj(["squash", "--from=main"]);
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
-    Error: Commit 1ca17106e94f is immutable
-    Hint: Could not modify commit: mzvwutvl 1ca17106 main | (conflict) merge
+    Error: Commit 050a0608f6f5 is immutable
+    Hint: Could not modify commit: rzvwutvl 050a0608 main | (conflict) merge
     Hint: Immutable commits are used to protect shared history.
     Hint: For more information, see:
           - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
@@ -639,8 +639,8 @@ fn test_rewrite_immutable_commands() {
     let output = work_dir.run_jj(["squash", "--into=main"]);
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
-    Error: Commit 1ca17106e94f is immutable
-    Hint: Could not modify commit: mzvwutvl 1ca17106 main | (conflict) merge
+    Error: Commit 050a0608f6f5 is immutable
+    Hint: Could not modify commit: rzvwutvl 050a0608 main | (conflict) merge
     Hint: Immutable commits are used to protect shared history.
     Hint: For more information, see:
           - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
@@ -653,8 +653,8 @@ fn test_rewrite_immutable_commands() {
     let output = work_dir.run_jj(["squash", "--after=main-"]);
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
-    Error: Commit 1ca17106e94f is immutable
-    Hint: Could not modify commit: mzvwutvl 1ca17106 main | (conflict) merge
+    Error: Commit 050a0608f6f5 is immutable
+    Hint: Could not modify commit: rzvwutvl 050a0608 main | (conflict) merge
     Hint: Immutable commits are used to protect shared history.
     Hint: For more information, see:
           - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
@@ -667,8 +667,8 @@ fn test_rewrite_immutable_commands() {
     let output = work_dir.run_jj(["squash", "--before=main"]);
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
-    Error: Commit 1ca17106e94f is immutable
-    Hint: Could not modify commit: mzvwutvl 1ca17106 main | (conflict) merge
+    Error: Commit 050a0608f6f5 is immutable
+    Hint: Could not modify commit: rzvwutvl 050a0608 main | (conflict) merge
     Hint: Immutable commits are used to protect shared history.
     Hint: For more information, see:
           - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
@@ -681,8 +681,8 @@ fn test_rewrite_immutable_commands() {
     let output = work_dir.run_jj(["sign", "-r=main", "--config=signing.backend=test"]);
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
-    Error: Commit 1ca17106e94f is immutable
-    Hint: Could not modify commit: mzvwutvl 1ca17106 main | (conflict) merge
+    Error: Commit 050a0608f6f5 is immutable
+    Hint: Could not modify commit: rzvwutvl 050a0608 main | (conflict) merge
     Hint: Immutable commits are used to protect shared history.
     Hint: For more information, see:
           - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
@@ -695,8 +695,8 @@ fn test_rewrite_immutable_commands() {
     let output = work_dir.run_jj(["unsign", "-r=main"]);
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
-    Error: Commit 1ca17106e94f is immutable
-    Hint: Could not modify commit: mzvwutvl 1ca17106 main | (conflict) merge
+    Error: Commit 050a0608f6f5 is immutable
+    Hint: Could not modify commit: rzvwutvl 050a0608 main | (conflict) merge
     Hint: Immutable commits are used to protect shared history.
     Hint: For more information, see:
           - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
@@ -718,7 +718,7 @@ fn test_immutable_log() {
     // `--ignore-immutable`
     let output = work_dir.run_jj(["log", "--ignore-immutable"]);
     insta::assert_snapshot!(output, @"
-    @  rlvkpnrz test.user@example.com 2001-02-03 08:05:08 43444d88
+    @  ylvkpnrz test.user@example.com 2001-02-03 08:05:08 e521ae80
     │  (empty) (no description set)
     ◆  qpvuntsm test.user@example.com 2001-02-03 08:05:07 e8849ae1
     │  (empty) (no description set)

--- a/cli/tests/test_interdiff_command.rs
+++ b/cli/tests/test_interdiff_command.rs
@@ -198,10 +198,10 @@ fn test_interdiff_conflicting() {
     @@ -1,8 +1,1 @@
     -<<<<<<< conflict 1 of 1
     -%%%%%%% diff from: qpvuntsm d0c049cd (original parents)
-    -\\\\\\\        to: zsuskuln 0b2c304e (new parents)
+    -\\\\\\\        to: osuskuln 978660a0 (new parents)
     --foo
     -+abc
-    -+++++++ rlvkpnrz b23f92c3 (original revision)
+    -+++++++ ylvkpnrz ab2bba2b (original revision)
     -bar
     ->>>>>>> conflict 1 of 1 ends
     +def

--- a/cli/tests/test_log_command.rs
+++ b/cli/tests/test_log_command.rs
@@ -177,7 +177,7 @@ fn test_log_with_or_without_diff() {
     // `-G` is the short name of --no-graph
     let output = work_dir.run_jj(["log", "-T", r#"commit_id.short() ++ "\n""#, "-G"]);
     insta::assert_snapshot!(output, @"
-    58c940c45833
+    432d7823bbf4
     007859d3ad71
     000000000000
     [EOF]
@@ -488,15 +488,15 @@ fn test_log_shortest_accessors() {
 
     insta::assert_snapshot!(
         render("::@", r#"change_id.shortest() ++ " " ++ commit_id.shortest() ++ "\n""#), @"
-    wq c2
-    km 74
-    kp 97
-    zn 78
-    yo 40
-    vr bc9
-    yq 28
-    ro af
-    mz 04
+    wq 12
+    ym 21
+    kp 02
+    rn b4
+    so ab2
+    ur 57
+    nq 46
+    oo d9
+    pz 427
     qpv 82
     zzz 00
     [EOF]
@@ -504,15 +504,15 @@ fn test_log_shortest_accessors() {
 
     insta::assert_snapshot!(
         render("::@", r#"format_id(change_id) ++ " " ++ format_id(commit_id) ++ "\n""#), @"
-    wq[nwkozpkust] c2[b4c0bb3362]
-    km[kuslswpqwq] 74[fcd50c0643]
-    kp[qxywonksrl] 97[dcaada9b8d]
-    zn[kkpsqqskkl] 78[c03ab2235b]
-    yo[stqsxwqrlt] 40[1119280761]
-    vr[uxwmqvtpmx] bc9[e8942b459]
-    yq[osqzytrlsw] 28[edbc9658ef]
-    ro[yxmykxtrkr] af[3e6a27a1d0]
-    mz[vwutvlkqwt] 04[6c6a1df762]
+    wq[nwkozpkust] 12[e1f454fa3b]
+    ym[kuslswpqwq] 21[c77e28c563]
+    kp[qxywonksrl] 02[750769a49e]
+    rn[kkpsqqskkl] b4[276b7bb100]
+    so[stqsxwqrlt] ab2[72148812b]
+    ur[uxwmqvtpmx] 57[d01027f6f5]
+    nq[osqzytrlsw] 46[f55119533b]
+    oo[yxmykxtrkr] d9[ff104305ca]
+    pz[vwutvlkqwt] 427[cc156acbe]
     qpv[untsmwlqt] 82[16f646c36d]
     zzz[zzzzzzzzz] 00[0000000000]
     [EOF]
@@ -522,15 +522,15 @@ fn test_log_shortest_accessors() {
     test_env.add_config(r#"revsets.short-prefixes = "(@----)::""#);
     insta::assert_snapshot!(
         render("::@", r#"format_id(change_id) ++ " " ++ format_id(commit_id) ++ "\n""#), @"
-    w[qnwkozpkust] c[2b4c0bb3362]
-    km[kuslswpqwq] 74[fcd50c0643]
-    kp[qxywonksrl] 9[7dcaada9b8d]
-    z[nkkpsqqskkl] 78[c03ab2235b]
-    y[ostqsxwqrlt] 4[01119280761]
-    vr[uxwmqvtpmx] bc9[e8942b459]
-    yq[osqzytrlsw] 28[edbc9658ef]
-    ro[yxmykxtrkr] af[3e6a27a1d0]
-    mz[vwutvlkqwt] 04[6c6a1df762]
+    w[qnwkozpkust] 1[2e1f454fa3b]
+    y[mkuslswpqwq] 2[1c77e28c563]
+    k[pqxywonksrl] 0[2750769a49e]
+    r[nkkpsqqskkl] b[4276b7bb100]
+    s[ostqsxwqrlt] a[b272148812b]
+    ur[uxwmqvtpmx] 57[d01027f6f5]
+    nq[osqzytrlsw] 46[f55119533b]
+    oo[yxmykxtrkr] d9[ff104305ca]
+    pz[vwutvlkqwt] 427[cc156acbe]
     qpv[untsmwlqt] 82[16f646c36d]
     zzz[zzzzzzzzz] 00[0000000000]
     [EOF]
@@ -540,15 +540,15 @@ fn test_log_shortest_accessors() {
     test_env.add_config(r#"revsets.short-prefixes = """#);
     insta::assert_snapshot!(
         render("::@", r#"format_id(change_id) ++ " " ++ format_id(commit_id) ++ "\n""#), @"
-    wq[nwkozpkust] c2[b4c0bb3362]
-    km[kuslswpqwq] 74[fcd50c0643]
-    kp[qxywonksrl] 97[dcaada9b8d]
-    zn[kkpsqqskkl] 78[c03ab2235b]
-    yo[stqsxwqrlt] 401[119280761]
-    vr[uxwmqvtpmx] bc9[e8942b459]
-    yq[osqzytrlsw] 28[edbc9658ef]
-    ro[yxmykxtrkr] af[3e6a27a1d0]
-    mz[vwutvlkqwt] 04[6c6a1df762]
+    wq[nwkozpkust] 12[e1f454fa3b]
+    ym[kuslswpqwq] 21[c77e28c563]
+    kp[qxywonksrl] 02[750769a49e]
+    rn[kkpsqqskkl] b42[76b7bb100]
+    so[stqsxwqrlt] ab2[72148812b]
+    ur[uxwmqvtpmx] 57[d01027f6f5]
+    nq[osqzytrlsw] 46[f55119533b]
+    oo[yxmykxtrkr] d9[ff104305ca]
+    pz[vwutvlkqwt] 427[cc156acbe]
     qpv[untsmwlqt] 82[16f646c36d]
     zzz[zzzzzzzzz] 00[0000000000]
     [EOF]
@@ -685,15 +685,15 @@ fn test_log_prefix_highlight_styled() {
         &prefix_format(Some(12)),
     ]);
     insta::assert_snapshot!(output, @"
-    [1m[38;5;2m@[0m  Change [1m[38;5;5mwq[0m[38;5;8mnwkozpkust[39m commit9 [1m[38;5;4mc2[0m[38;5;8mb4c0bb3362[39m
-    ○  Change [1m[38;5;5mkm[0m[38;5;8mkuslswpqwq[39m commit8 [1m[38;5;4m74[0m[38;5;8mfcd50c0643[39m
-    ○  Change [1m[38;5;5mkp[0m[38;5;8mqxywonksrl[39m commit7 [1m[38;5;4m97[0m[38;5;8mdcaada9b8d[39m
-    ○  Change [1m[38;5;5mzn[0m[38;5;8mkkpsqqskkl[39m commit6 [1m[38;5;4m78[0m[38;5;8mc03ab2235b[39m
-    ○  Change [1m[38;5;5myo[0m[38;5;8mstqsxwqrlt[39m commit5 [1m[38;5;4m40[0m[38;5;8m1119280761[39m
-    ○  Change [1m[38;5;5mvr[0m[38;5;8muxwmqvtpmx[39m commit4 [1m[38;5;4mbc9[0m[38;5;8me8942b459[39m
-    ○  Change [1m[38;5;5myq[0m[38;5;8mosqzytrlsw[39m commit3 [1m[38;5;4m28[0m[38;5;8medbc9658ef[39m
-    ○  Change [1m[38;5;5mro[0m[38;5;8myxmykxtrkr[39m commit2 [1m[38;5;4maf[0m[38;5;8m3e6a27a1d0[39m
-    ○  Change [1m[38;5;5mmz[0m[38;5;8mvwutvlkqwt[39m commit1 [1m[38;5;4m04[0m[38;5;8m6c6a1df762[39m
+    [1m[38;5;2m@[0m  Change [1m[38;5;5mwq[0m[38;5;8mnwkozpkust[39m commit9 [1m[38;5;4m12[0m[38;5;8me1f454fa3b[39m
+    ○  Change [1m[38;5;5mym[0m[38;5;8mkuslswpqwq[39m commit8 [1m[38;5;4m21[0m[38;5;8mc77e28c563[39m
+    ○  Change [1m[38;5;5mkp[0m[38;5;8mqxywonksrl[39m commit7 [1m[38;5;4m02[0m[38;5;8m750769a49e[39m
+    ○  Change [1m[38;5;5mrn[0m[38;5;8mkkpsqqskkl[39m commit6 [1m[38;5;4mb4[0m[38;5;8m276b7bb100[39m
+    ○  Change [1m[38;5;5mso[0m[38;5;8mstqsxwqrlt[39m commit5 [1m[38;5;4mab2[0m[38;5;8m72148812b[39m
+    ○  Change [1m[38;5;5mur[0m[38;5;8muxwmqvtpmx[39m commit4 [1m[38;5;4m57[0m[38;5;8md01027f6f5[39m
+    ○  Change [1m[38;5;5mnq[0m[38;5;8mosqzytrlsw[39m commit3 [1m[38;5;4m46[0m[38;5;8mf55119533b[39m
+    ○  Change [1m[38;5;5moo[0m[38;5;8myxmykxtrkr[39m commit2 [1m[38;5;4md9[0m[38;5;8mff104305ca[39m
+    ○  Change [1m[38;5;5mpz[0m[38;5;8mvwutvlkqwt[39m commit1 [1m[38;5;4m427[0m[38;5;8mcc156acbe[39m
     ○  Change [1m[38;5;5mqpv[0m[38;5;8muntsmwlqt[39m initial [1m[38;5;4m82[0m[38;5;8m16f646c36d[39m [38;5;5moriginal[39m
     [1m[38;5;14m◆[0m  Change [1m[38;5;5mzzz[0m[38;5;8mzzzzzzzzz[39m [1m[38;5;4m00[0m[38;5;8m0000000000[39m
     [EOF]
@@ -707,15 +707,15 @@ fn test_log_prefix_highlight_styled() {
         &prefix_format(Some(3)),
     ]);
     insta::assert_snapshot!(output, @"
-    [1m[38;5;2m@[0m  Change [1m[38;5;5mwq[0m[38;5;8mn[39m commit9 [1m[38;5;4mc2[0m[38;5;8mb[39m
-    ○  Change [1m[38;5;5mkm[0m[38;5;8mk[39m commit8 [1m[38;5;4m74[0m[38;5;8mf[39m
-    ○  Change [1m[38;5;5mkp[0m[38;5;8mq[39m commit7 [1m[38;5;4m97[0m[38;5;8md[39m
-    ○  Change [1m[38;5;5mzn[0m[38;5;8mk[39m commit6 [1m[38;5;4m78[0m[38;5;8mc[39m
-    ○  Change [1m[38;5;5myo[0m[38;5;8ms[39m commit5 [1m[38;5;4m40[0m[38;5;8m1[39m
-    ○  Change [1m[38;5;5mvr[0m[38;5;8mu[39m commit4 [1m[38;5;4mbc9[0m
-    ○  Change [1m[38;5;5myq[0m[38;5;8mo[39m commit3 [1m[38;5;4m28[0m[38;5;8me[39m
-    ○  Change [1m[38;5;5mro[0m[38;5;8my[39m commit2 [1m[38;5;4maf[0m[38;5;8m3[39m
-    ○  Change [1m[38;5;5mmz[0m[38;5;8mv[39m commit1 [1m[38;5;4m04[0m[38;5;8m6[39m
+    [1m[38;5;2m@[0m  Change [1m[38;5;5mwq[0m[38;5;8mn[39m commit9 [1m[38;5;4m12[0m[38;5;8me[39m
+    ○  Change [1m[38;5;5mym[0m[38;5;8mk[39m commit8 [1m[38;5;4m21[0m[38;5;8mc[39m
+    ○  Change [1m[38;5;5mkp[0m[38;5;8mq[39m commit7 [1m[38;5;4m02[0m[38;5;8m7[39m
+    ○  Change [1m[38;5;5mrn[0m[38;5;8mk[39m commit6 [1m[38;5;4mb4[0m[38;5;8m2[39m
+    ○  Change [1m[38;5;5mso[0m[38;5;8ms[39m commit5 [1m[38;5;4mab2[0m
+    ○  Change [1m[38;5;5mur[0m[38;5;8mu[39m commit4 [1m[38;5;4m57[0m[38;5;8md[39m
+    ○  Change [1m[38;5;5mnq[0m[38;5;8mo[39m commit3 [1m[38;5;4m46[0m[38;5;8mf[39m
+    ○  Change [1m[38;5;5moo[0m[38;5;8my[39m commit2 [1m[38;5;4md9[0m[38;5;8mf[39m
+    ○  Change [1m[38;5;5mpz[0m[38;5;8mv[39m commit1 [1m[38;5;4m427[0m
     ○  Change [1m[38;5;5mqpv[0m initial [1m[38;5;4m82[0m[38;5;8m1[39m [38;5;5moriginal[39m
     [1m[38;5;14m◆[0m  Change [1m[38;5;5mzzz[0m [1m[38;5;4m00[0m[38;5;8m0[39m
     [EOF]
@@ -729,15 +729,15 @@ fn test_log_prefix_highlight_styled() {
         &prefix_format(None),
     ]);
     insta::assert_snapshot!(output, @"
-    [1m[38;5;2m@[0m  Change [1m[38;5;5mwq[0m commit9 [1m[38;5;4mc2[0m
-    ○  Change [1m[38;5;5mkm[0m commit8 [1m[38;5;4m74[0m
-    ○  Change [1m[38;5;5mkp[0m commit7 [1m[38;5;4m97[0m
-    ○  Change [1m[38;5;5mzn[0m commit6 [1m[38;5;4m78[0m
-    ○  Change [1m[38;5;5myo[0m commit5 [1m[38;5;4m40[0m
-    ○  Change [1m[38;5;5mvr[0m commit4 [1m[38;5;4mbc9[0m
-    ○  Change [1m[38;5;5myq[0m commit3 [1m[38;5;4m28[0m
-    ○  Change [1m[38;5;5mro[0m commit2 [1m[38;5;4maf[0m
-    ○  Change [1m[38;5;5mmz[0m commit1 [1m[38;5;4m04[0m
+    [1m[38;5;2m@[0m  Change [1m[38;5;5mwq[0m commit9 [1m[38;5;4m12[0m
+    ○  Change [1m[38;5;5mym[0m commit8 [1m[38;5;4m21[0m
+    ○  Change [1m[38;5;5mkp[0m commit7 [1m[38;5;4m02[0m
+    ○  Change [1m[38;5;5mrn[0m commit6 [1m[38;5;4mb4[0m
+    ○  Change [1m[38;5;5mso[0m commit5 [1m[38;5;4mab2[0m
+    ○  Change [1m[38;5;5mur[0m commit4 [1m[38;5;4m57[0m
+    ○  Change [1m[38;5;5mnq[0m commit3 [1m[38;5;4m46[0m
+    ○  Change [1m[38;5;5moo[0m commit2 [1m[38;5;4md9[0m
+    ○  Change [1m[38;5;5mpz[0m commit1 [1m[38;5;4m427[0m
     ○  Change [1m[38;5;5mqpv[0m initial [1m[38;5;4m82[0m [38;5;5moriginal[39m
     [1m[38;5;14m◆[0m  Change [1m[38;5;5mzzz[0m [1m[38;5;4m00[0m
     [EOF]
@@ -1446,33 +1446,33 @@ fn test_log_word_wrap() {
 
     // ui.log-word-wrap option applies to both graph/no-graph outputs
     insta::assert_snapshot!(render(&["log", "-r@"], 40, false), @"
-    @  mzvwutvl test.user@example.com 2001-02-03 08:05:11 bafb1ee5
+    @  pzvwutvl test.user@example.com 2001-02-03 08:05:11 f79d2360
     │  (empty) merge
     ~
     [EOF]
     ");
     insta::assert_snapshot!(render(&["log", "-r@"], 40, true), @"
-    @  mzvwutvl test.user@example.com
-    │  2001-02-03 08:05:11 bafb1ee5
+    @  pzvwutvl test.user@example.com
+    │  2001-02-03 08:05:11 f79d2360
     ~  (empty) merge
     [EOF]
     ");
     insta::assert_snapshot!(render(&["log", "--no-graph", "-r@"], 40, false), @"
-    mzvwutvl test.user@example.com 2001-02-03 08:05:11 bafb1ee5
+    pzvwutvl test.user@example.com 2001-02-03 08:05:11 f79d2360
     (empty) merge
     [EOF]
     ");
     insta::assert_snapshot!(render(&["log", "--no-graph", "-r@"], 40, true), @"
-    mzvwutvl test.user@example.com
-    2001-02-03 08:05:11 bafb1ee5
+    pzvwutvl test.user@example.com
+    2001-02-03 08:05:11 f79d2360
     (empty) merge
     [EOF]
     ");
 
     // Color labels should be preserved
     insta::assert_snapshot!(render(&["log", "-r@", "--color=always"], 40, true), @"
-    [1m[38;5;2m@[0m  [1m[38;5;13mm[38;5;8mzvwutvl[39m [38;5;3mtest.user@example.com[39m[0m
-    │  [1m[38;5;14m2001-02-03 08:05:11[39m [38;5;12mb[38;5;8mafb1ee5[39m[0m
+    [1m[38;5;2m@[0m  [1m[38;5;13mp[38;5;8mzvwutvl[39m [38;5;3mtest.user@example.com[39m[0m
+    │  [1m[38;5;14m2001-02-03 08:05:11[39m [38;5;12mf[38;5;8m79d2360[39m[0m
     ~  [1m[38;5;10m(empty)[39m merge[0m
     [EOF]
     ");
@@ -1503,21 +1503,21 @@ fn test_log_word_wrap() {
 
     // Shouldn't panic with $COLUMNS < graph_width
     insta::assert_snapshot!(render(&["log", "-r@"], 0, true), @"
-    @  mzvwutvl
+    @  pzvwutvl
     │  test.user@example.com
     ~  2001-02-03
        08:05:11
-       bafb1ee5
+       f79d2360
        (empty)
        merge
     [EOF]
     ");
     insta::assert_snapshot!(render(&["log", "-r@"], 1, true), @"
-    @  mzvwutvl
+    @  pzvwutvl
     │  test.user@example.com
     ~  2001-02-03
        08:05:11
-       bafb1ee5
+       f79d2360
        (empty)
        merge
     [EOF]
@@ -1559,7 +1559,7 @@ fn test_log_diff_stat_width() {
     work_dir.write_file("file2", "foo\n".repeat(100));
 
     insta::assert_snapshot!(render(&["log", "--stat", "--no-graph"], 30), @"
-    rlvkpnrz test.user@example.com 2001-02-03 08:05:09 9490cfd3
+    ylvkpnrz test.user@example.com 2001-02-03 08:05:09 3717a8ae
     (no description set)
     file2 | 100 ++++++++++++++++++
     1 file changed, 100 insertions(+), 0 deletions(-)
@@ -1574,7 +1574,7 @@ fn test_log_diff_stat_width() {
 
     // Graph width should be subtracted
     insta::assert_snapshot!(render(&["log", "--stat"], 30), @"
-    @  rlvkpnrz test.user@example.com 2001-02-03 08:05:09 9490cfd3
+    @  ylvkpnrz test.user@example.com 2001-02-03 08:05:09 3717a8ae
     │  (no description set)
     │  file2 | 100 +++++++++++++++
     │  1 file changed, 100 insertions(+), 0 deletions(-)
@@ -1816,7 +1816,7 @@ fn test_log_anonymize() {
 
     let output = work_dir.run_jj(["log", "-r::", "-Tbuiltin_log_redacted"]);
     insta::assert_snapshot!(output, @"
-    @  yqosqzyt user-78cd 2001-02-03 08:05:13 bookmark-dc8b* de3c47af
+    @  pqosqzyt user-78cd 2001-02-03 08:05:13 bookmark-dc8b* 9b95dae1
     │  (empty) (redacted)
     ◆  qpvuntsm user-78cd 2001-02-03 08:05:08 bookmark-dc8b@remote-86e9 bookmark-56f1 bookmark-ff9e@remote-86e9 37b69cda
     │  (empty) (redacted)

--- a/cli/tests/test_metaedit_command.rs
+++ b/cli/tests/test_metaedit_command.rs
@@ -38,16 +38,16 @@ fn test_metaedit() {
     work_dir.write_file("file1", "c\n");
     // Test the setup
     insta::assert_snapshot!(get_log(&work_dir), @"
-    @  Commit ID: 22be6c4e01da7039a1a8c3adb91b8841252bb354
-    │  Change ID: mzvwutvlkqwtuzoztpszkqxkqmqyqyxo
+    @  Commit ID: 1cc10709fbc078f11bacb8640a3dc11a41ec8221
+    │  Change ID: pzvwutvlkqwtuzoztpszkqxkqmqyqyxo
     │  Bookmarks: c
     │  Author   : Test User <test.user@example.com> (2001-02-03 04:05:13.000 +07:00)
     │  Committer: Test User <test.user@example.com> (2001-02-03 04:05:13.000 +07:00)
     │
     │      (no description set)
     │
-    ○  Commit ID: 75591b1896b4990e7695701fd7cdbb32dba3ff50
-    │  Change ID: kkmpptxzrspxrzommnulwmwkkqwworpl
+    ○  Commit ID: 099a44efcab4d977ed5b622bf030b3de2b59fcef
+    │  Change ID: nkmpptxzrspxrzommnulwmwkkqwworpl
     │  Bookmarks: b
     │  Author   : Test User <test.user@example.com> (2001-02-03 04:05:11.000 +07:00)
     │  Committer: Test User <test.user@example.com> (2001-02-03 04:05:11.000 +07:00)
@@ -75,7 +75,7 @@ fn test_metaedit() {
 
     // Without arguments, the commits are not rewritten.
     // TODO: Require an argument?
-    let output = work_dir.run_jj(["metaedit", "kkmpptxzrspx"]);
+    let output = work_dir.run_jj(["metaedit", "nkmpptxzrspx"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Nothing changed.
@@ -87,7 +87,7 @@ fn test_metaedit() {
         "metaedit",
         "--config=user.name=Test User",
         "--update-author",
-        "kkmpptxzrspx",
+        "nkmpptxzrspx",
     ]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
@@ -104,20 +104,20 @@ fn test_metaedit() {
             "--config=user.email=ove.ridder@example.com",
             "--update-author",
             "-r",
-            "kkmpptxzrspx",
+            "nkmpptxzrspx",
         ])
         .success();
     insta::assert_snapshot!(get_log(&work_dir), @"
-    @  Commit ID: 6f31b2555777ac2261dd17008b6fdc42619ebe1f
-    │  Change ID: mzvwutvlkqwtuzoztpszkqxkqmqyqyxo
+    @  Commit ID: ae4f674f90aa5e6cb5e35dbba89f07fbadda7212
+    │  Change ID: pzvwutvlkqwtuzoztpszkqxkqmqyqyxo
     │  Bookmarks: c
     │  Author   : Test User <test.user@example.com> (2001-02-03 04:05:13.000 +07:00)
     │  Committer: Ove Ridder <ove.ridder@example.com> (2001-02-03 04:05:17.000 +07:00)
     │
     │      (no description set)
     │
-    ○  Commit ID: 590c8b6945666401d01269190c1b82cd3311a0cd
-    │  Change ID: kkmpptxzrspxrzommnulwmwkkqwworpl
+    ○  Commit ID: 4030125719ab8eab6bf3512f2e94ef1086f6f719
+    │  Change ID: nkmpptxzrspxrzommnulwmwkkqwworpl
     │  Bookmarks: b
     │  Author   : Ove Ridder <ove.ridder@example.com> (2001-02-03 04:05:11.000 +07:00)
     │  Committer: Ove Ridder <ove.ridder@example.com> (2001-02-03 04:05:17.000 +07:00)
@@ -145,19 +145,19 @@ fn test_metaedit() {
     // Update author timestamp
     work_dir.run_jj(["op", "restore", &setup_opid]).success();
     work_dir
-        .run_jj(["metaedit", "--update-author-timestamp", "kkmpptxzrspx"])
+        .run_jj(["metaedit", "--update-author-timestamp", "nkmpptxzrspx"])
         .success();
     insta::assert_snapshot!(get_log(&work_dir), @"
-    @  Commit ID: b23f6a3f160d122f8d8dacd8d2acff2d29d5ba84
-    │  Change ID: mzvwutvlkqwtuzoztpszkqxkqmqyqyxo
+    @  Commit ID: 2ffc2fd0145bb13872d5824292192464269a7c74
+    │  Change ID: pzvwutvlkqwtuzoztpszkqxkqmqyqyxo
     │  Bookmarks: c
     │  Author   : Test User <test.user@example.com> (2001-02-03 04:05:13.000 +07:00)
     │  Committer: Test User <test.user@example.com> (2001-02-03 04:05:20.000 +07:00)
     │
     │      (no description set)
     │
-    ○  Commit ID: f121a0fb72e1790e4116b2e3b6989c795ac7f74b
-    │  Change ID: kkmpptxzrspxrzommnulwmwkkqwworpl
+    ○  Commit ID: 636156987ae8c5e2659afeee34f167448d2cf80c
+    │  Change ID: nkmpptxzrspxrzommnulwmwkkqwworpl
     │  Bookmarks: b
     │  Author   : Test User <test.user@example.com> (2001-02-03 04:05:20.000 +07:00)
     │  Committer: Test User <test.user@example.com> (2001-02-03 04:05:20.000 +07:00)
@@ -189,20 +189,20 @@ fn test_metaedit() {
             "metaedit",
             "--author",
             "Alice <alice@example.com>",
-            "kkmpptxzrspx",
+            "nkmpptxzrspx",
         ])
         .success();
     insta::assert_snapshot!(get_log(&work_dir), @"
-    @  Commit ID: 74007c679b9e4f13d1e3d553ef8397586b033421
-    │  Change ID: mzvwutvlkqwtuzoztpszkqxkqmqyqyxo
+    @  Commit ID: 36bf20bf6335c7cd930d34609a71ebd221d0b9ab
+    │  Change ID: pzvwutvlkqwtuzoztpszkqxkqmqyqyxo
     │  Bookmarks: c
     │  Author   : Test User <test.user@example.com> (2001-02-03 04:05:13.000 +07:00)
     │  Committer: Test User <test.user@example.com> (2001-02-03 04:05:23.000 +07:00)
     │
     │      (no description set)
     │
-    ○  Commit ID: d070c8adbc590813c81e296591d6b2cac8f3bb41
-    │  Change ID: kkmpptxzrspxrzommnulwmwkkqwworpl
+    ○  Commit ID: 0e1a59998553e269e4fc5a72e500abc4d65cbc99
+    │  Change ID: nkmpptxzrspxrzommnulwmwkkqwworpl
     │  Bookmarks: b
     │  Author   : Alice <alice@example.com> (2001-02-03 04:05:11.000 +07:00)
     │  Committer: Test User <test.user@example.com> (2001-02-03 04:05:23.000 +07:00)
@@ -237,16 +237,16 @@ fn test_metaedit() {
         ])
         .success();
     insta::assert_snapshot!(get_log(&work_dir), @"
-    @  Commit ID: a527219f85839d58ddb6115fbc4f0f8bc6649266
-    │  Change ID: mzvwutvlkqwtuzoztpszkqxkqmqyqyxo
+    @  Commit ID: 50da9de3c56ed519d452f6070e9b6f4b45cc83c5
+    │  Change ID: pzvwutvlkqwtuzoztpszkqxkqmqyqyxo
     │  Bookmarks: c
     │  Author   : Test User <test.user@example.com> (1995-12-19 16:39:57.000 -08:00)
     │  Committer: Test User <test.user@example.com> (2001-02-03 04:05:26.000 +07:00)
     │
     │      (no description set)
     │
-    ○  Commit ID: 75591b1896b4990e7695701fd7cdbb32dba3ff50
-    │  Change ID: kkmpptxzrspxrzommnulwmwkkqwworpl
+    ○  Commit ID: 099a44efcab4d977ed5b622bf030b3de2b59fcef
+    │  Change ID: nkmpptxzrspxrzommnulwmwkkqwworpl
     │  Bookmarks: b
     │  Author   : Test User <test.user@example.com> (2001-02-03 04:05:11.000 +07:00)
     │  Committer: Test User <test.user@example.com> (2001-02-03 04:05:11.000 +07:00)
@@ -286,19 +286,19 @@ fn test_metaedit() {
     // Update committer timestamp
     work_dir.run_jj(["op", "restore", &setup_opid]).success();
     work_dir
-        .run_jj(["metaedit", "--force-rewrite", "kkmpptxzrspx"])
+        .run_jj(["metaedit", "--force-rewrite", "nkmpptxzrspx"])
         .success();
     insta::assert_snapshot!(get_log(&work_dir), @"
-    @  Commit ID: 6c0aa6574ef6450eaf7eae1391cc6c769c53a50c
-    │  Change ID: mzvwutvlkqwtuzoztpszkqxkqmqyqyxo
+    @  Commit ID: ebc5d975db02477c3203e21ef442454dd31682f5
+    │  Change ID: pzvwutvlkqwtuzoztpszkqxkqmqyqyxo
     │  Bookmarks: c
     │  Author   : Test User <test.user@example.com> (2001-02-03 04:05:13.000 +07:00)
     │  Committer: Test User <test.user@example.com> (2001-02-03 04:05:31.000 +07:00)
     │
     │      (no description set)
     │
-    ○  Commit ID: 0a570dfbbaf794cd15bbdbf28f94785405ef5b3b
-    │  Change ID: kkmpptxzrspxrzommnulwmwkkqwworpl
+    ○  Commit ID: 6df7d0b4a9a9ce270e201fb2d906ef75bb2c1c62
+    │  Change ID: nkmpptxzrspxrzommnulwmwkkqwworpl
     │  Bookmarks: b
     │  Author   : Test User <test.user@example.com> (2001-02-03 04:05:11.000 +07:00)
     │  Committer: Test User <test.user@example.com> (2001-02-03 04:05:31.000 +07:00)
@@ -332,14 +332,14 @@ fn test_metaedit() {
     insta::assert_snapshot!(work_dir.run_jj(["metaedit", "--force-rewrite"]), @"
     ------- stderr -------
     Modified 1 commits:
-      mzvwutvl 75259df4 c | (no description set)
-    Working copy  (@) now at: mzvwutvl 75259df4 c | (no description set)
-    Parent commit (@-)      : kkmpptxz 0a570dfb b | (no description set)
+      pzvwutvl 82611617 c | (no description set)
+    Working copy  (@) now at: pzvwutvl 82611617 c | (no description set)
+    Parent commit (@-)      : nkmpptxz 6df7d0b4 b | (no description set)
     [EOF]
     ");
     insta::assert_snapshot!(work_dir.run_jj(["show"]), @"
-    Commit ID: 75259df433eebc10b3ad78a9814d6647b764ce28
-    Change ID: mzvwutvlkqwtuzoztpszkqxkqmqyqyxo
+    Commit ID: 82611617f1bc287e1ee773eb65f11c946a77fc75
+    Change ID: pzvwutvlkqwtuzoztpszkqxkqmqyqyxo
     Bookmarks: c
     Author   : Test User <test.user@example.com> (2001-02-03 08:05:13)
     Committer: Test Committer <test.committer@example.com> (2001-02-03 08:05:33)
@@ -354,7 +354,7 @@ fn test_metaedit() {
 
     // When resetting the description has no effect, the commits are not rewritten.
     work_dir.run_jj(["op", "restore", &setup_opid]).success();
-    let output = work_dir.run_jj(["metaedit", "--message", "", "kkmpptxzrspx"]);
+    let output = work_dir.run_jj(["metaedit", "--message", "", "nkmpptxzrspx"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Nothing changed.
@@ -366,8 +366,8 @@ fn test_metaedit() {
         .run_jj(["metaedit", "--message", "d\ne\nf"])
         .success();
     insta::assert_snapshot!(get_log(&work_dir), @"
-    @  Commit ID: 502004368461738c866bc690ce08f7c219a4de10
-    │  Change ID: mzvwutvlkqwtuzoztpszkqxkqmqyqyxo
+    @  Commit ID: b1d3b74bbc7edf70c6bcd708b125ba02bf39ea73
+    │  Change ID: pzvwutvlkqwtuzoztpszkqxkqmqyqyxo
     │  Bookmarks: c
     │  Author   : Test User <test.user@example.com> (2001-02-03 04:05:13.000 +07:00)
     │  Committer: Test Committer <test.committer@example.com> (2001-02-03 04:05:37.000 +07:00)
@@ -376,8 +376,8 @@ fn test_metaedit() {
     │      e
     │      f
     │
-    ○  Commit ID: 75591b1896b4990e7695701fd7cdbb32dba3ff50
-    │  Change ID: kkmpptxzrspxrzommnulwmwkkqwworpl
+    ○  Commit ID: 099a44efcab4d977ed5b622bf030b3de2b59fcef
+    │  Change ID: nkmpptxzrspxrzommnulwmwkkqwworpl
     │  Bookmarks: b
     │  Author   : Test User <test.user@example.com> (2001-02-03 04:05:11.000 +07:00)
     │  Committer: Test User <test.user@example.com> (2001-02-03 04:05:11.000 +07:00)
@@ -405,16 +405,16 @@ fn test_metaedit() {
     // Set empty description
     work_dir.run_jj(["metaedit", "--message", ""]).success();
     insta::assert_snapshot!(get_log(&work_dir), @"
-    @  Commit ID: a44f230f9af7eed606af7713774feba5e39f36f7
-    │  Change ID: mzvwutvlkqwtuzoztpszkqxkqmqyqyxo
+    @  Commit ID: a2e143c4646126b61caa10c275e886a5c92f1113
+    │  Change ID: pzvwutvlkqwtuzoztpszkqxkqmqyqyxo
     │  Bookmarks: c
     │  Author   : Test User <test.user@example.com> (2001-02-03 04:05:13.000 +07:00)
     │  Committer: Test Committer <test.committer@example.com> (2001-02-03 04:05:39.000 +07:00)
     │
     │      (no description set)
     │
-    ○  Commit ID: 75591b1896b4990e7695701fd7cdbb32dba3ff50
-    │  Change ID: kkmpptxzrspxrzommnulwmwkkqwworpl
+    ○  Commit ID: 099a44efcab4d977ed5b622bf030b3de2b59fcef
+    │  Change ID: nkmpptxzrspxrzommnulwmwkkqwworpl
     │  Bookmarks: b
     │  Author   : Test User <test.user@example.com> (2001-02-03 04:05:11.000 +07:00)
     │  Committer: Test User <test.user@example.com> (2001-02-03 04:05:11.000 +07:00)
@@ -475,16 +475,16 @@ fn test_metaedit_multiple_revisions() {
     work_dir.write_file("file1", "c\n");
     // Test the setup
     insta::assert_snapshot!(get_log(&work_dir), @"
-    @  Commit ID: 22be6c4e01da7039a1a8c3adb91b8841252bb354
-    │  Change ID: mzvwutvlkqwtuzoztpszkqxkqmqyqyxo
+    @  Commit ID: 1cc10709fbc078f11bacb8640a3dc11a41ec8221
+    │  Change ID: pzvwutvlkqwtuzoztpszkqxkqmqyqyxo
     │  Bookmarks: c
     │  Author   : Test User <test.user@example.com> (2001-02-03 04:05:13.000 +07:00)
     │  Committer: Test User <test.user@example.com> (2001-02-03 04:05:13.000 +07:00)
     │
     │      (no description set)
     │
-    ○  Commit ID: 75591b1896b4990e7695701fd7cdbb32dba3ff50
-    │  Change ID: kkmpptxzrspxrzommnulwmwkkqwworpl
+    ○  Commit ID: 099a44efcab4d977ed5b622bf030b3de2b59fcef
+    │  Change ID: nkmpptxzrspxrzommnulwmwkkqwworpl
     │  Bookmarks: b
     │  Author   : Test User <test.user@example.com> (2001-02-03 04:05:11.000 +07:00)
     │  Committer: Test User <test.user@example.com> (2001-02-03 04:05:11.000 +07:00)
@@ -518,36 +518,36 @@ fn test_metaedit_multiple_revisions() {
         "--config=user.name=Ove Ridder",
         "--config=user.email=ove.ridder@example.com",
         "--update-author",
-        "kkmpptxz::mzvwutvl",
+        "nkmpptxz::pzvwutvl",
     ]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Modified 2 commits:
-      kkmpptxz d84add51 b | (no description set)
-      mzvwutvl 447d6d8a c | (no description set)
+      nkmpptxz c2cf6241 b | (no description set)
+      pzvwutvl 819e7624 c | (no description set)
     Rebased 1 descendant commits
-    Working copy  (@) now at: yostqsxw ebd66676 (empty) (no description set)
-    Parent commit (@-)      : mzvwutvl 447d6d8a c | (no description set)
+    Working copy  (@) now at: sostqsxw d2aae73d (empty) (no description set)
+    Parent commit (@-)      : pzvwutvl 819e7624 c | (no description set)
     [EOF]
     ");
     insta::assert_snapshot!(get_log(&work_dir), @"
-    @  Commit ID: ebd66676fa9e0cd2c9f560bc0dc343b8809e4dfe
-    │  Change ID: yostqsxwqrltovqlrlzszywzslusmuup
+    @  Commit ID: d2aae73d443bec2e01e223987d27c002e854f622
+    │  Change ID: sostqsxwqrltovqlrlzszywzslusmuup
     │  Author   : Test User <test.user@example.com> (2001-02-03 04:05:15.000 +07:00)
     │  Committer: Ove Ridder <ove.ridder@example.com> (2001-02-03 04:05:16.000 +07:00)
     │
     │      (no description set)
     │
-    ○  Commit ID: 447d6d8a12d90ff0f10bbefc552f9272694389d6
-    │  Change ID: mzvwutvlkqwtuzoztpszkqxkqmqyqyxo
+    ○  Commit ID: 819e762406dd4f214ea8ac63b7aff1e2ae1465fc
+    │  Change ID: pzvwutvlkqwtuzoztpszkqxkqmqyqyxo
     │  Bookmarks: c
     │  Author   : Ove Ridder <ove.ridder@example.com> (2001-02-03 04:05:13.000 +07:00)
     │  Committer: Ove Ridder <ove.ridder@example.com> (2001-02-03 04:05:16.000 +07:00)
     │
     │      (no description set)
     │
-    ○  Commit ID: d84add5150537e89db428790c0f9413320127f00
-    │  Change ID: kkmpptxzrspxrzommnulwmwkkqwworpl
+    ○  Commit ID: c2cf62419f1c0bd5022bd4c33fa6d055d5c75384
+    │  Change ID: nkmpptxzrspxrzommnulwmwkkqwworpl
     │  Bookmarks: b
     │  Author   : Ove Ridder <ove.ridder@example.com> (2001-02-03 04:05:11.000 +07:00)
     │  Committer: Ove Ridder <ove.ridder@example.com> (2001-02-03 04:05:16.000 +07:00)
@@ -594,19 +594,19 @@ fn test_new_change_id() {
         .success();
     work_dir.write_file("file1", "c\n");
 
-    let output = work_dir.run_jj(["metaedit", "--update-change-id", "kkmpptxzrspx"]);
+    let output = work_dir.run_jj(["metaedit", "--update-change-id", "nkmpptxzrspx"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Modified 1 commits:
       yqosqzyt 01d6741e b | (no description set)
     Rebased 1 descendant commits
-    Working copy  (@) now at: mzvwutvl 0c3fe2d8 c | (no description set)
+    Working copy  (@) now at: pzvwutvl 97c0b8a6 c | (no description set)
     Parent commit (@-)      : yqosqzyt 01d6741e b | (no description set)
     [EOF]
     ");
     insta::assert_snapshot!(get_log(&work_dir), @"
-    @  Commit ID: 0c3fe2d854b2b492a053156a505d6c40fe783138
-    │  Change ID: mzvwutvlkqwtuzoztpszkqxkqmqyqyxo
+    @  Commit ID: 97c0b8a6c66784b8ee76df8f7636f34336b5ef1a
+    │  Change ID: pzvwutvlkqwtuzoztpszkqxkqmqyqyxo
     │  Bookmarks: c
     │  Author   : Test User <test.user@example.com> (2001-02-03 04:05:13.000 +07:00)
     │  Committer: Test User <test.user@example.com> (2001-02-03 04:05:13.000 +07:00)
@@ -641,25 +641,25 @@ fn test_new_change_id() {
     insta::assert_snapshot!(work_dir.run_jj(["evolog", "-r", "yqosqzytrlswkspswpqrmlplxylrzsnz"]), @"
     ○  yqosqzyt test.user@example.com 2001-02-03 08:05:13 b 01d6741e
     │  (no description set)
-    │  -- operation 35c9be8faa47 edit commit metadata for commit 75591b1896b4990e7695701fd7cdbb32dba3ff50
-    ○  kkmpptxz/0 test.user@example.com 2001-02-03 08:05:11 75591b18 (hidden)
+    │  -- operation 5b02e577448e edit commit metadata for commit 099a44efcab4d977ed5b622bf030b3de2b59fcef
+    ○  nkmpptxz/0 test.user@example.com 2001-02-03 08:05:11 099a44ef (hidden)
     │  (no description set)
-    │  -- operation 96903839b342 snapshot working copy
-    ○  kkmpptxz/1 test.user@example.com 2001-02-03 08:05:09 acebf2bd (hidden)
+    │  -- operation 7b1b5edae383 snapshot working copy
+    ○  nkmpptxz/1 test.user@example.com 2001-02-03 08:05:09 11ba6b0f (hidden)
        (empty) (no description set)
-       -- operation 35de69400054 new empty commit
+       -- operation 130349b44890 new empty commit
     [EOF]
     ");
-    insta::assert_snapshot!(work_dir.run_jj(["evolog", "-r", "mzvwut"]), @"
-    @  mzvwutvl test.user@example.com 2001-02-03 08:05:13 c 0c3fe2d8
+    insta::assert_snapshot!(work_dir.run_jj(["evolog", "-r", "pzvwut"]), @"
+    @  pzvwutvl test.user@example.com 2001-02-03 08:05:13 c 97c0b8a6
     │  (no description set)
-    │  -- operation 35c9be8faa47 edit commit metadata for commit 75591b1896b4990e7695701fd7cdbb32dba3ff50
-    ○  mzvwutvl/1 test.user@example.com 2001-02-03 08:05:13 22be6c4e (hidden)
+    │  -- operation 5b02e577448e edit commit metadata for commit 099a44efcab4d977ed5b622bf030b3de2b59fcef
+    ○  pzvwutvl/1 test.user@example.com 2001-02-03 08:05:13 1cc10709 (hidden)
     │  (no description set)
-    │  -- operation 7d623f9b6867 snapshot working copy
-    ○  mzvwutvl/2 test.user@example.com 2001-02-03 08:05:11 b9f5490a (hidden)
+    │  -- operation 543f77a89e53 snapshot working copy
+    ○  pzvwutvl/2 test.user@example.com 2001-02-03 08:05:11 e0a459cb (hidden)
        (empty) (no description set)
-       -- operation 80928a366fe1 new empty commit
+       -- operation 2a59b6403d9d new empty commit
     [EOF]
     ");
 }

--- a/cli/tests/test_new_command.rs
+++ b/cli/tests/test_new_command.rs
@@ -28,7 +28,7 @@ fn test_new() {
     work_dir.run_jj(["new", "-m", "a new commit"]).success();
 
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  22aec45f30a36a2d244c70e131e369d79e400962 a new commit
+    @  c7be36d5c1768e7731056dcce3c3ff2503b63b5a a new commit
     ○  55eabcc47301440da7a71d5610d3db021d1925ca add a file
     ◆  0000000000000000000000000000000000000000
     [EOF]
@@ -39,8 +39,8 @@ fn test_new() {
         .run_jj(["new", "-m", "off of root", "root()"])
         .success();
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  8818c9ee28d00667cb3072a2114a67619ded7ceb off of root
-    │ ○  22aec45f30a36a2d244c70e131e369d79e400962 a new commit
+    @  ade1c2296c9b3294b783f2ffc6208808a621c321 off of root
+    │ ○  c7be36d5c1768e7731056dcce3c3ff2503b63b5a a new commit
     │ ○  55eabcc47301440da7a71d5610d3db021d1925ca add a file
     ├─╯
     ◆  0000000000000000000000000000000000000000
@@ -52,9 +52,9 @@ fn test_new() {
         .run_jj(["new", "--edit", "-m", "yet another commit"])
         .success();
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  9629f035563a7d9fa86becc783ae71557bd25269 yet another commit
-    ○  8818c9ee28d00667cb3072a2114a67619ded7ceb off of root
-    │ ○  22aec45f30a36a2d244c70e131e369d79e400962 a new commit
+    @  aec5b3a25e62407c315b8b7a2bf676c3fe31ba4d yet another commit
+    ○  ade1c2296c9b3294b783f2ffc6208808a621c321 off of root
+    │ ○  c7be36d5c1768e7731056dcce3c3ff2503b63b5a a new commit
     │ ○  55eabcc47301440da7a71d5610d3db021d1925ca add a file
     ├─╯
     ◆  0000000000000000000000000000000000000000
@@ -63,7 +63,7 @@ fn test_new() {
 
     // --edit cannot be used with --no-edit
     let output = work_dir.run_jj(["new", "--edit", "B", "--no-edit", "D"]);
-    insta::assert_snapshot!(output, @"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
     error: the argument '--edit' cannot be used with '--no-edit'
 
@@ -96,9 +96,9 @@ fn test_new_merge() {
     // Create a merge commit
     work_dir.run_jj(["new", "main", "@"]).success();
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @    94ce38ef81dc7912c1574cc5aa2f434b9057d58a
+    @    d4b1aaaf202e623d8fc50704d8d9593169344d21
     ├─╮
-    │ ○  5bf404a038660799fae348cc31b9891349c128c1 add file2
+    │ ○  d0687397deaf2dae0df4ac9acc14a7e33308fa3c add file2
     ○ │  96ab002e5b86c39a661adc0524df211a3dac3f1b add file1
     ├─╯
     ◆  0000000000000000000000000000000000000000
@@ -114,13 +114,13 @@ fn test_new_merge() {
     let output = work_dir.run_jj(["new", "main", "@", "--no-edit"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Created new commit kpqxywon 061f4210 (empty) (no description set)
+    Created new commit lpqxywon 8dd19532 (empty) (no description set)
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    ○    061f42107e030034242b424264f22985429552c1
+    ○    8dd195327ba0c74f720c5a854cad4e6b7cb6e9ec
     ├─╮
-    │ @  5bf404a038660799fae348cc31b9891349c128c1 add file2
+    │ @  d0687397deaf2dae0df4ac9acc14a7e33308fa3c add file2
     ○ │  96ab002e5b86c39a661adc0524df211a3dac3f1b add file1
     ├─╯
     ◆  0000000000000000000000000000000000000000
@@ -131,9 +131,9 @@ fn test_new_merge() {
     work_dir.run_jj(["op", "restore", &setup_opid]).success();
     work_dir.run_jj(["new", "main", "@"]).success();
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @    cee60a55c085ff349af7fa1e7d6b7d4b7bdd4c3a
+    @    1a2683ac02c9ed76b159cbc335ba8908c639fc86
     ├─╮
-    │ ○  5bf404a038660799fae348cc31b9891349c128c1 add file2
+    │ ○  d0687397deaf2dae0df4ac9acc14a7e33308fa3c add file2
     ○ │  96ab002e5b86c39a661adc0524df211a3dac3f1b add file1
     ├─╯
     ◆  0000000000000000000000000000000000000000
@@ -152,8 +152,8 @@ fn test_new_merge() {
     let output = work_dir.run_jj(["new", "@", "visible_heads()"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: uyznsvlq 68a7f50c (empty) (no description set)
-    Parent commit (@-)      : lylxulpl cee60a55 (empty) (no description set)
+    Working copy  (@) now at: wyznsvlq a8125eab (empty) (no description set)
+    Parent commit (@-)      : mylxulpl 1a2683ac (empty) (no description set)
     [EOF]
     ");
 
@@ -191,16 +191,16 @@ fn test_new_merge_parents_order() {
         ])
         .success();
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @          2034dc93c6ddad404d1aa677ab99b0621d8e109d
+    @          cce3ff23115e7f554a9c77389b48c49b4f7962fb
     ├─┬─┬─┬─╮
-    │ │ │ │ ○  de5bab19f679c52a021c343b8942ca875ec6aae7 4
-    │ │ │ ○ │  de3c6b2c8e065351203063817ef0794df1adb2f9 5
+    │ │ │ │ ○  a9a58f3dbfe40e8ea0901e381324498b68046bf2 4
+    │ │ │ ○ │  abe836bad23ae391a542ee1c0eacaa392aec0249 5
     │ │ │ ├─╯
-    │ │ ○ │  1783ad0eb5c21d958b2e1bf8caab9b019f3d16e9 1
+    │ │ ○ │  9a6abef0dba86ff0abb65f9899584be39a11114b 1
     │ │ ├─╯
-    │ ○ │  fb047eea4c2bec04e2fd3cd21eca0193d5720341 3
+    │ ○ │  f7edbc03066334b554f52800af76dd0aefab4b5c 3
     │ ├─╯
-    ○ │  36b1b4840ac943a08e7f953df4eadc53e825f2a6 2
+    ○ │  60bb72a1e8b37d6dbb279b0d088030c6f9fb9266 2
     ├─╯
     ◆  0000000000000000000000000000000000000000
     [EOF]
@@ -221,9 +221,9 @@ fn test_new_merge_conflicts() {
     let output = work_dir.run_jj(["new", "2|3"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: vruxwmqv 4665f78e (conflict) (empty) (no description set)
-    Parent commit (@-)      : royxmykx 1b282e07 3 | 3
-    Parent commit (@-)      : zsuskuln 7ac709e5 2 | 2
+    Working copy  (@) now at: truxwmqv 2d1dc9f3 (conflict) (empty) (no description set)
+    Parent commit (@-)      : ooyxmykx 262ef62a 3 | 3
+    Parent commit (@-)      : psuskuln 0f19fe92 2 | 2
     Added 0 files, modified 1 files, removed 0 files
     Warning: There are unresolved conflicts at these paths:
     file    2-sided conflict
@@ -231,11 +231,11 @@ fn test_new_merge_conflicts() {
     ");
     insta::assert_snapshot!(work_dir.read_file("file"), @r#"
     <<<<<<< conflict 1 of 1
-    %%%%%%% diff from: rlvkpnrz a93ed0a5 "1"
-    \\\\\\\        to: royxmykx 1b282e07 "3"
+    %%%%%%% diff from: ylvkpnrz b4ea5b9e "1"
+    \\\\\\\        to: ooyxmykx 262ef62a "3"
     -1a
     +3a 1a
-    +++++++ zsuskuln 7ac709e5 "2"
+    +++++++ psuskuln 0f19fe92 "2"
     1a 2a
     >>>>>>> conflict 1 of 1 ends
     1b
@@ -249,9 +249,9 @@ fn test_new_merge_conflicts() {
     let output = work_dir.run_jj(["new", "2|3", "--config=merge.hunk-level=word"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: znkkpsqq 892ac90f (empty) (no description set)
-    Parent commit (@-)      : royxmykx 1b282e07 3 | 3
-    Parent commit (@-)      : zsuskuln 7ac709e5 2 | 2
+    Working copy  (@) now at: nnkkpsqq 26047b15 (empty) (no description set)
+    Parent commit (@-)      : ooyxmykx 262ef62a 3 | 3
+    Parent commit (@-)      : psuskuln 0f19fe92 2 | 2
     Added 1 files, modified 0 files, removed 0 files
     [EOF]
     ");
@@ -276,9 +276,9 @@ fn test_new_merge_same_change() {
     let output = work_dir.run_jj(["new", "2|3"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: vruxwmqv 7bebf0fe (empty) (no description set)
-    Parent commit (@-)      : royxmykx 1b9fe696 3 | 3
-    Parent commit (@-)      : zsuskuln 829e1e90 2 | 2
+    Working copy  (@) now at: truxwmqv 751bd5bc (empty) (no description set)
+    Parent commit (@-)      : ooyxmykx b7c11bbc 3 | 3
+    Parent commit (@-)      : psuskuln d6387571 2 | 2
     [EOF]
     ");
     insta::assert_snapshot!(work_dir.read_file("file"), @"
@@ -293,9 +293,9 @@ fn test_new_merge_same_change() {
     let output = work_dir.run_jj(["new", "2|3", "--config=merge.same-change=keep"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: znkkpsqq 7be86433 (conflict) (empty) (no description set)
-    Parent commit (@-)      : royxmykx 1b9fe696 3 | 3
-    Parent commit (@-)      : zsuskuln 829e1e90 2 | 2
+    Working copy  (@) now at: nnkkpsqq 74eddf2f (conflict) (empty) (no description set)
+    Parent commit (@-)      : ooyxmykx b7c11bbc 3 | 3
+    Parent commit (@-)      : psuskuln d6387571 2 | 2
     Added 1 files, modified 0 files, removed 0 files
     Warning: There are unresolved conflicts at these paths:
     file    2-sided conflict
@@ -304,10 +304,10 @@ fn test_new_merge_same_change() {
     insta::assert_snapshot!(work_dir.read_file("file"), @r#"
     a
     <<<<<<< conflict 1 of 1
-    %%%%%%% diff from: rlvkpnrz 2adf972b "1"
-    \\\\\\\        to: royxmykx 1b9fe696 "3"
+    %%%%%%% diff from: ylvkpnrz 2883207c "1"
+    \\\\\\\        to: ooyxmykx b7c11bbc "3"
     +b
-    +++++++ zsuskuln 829e1e90 "2"
+    +++++++ psuskuln d6387571 "2"
     b
     >>>>>>> conflict 1 of 1 ends
     "#);
@@ -324,7 +324,7 @@ fn test_new_description_template() {
     let output = work_dir.run_jj(["new"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: rlvkpnrz 0cdaf03d (empty) custom default
+    Working copy  (@) now at: ylvkpnrz a5fa58b3 (empty) custom default
     Parent commit (@-)      : qpvuntsm e8849ae1 (empty) (no description set)
     [EOF]
     ");
@@ -332,8 +332,8 @@ fn test_new_description_template() {
     let output = work_dir.run_jj(["new", "-m", "explicit message"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: kkmpptxz ccc7aea5 (empty) explicit message
-    Parent commit (@-)      : rlvkpnrz 0cdaf03d (empty) custom default
+    Working copy  (@) now at: nkmpptxz 9889dd1a (empty) explicit message
+    Parent commit (@-)      : ylvkpnrz a5fa58b3 (empty) custom default
     [EOF]
     ");
 
@@ -341,8 +341,8 @@ fn test_new_description_template() {
     let output = work_dir.run_jj(["new"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: zsuskuln 49261437 (empty) (no description set)
-    Parent commit (@-)      : kkmpptxz ccc7aea5 (empty) explicit message
+    Working copy  (@) now at: psuskuln 810ff317 (empty) (no description set)
+    Parent commit (@-)      : nkmpptxz 9889dd1a (empty) explicit message
     [EOF]
     ");
 
@@ -351,8 +351,8 @@ fn test_new_description_template() {
     let output = work_dir.run_jj(["new"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Working copy  (@) now at: mzvwutvl 10155342 (empty) parents: 1
-    Parent commit (@-)      : zsuskuln 49261437 (empty) (no description set)
+    Working copy  (@) now at: rzvwutvl 6c4cf5e6 (empty) parents: 1
+    Parent commit (@-)      : psuskuln 810ff317 (empty) (no description set)
     [EOF]
     ");
 }
@@ -382,9 +382,9 @@ fn test_new_insert_after() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Rebased 2 descendant commits
-    Working copy  (@) now at: kxryzmor 57acfedf (empty) G
+    Working copy  (@) now at: vxryzmor 3da64d04 (empty) G
     Parent commit (@-)      : kkmpptxz bb98b010 B | (empty) B
-    Parent commit (@-)      : vruxwmqv 521674f5 D | (empty) D
+    Parent commit (@-)      : uruxwmqv 1c0d5121 D | (empty) D
     [EOF]
     ");
     insta::assert_snapshot!(get_short_log_output(&work_dir), @"
@@ -409,7 +409,7 @@ fn test_new_insert_after() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Rebased 3 descendant commits
-    Working copy  (@) now at: uyznsvlq ec395e2e (empty) H
+    Working copy  (@) now at: wyznsvlq 4a5952c4 (empty) H
     Parent commit (@-)      : kkmpptxz bb98b010 B | (empty) B
     [EOF]
     ");
@@ -517,10 +517,10 @@ fn test_new_insert_before() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Rebased 2 descendant commits
-    Working copy  (@) now at: kxryzmor 2f16c40d (empty) G
+    Working copy  (@) now at: vxryzmor 73470f9b (empty) G
     Parent commit (@-)      : kkmpptxz bb98b010 B | (empty) B
-    Parent commit (@-)      : vruxwmqv 521674f5 D | (empty) D
-    Parent commit (@-)      : znkkpsqq 56a33cd0 E | (empty) E
+    Parent commit (@-)      : uruxwmqv 1c0d5121 D | (empty) D
+    Parent commit (@-)      : pnkkpsqq 3ec50fe1 E | (empty) E
     [EOF]
     ");
     insta::assert_snapshot!(get_short_log_output(&work_dir), @"
@@ -587,7 +587,7 @@ fn test_new_insert_before_root_successors() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Rebased 5 descendant commits
-    Working copy  (@) now at: kxryzmor 8c026b06 (empty) G
+    Working copy  (@) now at: vxryzmor 22be0be4 (empty) G
     Parent commit (@-)      : zzzzzzzz 00000000 (empty) (no description set)
     [EOF]
     ");
@@ -616,10 +616,10 @@ fn test_new_insert_before_no_loop() {
     let template = r#"commit_id.short() ++ " " ++ if(description, description, "root")"#;
     let output = work_dir.run_jj(["log", "-T", template]);
     insta::assert_snapshot!(output, @"
-    @    a8176a8a5348 F
+    @    6b02b566593b F
     ├─╮
-    │ ○  56a33cd09d90 E
-    ○ │  521674f591a6 D
+    │ ○  3ec50fe121ee E
+    ○ │  1c0d5121740c D
     ├─╯
     │ ○  d32ebe56a293 C
     │ ○  bb98b0102ef5 B
@@ -736,7 +736,7 @@ fn test_new_insert_after_before() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Rebased 1 descendant commits
-    Working copy  (@) now at: kxryzmor 55a63f47 (empty) G
+    Working copy  (@) now at: vxryzmor e98f75cd (empty) G
     Parent commit (@-)      : mzvwutvl d32ebe56 C | (empty) C
     [EOF]
     ");
@@ -759,8 +759,8 @@ fn test_new_insert_after_before() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Rebased 4 descendant commits
-    Working copy  (@) now at: uyznsvlq fd3f1413 (empty) H
-    Parent commit (@-)      : vruxwmqv 521674f5 D | (empty) D
+    Working copy  (@) now at: wyznsvlq 4b778f26 (empty) H
+    Parent commit (@-)      : uruxwmqv 1c0d5121 D | (empty) D
     [EOF]
     ");
     insta::assert_snapshot!(get_short_log_output(&work_dir), @"
@@ -791,10 +791,10 @@ fn test_new_insert_after_before_no_loop() {
     let template = r#"commit_id.short() ++ " " ++ if(description, description, "root")"#;
     let output = work_dir.run_jj(["log", "-T", template]);
     insta::assert_snapshot!(output, @"
-    @    a8176a8a5348 F
+    @    6b02b566593b F
     ├─╮
-    │ ○  56a33cd09d90 E
-    ○ │  521674f591a6 D
+    │ ○  3ec50fe121ee E
+    ○ │  1c0d5121740c D
     ├─╯
     │ ○  d32ebe56a293 C
     │ ○  bb98b0102ef5 B
@@ -830,10 +830,10 @@ fn test_new_insert_after_empty_before() {
     let template = r#"commit_id.short() ++ " " ++ if(description, description, "root")"#;
     let output = work_dir.run_jj(["log", "-T", template]);
     insta::assert_snapshot!(output, @"
-    @    a8176a8a5348 F
+    @    6b02b566593b F
     ├─╮
-    │ ○  56a33cd09d90 E
-    ○ │  521674f591a6 D
+    │ ○  3ec50fe121ee E
+    ○ │  1c0d5121740c D
     ├─╯
     │ ○  d32ebe56a293 C
     │ ○  bb98b0102ef5 B
@@ -854,7 +854,7 @@ fn test_new_insert_after_empty_before() {
     let output = work_dir.run_jj(["new", "-mG", "--insert-before=none()", "--insert-after=B"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: nkmrtpmo d7088f92 (empty) G
+    Working copy  (@) now at: tkmrtpmo 7e66ad61 (empty) G
     Parent commit (@-)      : kkmpptxz bb98b010 B | (empty) B
     [EOF]
     ");
@@ -897,7 +897,7 @@ fn test_new_conflicting_bookmarks() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Error: Name `foo` is conflicted
-    Hint: Use commit ID to select single revision from: 96948328bc42, 401ea16fc3fe
+    Hint: Use commit ID to select single revision from: 6dec1091a14e, 401ea16fc3fe
     Hint: Use `bookmarks(foo)` to select all revisions
     Hint: To set which revision the bookmark points to, run `jj bookmark set foo -r <REVISION>`
     [EOF]

--- a/cli/tests/test_next_prev_commands.rs
+++ b/cli/tests/test_next_prev_commands.rs
@@ -47,7 +47,7 @@ fn test_next_simple() {
     work_dir.run_jj(["new", "@--"]).success();
 
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  royxmykxtrkr
+    @  poyxmykxtrkr
     │ ○  kkmpptxzrspx third
     ├─╯
     ○  rlvkpnrzqnoo second
@@ -87,7 +87,7 @@ fn test_next_multiple() {
     work_dir.run_jj(["new", "@---"]).success();
 
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  royxmykxtrkr
+    @  soyxmykxtrkr
     │ ○  zsuskulnrvyr fourth
     │ ○  kkmpptxzrspx third
     ├─╯
@@ -206,7 +206,7 @@ fn test_next_exceeding_history() {
     work_dir.run_jj(["new", "-r", "@--"]).success();
 
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  mzvwutvlkqwt
+    @  pzvwutvlkqwt
     │ ○  kkmpptxzrspx third
     ├─╯
     ○  rlvkpnrzqnoo second
@@ -240,9 +240,9 @@ fn test_next_parent_has_multiple_descendants() {
     work_dir.run_jj(["new", "-m", "4"]).success();
     work_dir.run_jj(["edit", "subject(3)"]).success();
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    ○  mzvwutvlkqwt 4
-    @  zsuskulnrvyr 3
-    │ ○  kkmpptxzrspx 2
+    ○  rzvwutvlkqwt 4
+    @  psuskulnrvyr 3
+    │ ○  nkmpptxzrspx 2
     │ ○  qpvuntsmwlqt 1
     ├─╯
     ◆  zzzzzzzzzzzz
@@ -252,14 +252,14 @@ fn test_next_parent_has_multiple_descendants() {
     let output = work_dir.run_jj(["next", "--edit"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: mzvwutvl e5543950 (empty) 4
-    Parent commit (@-)      : zsuskuln 83df6e43 (empty) 3
+    Working copy  (@) now at: rzvwutvl 328e08e0 (empty) 4
+    Parent commit (@-)      : psuskuln 88bb7ab8 (empty) 3
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  mzvwutvlkqwt 4
-    ○  zsuskulnrvyr 3
-    │ ○  kkmpptxzrspx 2
+    @  rzvwutvlkqwt 4
+    ○  psuskulnrvyr 3
+    │ ○  nkmpptxzrspx 2
     │ ○  qpvuntsmwlqt 1
     ├─╯
     ◆  zzzzzzzzzzzz
@@ -282,11 +282,11 @@ fn test_next_with_merge_commit_parent() {
     work_dir.run_jj(["prev", "0"]).success();
     insta::assert_snapshot!(get_log_output(&work_dir), @"
     @  royxmykxtrkr
-    │ ○  mzvwutvlkqwt 4
+    │ ○  rzvwutvlkqwt 4
     ├─╯
-    ○    zsuskulnrvyr 3
+    ○    psuskulnrvyr 3
     ├─╮
-    │ ○  kkmpptxzrspx 2
+    │ ○  nkmpptxzrspx 2
     ○ │  qpvuntsmwlqt 1
     ├─╯
     ◆  zzzzzzzzzzzz
@@ -296,16 +296,16 @@ fn test_next_with_merge_commit_parent() {
     let output = work_dir.run_jj(["next"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: vruxwmqv 7a09c355 (empty) (no description set)
-    Parent commit (@-)      : mzvwutvl f02c921e (empty) 4
+    Working copy  (@) now at: vruxwmqv 7de8ff38 (empty) (no description set)
+    Parent commit (@-)      : rzvwutvl 966ab362 (empty) 4
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
     @  vruxwmqvtpmx
-    ○  mzvwutvlkqwt 4
-    ○    zsuskulnrvyr 3
+    ○  rzvwutvlkqwt 4
+    ○    psuskulnrvyr 3
     ├─╮
-    │ ○  kkmpptxzrspx 2
+    │ ○  nkmpptxzrspx 2
     ○ │  qpvuntsmwlqt 1
     ├─╯
     ◆  zzzzzzzzzzzz
@@ -327,10 +327,10 @@ fn test_next_on_merge_commit() {
     work_dir.run_jj(["new", "-m", "4"]).success();
     work_dir.run_jj(["edit", "subject(3)"]).success();
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    ○  mzvwutvlkqwt 4
-    @    zsuskulnrvyr 3
+    ○  rzvwutvlkqwt 4
+    @    psuskulnrvyr 3
     ├─╮
-    │ ○  kkmpptxzrspx 2
+    │ ○  nkmpptxzrspx 2
     ○ │  qpvuntsmwlqt 1
     ├─╯
     ◆  zzzzzzzzzzzz
@@ -340,15 +340,15 @@ fn test_next_on_merge_commit() {
     let output = work_dir.run_jj(["next", "--edit"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: mzvwutvl f02c921e (empty) 4
-    Parent commit (@-)      : zsuskuln d2500577 (empty) 3
+    Working copy  (@) now at: rzvwutvl 966ab362 (empty) 4
+    Parent commit (@-)      : psuskuln b9ab0058 (empty) 3
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  mzvwutvlkqwt 4
-    ○    zsuskulnrvyr 3
+    @  rzvwutvlkqwt 4
+    ○    psuskulnrvyr 3
     ├─╮
-    │ ○  kkmpptxzrspx 2
+    │ ○  nkmpptxzrspx 2
     ○ │  qpvuntsmwlqt 1
     ├─╯
     ◆  zzzzzzzzzzzz
@@ -368,8 +368,8 @@ fn test_next_fails_on_bookmarking_children_no_stdin() {
     work_dir.run_jj(["new", "@--"]).success();
 
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  royxmykxtrkr
-    │ ○  zsuskulnrvyr third
+    @  soyxmykxtrkr
+    │ ○  psuskulnrvyr third
     ├─╯
     │ ○  rlvkpnrzqnoo second
     ├─╯
@@ -383,7 +383,7 @@ fn test_next_fails_on_bookmarking_children_no_stdin() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     ambiguous next commit, choose one to target:
-    1: zsuskuln 6fc6af46 (empty) third
+    1: psuskuln ba314099 (empty) third
     2: rlvkpnrz 9439bf06 (empty) second
     q: quit the prompt
     Error: Cannot prompt for input since the output is not connected to a terminal
@@ -404,8 +404,8 @@ fn test_next_fails_on_bookmarking_children_quit_prompt() {
     work_dir.run_jj(["new", "@--"]).success();
 
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  royxmykxtrkr
-    │ ○  zsuskulnrvyr third
+    @  soyxmykxtrkr
+    │ ○  psuskulnrvyr third
     ├─╯
     │ ○  rlvkpnrzqnoo second
     ├─╯
@@ -419,7 +419,7 @@ fn test_next_fails_on_bookmarking_children_quit_prompt() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     ambiguous next commit, choose one to target:
-    1: zsuskuln 6fc6af46 (empty) third
+    1: psuskuln ba314099 (empty) third
     2: rlvkpnrz 9439bf06 (empty) second
     q: quit the prompt
     enter the index of the commit you want to target: Error: ambiguous target commit
@@ -445,12 +445,12 @@ fn test_next_choose_bookmarking_child() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     ambiguous next commit, choose one to target:
-    1: royxmykx 3522c887 (empty) fourth
-    2: zsuskuln 6fc6af46 (empty) third
+    1: soyxmykx 83d7ed98 (empty) fourth
+    2: psuskuln ba314099 (empty) third
     3: rlvkpnrz 9439bf06 (empty) second
     q: quit the prompt
-    enter the index of the commit you want to target: Working copy  (@) now at: yostqsxw 683938a4 (empty) (no description set)
-    Parent commit (@-)      : zsuskuln 6fc6af46 (empty) third
+    enter the index of the commit you want to target: Working copy  (@) now at: yostqsxw 338a11be (empty) (no description set)
+    Parent commit (@-)      : psuskuln ba314099 (empty) third
     [EOF]
     ");
 }
@@ -468,9 +468,9 @@ fn test_prev_on_merge_commit() {
 
     // Check that the graph looks the way we expect.
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @    royxmykxtrkr
+    @    ooyxmykxtrkr
     ├─╮
-    │ ○  zsuskulnrvyr right second
+    │ ○  psuskulnrvyr right second
     ○ │  qpvuntsmwlqt left first
     ├─╯
     ◆  zzzzzzzzzzzz
@@ -495,7 +495,7 @@ fn test_prev_on_merge_commit() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     ambiguous prev commit, choose one to target:
-    1: zsuskuln 22a08bc0 right | (empty) second
+    1: psuskuln a3d0b67c right | (empty) second
     2: qpvuntsm 68a50538 left | (empty) first
     q: quit the prompt
     enter the index of the commit you want to target: Working copy  (@) now at: qpvuntsm 68a50538 left | (empty) first
@@ -521,12 +521,12 @@ fn test_prev_on_merge_commit_with_parent_merge() {
 
     // Check that the graph looks the way we expect.
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @    royxmykxtrkr M
+    @    soyxmykxtrkr M
     ├─╮
-    │ ○  mzvwutvlkqwt 1
-    ○ │    zsuskulnrvyr z
+    │ ○  rzvwutvlkqwt 1
+    ○ │    psuskulnrvyr z
     ├───╮
-    │ │ ○  kkmpptxzrspx y
+    │ │ ○  nkmpptxzrspx y
     │ ├─╯
     ○ │  qpvuntsmwlqt x
     ├─╯
@@ -539,7 +539,7 @@ fn test_prev_on_merge_commit_with_parent_merge() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     ambiguous prev commit, choose one to target:
-    1: kkmpptxz ab947132 (empty) y
+    1: nkmpptxz 320eef91 (empty) y
     2: qpvuntsm 007e88d2 (empty) x
     3: zzzzzzzz 00000000 (empty) (no description set)
     q: quit the prompt
@@ -557,12 +557,12 @@ fn test_prev_on_merge_commit_with_parent_merge() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     ambiguous prev commit, choose one to target:
-    1: mzvwutvl 0e8fc48c (empty) 1
-    2: zsuskuln e7382ca4 (empty) z
+    1: rzvwutvl 63f4e8e7 (empty) 1
+    2: psuskuln 542c33fa (empty) z
     q: quit the prompt
-    enter the index of the commit you want to target: Working copy  (@) now at: zsuskuln e7382ca4 (empty) z
+    enter the index of the commit you want to target: Working copy  (@) now at: psuskuln 542c33fa (empty) z
     Parent commit (@-)      : qpvuntsm 007e88d2 (empty) x
-    Parent commit (@-)      : kkmpptxz ab947132 (empty) y
+    Parent commit (@-)      : nkmpptxz 320eef91 (empty) y
     [EOF]
     ");
 }
@@ -586,12 +586,12 @@ fn test_prev_prompts_on_multiple_parents() {
     insta::assert_snapshot!(get_log_output(&work_dir), @"
     @  yostqsxwqrlt
     ○  vruxwmqvtpmx merge+1
-    ○      yqosqzytrlsw merge
+    ○      oqosqzytrlsw merge
     ├─┬─╮
     │ │ ○  qpvuntsmwlqt first
-    │ ○ │  kkmpptxzrspx second
+    │ ○ │  nkmpptxzrspx second
     │ ├─╯
-    ○ │  mzvwutvlkqwt third
+    ○ │  pzvwutvlkqwt third
     ├─╯
     ◆  zzzzzzzzzzzz
     [EOF]
@@ -606,8 +606,8 @@ fn test_prev_prompts_on_multiple_parents() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     ambiguous prev commit, choose one to target:
-    1: mzvwutvl 5ec63817 (empty) third
-    2: kkmpptxz e8959fbd (empty) second
+    1: pzvwutvl 748bcabd (empty) third
+    2: nkmpptxz 932a5f25 (empty) second
     3: qpvuntsm 68a50538 (empty) first
     q: quit the prompt
     enter the index of the commit you want to target: Working copy  (@) now at: kpqxywon 5448803a (empty) (no description set)
@@ -618,12 +618,12 @@ fn test_prev_prompts_on_multiple_parents() {
     insta::assert_snapshot!(get_log_output(&work_dir), @"
     @  kpqxywonksrl
     │ ○  vruxwmqvtpmx merge+1
-    │ ○    yqosqzytrlsw merge
+    │ ○    oqosqzytrlsw merge
     ╭─┼─╮
     ○ │ │  qpvuntsmwlqt first
-    │ │ ○  kkmpptxzrspx second
+    │ │ ○  nkmpptxzrspx second
     ├───╯
-    │ ○  mzvwutvlkqwt third
+    │ ○  pzvwutvlkqwt third
     ├─╯
     ◆  zzzzzzzzzzzz
     [EOF]
@@ -634,12 +634,12 @@ fn test_prev_prompts_on_multiple_parents() {
     @  wqnwkozpkust
     │ ○  vruxwmqvtpmx merge+1
     ├─╯
-    ○      yqosqzytrlsw merge
+    ○      oqosqzytrlsw merge
     ├─┬─╮
     │ │ ○  qpvuntsmwlqt first
-    │ ○ │  kkmpptxzrspx second
+    │ ○ │  nkmpptxzrspx second
     │ ├─╯
-    ○ │  mzvwutvlkqwt third
+    ○ │  pzvwutvlkqwt third
     ├─╯
     ◆  zzzzzzzzzzzz
     [EOF]
@@ -773,7 +773,7 @@ fn test_prev_conflict() {
     // Test the setup
     insta::assert_snapshot!(get_log_output(&work_dir), @"
     @  yqosqzytrlsw conflict
-    ×  royxmykxtrkr conflict fourth
+    ×  poyxmykxtrkr conflict fourth
     ×  kkmpptxzrspx conflict third
     ×  rlvkpnrzqnoo conflict second
     ○  qpvuntsmwlqt first
@@ -783,7 +783,7 @@ fn test_prev_conflict() {
     work_dir.run_jj(["prev", "--conflict"]).success();
     insta::assert_snapshot!(get_log_output(&work_dir), @"
     @  yostqsxwqrlt conflict
-    │ ×  royxmykxtrkr conflict fourth
+    │ ×  poyxmykxtrkr conflict fourth
     ├─╯
     ×  kkmpptxzrspx conflict third
     ×  rlvkpnrzqnoo conflict second
@@ -809,7 +809,7 @@ fn test_prev_conflict_editing() {
     work_dir.run_jj(["new", "subject(third)"]).success();
     // Test the setup
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  royxmykxtrkr conflict
+    @  poyxmykxtrkr conflict
     ×  kkmpptxzrspx conflict third
     ○  rlvkpnrzqnoo second
     ○  qpvuntsmwlqt first
@@ -911,7 +911,7 @@ fn test_next_conflict_head() {
     work_dir.run_jj(["abandon", "@-"]).success();
     // Test the setup
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  rlvkpnrzqnoo conflict
+    @  ylvkpnrzqnoo conflict
     ◆  zzzzzzzzzzzz
     [EOF]
     ");
@@ -929,7 +929,7 @@ fn test_next_conflict_head() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Error: The working copy has no descendants with conflicts
-    Hint: Working copy: rlvkpnrz 27780096 (conflict) (no description set)
+    Hint: Working copy: ylvkpnrz c3317f99 (conflict) (no description set)
     [EOF]
     [exit status: 1]
     ");

--- a/cli/tests/test_op_integrate_command.rs
+++ b/cli/tests/test_op_integrate_command.rs
@@ -64,8 +64,8 @@ fn test_integrate_sibling_operation() -> TestResult {
     let output = work_dir.run_jj(["op", "log"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Internal error: The repo was loaded at operation f0f64355037e, which seems to be a sibling of the working copy's operation 4f1ea5911f2f
-    Hint: Run `jj op integrate 4f1ea5911f2f` to add the working copy's operation to the operation log.
+    Internal error: The repo was loaded at operation f18ccd3bfa74, which seems to be a sibling of the working copy's operation 7a2b59297e0e
+    Hint: Run `jj op integrate 7a2b59297e0e` to add the working copy's operation to the operation log.
     [EOF]
     [exit status: 255]
     ");
@@ -79,13 +79,13 @@ fn test_integrate_sibling_operation() -> TestResult {
     ");
     let output = work_dir.run_jj(["op", "log"]);
     insta::assert_snapshot!(output, @"
-    @    c07a58eed726 test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    @    8e55362edb3b test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
     ├─╮  reconcile divergent operations
-    │ │  args: jj op integrate 4f1ea5911f2f5d4e94a1620c9f762f33ab985d1635eb345027ed85c54bce3c085d0e0fa14c104743e26df5e565b47b2ca8c90dd7b548dbefed192b775ee2e3bc
-    ○ │  4f1ea5911f2f test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    │ │  args: jj op integrate 7a2b59297e0e60fd21595c2f349842a15d04f9ba0a432c982a562a1473fa9fd4f69a04a6907493e62b45bc2a7d8a412d8502b4e0e9ed1a13646cfc6bd5437b86
+    ○ │  7a2b59297e0e test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │ │  new empty commit
     │ │  args: jj new '-m=first'
-    │ ○  f0f64355037e test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    │ ○  f18ccd3bfa74 test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     ├─╯  new empty commit
     │    args: jj new '-m=second' --ignore-working-copy
     ○  90267f31f904 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
@@ -132,8 +132,8 @@ fn test_integrate_rebase_descendants() -> TestResult {
     let output = work_dir.run_jj(["op", "log"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Internal error: The repo was loaded at operation dfab2903608d, which seems to be a sibling of the working copy's operation 17c93f71a912
-    Hint: Run `jj op integrate 17c93f71a912` to add the working copy's operation to the operation log.
+    Internal error: The repo was loaded at operation de930e1713ca, which seems to be a sibling of the working copy's operation 1d87b9209f7f
+    Hint: Run `jj op integrate 1d87b9209f7f` to add the working copy's operation to the operation log.
     [EOF]
     [exit status: 255]
     ");
@@ -148,16 +148,16 @@ fn test_integrate_rebase_descendants() -> TestResult {
     ");
     let output = work_dir.run_jj(["op", "log"]);
     insta::assert_snapshot!(output, @"
-    @    e9ad6c38ebf5 test-username@host.example.com default@ 2001-02-03 04:05:12.000 +07:00 - 2001-02-03 04:05:12.000 +07:00
+    @    c589859f0d79 test-username@host.example.com default@ 2001-02-03 04:05:12.000 +07:00 - 2001-02-03 04:05:12.000 +07:00
     ├─╮  reconcile divergent operations
-    │ │  args: jj op integrate 17c93f71a9128fbc6c2a7ea7a310efc2f6e476638b58caed13735a7b2e20a6c6dae9dcc84795dd7cca1eecf38ae2812e0216f46430250b1ce3aef4330522012c
-    ○ │  17c93f71a912 test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    │ │  args: jj op integrate 1d87b9209f7f9cf04ffaaa849deac095ac2d942b97471fb1968c668b9120ce5a805fddb3d3834fe19c9afa1e11e780b887968885de9979642b2e64a5cd7dd6b4
+    ○ │  1d87b9209f7f test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     │ │  new empty commit
     │ │  args: jj new '-m=child 2'
-    │ ○  dfab2903608d test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    │ ○  de930e1713ca test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     ├─╯  describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     │    args: jj describe '-m=parent' --ignore-working-copy
-    ○  78dcb3cf0b64 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    ○  5d5fd3f3a2fe test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  new empty commit
     │  args: jj new --no-edit '-m=child 1'
     ○  90267f31f904 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
@@ -169,9 +169,9 @@ fn test_integrate_rebase_descendants() -> TestResult {
     // Child 2 was successfully rebased
     let output = work_dir.run_jj(["log"]);
     insta::assert_snapshot!(output, @"
-    @  kkmpptxz test.user@example.com 2001-02-03 08:05:12 9780be6d
+    @  nkmpptxz test.user@example.com 2001-02-03 08:05:12 4a1fe649
     │  (empty) child 2
-    │ ○  rlvkpnrz test.user@example.com 2001-02-03 08:05:10 ce1fb6c9
+    │ ○  ylvkpnrz test.user@example.com 2001-02-03 08:05:10 afe37616
     ├─╯  (empty) child 1
     ○  qpvuntsm test.user@example.com 2001-02-03 08:05:10 5f8729eb
     │  (empty) parent

--- a/cli/tests/test_operations.rs
+++ b/cli/tests/test_operations.rs
@@ -1003,7 +1003,7 @@ fn test_op_recover_from_bad_gc() -> TestResult {
         .run_jj(["op", "log", "--no-graph", r#"-Tid.short() ++ "\n""#])
         .success();
     let [head_op_id, _, _, bad_op_id] = output.stdout.raw().lines().next_array().unwrap();
-    insta::assert_snapshot!(head_op_id, @"73ddac1568ed");
+    insta::assert_snapshot!(head_op_id, @"129d781d29eb");
     insta::assert_snapshot!(bad_op_id, @"c433ad465d84");
 
     // Corrupt the repo by removing hidden but reachable commit object.
@@ -1040,10 +1040,10 @@ fn test_op_recover_from_bad_gc() -> TestResult {
     // "op log" should still be usable.
     let output = work_dir.run_jj(["op", "log", "--ignore-working-copy", "--at-op", head_op_id]);
     insta::assert_snapshot!(output, @"
-    @  73ddac1568ed test-username@host.example.com default@ 2001-02-03 04:05:12.000 +07:00 - 2001-02-03 04:05:12.000 +07:00
-    │  describe commit a053bc8736064a739ab73f2c775a6ac2851bf1a3
+    @  129d781d29eb test-username@host.example.com default@ 2001-02-03 04:05:12.000 +07:00 - 2001-02-03 04:05:12.000 +07:00
+    │  describe commit 7c9f3148eea934758d81c7fc7228664f7524796a
     │  args: jj describe -m4
-    ○  398ac785f287 test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    ○  a2269dd67dd7 test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
     │  new empty commit
     │  args: jj new -m3
     ○  55e7a799e145 test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
@@ -1072,9 +1072,9 @@ fn test_op_recover_from_bad_gc() -> TestResult {
     // The repo should no longer be corrupt.
     let output = work_dir.run_jj(["log"]);
     insta::assert_snapshot!(output, @"
-    @  mzvwutvl/1 test.user@example.com 2001-02-03 08:05:12 29d07a2d (divergent)
+    @  pzvwutvl/1 test.user@example.com 2001-02-03 08:05:12 6745fed5 (divergent)
     │  (empty) 4
-    │ ○  mzvwutvl/0 test.user@example.com 2001-02-03 08:05:15 bc027e2c (divergent)
+    │ ○  pzvwutvl/0 test.user@example.com 2001-02-03 08:05:15 96614d24 (divergent)
     ├─╯  (empty) 4.1
     ○  zsuskuln test.user@example.com 2001-02-03 08:05:10 c2934cfb
     │  (empty) (no description set)
@@ -1143,7 +1143,7 @@ fn test_op_summary_diff_template() {
     let output = work_dir.run_jj(["op", "revert", "--color=always"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Reverted operation: [38;5;4md336cf245e9c[39m ([38;5;6m2001-02-03 08:05:08[39m) new empty commit
+    Reverted operation: [38;5;4m754fdc04e3bf[39m ([38;5;6m2001-02-03 08:05:08[39m) new empty commit
     [EOF]
     ");
     let output = work_dir.run_jj([
@@ -1157,7 +1157,7 @@ fn test_op_summary_diff_template() {
     ]);
     insta::assert_snapshot!(output, @"
     From operation: [38;5;4m000000000000[39m [38;5;2mroot()[39m
-      To operation: [38;5;4mcbae8e2b3bfb[39m ([38;5;6m2001-02-03 08:05:09[39m) revert operation d336cf245e9cc589b053feee9e8c05d3340ab7717378a8a70ca17d9ebf7c5c0c2aa40093a826aa8df143297a4628b7ea714194b50bfedc2b5835630522af4079
+      To operation: [38;5;4m4cf066a4943e[39m ([38;5;6m2001-02-03 08:05:09[39m) revert operation 754fdc04e3bff7bb7463cd20d441602cbe4754c1f97a105ee37fbda13e737030c351f860b0be3213a61ef7c1fb06f322e5d13d2935070b992e9eca1b15f6ddc5
 
     Changed commits:
     ○  [38;5;2m+[39m [1m[38;5;13mq[38;5;8mpvuntsm[39m [38;5;12me[38;5;8m8849ae1[39m [38;5;10m(empty)[39m [38;5;10m(no description set)[0m
@@ -1175,7 +1175,7 @@ fn test_op_summary_diff_template() {
     let output = work_dir.run_jj(["op", "revert", "--color=debug"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Reverted operation: [38;5;4m<<operation id short::20994955e4c2>>[39m<<operation:: (>>[38;5;6m<<operation time end local format::2001-02-03 08:05:11>>[39m<<operation::) >><<operation description first_line::new empty commit>>
+    Reverted operation: [38;5;4m<<operation id short::fb479e35f8da>>[39m<<operation:: (>>[38;5;6m<<operation time end local format::2001-02-03 08:05:11>>[39m<<operation::) >><<operation description first_line::new empty commit>>
     [EOF]
     ");
     let output = work_dir.run_jj([
@@ -1189,7 +1189,7 @@ fn test_op_summary_diff_template() {
     ]);
     insta::assert_snapshot!(output, @"
     From operation: [38;5;4m<<op_diff operation id short::000000000000>>[39m<<op_diff operation:: >>[38;5;2m<<op_diff operation root::root()>>[39m
-      To operation: [38;5;4m<<op_diff operation id short::f3a2dab03704>>[39m<<op_diff operation:: (>>[38;5;6m<<op_diff operation time end local format::2001-02-03 08:05:12>>[39m<<op_diff operation::) >><<op_diff operation description first_line::revert operation 20994955e4c238d6d34c6dc6942e9111e385c06676c575cd2d5d4908c6ba5a1bea26ecaccf8d420da641f9aa250aea0a33bf677601ce66ba111ac4eaf5334a95>>
+      To operation: [38;5;4m<<op_diff operation id short::930182148b70>>[39m<<op_diff operation:: (>>[38;5;6m<<op_diff operation time end local format::2001-02-03 08:05:12>>[39m<<op_diff operation::) >><<op_diff operation description first_line::revert operation fb479e35f8da1e7907ea6062f45d5ee370f86b42e88a4185067b313f5bc3e5c68fb6a9dce8b3367aebf06863b4ce2b9166f655d7af378def81efb66bfaef2281>>
 
     Changed commits:
     ○  [38;5;2m<<diff added::+>>[39m [1m[38;5;13m<<op_diff commit working_copy change_id shortest prefix::q>>[38;5;8m<<op_diff commit working_copy change_id shortest rest::pvuntsm>>[39m<<op_diff commit working_copy:: >>[38;5;12m<<op_diff commit working_copy commit_id shortest prefix::e>>[38;5;8m<<op_diff commit working_copy commit_id shortest rest::8849ae1>>[39m<<op_diff commit working_copy:: >>[38;5;10m<<op_diff commit working_copy empty::(empty)>>[39m<<op_diff commit working_copy:: >>[38;5;10m<<op_diff commit working_copy empty description placeholder::(no description set)>>[0m
@@ -1583,7 +1583,7 @@ fn test_op_diff() {
     let output = work_dir.run_jj(["new", "bookmark-1@origin", "-m", "new commit"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: qmkrwlvp 96f3a57c (empty) new commit
+    Working copy  (@) now at: ymkrwlvp 3d680414 (empty) new commit
     Parent commit (@-)      : zkmtkqvo 0dee6313 bookmark-1?? bookmark-1@origin | Commit 4
     Added 2 files, modified 0 files, removed 0 files
     [EOF]
@@ -1591,13 +1591,13 @@ fn test_op_diff() {
     let output = work_dir.run_jj(["op", "diff"]);
     insta::assert_snapshot!(output, @"
     From operation: 01bb085b8fc7 (2001-02-03 08:05:29) track remote bookmark bookmark-2@origin
-      To operation: d35a1766fd20 (2001-02-03 08:05:33) new empty commit
+      To operation: df546e4715aa (2001-02-03 08:05:33) new empty commit
 
     Changed commits:
-    ○  + qmkrwlvp 96f3a57c (empty) new commit
+    ○  + ymkrwlvp 3d680414 (empty) new commit
 
     Changed working copy default@:
-    + qmkrwlvp 96f3a57c (empty) new commit
+    + ymkrwlvp 3d680414 (empty) new commit
     - qpvuntsm e8849ae1 bookmark-1?? | (empty) (no description set)
     [EOF]
     ");
@@ -1606,17 +1606,17 @@ fn test_op_diff() {
     let output = work_dir.run_jj(["bookmark", "set", "bookmark-1", "-r", "@"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Moved 1 bookmarks to qmkrwlvp 96f3a57c bookmark-1* | (empty) new commit
+    Moved 1 bookmarks to ymkrwlvp 3d680414 bookmark-1* | (empty) new commit
     [EOF]
     ");
     let output = work_dir.run_jj(["op", "diff"]);
     insta::assert_snapshot!(output, @"
-    From operation: d35a1766fd20 (2001-02-03 08:05:33) new empty commit
-      To operation: 8980611368bb (2001-02-03 08:05:35) point bookmark bookmark-1 to commit 96f3a57c9a4a4ae7bb45d1eafe32fe3b6e33f458
+    From operation: df546e4715aa (2001-02-03 08:05:33) new empty commit
+      To operation: 4d6d4d2188f4 (2001-02-03 08:05:35) point bookmark bookmark-1 to commit 3d68041448fda3d6206cbed2648cc7735601c0d2
 
     Changed local bookmarks:
     bookmark-1:
-    + qmkrwlvp 96f3a57c bookmark-1* | (empty) new commit
+    + ymkrwlvp 3d680414 bookmark-1* | (empty) new commit
     - (added) qpvuntsm e8849ae1 (empty) (no description set)
     - (added) rnnslrkn 4ff62539 Commit 2
     - (added) zkmtkqvo 0dee6313 bookmark-1@origin | Commit 4
@@ -1634,8 +1634,8 @@ fn test_op_diff() {
     ");
     let output = work_dir.run_jj(["op", "diff"]);
     insta::assert_snapshot!(output, @"
-    From operation: 8980611368bb (2001-02-03 08:05:35) point bookmark bookmark-1 to commit 96f3a57c9a4a4ae7bb45d1eafe32fe3b6e33f458
-      To operation: 4eb5978447d4 (2001-02-03 08:05:37) delete bookmark bookmark-2
+    From operation: 4d6d4d2188f4 (2001-02-03 08:05:35) point bookmark bookmark-1 to commit 3d68041448fda3d6206cbed2648cc7735601c0d2
+      To operation: ffe3bc67e24f (2001-02-03 08:05:37) delete bookmark bookmark-2
 
     Changed local bookmarks:
     bookmark-2:
@@ -1649,18 +1649,18 @@ fn test_op_diff() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Changes to push to origin:
-      bookmark: bookmark-1 [move forward from 0dee631320b1 to 96f3a57c9a4a]
+      bookmark: bookmark-1 [move forward from 0dee631320b1 to 3d68041448fd]
       bookmark: bookmark-2 [delete from e1a239a57eb1]
     [EOF]
     ");
     let output = work_dir.run_jj(["op", "diff"]);
     insta::assert_snapshot!(output, @"
-    From operation: 4eb5978447d4 (2001-02-03 08:05:37) delete bookmark bookmark-2
-      To operation: 925fba501129 (2001-02-03 08:05:39) push all tracked bookmarks/tags to git remote origin
+    From operation: ffe3bc67e24f (2001-02-03 08:05:37) delete bookmark bookmark-2
+      To operation: 289c4ce6d86a (2001-02-03 08:05:39) push all tracked bookmarks/tags to git remote origin
 
     Changed remote bookmarks:
     bookmark-1@origin:
-    + tracked qmkrwlvp 96f3a57c bookmark-1 | (empty) new commit
+    + tracked ymkrwlvp 3d680414 bookmark-1 | (empty) new commit
     - tracked zkmtkqvo 0dee6313 Commit 4
     bookmark-2@origin:
     + untracked (absent)
@@ -1673,12 +1673,12 @@ fn test_op_diff() {
     work_dir.run_jj(["tag", "set", "-r@-", "tag1"]).success();
     let output = work_dir.run_jj(["op", "diff"]);
     insta::assert_snapshot!(output, @"
-    From operation: 63850be91e93 (2001-02-03 08:05:41) new empty commit
-      To operation: 2cb390841ae9 (2001-02-03 08:05:42) set tag tag1 to commit 96f3a57c9a4a4ae7bb45d1eafe32fe3b6e33f458
+    From operation: bb215a9013a4 (2001-02-03 08:05:41) new empty commit
+      To operation: 87a24a5f8d05 (2001-02-03 08:05:42) set tag tag1 to commit 3d68041448fda3d6206cbed2648cc7735601c0d2
 
     Changed local tags:
     tag1:
-    + qmkrwlvp 96f3a57c bookmark-1 | (empty) new commit
+    + ymkrwlvp 3d680414 bookmark-1 | (empty) new commit
     - (absent)
     [EOF]
     ");
@@ -1689,13 +1689,13 @@ fn test_op_diff() {
         .success();
     let output = work_dir.run_jj(["op", "diff"]);
     insta::assert_snapshot!(output, @"
-    From operation: 2cb390841ae9 (2001-02-03 08:05:42) set tag tag1 to commit 96f3a57c9a4a4ae7bb45d1eafe32fe3b6e33f458
-      To operation: dda59985de35 (2001-02-03 08:05:44) set tag tag1 to commit 0dee631320b13c6a6542c80bced33b9dd29f6bf0
+    From operation: 87a24a5f8d05 (2001-02-03 08:05:42) set tag tag1 to commit 3d68041448fda3d6206cbed2648cc7735601c0d2
+      To operation: ad7d66abf858 (2001-02-03 08:05:44) set tag tag1 to commit 0dee631320b13c6a6542c80bced33b9dd29f6bf0
 
     Changed local tags:
     tag1:
     + zkmtkqvo 0dee6313 Commit 4
-    - qmkrwlvp 96f3a57c bookmark-1 | (empty) new commit
+    - ymkrwlvp 3d680414 bookmark-1 | (empty) new commit
     [EOF]
     ");
 
@@ -1703,8 +1703,8 @@ fn test_op_diff() {
     work_dir.run_jj(["tag", "delete", "tag1"]).success();
     let output = work_dir.run_jj(["op", "diff"]);
     insta::assert_snapshot!(output, @"
-    From operation: dda59985de35 (2001-02-03 08:05:44) set tag tag1 to commit 0dee631320b13c6a6542c80bced33b9dd29f6bf0
-      To operation: 3d6fb6fecc79 (2001-02-03 08:05:46) delete tag tag1
+    From operation: ad7d66abf858 (2001-02-03 08:05:44) set tag tag1 to commit 0dee631320b13c6a6542c80bced33b9dd29f6bf0
+      To operation: da01996f78d8 (2001-02-03 08:05:46) delete tag tag1
 
     Changed local tags:
     tag1:
@@ -1725,7 +1725,7 @@ fn test_op_diff_patch() {
     let output = work_dir.run_jj(["new"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: rlvkpnrz c1c924b8 (empty) (no description set)
+    Working copy  (@) now at: ylvkpnrz 9348e934 (empty) (no description set)
     Parent commit (@-)      : qpvuntsm 6b57e33c (no description set)
     [EOF]
     ");
@@ -1753,13 +1753,13 @@ fn test_op_diff_patch() {
     let output = work_dir.run_jj(["op", "diff", "--op", "@", "-p", "--git"]);
     insta::assert_snapshot!(output, @"
     From operation: 2f45e55601da (2001-02-03 08:05:08) snapshot working copy
-      To operation: cf0770d7100e (2001-02-03 08:05:08) new empty commit
+      To operation: 18f25087c84c (2001-02-03 08:05:08) new empty commit
 
     Changed commits:
-    ○  + rlvkpnrz c1c924b8 (empty) (no description set)
+    ○  + ylvkpnrz 9348e934 (empty) (no description set)
 
     Changed working copy default@:
-    + rlvkpnrz c1c924b8 (empty) (no description set)
+    + ylvkpnrz 9348e934 (empty) (no description set)
     - qpvuntsm 6b57e33c (no description set)
     [EOF]
     ");
@@ -1775,14 +1775,14 @@ fn test_op_diff_patch() {
     ");
     let output = work_dir.run_jj(["op", "diff", "-p", "--git"]);
     insta::assert_snapshot!(output, @"
-    From operation: 1411dd0524ab (2001-02-03 08:05:11) snapshot working copy
-      To operation: e6ae6bef0dc4 (2001-02-03 08:05:11) squash commits into 6b57e33cc56babbeaa6bcd6e2a296236b52ad93c
+    From operation: f71550287733 (2001-02-03 08:05:11) snapshot working copy
+      To operation: 11e6ef0505b9 (2001-02-03 08:05:11) squash commits into 6b57e33cc56babbeaa6bcd6e2a296236b52ad93c
 
     Changed commits:
     ○  + mzvwutvl 6cbd01ae (empty) (no description set)
     ○  + qpvuntsm 7aa2ec5d (no description set)
        - qpvuntsm/1 6b57e33c (hidden) (no description set)
-       - rlvkpnrz/0 05a2969e (hidden) (no description set)
+       - ylvkpnrz/0 82d265bf (hidden) (no description set)
        diff --git a/file b/file
        index 7898192261..6178079822 100644
        --- a/file
@@ -1793,7 +1793,7 @@ fn test_op_diff_patch() {
 
     Changed working copy default@:
     + mzvwutvl 6cbd01ae (empty) (no description set)
-    - rlvkpnrz/0 05a2969e (hidden) (no description set)
+    - ylvkpnrz/0 82d265bf (hidden) (no description set)
     [EOF]
     ");
 
@@ -1809,8 +1809,8 @@ fn test_op_diff_patch() {
     ");
     let output = work_dir.run_jj(["op", "diff", "-p", "--git"]);
     insta::assert_snapshot!(output, @"
-    From operation: e6ae6bef0dc4 (2001-02-03 08:05:11) squash commits into 6b57e33cc56babbeaa6bcd6e2a296236b52ad93c
-      To operation: 0b9a2eef07b2 (2001-02-03 08:05:13) abandon commit 6cbd01aefe5ae05a015328311dbd63b7305b8ebe
+    From operation: 11e6ef0505b9 (2001-02-03 08:05:11) squash commits into 6b57e33cc56babbeaa6bcd6e2a296236b52ad93c
+      To operation: c2071bf78ef4 (2001-02-03 08:05:13) abandon commit 6cbd01aefe5ae05a015328311dbd63b7305b8ebe
 
     Changed commits:
     ○  + yqosqzyt c97a8573 (empty) (no description set)
@@ -1850,22 +1850,22 @@ fn test_op_diff_sibling() {
 
     let output = work_dir.run_jj(["op", "log"]);
     insta::assert_snapshot!(output, @"
-    @    1c4db3c4a594 test-username@host.example.com default@ 2001-02-03 04:05:13.000 +07:00 - 2001-02-03 04:05:13.000 +07:00
+    @    fcd1e794958e test-username@host.example.com default@ 2001-02-03 04:05:13.000 +07:00 - 2001-02-03 04:05:13.000 +07:00
     ├─╮  reconcile divergent operations
     │ │  args: jj op log
-    ○ │  8276f97c320d test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    ○ │  f212ec1c9291 test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
     │ │  new empty commit
     │ │  args: jj new '@-+' -mA
-    ○ │  ff1fbea612d5 test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    ○ │  c98b96961857 test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
     │ │  snapshot working copy
     │ │  args: jj new '@-+' -mA
-    ○ │  bf40689e8204 test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    ○ │  8dc574a9e220 test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     │ │  new empty commit
     │ │  args: jj new 'root()' -mA.2
-    ○ │  0075fc491372 test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    ○ │  f31529e1cfd7 test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     │ │  snapshot working copy
     │ │  args: jj new 'root()' -mA.2
-    ○ │  7adb656f42e2 test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    ○ │  e001e23e9061 test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     │ │  new empty commit
     │ │  args: jj new 'root()' -mA.1
     │ ○  1220c0f6978f test-username@host.example.com default@ 2001-02-03 04:05:12.000 +07:00 - 2001-02-03 04:05:12.000 +07:00
@@ -1884,8 +1884,8 @@ fn test_op_diff_sibling() {
         .success();
     let [head_op_id, p1_op_id, _, _, _, _, p2_op_id] =
         output.stdout.raw().lines().next_array().unwrap();
-    insta::assert_snapshot!(head_op_id, @"1c4db3c4a594");
-    insta::assert_snapshot!(p1_op_id, @"8276f97c320d");
+    insta::assert_snapshot!(head_op_id, @"fcd1e794958e");
+    insta::assert_snapshot!(p1_op_id, @"f212ec1c9291");
     insta::assert_snapshot!(p2_op_id, @"1220c0f6978f");
 
     // Diff between p1 and p2 operations should work no matter if p2 is chosen
@@ -1902,22 +1902,22 @@ fn test_op_diff_sibling() {
         "--summary",
     ]);
     insta::assert_snapshot!(output, @"
-    From operation: 8276f97c320d (2001-02-03 08:05:11) new empty commit
+    From operation: f212ec1c9291 (2001-02-03 08:05:11) new empty commit
       To operation: 1220c0f6978f (2001-02-03 08:05:12) describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
 
     Changed commits:
-    ○    - mzvwutvl/0 08c63613 (hidden) (empty) A
+    ○    - pzvwutvl/0 33c1ee1f (hidden) (empty) A
     ├─╮
-    │ ○  - kkmpptxz/0 6c70a4f7 (hidden) A.1
+    │ ○  - nkmpptxz/0 2c90d7cd (hidden) A.1
     │    A file1
-    ○  - zsuskuln/0 47b9525e (hidden) A.2
+    ○  - qsuskuln/0 054fa17c (hidden) A.2
        A file2
     ○  + qpvuntsm b1ca67e2 (empty) B
        - qpvuntsm/1 e8849ae1 (hidden) (empty) (no description set)
 
     Changed working copy default@:
     + qpvuntsm b1ca67e2 (empty) B
-    - mzvwutvl/0 08c63613 (hidden) (empty) A
+    - pzvwutvl/0 33c1ee1f (hidden) (empty) A
     [EOF]
     ");
     let output = work_dir.run_jj([
@@ -1933,19 +1933,19 @@ fn test_op_diff_sibling() {
     ]);
     insta::assert_snapshot!(output, @"
     From operation: 1220c0f6978f (2001-02-03 08:05:12) describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
-      To operation: 8276f97c320d (2001-02-03 08:05:11) new empty commit
+      To operation: f212ec1c9291 (2001-02-03 08:05:11) new empty commit
 
     Changed commits:
     ○  - qpvuntsm/0 b1ca67e2 (hidden) (empty) B
-    ○    + mzvwutvl 08c63613 (empty) A
+    ○    + pzvwutvl 33c1ee1f (empty) A
     ├─╮
-    │ ○  + kkmpptxz 6c70a4f7 A.1
+    │ ○  + nkmpptxz 2c90d7cd A.1
     │    A file1
-    ○  + zsuskuln 47b9525e A.2
+    ○  + qsuskuln 054fa17c A.2
        A file2
 
     Changed working copy default@:
-    + mzvwutvl 08c63613 (empty) A
+    + pzvwutvl 33c1ee1f (empty) A
     - qpvuntsm/0 b1ca67e2 (hidden) (empty) B
     [EOF]
     ");
@@ -1965,18 +1965,18 @@ fn test_op_diff_sibling() {
     ]);
     insta::assert_snapshot!(output, @"
     From operation: 1220c0f6978f (2001-02-03 08:05:12) describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
-      To operation: 8276f97c320d (2001-02-03 08:05:11) new empty commit
+      To operation: f212ec1c9291 (2001-02-03 08:05:11) new empty commit
 
     Changed commits:
     - qpvuntsm/0 b1ca67e2 (hidden) (empty) B
-    + mzvwutvl 08c63613 (empty) A
-    + zsuskuln 47b9525e A.2
+    + pzvwutvl 33c1ee1f (empty) A
+    + qsuskuln 054fa17c A.2
     A file2
-    + kkmpptxz 6c70a4f7 A.1
+    + nkmpptxz 2c90d7cd A.1
     A file1
 
     Changed working copy default@:
-    + mzvwutvl 08c63613 (empty) A
+    + pzvwutvl 33c1ee1f (empty) A
     - qpvuntsm/0 b1ca67e2 (hidden) (empty) B
     [EOF]
     ");
@@ -2225,9 +2225,9 @@ fn test_op_diff_at_merge_op_with_rebased_commits() {
     work_dir.run_jj(["desc", "--at-op=@-", "-m2b"]).success();
 
     insta::assert_snapshot!(work_dir.run_jj(["log"]), @"
-    @  rlvkpnrz/2 test.user@example.com 2001-02-03 08:05:09 7ed5a610 (divergent)
+    @  ylvkpnrz/2 test.user@example.com 2001-02-03 08:05:09 20343652 (divergent)
     │  (empty) 2a
-    │ ○  rlvkpnrz/0 test.user@example.com 2001-02-03 08:05:11 8f35f6a6 (divergent)
+    │ ○  ylvkpnrz/0 test.user@example.com 2001-02-03 08:05:11 4747853e (divergent)
     ├─╯  (empty) 2b
     ○  qpvuntsm test.user@example.com 2001-02-03 08:05:09 6666e5c3
     │  (empty) 1
@@ -2242,19 +2242,19 @@ fn test_op_diff_at_merge_op_with_rebased_commits() {
     // FIXME: the diff should be empty
     let output = work_dir.run_jj(["op", "diff"]);
     insta::assert_snapshot!(output, @"
-    From operation: aebc639c7fdb (2001-02-03 08:05:09) describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
-    From operation: f36a8c8cba9e (2001-02-03 08:05:10) describe commit ab92d1a87bebb4300165a16a753c5403bd7bc578
-      To operation: 8f0e2ab3b7cc (2001-02-03 08:05:11) reconcile divergent operations
+    From operation: 1a2ee34c48cd (2001-02-03 08:05:09) describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
+    From operation: 91705c063c09 (2001-02-03 08:05:10) describe commit 9e59011a63aa8d7111aa49fbb58342eee1d9dc4b
+      To operation: 1c512f74a1bb (2001-02-03 08:05:11) reconcile divergent operations
 
     Changed commits:
-    ○  + rlvkpnrz/1 8f35f6a6 (divergent) (empty) 2b
-       - rlvkpnrz/0 4545eaf5 (hidden) (empty) 2b
+    ○  + ylvkpnrz/1 4747853e (divergent) (empty) 2b
+       - ylvkpnrz/0 84fa41e7 (hidden) (empty) 2b
     [EOF]
     ");
 
     let output = work_dir.run_jj(["op", "show"]);
     insta::assert_snapshot!(output, @"
-    8f0e2ab3b7cc test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    1c512f74a1bb test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
     reconcile divergent operations
     args: jj log
     [EOF]
@@ -2262,33 +2262,33 @@ fn test_op_diff_at_merge_op_with_rebased_commits() {
 
     let output = work_dir.run_jj(["op", "log", "--op-diff", "--limit=3"]);
     insta::assert_snapshot!(output, @"
-    @    8f0e2ab3b7cc test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    @    1c512f74a1bb test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
     ├─╮  reconcile divergent operations
     │ │  args: jj log
-    ○ │  aebc639c7fdb test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    ○ │  1a2ee34c48cd test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     │ │  describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     │ │  args: jj describe -r@- -m1
     │ │
     │ │  Changed commits:
-    │ │  ○  + rlvkpnrz 7ed5a610 (empty) 2a
-    │ │  │  - rlvkpnrz/1 ab92d1a8 (hidden) (empty) 2a
+    │ │  ○  + ylvkpnrz 20343652 (empty) 2a
+    │ │  │  - ylvkpnrz/1 9e59011a (hidden) (empty) 2a
     │ │  ○  + qpvuntsm 6666e5c3 (empty) 1
     │ │     - qpvuntsm/1 e8849ae1 (hidden) (empty) (no description set)
     │ │
     │ │  Changed working copy default@:
-    │ │  + rlvkpnrz 7ed5a610 (empty) 2a
-    │ │  - rlvkpnrz/1 ab92d1a8 (hidden) (empty) 2a
-    │ ○  f36a8c8cba9e test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
-    ├─╯  describe commit ab92d1a87bebb4300165a16a753c5403bd7bc578
+    │ │  + ylvkpnrz 20343652 (empty) 2a
+    │ │  - ylvkpnrz/1 9e59011a (hidden) (empty) 2a
+    │ ○  91705c063c09 test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    ├─╯  describe commit 9e59011a63aa8d7111aa49fbb58342eee1d9dc4b
     │    args: jj describe '--at-op=@-' -m2b
     │
     │    Changed commits:
-    │    ○  + rlvkpnrz 50ec12eb (empty) 2b
-    │       - rlvkpnrz/1 ab92d1a8 (hidden) (empty) 2a
+    │    ○  + ylvkpnrz 6fb602fb (empty) 2b
+    │       - ylvkpnrz/1 9e59011a (hidden) (empty) 2a
     │
     │    Changed working copy default@:
-    │    + rlvkpnrz 50ec12eb (empty) 2b
-    │    - rlvkpnrz/1 ab92d1a8 (hidden) (empty) 2a
+    │    + ylvkpnrz 6fb602fb (empty) 2b
+    │    - ylvkpnrz/1 9e59011a (hidden) (empty) 2a
     [EOF]
     ");
 }
@@ -2712,23 +2712,23 @@ fn test_op_show() {
     let output = work_dir.run_jj(["new", "bookmark-1@origin", "-m", "new commit"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: tlkvzzqu 8f340dd7 (empty) new commit
+    Working copy  (@) now at: nlkvzzqu ebabca3e (empty) new commit
     Parent commit (@-)      : zkmtkqvo 0dee6313 bookmark-1?? bookmark-1@origin | Commit 4
     Added 2 files, modified 0 files, removed 0 files
     [EOF]
     ");
     let output = work_dir.run_jj(["op", "show"]);
     insta::assert_snapshot!(output, @"
-    6a8c47fa9bd0 test-username@host.example.com default@ 2001-02-03 04:05:27.000 +07:00 - 2001-02-03 04:05:27.000 +07:00
+    111cac440c25 test-username@host.example.com default@ 2001-02-03 04:05:27.000 +07:00 - 2001-02-03 04:05:27.000 +07:00
     new empty commit
     args: jj new bookmark-1@origin -m 'new commit'
 
     Changed commits:
-    ○  + tlkvzzqu 8f340dd7 (empty) new commit
+    ○  + nlkvzzqu ebabca3e (empty) new commit
     ○  - qpvuntsm/0 e8849ae1 (hidden) (empty) (no description set)
 
     Changed working copy default@:
-    + tlkvzzqu 8f340dd7 (empty) new commit
+    + nlkvzzqu ebabca3e (empty) new commit
     - qpvuntsm/0 e8849ae1 (hidden) (empty) (no description set)
     [EOF]
     ");
@@ -2737,18 +2737,18 @@ fn test_op_show() {
     let output = work_dir.run_jj(["bookmark", "set", "bookmark-1", "-r", "@"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Moved 1 bookmarks to tlkvzzqu 8f340dd7 bookmark-1* | (empty) new commit
+    Moved 1 bookmarks to nlkvzzqu ebabca3e bookmark-1* | (empty) new commit
     [EOF]
     ");
     let output = work_dir.run_jj(["op", "show"]);
     insta::assert_snapshot!(output, @"
-    6dcf762ef8fa test-username@host.example.com default@ 2001-02-03 04:05:29.000 +07:00 - 2001-02-03 04:05:29.000 +07:00
-    point bookmark bookmark-1 to commit 8f340dd76dc637e4deac17f30056eef7d8eaf682
+    41c202959e84 test-username@host.example.com default@ 2001-02-03 04:05:29.000 +07:00 - 2001-02-03 04:05:29.000 +07:00
+    point bookmark bookmark-1 to commit ebabca3e5e9cf1c2880c65376d70dfe5c22972f7
     args: jj bookmark set bookmark-1 -r @
 
     Changed local bookmarks:
     bookmark-1:
-    + tlkvzzqu 8f340dd7 bookmark-1* | (empty) new commit
+    + nlkvzzqu ebabca3e bookmark-1* | (empty) new commit
     - (added) zkmtkqvo 0dee6313 bookmark-1@origin | Commit 4
     - (added) rnnslrkn 4ff62539 Commit 2
     [EOF]
@@ -2763,7 +2763,7 @@ fn test_op_show() {
     ");
     let output = work_dir.run_jj(["op", "show"]);
     insta::assert_snapshot!(output, @"
-    7b58e5b895cb test-username@host.example.com default@ 2001-02-03 04:05:31.000 +07:00 - 2001-02-03 04:05:31.000 +07:00
+    3e72a33f1d98 test-username@host.example.com default@ 2001-02-03 04:05:31.000 +07:00 - 2001-02-03 04:05:31.000 +07:00
     delete bookmark bookmark-2
     args: jj bookmark delete bookmark-2
 
@@ -2779,19 +2779,19 @@ fn test_op_show() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Changes to push to origin:
-      bookmark: bookmark-1 [move forward from 0dee631320b1 to 8f340dd76dc6]
+      bookmark: bookmark-1 [move forward from 0dee631320b1 to ebabca3e5e9c]
       bookmark: bookmark-2 [delete from e1a239a57eb1]
     [EOF]
     ");
     let output = work_dir.run_jj(["op", "show"]);
     insta::assert_snapshot!(output, @"
-    baf30d0ec0af test-username@host.example.com default@ 2001-02-03 04:05:33.000 +07:00 - 2001-02-03 04:05:33.000 +07:00
+    8c98bf512691 test-username@host.example.com default@ 2001-02-03 04:05:33.000 +07:00 - 2001-02-03 04:05:33.000 +07:00
     push all tracked bookmarks/tags to git remote origin
     args: jj git push --tracked --deleted
 
     Changed remote bookmarks:
     bookmark-1@origin:
-    + tracked tlkvzzqu 8f340dd7 bookmark-1 | (empty) new commit
+    + tracked nlkvzzqu ebabca3e bookmark-1 | (empty) new commit
     - tracked zkmtkqvo 0dee6313 Commit 4
     bookmark-2@origin:
     + untracked (absent)
@@ -2800,18 +2800,18 @@ fn test_op_show() {
     ");
 
     // Showing a given operation, without graph
-    let output = work_dir.run_jj(["op", "show", "--no-graph", "6a8c47fa9bd0"]);
+    let output = work_dir.run_jj(["op", "show", "--no-graph", "111cac440c25"]);
     insta::assert_snapshot!(output, @"
-    6a8c47fa9bd0 test-username@host.example.com default@ 2001-02-03 04:05:27.000 +07:00 - 2001-02-03 04:05:27.000 +07:00
+    111cac440c25 test-username@host.example.com default@ 2001-02-03 04:05:27.000 +07:00 - 2001-02-03 04:05:27.000 +07:00
     new empty commit
     args: jj new bookmark-1@origin -m 'new commit'
 
     Changed commits:
-    + tlkvzzqu 8f340dd7 (empty) new commit
+    + nlkvzzqu ebabca3e (empty) new commit
     - qpvuntsm/0 e8849ae1 (hidden) (empty) (no description set)
 
     Changed working copy default@:
-    + tlkvzzqu 8f340dd7 (empty) new commit
+    + nlkvzzqu ebabca3e (empty) new commit
     - qpvuntsm/0 e8849ae1 (hidden) (empty) (no description set)
     [EOF]
     ");
@@ -2828,7 +2828,7 @@ fn test_op_show_patch() {
     let output = work_dir.run_jj(["new"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: rlvkpnrz c1c924b8 (empty) (no description set)
+    Working copy  (@) now at: ylvkpnrz 9348e934 (empty) (no description set)
     Parent commit (@-)      : qpvuntsm 6b57e33c (no description set)
     [EOF]
     ");
@@ -2856,15 +2856,15 @@ fn test_op_show_patch() {
     ");
     let output = work_dir.run_jj(["op", "show", "@", "-p", "--git"]);
     insta::assert_snapshot!(output, @"
-    cf0770d7100e test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    18f25087c84c test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     new empty commit
     args: jj new
 
     Changed commits:
-    ○  + rlvkpnrz c1c924b8 (empty) (no description set)
+    ○  + ylvkpnrz 9348e934 (empty) (no description set)
 
     Changed working copy default@:
-    + rlvkpnrz c1c924b8 (empty) (no description set)
+    + ylvkpnrz 9348e934 (empty) (no description set)
     - qpvuntsm 6b57e33c (no description set)
     [EOF]
     ");
@@ -2880,7 +2880,7 @@ fn test_op_show_patch() {
     ");
     let output = work_dir.run_jj(["op", "show", "-p", "--git"]);
     insta::assert_snapshot!(output, @"
-    e6ae6bef0dc4 test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    11e6ef0505b9 test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
     squash commits into 6b57e33cc56babbeaa6bcd6e2a296236b52ad93c
     args: jj squash
 
@@ -2888,7 +2888,7 @@ fn test_op_show_patch() {
     ○  + mzvwutvl 6cbd01ae (empty) (no description set)
     ○  + qpvuntsm 7aa2ec5d (no description set)
        - qpvuntsm/1 6b57e33c (hidden) (no description set)
-       - rlvkpnrz/0 05a2969e (hidden) (no description set)
+       - ylvkpnrz/0 82d265bf (hidden) (no description set)
        diff --git a/file b/file
        index 7898192261..6178079822 100644
        --- a/file
@@ -2899,7 +2899,7 @@ fn test_op_show_patch() {
 
     Changed working copy default@:
     + mzvwutvl 6cbd01ae (empty) (no description set)
-    - rlvkpnrz/0 05a2969e (hidden) (no description set)
+    - ylvkpnrz/0 82d265bf (hidden) (no description set)
     [EOF]
     ");
 
@@ -2915,7 +2915,7 @@ fn test_op_show_patch() {
     ");
     let output = work_dir.run_jj(["op", "show", "-p", "--git"]);
     insta::assert_snapshot!(output, @"
-    0b9a2eef07b2 test-username@host.example.com default@ 2001-02-03 04:05:13.000 +07:00 - 2001-02-03 04:05:13.000 +07:00
+    c2071bf78ef4 test-username@host.example.com default@ 2001-02-03 04:05:13.000 +07:00 - 2001-02-03 04:05:13.000 +07:00
     abandon commit 6cbd01aefe5ae05a015328311dbd63b7305b8ebe
     args: jj abandon
 
@@ -2932,7 +2932,7 @@ fn test_op_show_patch() {
     // Try again with "op log".
     let output = work_dir.run_jj(["op", "log", "--git"]);
     insta::assert_snapshot!(output, @"
-    @  0b9a2eef07b2 test-username@host.example.com default@ 2001-02-03 04:05:13.000 +07:00 - 2001-02-03 04:05:13.000 +07:00
+    @  c2071bf78ef4 test-username@host.example.com default@ 2001-02-03 04:05:13.000 +07:00 - 2001-02-03 04:05:13.000 +07:00
     │  abandon commit 6cbd01aefe5ae05a015328311dbd63b7305b8ebe
     │  args: jj abandon
     │
@@ -2943,7 +2943,7 @@ fn test_op_show_patch() {
     │  Changed working copy default@:
     │  + yqosqzyt c97a8573 (empty) (no description set)
     │  - mzvwutvl/0 6cbd01ae (hidden) (empty) (no description set)
-    ○  e6ae6bef0dc4 test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    ○  11e6ef0505b9 test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
     │  squash commits into 6b57e33cc56babbeaa6bcd6e2a296236b52ad93c
     │  args: jj squash
     │
@@ -2951,7 +2951,7 @@ fn test_op_show_patch() {
     │  ○  + mzvwutvl 6cbd01ae (empty) (no description set)
     │  ○  + qpvuntsm 7aa2ec5d (no description set)
     │     - qpvuntsm/1 6b57e33c (hidden) (no description set)
-    │     - rlvkpnrz/0 05a2969e (hidden) (no description set)
+    │     - ylvkpnrz/0 82d265bf (hidden) (no description set)
     │     diff --git a/file b/file
     │     index 7898192261..6178079822 100644
     │     --- a/file
@@ -2962,14 +2962,14 @@ fn test_op_show_patch() {
     │
     │  Changed working copy default@:
     │  + mzvwutvl 6cbd01ae (empty) (no description set)
-    │  - rlvkpnrz/0 05a2969e (hidden) (no description set)
-    ○  1411dd0524ab test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    │  - ylvkpnrz/0 82d265bf (hidden) (no description set)
+    ○  f71550287733 test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
     │  snapshot working copy
     │  args: jj squash
     │
     │  Changed commits:
-    │  ○  + rlvkpnrz 05a2969e (no description set)
-    │     - rlvkpnrz/1 c1c924b8 (hidden) (empty) (no description set)
+    │  ○  + ylvkpnrz 82d265bf (no description set)
+    │     - ylvkpnrz/1 9348e934 (hidden) (empty) (no description set)
     │     diff --git a/file b/file
     │     index 7898192261..6178079822 100644
     │     --- a/file
@@ -2979,17 +2979,17 @@ fn test_op_show_patch() {
     │     +b
     │
     │  Changed working copy default@:
-    │  + rlvkpnrz 05a2969e (no description set)
-    │  - rlvkpnrz/1 c1c924b8 (hidden) (empty) (no description set)
-    ○  cf0770d7100e test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    │  + ylvkpnrz 82d265bf (no description set)
+    │  - ylvkpnrz/1 9348e934 (hidden) (empty) (no description set)
+    ○  18f25087c84c test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  new empty commit
     │  args: jj new
     │
     │  Changed commits:
-    │  ○  + rlvkpnrz c1c924b8 (empty) (no description set)
+    │  ○  + ylvkpnrz 9348e934 (empty) (no description set)
     │
     │  Changed working copy default@:
-    │  + rlvkpnrz c1c924b8 (empty) (no description set)
+    │  + ylvkpnrz 9348e934 (empty) (no description set)
     │  - qpvuntsm 6b57e33c (no description set)
     ○  2f45e55601da test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  snapshot working copy
@@ -3151,12 +3151,12 @@ fn test_op_immutable_revisions() {
         .run_jj(["abandon", "--ignore-immutable", "::t1 & ~root()"])
         .success();
     insta::assert_snapshot!(work_dir.run_jj(["op", "show"]), @"
-    d86e21bb08c0 test-username@host.example.com default@ 2001-02-03 04:05:16.000 +07:00 - 2001-02-03 04:05:16.000 +07:00
-    abandon commit 9c86781f3fe9097ffc530e65fd2ab4aff1e654bd and 5 more
+    da504b24ce4f test-username@host.example.com default@ 2001-02-03 04:05:16.000 +07:00 - 2001-02-03 04:05:16.000 +07:00
+    abandon commit 2d2caca575892f33ca4e8b0dbf04c6745906c083 and 5 more
     args: jj abandon --ignore-immutable '::t1 & ~root()'
 
     Changed commits:
-    ○  - royxmykx/0 9c86781f (hidden) (empty) commit 5
+    ○  - ooyxmykx/0 2d2caca5 (hidden) (empty) commit 5
        (Elided 5 newly removed revisions)
     [EOF]
     ");
@@ -3164,12 +3164,12 @@ fn test_op_immutable_revisions() {
     // Undo
     work_dir.run_jj(["op", "revert"]).success();
     insta::assert_snapshot!(work_dir.run_jj(["op", "show"]), @"
-    abbb2399227e test-username@host.example.com default@ 2001-02-03 04:05:18.000 +07:00 - 2001-02-03 04:05:18.000 +07:00
-    revert operation d86e21bb08c07020add3b8624a72211b087501d2cce3e1fc90ef0e37596385b73b5470b1754dfbaf1ec28df0df5d61dadb6cf338ceb1ae2a1974a3a473ec8230
+    bf08f14bbdc1 test-username@host.example.com default@ 2001-02-03 04:05:18.000 +07:00 - 2001-02-03 04:05:18.000 +07:00
+    revert operation da504b24ce4f72af70b3e0059dab0c1e9226426f8e9e01f9b84f6f7a240f89a8807550fa10071a8f4ffb6ffe124c8b4fd095b6b23bcc73af0e56285d71670014
     args: jj op revert
 
     Changed commits:
-    ○  + royxmykx 9c86781f (empty) commit 5
+    ○  + ooyxmykx 2d2caca5 (empty) commit 5
        (Elided 5 newly added revisions)
     [EOF]
     ");
@@ -3196,23 +3196,23 @@ fn test_op_immutable_revisions() {
         .success();
     let op_id_for_diff = work_dir.current_operation_id();
     insta::assert_snapshot!(work_dir.run_jj(["op", "show"]), @"
-    cf3d5f839512 test-username@host.example.com default@ 2001-02-03 04:05:31.000 +07:00 - 2001-02-03 04:05:31.000 +07:00
-    abandon commit 7c60d8fd187f77196d1def564b0d893d477b7e56 and 11 more
+    1ae80c047bc1 test-username@host.example.com default@ 2001-02-03 04:05:31.000 +07:00 - 2001-02-03 04:05:31.000 +07:00
+    abandon commit 07d6b626c8878f3328b5e5442a8828eb7deeed97 and 11 more
     args: jj abandon --ignore-immutable '(::f1 | ::f2) & ~root()'
 
     Changed commits:
-    ○  - tlkvzzqu/0 7c60d8fd (hidden) (empty) f2 3
-    ╷ ○  - nkmrtpmo/0 caf991b6 (hidden) (empty) f1 3
+    ○  - mlkvzzqu/0 07d6b626 (hidden) (empty) f2 3
+    ╷ ○  - tkmrtpmo/0 6197e527 (hidden) (empty) f1 3
     ╭─╯
-    ○  - royxmykx/0 9c86781f (hidden) (empty) commit 5
+    ○  - ooyxmykx/0 2d2caca5 (hidden) (empty) commit 5
        (Elided 9 newly removed revisions)
     [EOF]
     ");
 
     // Use `--show-changes-in none()` to see only elisions
     insta::assert_snapshot!(work_dir.run_jj(["op", "show", "--show-changes-in", "none()"]), @"
-    cf3d5f839512 test-username@host.example.com default@ 2001-02-03 04:05:31.000 +07:00 - 2001-02-03 04:05:31.000 +07:00
-    abandon commit 7c60d8fd187f77196d1def564b0d893d477b7e56 and 11 more
+    1ae80c047bc1 test-username@host.example.com default@ 2001-02-03 04:05:31.000 +07:00 - 2001-02-03 04:05:31.000 +07:00
+    abandon commit 07d6b626c8878f3328b5e5442a8828eb7deeed97 and 11 more
     args: jj abandon --ignore-immutable '(::f1 | ::f2) & ~root()'
 
     Changed commits:
@@ -3248,45 +3248,45 @@ fn test_op_immutable_revisions() {
         .run_jj(["rebase", "--ignore-immutable", "-s", "bb----", "-d", "ba"])
         .success();
     insta::assert_snapshot!(work_dir.run_jj(["op", "show"]), @"
-    5139db3ae21c test-username@host.example.com default@ 2001-02-03 04:05:48.000 +07:00 - 2001-02-03 04:05:48.000 +07:00
-    rebase commit 6c3a9c2476ba8a8e5bac722f9c0e2ca914b9577d and descendants
+    d32c0540b738 test-username@host.example.com default@ 2001-02-03 04:05:48.000 +07:00 - 2001-02-03 04:05:48.000 +07:00
+    rebase commit 83b39a09684641b8d3b988cd671bbe8b449f22ae and descendants
     args: jj rebase --ignore-immutable -s bb---- -d ba
 
     Changed commits:
-    ○  + wtlqussy bf3146c8 (empty) (no description set)
-    │  - wtlqussy/1 371fd4fe (hidden) (empty) (no description set)
-    ○  + xpnwykqz 741a5187 bb | (empty) mix-b5
-       - xpnwykqz/1 1c52a7a2 (hidden) (empty) mix-b5
+    ○  + qtlqussy fa5ba2f6 (empty) (no description set)
+    │  - qtlqussy/1 03c8229a (hidden) (empty) (no description set)
+    ○  + opnwykqz f0e0c4eb bb | (empty) mix-b5
+       - opnwykqz/1 2dc53827 (hidden) (empty) mix-b5
        (Elided 4 newly added and 4 newly removed revisions)
 
     Changed working copy default@:
-    + wtlqussy bf3146c8 (empty) (no description set)
-    - wtlqussy/1 371fd4fe (hidden) (empty) (no description set)
+    + qtlqussy fa5ba2f6 (empty) (no description set)
+    - qtlqussy/1 03c8229a (hidden) (empty) (no description set)
 
     Changed local bookmarks:
     bb:
-    + xpnwykqz 741a5187 bb | (empty) mix-b5
-    - xpnwykqz/1 1c52a7a2 (hidden) (empty) mix-b5
+    + opnwykqz f0e0c4eb bb | (empty) mix-b5
+    - opnwykqz/1 2dc53827 (hidden) (empty) mix-b5
     [EOF]
     ");
 
     // Use `--show-changes-in none()` to see only elisions
     insta::assert_snapshot!(work_dir.run_jj(["op", "show", "--show-changes-in", "none()"]), @"
-    5139db3ae21c test-username@host.example.com default@ 2001-02-03 04:05:48.000 +07:00 - 2001-02-03 04:05:48.000 +07:00
-    rebase commit 6c3a9c2476ba8a8e5bac722f9c0e2ca914b9577d and descendants
+    d32c0540b738 test-username@host.example.com default@ 2001-02-03 04:05:48.000 +07:00 - 2001-02-03 04:05:48.000 +07:00
+    rebase commit 83b39a09684641b8d3b988cd671bbe8b449f22ae and descendants
     args: jj rebase --ignore-immutable -s bb---- -d ba
 
     Changed commits:
        (Elided 6 newly added and 6 newly removed revisions)
 
     Changed working copy default@:
-    + wtlqussy bf3146c8 (empty) (no description set)
-    - wtlqussy/1 371fd4fe (hidden) (empty) (no description set)
+    + qtlqussy fa5ba2f6 (empty) (no description set)
+    - qtlqussy/1 03c8229a (hidden) (empty) (no description set)
 
     Changed local bookmarks:
     bb:
-    + xpnwykqz 741a5187 bb | (empty) mix-b5
-    - xpnwykqz/1 1c52a7a2 (hidden) (empty) mix-b5
+    + opnwykqz f0e0c4eb bb | (empty) mix-b5
+    - opnwykqz/1 2dc53827 (hidden) (empty) mix-b5
     [EOF]
     ");
 
@@ -3304,89 +3304,89 @@ fn test_op_immutable_revisions() {
         .run_jj(["abandon", "--ignore-immutable", "::ts & ~root()"])
         .success();
     insta::assert_snapshot!(work_dir.run_jj(["op", "show"]), @"
-    e660cbda9711 test-username@host.example.com default@ 2001-02-03 04:05:55.000 +07:00 - 2001-02-03 04:05:55.000 +07:00
-    abandon commit 4ebd4aa1d0bfee524ccd21882606990e3b75fc12 and 1 more
+    e23251e3911e test-username@host.example.com default@ 2001-02-03 04:05:55.000 +07:00 - 2001-02-03 04:05:55.000 +07:00
+    abandon commit 2233451f96910b0c2e499f65b6c794ec045dc50e and 1 more
     args: jj abandon --ignore-immutable '::ts & ~root()'
 
     Changed commits:
-    ○  + ztnvrxlv 41578768 (empty) (no description set)
-       - ztnvrxlv/1 13887367 (hidden) (empty) (no description set)
-    ○  - wqxolloz/0 4ebd4aa1 (hidden) (empty) single-2
+    ○  + ytnvrxlv 8e13b44d (empty) (no description set)
+       - ytnvrxlv/1 2b169b47 (hidden) (empty) (no description set)
+    ○  - nqxolloz/0 2233451f (hidden) (empty) single-2
        (Elided 1 newly removed revisions)
 
     Changed working copy default@:
-    + ztnvrxlv 41578768 (empty) (no description set)
-    - ztnvrxlv/1 13887367 (hidden) (empty) (no description set)
+    + ytnvrxlv 8e13b44d (empty) (no description set)
+    - ytnvrxlv/1 2b169b47 (hidden) (empty) (no description set)
     [EOF]
     ");
 
     // Undo to see single addition elision
     work_dir.run_jj(["op", "revert"]).success();
     insta::assert_snapshot!(work_dir.run_jj(["op", "show"]), @"
-    d4f2cba9248e test-username@host.example.com default@ 2001-02-03 04:05:57.000 +07:00 - 2001-02-03 04:05:57.000 +07:00
-    revert operation e660cbda9711f6258fca5dffa47b356ace070baff91ee1ff29dee57432d2d44a65cc96375ef6a6e0f0c17171a3a4e209df9f8613790abb28c87acb6fbe107f8d
+    0dafda2a370f test-username@host.example.com default@ 2001-02-03 04:05:57.000 +07:00 - 2001-02-03 04:05:57.000 +07:00
+    revert operation e23251e3911e6e32e94e64ab505a8141c6b8e32a7625571d481114f9ec08304a62cf04f5a32afe24b1a5439ab0043793d548e05a2c6cbb34f62f1af1d548c6f9
     args: jj op revert
 
     Changed commits:
-    ○  + ztnvrxlv 13887367 (empty) (no description set)
-    │  - ztnvrxlv/0 41578768 (hidden) (empty) (no description set)
-    ○  + wqxolloz 4ebd4aa1 (empty) single-2
+    ○  + ytnvrxlv 2b169b47 (empty) (no description set)
+    │  - ytnvrxlv/0 8e13b44d (hidden) (empty) (no description set)
+    ○  + nqxolloz 2233451f (empty) single-2
        (Elided 1 newly added revisions)
 
     Changed working copy default@:
-    + ztnvrxlv 13887367 (empty) (no description set)
-    - ztnvrxlv/0 41578768 (hidden) (empty) (no description set)
+    + ytnvrxlv 2b169b47 (empty) (no description set)
+    - ytnvrxlv/0 8e13b44d (hidden) (empty) (no description set)
     [EOF]
     ");
 
     // 5. op diff and op log tests
     insta::assert_snapshot!(work_dir.run_jj(["op", "diff", "--from", &op_id_for_diff]), @"
-    From operation: cf3d5f839512 (2001-02-03 08:05:31) abandon commit 7c60d8fd187f77196d1def564b0d893d477b7e56 and 11 more
-      To operation: d4f2cba9248e (2001-02-03 08:05:57) revert operation e660cbda9711f6258fca5dffa47b356ace070baff91ee1ff29dee57432d2d44a65cc96375ef6a6e0f0c17171a3a4e209df9f8613790abb28c87acb6fbe107f8d
+    From operation: 1ae80c047bc1 (2001-02-03 08:05:31) abandon commit 07d6b626c8878f3328b5e5442a8828eb7deeed97 and 11 more
+      To operation: 0dafda2a370f (2001-02-03 08:05:57) revert operation e23251e3911e6e32e94e64ab505a8141c6b8e32a7625571d481114f9ec08304a62cf04f5a32afe24b1a5439ab0043793d548e05a2c6cbb34f62f1af1d548c6f9
 
     Changed commits:
-    ○  + ztnvrxlv 13887367 (empty) (no description set)
-    ○  + wqxolloz 4ebd4aa1 (empty) single-2
-    ○  + xpnwykqz 741a5187 bb | (empty) mix-b5
-    ○  + zowrlwsv 5653a1de ba | (empty) mix-a5
-    ○  - pzsxstzt/0 8192fa83 (hidden) (empty) (no description set)
+    ○  + ytnvrxlv 2b169b47 (empty) (no description set)
+    ○  + nqxolloz 2233451f (empty) single-2
+    ○  + opnwykqz f0e0c4eb bb | (empty) mix-b5
+    ○  + nowrlwsv 19a549f5 ba | (empty) mix-a5
+    ○  - lzsxstzt/0 73e73513 (hidden) (empty) (no description set)
        (Elided 9 newly added revisions)
 
     Changed working copy default@:
-    + ztnvrxlv 13887367 (empty) (no description set)
-    - pzsxstzt/0 8192fa83 (hidden) (empty) (no description set)
+    + ytnvrxlv 2b169b47 (empty) (no description set)
+    - lzsxstzt/0 73e73513 (hidden) (empty) (no description set)
 
     Changed local bookmarks:
     ba:
-    + zowrlwsv 5653a1de ba | (empty) mix-a5
+    + nowrlwsv 19a549f5 ba | (empty) mix-a5
     - (absent)
     bb:
-    + xpnwykqz 741a5187 bb | (empty) mix-b5
+    + opnwykqz f0e0c4eb bb | (empty) mix-b5
     - (absent)
 
     Changed local tags:
     ts:
-    + wqxolloz 4ebd4aa1 (empty) single-2
+    + nqxolloz 2233451f (empty) single-2
     - (absent)
     [EOF]
     ");
 
     insta::assert_snapshot!(work_dir.run_jj(["op", "log", "-p", "--limit", "1"]), @"
-    @  d4f2cba9248e test-username@host.example.com default@ 2001-02-03 04:05:57.000 +07:00 - 2001-02-03 04:05:57.000 +07:00
-    │  revert operation e660cbda9711f6258fca5dffa47b356ace070baff91ee1ff29dee57432d2d44a65cc96375ef6a6e0f0c17171a3a4e209df9f8613790abb28c87acb6fbe107f8d
+    @  0dafda2a370f test-username@host.example.com default@ 2001-02-03 04:05:57.000 +07:00 - 2001-02-03 04:05:57.000 +07:00
+    │  revert operation e23251e3911e6e32e94e64ab505a8141c6b8e32a7625571d481114f9ec08304a62cf04f5a32afe24b1a5439ab0043793d548e05a2c6cbb34f62f1af1d548c6f9
     │  args: jj op revert
     │
     │  Changed commits:
-    │  ○  + ztnvrxlv 13887367 (empty) (no description set)
-    │  │  - ztnvrxlv/0 41578768 (hidden) (empty) (no description set)
-    │  ○  + wqxolloz 4ebd4aa1 (empty) single-2
+    │  ○  + ytnvrxlv 2b169b47 (empty) (no description set)
+    │  │  - ytnvrxlv/0 8e13b44d (hidden) (empty) (no description set)
+    │  ○  + nqxolloz 2233451f (empty) single-2
     │     Modified commit description:
     │             1: single-2
     │     (Elided 1 newly added revisions)
     │
     │  Changed working copy default@:
-    │  + ztnvrxlv 13887367 (empty) (no description set)
-    │  - ztnvrxlv/0 41578768 (hidden) (empty) (no description set)
+    │  + ytnvrxlv 2b169b47 (empty) (no description set)
+    │  - ytnvrxlv/0 8e13b44d (hidden) (empty) (no description set)
     [EOF]
     ");
 
@@ -3461,11 +3461,11 @@ fn test_op_immutable_revisions() {
         "all()",
     ]);
     insta::assert_snapshot!(output, @"
-    From operation: 6065717c85c3 (2001-02-03 08:06:12) abandon commit 65f87c2d667d5088987ce6bed60f31f783b9e2ba
-      To operation: 15571d49e1b7 (2001-02-03 08:06:13) abandon commit 7d9fcee9d7dedaa91bee64d976a4252c74750905 and 1 more
+    From operation: 1b1882ecbab4 (2001-02-03 08:06:12) abandon commit ae489125d6d3efcef9b3288088b4a97d2e5c9f84
+      To operation: 22d38c969d3e (2001-02-03 08:06:13) abandon commit 6e7a720e5fad3112d7caa88186d5fdb7d01bcfbf and 1 more
 
     Changed commits:
-    ○  - quyylypw/0 7d9fcee9 (hidden) (empty) acc-c2
+    ○  - puyylypw/0 6e7a720e (hidden) (empty) acc-c2
     ○  - uzontzmm/0 593e25d0 (hidden) (empty) acc-c1
 
     Changed local bookmarks:
@@ -3474,7 +3474,7 @@ fn test_op_immutable_revisions() {
     - uzontzmm/0 593e25d0 (hidden) (empty) acc-c1
     ba2:
     + (absent)
-    - quyylypw/0 7d9fcee9 (hidden) (empty) acc-c2
+    - puyylypw/0 6e7a720e (hidden) (empty) acc-c2
     [EOF]
     ");
 
@@ -3482,11 +3482,11 @@ fn test_op_immutable_revisions() {
     // of the newly hidden set and elide c1.
     let output = work_dir.run_jj(["op", "diff", "--from", &op_a, "--to", &op_b]);
     insta::assert_snapshot!(output, @"
-    From operation: 6065717c85c3 (2001-02-03 08:06:12) abandon commit 65f87c2d667d5088987ce6bed60f31f783b9e2ba
-      To operation: 15571d49e1b7 (2001-02-03 08:06:13) abandon commit 7d9fcee9d7dedaa91bee64d976a4252c74750905 and 1 more
+    From operation: 1b1882ecbab4 (2001-02-03 08:06:12) abandon commit ae489125d6d3efcef9b3288088b4a97d2e5c9f84
+      To operation: 22d38c969d3e (2001-02-03 08:06:13) abandon commit 6e7a720e5fad3112d7caa88186d5fdb7d01bcfbf and 1 more
 
     Changed commits:
-    ○  - quyylypw/0 7d9fcee9 (hidden) (empty) acc-c2
+    ○  - puyylypw/0 6e7a720e (hidden) (empty) acc-c2
        (Elided 1 newly removed revisions)
 
     Changed local bookmarks:
@@ -3495,7 +3495,7 @@ fn test_op_immutable_revisions() {
     - uzontzmm/0 593e25d0 (hidden) (empty) acc-c1
     ba2:
     + (absent)
-    - quyylypw/0 7d9fcee9 (hidden) (empty) acc-c2
+    - puyylypw/0 6e7a720e (hidden) (empty) acc-c2
     [EOF]
     ");
 }
@@ -3550,27 +3550,27 @@ commit_summary = 'commit_id.short() ++ " " ++ description.first_line()'
     // 5. Test op show for op_rebase: should show ELISION summary.
     // bookmark_x exists in both states of the rebase.
     insta::assert_snapshot!(work_dir.run_jj(["op", "show", &op_rebase]), @"
-    ce91c7903087 test-username@host.example.com default@ 2001-02-03 04:05:14.000 +07:00 - 2001-02-03 04:05:14.000 +07:00
-    rebase commit 0f12cf5c679b373cb1ee0fa3e441c2f5030c4dc9 and descendants
+    31c26a90e828 test-username@host.example.com default@ 2001-02-03 04:05:14.000 +07:00 - 2001-02-03 04:05:14.000 +07:00
+    rebase commit 07185a93b19556cef06c3c6259ac0c78cdac473a and descendants
     args: jj rebase -s bookmark_x- -d @
 
     Changed commits:
-    ○  + 3cafca23bb81 stack 2
-       - 5456f1af47ed stack 2
+    ○  + 4b2b87d35a13 stack 2
+       - cd07cd2a6d7f stack 2
        (Elided 1 newly added and 1 newly removed revisions)
 
     Changed local bookmarks:
     bookmark_x:
-    + 3cafca23bb81 stack 2
-    - 5456f1af47ed stack 2
+    + 4b2b87d35a13 stack 2
+    - cd07cd2a6d7f stack 2
     [EOF]
     ");
 
     // 6. Test op show for op_create: should show WARNING.
     // bookmark_x did not exist in the 'from' state.
     insta::assert_snapshot!(work_dir.run_jj(["op", "show", &op_create]), @"
-    d3ffb3ae407a test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
-    create bookmark bookmark_x pointing to commit 2308e5a241f7a47f186b0686ffb17aa613a727d7
+    cb584a603788 test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    create bookmark bookmark_x pointing to commit a59b45ec2290746add5f7b5763bc50297ff36192
     args: jj bookmark create -r@ bookmark_x
 
     Warning: Could not resolve revset expression for elision: Revision `bookmark_x` doesn't exist
@@ -3578,7 +3578,7 @@ commit_summary = 'commit_id.short() ++ " " ++ description.first_line()'
 
     Changed local bookmarks:
     bookmark_x:
-    + 2308e5a241f7 base
+    + a59b45ec2290 base
     - (absent)
     [EOF]
     ");
@@ -3586,13 +3586,13 @@ commit_summary = 'commit_id.short() ++ " " ++ description.first_line()'
     // 7. Test op show for op_create with the flag: should show all changes and NO
     //    WARNING.
     insta::assert_snapshot!(work_dir.run_jj(["op", "show", &op_create, "--show-changes-in", "all()"]), @"
-    d3ffb3ae407a test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
-    create bookmark bookmark_x pointing to commit 2308e5a241f7a47f186b0686ffb17aa613a727d7
+    cb584a603788 test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    create bookmark bookmark_x pointing to commit a59b45ec2290746add5f7b5763bc50297ff36192
     args: jj bookmark create -r@ bookmark_x
 
     Changed local bookmarks:
     bookmark_x:
-    + 2308e5a241f7 base
+    + a59b45ec2290 base
     - (absent)
     [EOF]
     ");
@@ -3600,19 +3600,19 @@ commit_summary = 'commit_id.short() ++ " " ++ description.first_line()'
     // 8. Test op diff from BEFORE creation to op_rebase: should show WARNING.
     let op_before_create = format!("{op_create}-");
     insta::assert_snapshot!(work_dir.run_jj(["op", "diff", "--from", &op_before_create, "--to", &op_rebase]), @"
-    From operation: 2bd218a33e22 (2001-02-03 08:05:08) new empty commit
-      To operation: ce91c7903087 (2001-02-03 08:05:14) rebase commit 0f12cf5c679b373cb1ee0fa3e441c2f5030c4dc9 and descendants
+    From operation: a0f39ae0c4ae (2001-02-03 08:05:08) new empty commit
+      To operation: 31c26a90e828 (2001-02-03 08:05:14) rebase commit 07185a93b19556cef06c3c6259ac0c78cdac473a and descendants
 
     Warning: Could not resolve revset expression for elision: Revision `bookmark_x` doesn't exist
        (Use --show-changes-in=all() to see all changes)
 
     Changed working copy default@:
-    + 6b753f7043b4 new_base
-    - 2308e5a241f7 base
+    + fee1160607a9 new_base
+    - a59b45ec2290 base
 
     Changed local bookmarks:
     bookmark_x:
-    + 3cafca23bb81 stack 2
+    + 4b2b87d35a13 stack 2
     - (absent)
     [EOF]
     ");
@@ -3628,21 +3628,21 @@ commit_summary = 'commit_id.short() ++ " " ++ description.first_line()'
         "--show-changes-in",
         "all()",
     ]), @"
-    From operation: 2bd218a33e22 (2001-02-03 08:05:08) new empty commit
-      To operation: ce91c7903087 (2001-02-03 08:05:14) rebase commit 0f12cf5c679b373cb1ee0fa3e441c2f5030c4dc9 and descendants
+    From operation: a0f39ae0c4ae (2001-02-03 08:05:08) new empty commit
+      To operation: 31c26a90e828 (2001-02-03 08:05:14) rebase commit 07185a93b19556cef06c3c6259ac0c78cdac473a and descendants
 
     Changed commits:
-    ○  + 3cafca23bb81 stack 2
-    ○  + e7bd1678832f stack 1
-    ○  + 6b753f7043b4 new_base
+    ○  + 4b2b87d35a13 stack 2
+    ○  + f321f3b67e35 stack 1
+    ○  + fee1160607a9 new_base
 
     Changed working copy default@:
-    + 6b753f7043b4 new_base
-    - 2308e5a241f7 base
+    + fee1160607a9 new_base
+    - a59b45ec2290 base
 
     Changed local bookmarks:
     bookmark_x:
-    + 3cafca23bb81 stack 2
+    + 4b2b87d35a13 stack 2
     - (absent)
     [EOF]
     ");
@@ -3650,66 +3650,66 @@ commit_summary = 'commit_id.short() ++ " " ++ description.first_line()'
     // 10. Test op log -p: should show BOTH behaviors.
     test_env.add_config(r#"revsets.op-diff-changes-in = "mutable() | bookmark_x""#);
     insta::assert_snapshot!(work_dir.run_jj(["op", "log", "-p", "--limit", "6"]), @"
-    @  ce91c7903087 test-username@host.example.com default@ 2001-02-03 04:05:14.000 +07:00 - 2001-02-03 04:05:14.000 +07:00
-    │  rebase commit 0f12cf5c679b373cb1ee0fa3e441c2f5030c4dc9 and descendants
+    @  31c26a90e828 test-username@host.example.com default@ 2001-02-03 04:05:14.000 +07:00 - 2001-02-03 04:05:14.000 +07:00
+    │  rebase commit 07185a93b19556cef06c3c6259ac0c78cdac473a and descendants
     │  args: jj rebase -s bookmark_x- -d @
     │
     │  Changed commits:
-    │  ○  + 3cafca23bb81 stack 2
-    │  │  - 5456f1af47ed stack 2
-    │  ○  + e7bd1678832f stack 1
-    │     - 0f12cf5c679b stack 1
+    │  ○  + 4b2b87d35a13 stack 2
+    │  │  - cd07cd2a6d7f stack 2
+    │  ○  + f321f3b67e35 stack 1
+    │     - 07185a93b195 stack 1
     │
     │  Changed local bookmarks:
     │  bookmark_x:
-    │  + 3cafca23bb81 stack 2
-    │  - 5456f1af47ed stack 2
-    ○  86f2ef744e62 test-username@host.example.com default@ 2001-02-03 04:05:13.000 +07:00 - 2001-02-03 04:05:13.000 +07:00
+    │  + 4b2b87d35a13 stack 2
+    │  - cd07cd2a6d7f stack 2
+    ○  3479fe7584db test-username@host.example.com default@ 2001-02-03 04:05:13.000 +07:00 - 2001-02-03 04:05:13.000 +07:00
     │  new empty commit
     │  args: jj new 'root()' -m new_base
     │
     │  Changed commits:
-    │  ○  + 6b753f7043b4 new_base
+    │  ○  + fee1160607a9 new_base
     │     Modified commit description:
     │             1: new_base
     │
     │  Changed working copy default@:
-    │  + 6b753f7043b4 new_base
-    │  - 5456f1af47ed stack 2
-    ○  460a7cedc5a7 test-username@host.example.com default@ 2001-02-03 04:05:12.000 +07:00 - 2001-02-03 04:05:12.000 +07:00
-    │  point bookmark bookmark_x to commit 5456f1af47edb52cfd73d582364cc4dd6ddb08cf
+    │  + fee1160607a9 new_base
+    │  - cd07cd2a6d7f stack 2
+    ○  cc169f760ad1 test-username@host.example.com default@ 2001-02-03 04:05:12.000 +07:00 - 2001-02-03 04:05:12.000 +07:00
+    │  point bookmark bookmark_x to commit cd07cd2a6d7f84178f6620a5d297afebd84730fe
     │  args: jj bookmark set bookmark_x -r@
     │
     │  Changed local bookmarks:
     │  bookmark_x:
-    │  + 5456f1af47ed stack 2
-    │  - 2308e5a241f7 base
-    ○  f64dfa7b064f test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    │  + cd07cd2a6d7f stack 2
+    │  - a59b45ec2290 base
+    ○  1561086a3690 test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
     │  new empty commit
     │  args: jj new @ -m 'stack 2'
     │
     │  Changed commits:
-    │  ○  + 5456f1af47ed stack 2
+    │  ○  + cd07cd2a6d7f stack 2
     │     Modified commit description:
     │             1: stack 2
     │
     │  Changed working copy default@:
-    │  + 5456f1af47ed stack 2
-    │  - 0f12cf5c679b stack 1
-    ○  a6bc21ea52ed test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    │  + cd07cd2a6d7f stack 2
+    │  - 07185a93b195 stack 1
+    ○  970bc5734a88 test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     │  new empty commit
     │  args: jj new @ -m 'stack 1'
     │
     │  Changed commits:
-    │  ○  + 0f12cf5c679b stack 1
+    │  ○  + 07185a93b195 stack 1
     │     Modified commit description:
     │             1: stack 1
     │
     │  Changed working copy default@:
-    │  + 0f12cf5c679b stack 1
-    │  - 2308e5a241f7 base
-    ○  d3ffb3ae407a test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
-    │  create bookmark bookmark_x pointing to commit 2308e5a241f7a47f186b0686ffb17aa613a727d7
+    │  + 07185a93b195 stack 1
+    │  - a59b45ec2290 base
+    ○  cb584a603788 test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    │  create bookmark bookmark_x pointing to commit a59b45ec2290746add5f7b5763bc50297ff36192
     │  args: jj bookmark create -r@ bookmark_x
     │
     │  Warning: Could not resolve revset expression for elision: Revision `bookmark_x` doesn't exist
@@ -3717,7 +3717,7 @@ commit_summary = 'commit_id.short() ++ " " ++ description.first_line()'
     │
     │  Changed local bookmarks:
     │  bookmark_x:
-    │  + 2308e5a241f7 base
+    │  + a59b45ec2290 base
     │  - (absent)
     [EOF]
     ");
@@ -3732,71 +3732,71 @@ commit_summary = 'commit_id.short() ++ " " ++ description.first_line()'
         "--show-changes-in",
         "all()",
     ]), @"
-    @  ce91c7903087 test-username@host.example.com default@ 2001-02-03 04:05:14.000 +07:00 - 2001-02-03 04:05:14.000 +07:00
-    │  rebase commit 0f12cf5c679b373cb1ee0fa3e441c2f5030c4dc9 and descendants
+    @  31c26a90e828 test-username@host.example.com default@ 2001-02-03 04:05:14.000 +07:00 - 2001-02-03 04:05:14.000 +07:00
+    │  rebase commit 07185a93b19556cef06c3c6259ac0c78cdac473a and descendants
     │  args: jj rebase -s bookmark_x- -d @
     │
     │  Changed commits:
-    │  ○  + 3cafca23bb81 stack 2
-    │  │  - 5456f1af47ed stack 2
-    │  ○  + e7bd1678832f stack 1
-    │     - 0f12cf5c679b stack 1
+    │  ○  + 4b2b87d35a13 stack 2
+    │  │  - cd07cd2a6d7f stack 2
+    │  ○  + f321f3b67e35 stack 1
+    │     - 07185a93b195 stack 1
     │
     │  Changed local bookmarks:
     │  bookmark_x:
-    │  + 3cafca23bb81 stack 2
-    │  - 5456f1af47ed stack 2
-    ○  86f2ef744e62 test-username@host.example.com default@ 2001-02-03 04:05:13.000 +07:00 - 2001-02-03 04:05:13.000 +07:00
+    │  + 4b2b87d35a13 stack 2
+    │  - cd07cd2a6d7f stack 2
+    ○  3479fe7584db test-username@host.example.com default@ 2001-02-03 04:05:13.000 +07:00 - 2001-02-03 04:05:13.000 +07:00
     │  new empty commit
     │  args: jj new 'root()' -m new_base
     │
     │  Changed commits:
-    │  ○  + 6b753f7043b4 new_base
+    │  ○  + fee1160607a9 new_base
     │     Modified commit description:
     │             1: new_base
     │
     │  Changed working copy default@:
-    │  + 6b753f7043b4 new_base
-    │  - 5456f1af47ed stack 2
-    ○  460a7cedc5a7 test-username@host.example.com default@ 2001-02-03 04:05:12.000 +07:00 - 2001-02-03 04:05:12.000 +07:00
-    │  point bookmark bookmark_x to commit 5456f1af47edb52cfd73d582364cc4dd6ddb08cf
+    │  + fee1160607a9 new_base
+    │  - cd07cd2a6d7f stack 2
+    ○  cc169f760ad1 test-username@host.example.com default@ 2001-02-03 04:05:12.000 +07:00 - 2001-02-03 04:05:12.000 +07:00
+    │  point bookmark bookmark_x to commit cd07cd2a6d7f84178f6620a5d297afebd84730fe
     │  args: jj bookmark set bookmark_x -r@
     │
     │  Changed local bookmarks:
     │  bookmark_x:
-    │  + 5456f1af47ed stack 2
-    │  - 2308e5a241f7 base
-    ○  f64dfa7b064f test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    │  + cd07cd2a6d7f stack 2
+    │  - a59b45ec2290 base
+    ○  1561086a3690 test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
     │  new empty commit
     │  args: jj new @ -m 'stack 2'
     │
     │  Changed commits:
-    │  ○  + 5456f1af47ed stack 2
+    │  ○  + cd07cd2a6d7f stack 2
     │     Modified commit description:
     │             1: stack 2
     │
     │  Changed working copy default@:
-    │  + 5456f1af47ed stack 2
-    │  - 0f12cf5c679b stack 1
-    ○  a6bc21ea52ed test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    │  + cd07cd2a6d7f stack 2
+    │  - 07185a93b195 stack 1
+    ○  970bc5734a88 test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     │  new empty commit
     │  args: jj new @ -m 'stack 1'
     │
     │  Changed commits:
-    │  ○  + 0f12cf5c679b stack 1
+    │  ○  + 07185a93b195 stack 1
     │     Modified commit description:
     │             1: stack 1
     │
     │  Changed working copy default@:
-    │  + 0f12cf5c679b stack 1
-    │  - 2308e5a241f7 base
-    ○  d3ffb3ae407a test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
-    │  create bookmark bookmark_x pointing to commit 2308e5a241f7a47f186b0686ffb17aa613a727d7
+    │  + 07185a93b195 stack 1
+    │  - a59b45ec2290 base
+    ○  cb584a603788 test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    │  create bookmark bookmark_x pointing to commit a59b45ec2290746add5f7b5763bc50297ff36192
     │  args: jj bookmark create -r@ bookmark_x
     │
     │  Changed local bookmarks:
     │  bookmark_x:
-    │  + 2308e5a241f7 base
+    │  + a59b45ec2290 base
     │  - (absent)
     [EOF]
     ");

--- a/cli/tests/test_parallelize_command.rs
+++ b/cli/tests/test_parallelize_command.rs
@@ -115,7 +115,7 @@ fn test_parallelize_where_interior_has_non_target_children() {
     ○  44f4686efbe9 5 parents: 4
     ○  6858f6e16a6c 4 parents: 3
     ○  8cfb27e238c8 3 parents: 2
-    │ ○  a5a460ad9943 2c parents: 2
+    │ ○  bb6f24b28785 2c parents: 2
     ├─╯
     ○  320daf48ba58 2 parents: 1
     ○  884fe9b9c656 1 parents:
@@ -133,7 +133,7 @@ fn test_parallelize_where_interior_has_non_target_children() {
     │ │ │ ○  486dfbb53401 4 parents:
     │ │ ○ │  71c114f0dd4d 3 parents:
     │ │ ├─╯
-    │ │ │ ○  154d3801414a 2c parents: 1 2
+    │ │ │ ○  f07fee340c0b 2c parents: 1 2
     ╭─┬───╯
     │ ○ │  7c8f6e529b52 2 parents:
     │ ├─╯
@@ -156,10 +156,10 @@ fn test_parallelize_where_root_has_non_target_children() {
     work_dir.run_jj(["new", "subject(1)", "-m=1c"]).success();
     work_dir.run_jj(["new", "subject(3)", "-m=4"]).success();
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  4c392c2965f0 4 parents: 3
+    @  72aceb7fc062 4 parents: 3
     ○  8cfb27e238c8 3 parents: 2
     ○  320daf48ba58 2 parents: 1
-    │ ○  2935e6f82e54 1c parents: 1
+    │ ○  d0f2944abd65 1c parents: 1
     ├─╯
     ○  884fe9b9c656 1 parents:
     ◆  000000000000 parents:
@@ -169,12 +169,12 @@ fn test_parallelize_where_root_has_non_target_children() {
         .run_jj(["parallelize", "subject(1)::subject(3)"])
         .success();
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @      a5d4e90a54bf 4 parents: 1 2 3
+    @      bbe84ea27239 4 parents: 1 2 3
     ├─┬─╮
     │ │ ○  1d9fa9e05929 3 parents:
     │ ○ │  f773cf087413 2 parents:
     │ ├─╯
-    │ │ ○  2935e6f82e54 1c parents: 1
+    │ │ ○  d0f2944abd65 1c parents: 1
     ├───╯
     ○ │  884fe9b9c656 1 parents:
     ├─╯
@@ -200,11 +200,11 @@ fn test_parallelize_with_merge_commit_child() {
         .success();
     work_dir.run_jj(["new", "subject(3)", "-m", "4"]).success();
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  e6a543fcc5d8 4 parents: 3
+    @  e973fd6242d3 4 parents: 3
     ○  8cfb27e238c8 3 parents: 2
-    │ ○  af7ad8059bf1 2a-c parents: 2 a
+    │ ○  86ecf5b66397 2a-c parents: 2 a
     ╭─┤
-    │ ○  8fa549442479 a parents:
+    │ ○  f6b52d21d3b1 a parents:
     ○ │  320daf48ba58 2 parents: 1
     ○ │  884fe9b9c656 1 parents:
     ├─╯
@@ -217,12 +217,12 @@ fn test_parallelize_with_merge_commit_child() {
         .run_jj(["parallelize", "subject(1)::subject(3)"])
         .success();
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @      431d5005bab0 4 parents: 1 2 3
+    @      4d2b366781e1 4 parents: 1 2 3
     ├─┬─╮
     │ │ ○  3b6586259aa9 3 parents:
-    │ │ │ ○  67b28b5cc688 2a-c parents: 1 2 a
+    │ │ │ ○  d653025aafc9 2a-c parents: 1 2 a
     ╭─┬───┤
-    │ │ │ ○  8fa549442479 a parents:
+    │ │ │ ○  f6b52d21d3b1 a parents:
     │ │ ├─╯
     │ ○ │  dfd927ce07c0 2 parents:
     │ ├─╯
@@ -281,10 +281,10 @@ fn test_parallelize_head_is_a_merge() {
         .run_jj(["new", "subject(2)", "subject(b)", "-m=merged-head"])
         .success();
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @    c634925e6ac2 merged-head parents: 2 b
+    @    28a003dab4ae merged-head parents: 2 b
     ├─╮
-    │ ○  448c6310957c b parents: a
-    │ ○  07fb6466f0cd a parents:
+    │ ○  61c599910b31 b parents: a
+    │ ○  5d473ef2b320 a parents:
     ○ │  1ae5c538c8ef 2 parents: 1
     ○ │  42fc76489fb1 1 parents: 0
     ○ │  fc8a812f1b99 0 parents:
@@ -295,10 +295,10 @@ fn test_parallelize_head_is_a_merge() {
 
     work_dir.run_jj(["parallelize", "subject(1)::"]).success();
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @    f97b547cdca0 merged-head parents: 0 b
+    @    c00a7b308d15 merged-head parents: 0 b
     ├─╮
-    │ ○  448c6310957c b parents: a
-    │ ○  07fb6466f0cd a parents:
+    │ ○  61c599910b31 b parents: a
+    │ ○  5d473ef2b320 a parents:
     │ │ ○  b240f5a52f77 2 parents: 0
     ├───╯
     │ │ ○  42fc76489fb1 1 parents: 0
@@ -323,10 +323,10 @@ fn test_parallelize_interior_target_is_a_merge() {
         .success();
     work_dir.run_jj(["new", "-m=3"]).success();
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  d84d604297c3 3 parents: 2
-    ○    5684656729e6 2 parents: 1 a
+    @  37471d748332 3 parents: 2
+    ○    9b3e0159d764 2 parents: 1 a
     ├─╮
-    │ ○  55fc07cbd79b a parents:
+    │ ○  fc6a3235e302 a parents:
     ○ │  42fc76489fb1 1 parents: 0
     ○ │  fc8a812f1b99 0 parents:
     ├─╯
@@ -336,11 +336,11 @@ fn test_parallelize_interior_target_is_a_merge() {
 
     work_dir.run_jj(["parallelize", "subject(1)::"]).success();
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @    d0dae190124d 3 parents: 0 a
+    @    378ad6012f88 3 parents: 0 a
     ├─╮
-    │ │ ○  d5756d591190 2 parents: 0 a
+    │ │ ○  ba2f5b931d15 2 parents: 0 a
     ╭─┬─╯
-    │ ○  55fc07cbd79b a parents:
+    │ ○  fc6a3235e302 a parents:
     │ │ ○  42fc76489fb1 1 parents: 0
     ├───╯
     ○ │  fc8a812f1b99 0 parents:
@@ -363,11 +363,11 @@ fn test_parallelize_root_is_a_merge() {
     work_dir.run_jj(["new", "-m=2"]).success();
     work_dir.run_jj(["new", "-m=3"]).success();
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  ce0ec2d2d844 3 parents: 2
-    ○  44681d919431 2 parents: 1
-    ○    8a06bcc06aad 1 parents: y x
+    @  754cfe1ec718 3 parents: 2
+    ○  63f067d42867 2 parents: 1
+    ○    6086c98e22ad 1 parents: y x
     ├─╮
-    │ ○  2d5d6dbc7e1f x parents:
+    │ ○  2d7c42f7b30e x parents:
     ○ │  1ecf47f2262c y parents:
     ├─╯
     ◆  000000000000 parents:
@@ -378,13 +378,13 @@ fn test_parallelize_root_is_a_merge() {
         .run_jj(["parallelize", "subject(1)::subject(2)"])
         .success();
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @    2949bc60f108 3 parents: 1 2
+    @    d8da4317fbda 3 parents: 1 2
     ├─╮
-    │ ○    bf222a0e51d4 2 parents: y x
+    │ ○    2a7c5752a3bc 2 parents: y x
     │ ├─╮
-    ○ │ │  8a06bcc06aad 1 parents: y x
+    ○ │ │  6086c98e22ad 1 parents: y x
     ╰─┬─╮
-      │ ○  2d5d6dbc7e1f x parents:
+      │ ○  2d7c42f7b30e x parents:
       ○ │  1ecf47f2262c y parents:
       ├─╯
       ◆  000000000000 parents:
@@ -401,7 +401,7 @@ fn test_parallelize_multiple_heads() {
     work_dir.run_jj(["describe", "-m=1"]).success();
     work_dir.run_jj(["new", "subject(0)", "-m=2"]).success();
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  96d58e6cf428 2 parents: 0
+    @  771aef302228 2 parents: 0
     │ ○  42fc76489fb1 1 parents: 0
     ├─╯
     ○  fc8a812f1b99 0 parents:
@@ -411,7 +411,7 @@ fn test_parallelize_multiple_heads() {
 
     work_dir.run_jj(["parallelize", "subject(0)::"]).success();
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  fefea56b23ab 2 parents:
+    @  09a639be16a8 2 parents:
     │ ○  c4b1ea1106d1 1 parents:
     ├─╯
     │ ○  fc8a812f1b99 0 parents:
@@ -433,7 +433,7 @@ fn test_parallelize_multiple_heads_with_and_without_children() {
     work_dir.run_jj(["describe", "-m=1"]).success();
     work_dir.run_jj(["new", "subject(0)", "-m=2"]).success();
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  96d58e6cf428 2 parents: 0
+    @  771aef302228 2 parents: 0
     │ ○  42fc76489fb1 1 parents: 0
     ├─╯
     ○  fc8a812f1b99 0 parents:
@@ -445,7 +445,7 @@ fn test_parallelize_multiple_heads_with_and_without_children() {
         .run_jj(["parallelize", "-r=subject(0)", "subject(1)"])
         .success();
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  96d58e6cf428 2 parents: 0
+    @  771aef302228 2 parents: 0
     ○  fc8a812f1b99 0 parents:
     │ ○  c4b1ea1106d1 1 parents:
     ├─╯
@@ -466,10 +466,10 @@ fn test_parallelize_multiple_roots() {
         .success();
     work_dir.run_jj(["new", "-m=3"]).success();
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  9653da1c76e9 3 parents: 2
-    ○    248a57e1c968 2 parents: 1 a
+    @  7995e40dff61 3 parents: 2
+    ○    caf56efc50c4 2 parents: 1 a
     ├─╮
-    │ ○  3ce82963438f a parents:
+    │ ○  f407ec73f3df a parents:
     ○ │  884fe9b9c656 1 parents:
     ├─╯
     ◆  000000000000 parents:
@@ -479,10 +479,10 @@ fn test_parallelize_multiple_roots() {
     // Succeeds because the roots have the same parents.
     work_dir.run_jj(["parallelize", "root().."]).success();
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  0c77dac691b5 3 parents:
-    │ ○  1a23775d87d5 2 parents:
+    @  f808db46609b 3 parents:
+    │ ○  7e4bb64d08e1 2 parents:
     ├─╯
-    │ ○  3ce82963438f a parents:
+    │ ○  f407ec73f3df a parents:
     ├─╯
     │ ○  884fe9b9c656 1 parents:
     ├─╯
@@ -504,10 +504,10 @@ fn test_parallelize_multiple_heads_with_different_children() {
     work_dir.run_jj(["commit", "-m=b"]).success();
     work_dir.run_jj(["commit", "-m=c"]).success();
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  afa59494cb01 parents: c
-    ○  8897bad1837f c parents: b
-    ○  448c6310957c b parents: a
-    ○  07fb6466f0cd a parents:
+    @  a08ec053a742 parents: c
+    ○  f8da4b1f50a4 c parents: b
+    ○  61c599910b31 b parents: a
+    ○  5d473ef2b320 a parents:
     │ ○  8cfb27e238c8 3 parents: 2
     │ ○  320daf48ba58 2 parents: 1
     │ ○  884fe9b9c656 1 parents:
@@ -524,11 +524,11 @@ fn test_parallelize_multiple_heads_with_different_children() {
         ])
         .success();
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  7d3e76dfbc7b parents: c
-    ○    6dbfcf648fad c parents: a b
+    @  06450adb3fa2 parents: c
+    ○    cfca27dc8b42 c parents: a b
     ├─╮
     │ ○  8e5c55acd419 b parents:
-    ○ │  07fb6466f0cd a parents:
+    ○ │  5d473ef2b320 a parents:
     ├─╯
     │ ○    abdef66ee7e9 3 parents: 1 2
     │ ├─╮
@@ -555,10 +555,10 @@ fn test_parallelize_multiple_roots_with_different_parents() {
         .run_jj(["new", "subject(2)", "subject(b)", "-m=merged-head"])
         .success();
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @    4e5f16f52b5e merged-head parents: 2 b
+    @    efcc8bb8ed49 merged-head parents: 2 b
     ├─╮
-    │ ○  7686d0ce4f97 b parents: a
-    │ ○  331119737aad a parents:
+    │ ○  f981f9db15b1 b parents: a
+    │ ○  613642a76679 a parents:
     ○ │  320daf48ba58 2 parents: 1
     ○ │  884fe9b9c656 1 parents:
     ├─╯
@@ -570,11 +570,11 @@ fn test_parallelize_multiple_roots_with_different_parents() {
         .run_jj(["parallelize", "subject(2)::", "subject(b)::"])
         .success();
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @    180840c2f967 merged-head parents: 1 a
+    @    8bd22f2a0636 merged-head parents: 1 a
     ├─╮
-    │ │ ○  7686d0ce4f97 b parents: a
+    │ │ ○  f981f9db15b1 b parents: a
     │ ├─╯
-    │ ○  331119737aad a parents:
+    │ ○  613642a76679 a parents:
     │ │ ○  320daf48ba58 2 parents: 1
     ├───╯
     ○ │  884fe9b9c656 1 parents:
@@ -598,19 +598,19 @@ fn test_parallelize_complex_nonlinear_target() {
     work_dir.run_jj(["new", "-m=2c", "subject(2)"]).success();
     work_dir.run_jj(["new", "-m=3c", "subject(3)"]).success();
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  5cca06f145b2 3c parents: 3
-    │ ○    095be6de6f23 4 parents: 3 2 1
+    @  6f9e3f44440a 3c parents: 3
+    │ ○    98c8cd92bef7 4 parents: 3 2 1
     ╭─┼─╮
-    ○ │ │  46cc2c450bba 3 parents: 0
-    │ │ │ ○  24113692de1e 2c parents: 2
+    ○ │ │  25d0d46fa5dd 3 parents: 0
+    │ │ │ ○  6fa118e0f9f8 2c parents: 2
     │ ├───╯
-    │ ○ │  5664a1d6ac8f 2 parents: 0
+    │ ○ │  6f60f945406b 2 parents: 0
     ├─╯ │
-    │ ○ │  6d578e6cbc1a 1c parents: 1
+    │ ○ │  e08f5bf4147a 1c parents: 1
     │ ├─╯
-    │ ○  883b398bc1fd 1 parents: 0
+    │ ○  c2ba666f42b9 1 parents: 0
     ├─╯
-    ○  973f85cf2550 0 parents:
+    ○  ceba7ded0a6f 0 parents:
     ◆  000000000000 parents:
     [EOF]
     ");
@@ -618,24 +618,24 @@ fn test_parallelize_complex_nonlinear_target() {
     let output = work_dir.run_jj(["parallelize", "subject(0)::subject(4)"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: yostqsxw d6bb6520 (empty) 3c
-    Parent commit (@-)      : rlvkpnrz 973f85cf (empty) 0
-    Parent commit (@-)      : mzvwutvl 47ec86fe (empty) 3
+    Working copy  (@) now at: sostqsxw 5086906a (empty) 3c
+    Parent commit (@-)      : ylvkpnrz ceba7ded (empty) 0
+    Parent commit (@-)      : qzvwutvl 0054ae45 (empty) 3
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @    d6bb652004e4 3c parents: 0 3
+    @    5086906ab42f 3c parents: 0 3
     ├─╮
-    │ ○  47ec86fe7334 3 parents:
-    │ │ ○  79e22ba7b736 2c parents: 0 2
+    │ ○  0054ae459415 3 parents:
+    │ │ ○  7424f77d51de 2c parents: 0 2
     ╭───┤
-    │ │ ○  9d6818f73e0d 2 parents:
+    │ │ ○  ea19463dd1e8 2 parents:
     │ ├─╯
-    │ │ ○  bbeb29b59bee 1c parents: 0 1
+    │ │ ○  4bd394a36459 1c parents: 0 1
     ╭───┤
-    │ │ ○  ea96e6d5bb04 1 parents:
+    │ │ ○  abcccef95e4b 1 parents:
     │ ├─╯
-    ○ │  973f85cf2550 0 parents:
+    ○ │  ceba7ded0a6f 0 parents:
     ├─╯
     │ ○  0f9aae95edbe 4 parents:
     ├─╯
@@ -672,13 +672,13 @@ fn test_parallelize_immutable_base_commits() {
         .run_jj(["config", "set", "--repo", "revsets.log", "all()"])
         .success();
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  1a0f8336974a y2 parents: y1
-    ○  0e07ea90229f y1 parents: y
+    @  1fa61b6a7f42 y2 parents: y1
+    ○  e2d8b15b2710 y1 parents: y
     ◆  a0fb97fc193f y parents:
-    │ ○  d6c30fecfe88 x3 parents: x2
-    │ ○  6411b5818334 x2 parents: x1
-    │ ○  6d01ab1fb731 x1 parents: x
-    │ ◆  8ceb28e1dc31 x parents:
+    │ ○  fe953a05a00e x3 parents: x2
+    │ ○  544c8880e4e7 x2 parents: x1
+    │ ○  33676f246bb9 x1 parents: x
+    │ ◆  b568176074ba x parents:
     ├─╯
     ◆  000000000000 parents:
     [EOF]
@@ -688,18 +688,18 @@ fn test_parallelize_immutable_base_commits() {
         .run_jj(["parallelize", "subject(x*)", "subject(y*)"])
         .success();
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  264da1b87cf3 y2 parents:
-    │ ○  636008757721 y1 parents:
+    @  83b8d2615c8a y2 parents:
+    │ ○  c9dd4ef8bf8c y1 parents:
     ├─╯
-    │ ○  db5717c9c093 x3 parents:
+    │ ○  177442cdd04a x3 parents:
     ├─╯
-    │ ○  3e5fc34764e8 x2 parents:
+    │ ○  6514eaa1ab82 x2 parents:
     ├─╯
-    │ ○  71aeaa5e8891 x1 parents:
+    │ ○  ab71546914bd x1 parents:
     ├─╯
     │ ◆  a0fb97fc193f y parents:
     ├─╯
-    │ ◆  8ceb28e1dc31 x parents:
+    │ ◆  b568176074ba x parents:
     ├─╯
     ◆  000000000000 parents:
     [EOF]
@@ -730,10 +730,10 @@ fn test_parallelize_no_immutable_non_base_commits() {
         .run_jj(["config", "set", "--repo", "revsets.log", "all()"])
         .success();
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  d6c30fecfe88 x3 parents: x2
-    ○  6411b5818334 x2 parents: x1
-    ◆  6d01ab1fb731 x1 parents: x
-    ◆  8ceb28e1dc31 x parents:
+    @  fe953a05a00e x3 parents: x2
+    ○  544c8880e4e7 x2 parents: x1
+    ◆  33676f246bb9 x1 parents: x
+    ◆  b568176074ba x parents:
     ◆  000000000000 parents:
     [EOF]
     ");
@@ -741,8 +741,8 @@ fn test_parallelize_no_immutable_non_base_commits() {
     let output = work_dir.run_jj(["parallelize", "subject(x*)"]);
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
-    Error: Commit 6d01ab1fb731 is immutable
-    Hint: Could not modify commit: kkmpptxz 6d01ab1f (empty) x1
+    Error: Commit 33676f246bb9 is immutable
+    Hint: Could not modify commit: nkmpptxz 33676f24 (empty) x1
     Hint: Immutable commits are used to protect shared history.
     Hint: For more information, see:
           - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits

--- a/cli/tests/test_rebase_command.rs
+++ b/cli/tests/test_rebase_command.rs
@@ -97,7 +97,7 @@ fn test_rebase_invalid() {
     let output = work_dir.run_jj(["rebase", "-r", "a", "-o", "a"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Error: Cannot rebase 7d980be7a1d4 onto itself
+    Error: Cannot rebase a1afb5834d8e onto itself
     [EOF]
     [exit status: 1]
     ");
@@ -115,7 +115,7 @@ fn test_rebase_invalid() {
     let output = work_dir.run_jj(["rebase", "-s", "a", "-o", "b"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Error: Cannot rebase 7d980be7a1d4 onto descendant 123b4d91f6e5
+    Error: Cannot rebase a1afb5834d8e onto descendant dd148a1be8f0
     [EOF]
     [exit status: 1]
     ");
@@ -124,7 +124,7 @@ fn test_rebase_invalid() {
     let output = work_dir.run_jj(["rebase", "-s", "a", "-o", "a"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Error: Cannot rebase 7d980be7a1d4 onto itself
+    Error: Cannot rebase a1afb5834d8e onto itself
     [EOF]
     [exit status: 1]
     ");
@@ -215,8 +215,8 @@ fn test_rebase_bookmark() {
     ------- stderr -------
     Skipped rebase of 1 commits that were already in place
     Rebased 1 commits to destination
-    Working copy  (@) now at: znkkpsqq bbfb8557 e | e
-    Parent commit (@-)      : zsuskuln 123b4d91 b | b
+    Working copy  (@) now at: nnkkpsqq 43605c50 e | e
+    Parent commit (@-)      : psuskuln dd148a1b b | b
     Added 1 files, modified 0 files, removed 0 files
     [EOF]
     ");
@@ -239,8 +239,8 @@ fn test_rebase_bookmark() {
     ------- stderr -------
     Skipped rebase of 1 commits that were already in place
     Rebased 1 commits to destination
-    Working copy  (@) now at: znkkpsqq 1ffd7890 e | e
-    Parent commit (@-)      : zsuskuln 123b4d91 b | b
+    Working copy  (@) now at: nnkkpsqq c5d0887d e | e
+    Parent commit (@-)      : psuskuln dd148a1b b | b
     Added 1 files, modified 0 files, removed 0 files
     [EOF]
     ");
@@ -287,9 +287,9 @@ fn test_rebase_bookmark_with_merge() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Rebased 3 commits to destination
-    Working copy  (@) now at: znkkpsqq d5360d09 e | e
-    Parent commit (@-)      : rlvkpnrz 7d980be7 a | a
-    Parent commit (@-)      : vruxwmqv 85a741d7 d | d
+    Working copy  (@) now at: nnkkpsqq 96eb9563 e | e
+    Parent commit (@-)      : ylvkpnrz a1afb583 a | a
+    Parent commit (@-)      : truxwmqv 45bfb346 d | d
     Added 1 files, modified 0 files, removed 0 files
     [EOF]
     ");
@@ -310,9 +310,9 @@ fn test_rebase_bookmark_with_merge() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Rebased 3 commits to destination
-    Working copy  (@) now at: znkkpsqq d3091c0f e | e
-    Parent commit (@-)      : rlvkpnrz 7d980be7 a | a
-    Parent commit (@-)      : vruxwmqv 485905a3 d | d
+    Working copy  (@) now at: nnkkpsqq 73206d9a e | e
+    Parent commit (@-)      : ylvkpnrz a1afb583 a | a
+    Parent commit (@-)      : truxwmqv 0f80b7df d | d
     Added 1 files, modified 0 files, removed 0 files
     [EOF]
     ");
@@ -361,8 +361,8 @@ fn test_rebase_single_revision() {
     ------- stderr -------
     Rebased 1 commits to destination
     Rebased 2 descendant commits
-    Working copy  (@) now at: znkkpsqq 2baedee4 e | e
-    Parent commit (@-)      : vruxwmqv 45142a83 d | d
+    Working copy  (@) now at: nnkkpsqq f1a93137 e | e
+    Parent commit (@-)      : truxwmqv c12379e7 d | d
     Added 0 files, modified 0 files, removed 1 files
     [EOF]
     ");
@@ -387,9 +387,9 @@ fn test_rebase_single_revision() {
     ------- stderr -------
     Rebased 1 commits to destination
     Rebased 1 descendant commits
-    Working copy  (@) now at: znkkpsqq b981a2bc e | e
-    Parent commit (@-)      : zsuskuln 123b4d91 b | b
-    Parent commit (@-)      : royxmykx 991a7501 c | c
+    Working copy  (@) now at: nnkkpsqq 3fee6b6e e | e
+    Parent commit (@-)      : psuskuln dd148a1b b | b
+    Parent commit (@-)      : ooyxmykx 45ee1acd c | c
     Added 0 files, modified 0 files, removed 1 files
     [EOF]
     ");
@@ -436,9 +436,9 @@ fn test_rebase_single_revision_merge_parent() {
     ------- stderr -------
     Rebased 1 commits to destination
     Rebased 1 descendant commits
-    Working copy  (@) now at: vruxwmqv 0bb15a0f d | d
-    Parent commit (@-)      : rlvkpnrz 7d980be7 a | a
-    Parent commit (@-)      : zsuskuln d18ca3e8 b | b
+    Working copy  (@) now at: truxwmqv c645d2f2 d | d
+    Parent commit (@-)      : ylvkpnrz a1afb583 a | a
+    Parent commit (@-)      : psuskuln 68197203 b | b
     Added 0 files, modified 0 files, removed 1 files
     [EOF]
     ");
@@ -495,8 +495,8 @@ fn test_rebase_multiple_revisions() {
     ------- stderr -------
     Rebased 2 commits to destination
     Rebased 4 descendant commits
-    Working copy  (@) now at: xznxytkn 15078fab i | i
-    Parent commit (@-)      : kmkuslsw d8579ed7 f | f
+    Working copy  (@) now at: mznxytkn 66da4867 i | i
+    Parent commit (@-)      : wmkuslsw 9e5af42d f | f
     Added 0 files, modified 0 files, removed 2 files
     [EOF]
     ");
@@ -528,8 +528,8 @@ fn test_rebase_multiple_revisions() {
     ------- stderr -------
     Rebased 2 commits to destination
     Rebased 4 descendant commits
-    Working copy  (@) now at: xznxytkn 4dec544d i | i
-    Parent commit (@-)      : kmkuslsw b22816c9 f | f
+    Working copy  (@) now at: mznxytkn 418a1685 i | i
+    Parent commit (@-)      : wmkuslsw 1bed2ac3 f | f
     Added 0 files, modified 0 files, removed 2 files
     [EOF]
     ");
@@ -562,9 +562,9 @@ fn test_rebase_multiple_revisions() {
     ------- stderr -------
     Rebased 3 commits to destination
     Rebased 2 descendant commits
-    Working copy  (@) now at: xznxytkn e73a0787 i | i
-    Parent commit (@-)      : royxmykx dffaa0d4 c | c
-    Parent commit (@-)      : vruxwmqv 6354123d d | d
+    Working copy  (@) now at: mznxytkn c9744725 i | i
+    Parent commit (@-)      : ooyxmykx 26c624f4 c | c
+    Parent commit (@-)      : truxwmqv 4128ea23 d | d
     Added 0 files, modified 0 files, removed 2 files
     [EOF]
     ");
@@ -598,9 +598,9 @@ fn test_rebase_multiple_revisions() {
     ------- stderr -------
     Rebased 3 commits to destination
     Rebased 3 descendant commits
-    Working copy  (@) now at: xznxytkn f7c62b49 i | i
-    Parent commit (@-)      : royxmykx dffaa0d4 c | c
-    Parent commit (@-)      : znkkpsqq 1c3676c4 e | e
+    Working copy  (@) now at: mznxytkn dc967ff0 i | i
+    Parent commit (@-)      : ooyxmykx 26c624f4 c | c
+    Parent commit (@-)      : nnkkpsqq b1c30a09 e | e
     Added 0 files, modified 0 files, removed 2 files
     [EOF]
     ");
@@ -630,8 +630,8 @@ fn test_rebase_multiple_revisions() {
     ------- stderr -------
     Rebased 2 commits to destination
     Rebased 4 descendant commits
-    Working copy  (@) now at: xznxytkn b4ece7ad i | i
-    Parent commit (@-)      : kmkuslsw 1a05fe0d f | f
+    Working copy  (@) now at: mznxytkn fb7c5fda i | i
+    Parent commit (@-)      : wmkuslsw f2cd3f2f f | f
     Added 0 files, modified 0 files, removed 2 files
     [EOF]
     ");
@@ -682,9 +682,9 @@ fn test_rebase_revision_onto_descendant() {
     ------- stderr -------
     Rebased 1 commits to destination
     Rebased 3 descendant commits
-    Working copy  (@) now at: vruxwmqv 6a82c6c9 merge | merge
-    Parent commit (@-)      : royxmykx 934eadd8 b | b
-    Parent commit (@-)      : zsuskuln fd4e3113 a | a
+    Working copy  (@) now at: truxwmqv 19e391d7 merge | merge
+    Parent commit (@-)      : ooyxmykx d9d2f54e b | b
+    Parent commit (@-)      : psuskuln 6dd92f91 a | a
     Added 0 files, modified 0 files, removed 1 files
     [EOF]
     ");
@@ -704,10 +704,10 @@ fn test_rebase_revision_onto_descendant() {
     let output = work_dir.run_jj(["op", "restore", &setup_opid]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Restored to operation: 445e5af39d91 (2001-02-03 08:05:15) create bookmark merge pointing to commit 08c0951bf69d0362708a5223a78446d664823b50
-    Working copy  (@) now at: vruxwmqv 08c0951b merge | merge
-    Parent commit (@-)      : royxmykx 6a7081ef b | b
-    Parent commit (@-)      : zsuskuln 68fbc443 a | a
+    Restored to operation: e09af3b83472 (2001-02-03 08:05:15) create bookmark merge pointing to commit dd829e0392b85222f36fbe9ae7849485f21a42f8
+    Working copy  (@) now at: truxwmqv dd829e03 merge | merge
+    Parent commit (@-)      : ooyxmykx 0a53dfba b | b
+    Parent commit (@-)      : psuskuln b84f2eaa a | a
     Added 1 files, modified 0 files, removed 0 files
     [EOF]
     ");
@@ -716,9 +716,9 @@ fn test_rebase_revision_onto_descendant() {
     ------- stderr -------
     Rebased 1 commits to destination
     Rebased 3 descendant commits
-    Working copy  (@) now at: vruxwmqv 6091a06e merge | merge
-    Parent commit (@-)      : royxmykx 072bc1fa b | b
-    Parent commit (@-)      : zsuskuln afb318cf a | a
+    Working copy  (@) now at: truxwmqv 1f81f03c merge | merge
+    Parent commit (@-)      : ooyxmykx 38f11f69 b | b
+    Parent commit (@-)      : psuskuln 74823f78 a | a
     Added 0 files, modified 0 files, removed 1 files
     [EOF]
     ");
@@ -834,8 +834,8 @@ fn test_rebase_with_descendants() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Rebased 3 commits to destination
-    Working copy  (@) now at: vruxwmqv 7a9837e3 d | d
-    Parent commit (@-)      : royxmykx ee1edcc0 c | c
+    Working copy  (@) now at: truxwmqv 3f23f84f d | d
+    Parent commit (@-)      : ooyxmykx 44d8d318 c | c
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
@@ -855,8 +855,8 @@ fn test_rebase_with_descendants() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Rebased 2 commits to destination
-    Working copy  (@) now at: vruxwmqv e7720369 d | d
-    Parent commit (@-)      : rlvkpnrz 7d980be7 a | a
+    Working copy  (@) now at: truxwmqv 69451db8 d | d
+    Parent commit (@-)      : ylvkpnrz a1afb583 a | a
     Added 0 files, modified 0 files, removed 2 files
     [EOF]
     ");
@@ -890,8 +890,8 @@ fn test_rebase_with_descendants() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Rebased 3 commits to destination
-    Working copy  (@) now at: vruxwmqv 7186427a d | d
-    Parent commit (@-)      : rlvkpnrz 7d980be7 a | a
+    Working copy  (@) now at: truxwmqv f7da4541 d | d
+    Parent commit (@-)      : ylvkpnrz a1afb583 a | a
     Added 0 files, modified 0 files, removed 2 files
     [EOF]
     ");
@@ -912,8 +912,8 @@ fn test_rebase_with_descendants() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Rebased 3 commits to destination
-    Working copy  (@) now at: vruxwmqv f6c6224e d | d
-    Parent commit (@-)      : rlvkpnrz 7d980be7 a | a
+    Working copy  (@) now at: truxwmqv fa0a8327 d | d
+    Parent commit (@-)      : ylvkpnrz a1afb583 a | a
     Added 0 files, modified 0 files, removed 2 files
     [EOF]
     ");
@@ -1032,8 +1032,8 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Rebased 3 commits to destination
-    Working copy  (@) now at: znkkpsqq b65f55fb c | c
-    Parent commit (@-)      : vruxwmqv c90d30a4 b | b
+    Working copy  (@) now at: nnkkpsqq 28c8257b c | c
+    Parent commit (@-)      : truxwmqv bf656505 b | b
     [EOF]
     ");
     // Commit "a" should be rebased onto the root commit. Commit "b" should have
@@ -1091,8 +1091,8 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Rebased 2 commits to destination
-    Working copy  (@) now at: znkkpsqq 5b285fee c | c
-    Parent commit (@-)      : vruxwmqv 988d520d b | b
+    Working copy  (@) now at: nnkkpsqq 1ce813dd c | c
+    Parent commit (@-)      : truxwmqv 24bc9f16 b | b
     [EOF]
     ");
     // The commits in roots(a..c), i.e. commit "b" should be rebased onto "a",
@@ -1148,8 +1148,8 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     ------- stderr -------
     Rebased 1 commits to destination
     Rebased 3 descendant commits
-    Working copy  (@) now at: znkkpsqq ad772a82 c | c
-    Parent commit (@-)      : vruxwmqv 79030f30 b | b
+    Working copy  (@) now at: nnkkpsqq 24fecdce c | c
+    Parent commit (@-)      : truxwmqv 4ca66b87 b | b
     Added 0 files, modified 0 files, removed 1 files
     [EOF]
     ");
@@ -1175,8 +1175,8 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     ------- stderr -------
     Rebased 1 commits to destination
     Rebased 3 descendant commits
-    Working copy  (@) now at: znkkpsqq 3cdfeb24 c | c
-    Parent commit (@-)      : vruxwmqv d77e32e7 b | b
+    Working copy  (@) now at: nnkkpsqq 92dfe4c3 c | c
+    Parent commit (@-)      : truxwmqv dd6dfb0f b | b
     Added 0 files, modified 0 files, removed 1 files
     [EOF]
     ");
@@ -1201,8 +1201,8 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     ------- stderr -------
     Rebased 1 commits to destination
     Rebased 3 descendant commits
-    Working copy  (@) now at: znkkpsqq afc19fe0 c | c
-    Parent commit (@-)      : vruxwmqv c319447d b | b
+    Working copy  (@) now at: nnkkpsqq 007f3567 c | c
+    Parent commit (@-)      : truxwmqv b11b9da4 b | b
     Added 0 files, modified 0 files, removed 1 files
     [EOF]
     ");
@@ -1238,8 +1238,8 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     ------- stderr -------
     Rebased 1 commits to destination
     Rebased 2 descendant commits
-    Working copy  (@) now at: znkkpsqq 1cb17633 c | c
-    Parent commit (@-)      : vruxwmqv 801b1b8c b | b
+    Working copy  (@) now at: nnkkpsqq 8d6c0157 c | c
+    Parent commit (@-)      : truxwmqv 65268dcb b | b
     Added 0 files, modified 0 files, removed 1 files
     [EOF]
     ");
@@ -1262,9 +1262,9 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     ------- stderr -------
     Rebased 1 commits to destination
     Rebased 1 descendant commits
-    Working copy  (@) now at: znkkpsqq f8853d0d c | c
-    Parent commit (@-)      : zsuskuln 3a2d0837 base | base
-    Parent commit (@-)      : royxmykx c7aebf99 a | a
+    Working copy  (@) now at: nnkkpsqq 894aeb1a c | c
+    Parent commit (@-)      : psuskuln 6196dfbc base | base
+    Parent commit (@-)      : ooyxmykx 047e2289 a | a
     Added 0 files, modified 0 files, removed 1 files
     [EOF]
     ");
@@ -1290,9 +1290,9 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     ------- stderr -------
     Rebased 1 commits to destination
     Rebased 1 descendant commits
-    Working copy  (@) now at: znkkpsqq 6feb5c0f c | c
-    Parent commit (@-)      : zsuskuln 3a2d0837 base | base
-    Parent commit (@-)      : royxmykx c7aebf99 a | a
+    Working copy  (@) now at: nnkkpsqq 351a5a09 c | c
+    Parent commit (@-)      : psuskuln 6196dfbc base | base
+    Parent commit (@-)      : ooyxmykx 047e2289 a | a
     Added 0 files, modified 0 files, removed 1 files
     [EOF]
     ");
@@ -1315,8 +1315,8 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Rebased 1 commits to destination
-    Working copy  (@) now at: znkkpsqq a0c5ea8f c | c
-    Parent commit (@-)      : royxmykx c7aebf99 a | a
+    Working copy  (@) now at: nnkkpsqq 91590152 c | c
+    Parent commit (@-)      : ooyxmykx 047e2289 a | a
     Added 0 files, modified 0 files, removed 1 files
     [EOF]
     ");
@@ -1424,8 +1424,8 @@ fn test_rebase_after() {
     ------- stderr -------
     Rebased 1 commits to destination
     Rebased 3 descendant commits
-    Working copy  (@) now at: xznxytkn 2f59b944 f | f
-    Parent commit (@-)      : kmkuslsw 88ddc78c c | c
+    Working copy  (@) now at: mznxytkn bce7abff f | f
+    Parent commit (@-)      : wmkuslsw 50ffbdf1 c | c
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
@@ -1452,8 +1452,8 @@ fn test_rebase_after() {
     ------- stderr -------
     Rebased 1 commits to destination
     Rebased 1 descendant commits
-    Working copy  (@) now at: xznxytkn da215ecd f | f
-    Parent commit (@-)      : kmkuslsw ed86d82a c | c
+    Working copy  (@) now at: mznxytkn 6c2cc0e2 f | f
+    Parent commit (@-)      : wmkuslsw 4ced35a9 c | c
     Added 0 files, modified 0 files, removed 1 files
     [EOF]
     ");
@@ -1481,8 +1481,8 @@ fn test_rebase_after() {
     ------- stderr -------
     Rebased 1 commits to destination
     Rebased 4 descendant commits
-    Working copy  (@) now at: xznxytkn 2c606e19 f | f
-    Parent commit (@-)      : zsuskuln 62634b59 b1 | b1
+    Working copy  (@) now at: mznxytkn 53eb6e61 f | f
+    Parent commit (@-)      : psuskuln f25fb4a7 b1 | b1
     Added 0 files, modified 0 files, removed 5 files
     [EOF]
     ");
@@ -1510,8 +1510,8 @@ fn test_rebase_after() {
     ------- stderr -------
     Rebased 1 commits to destination
     Rebased 3 descendant commits
-    Working copy  (@) now at: xznxytkn e60a4b0c f | f
-    Parent commit (@-)      : royxmykx 40646d19 b2 | b2
+    Working copy  (@) now at: mznxytkn 97018816 f | f
+    Parent commit (@-)      : ooyxmykx 45d26d47 b2 | b2
     Added 0 files, modified 0 files, removed 4 files
     [EOF]
     ");
@@ -1541,8 +1541,8 @@ fn test_rebase_after() {
     ------- stderr -------
     Rebased 1 commits to destination
     Rebased 2 descendant commits
-    Working copy  (@) now at: xznxytkn 84786555 f | f
-    Parent commit (@-)      : kmkuslsw ed86d82a c | c
+    Working copy  (@) now at: mznxytkn b562ffed f | f
+    Parent commit (@-)      : wmkuslsw 4ced35a9 c | c
     Added 0 files, modified 0 files, removed 1 files
     [EOF]
     ");
@@ -1569,9 +1569,9 @@ fn test_rebase_after() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Rebased 1 commits to destination
-    Working copy  (@) now at: xznxytkn d5324bb4 f | f
-    Parent commit (@-)      : nkmrtpmo 50d9bd5d e | e
-    Parent commit (@-)      : lylxulpl 610f541b d | d
+    Working copy  (@) now at: mznxytkn 8d811d78 f | f
+    Parent commit (@-)      : ukmrtpmo d2187801 e | e
+    Parent commit (@-)      : lylxulpl 8cdda097 d | d
     Added 1 files, modified 0 files, removed 0 files
     [EOF]
     ");
@@ -1600,8 +1600,8 @@ fn test_rebase_after() {
     ------- stderr -------
     Rebased 2 commits to destination
     Rebased 6 descendant commits
-    Working copy  (@) now at: xznxytkn 17632090 f | f
-    Parent commit (@-)      : kmkuslsw 726c937e c | c
+    Working copy  (@) now at: mznxytkn facccbdf f | f
+    Parent commit (@-)      : wmkuslsw 7ddff975 c | c
     Added 1 files, modified 0 files, removed 0 files
     [EOF]
     ");
@@ -1631,8 +1631,8 @@ fn test_rebase_after() {
     ------- stderr -------
     Rebased 3 commits to destination
     Rebased 3 descendant commits
-    Working copy  (@) now at: xznxytkn 991bd3ac f | f
-    Parent commit (@-)      : nkmrtpmo f9ecf426 e | e
+    Working copy  (@) now at: mznxytkn 866e79ac f | f
+    Parent commit (@-)      : ukmrtpmo 8def8f6d e | e
     Added 0 files, modified 0 files, removed 3 files
     [EOF]
     ");
@@ -1662,8 +1662,8 @@ fn test_rebase_after() {
     ------- stderr -------
     Rebased 4 commits to destination
     Rebased 2 descendant commits
-    Working copy  (@) now at: xznxytkn 0123019e f | f
-    Parent commit (@-)      : nkmrtpmo 903f8aa0 e | e
+    Working copy  (@) now at: mznxytkn 75476d72 f | f
+    Parent commit (@-)      : ukmrtpmo ec42d80d e | e
     Added 1 files, modified 0 files, removed 0 files
     [EOF]
     ");
@@ -1693,8 +1693,8 @@ fn test_rebase_after() {
     ------- stderr -------
     Rebased 3 commits to destination
     Rebased 6 descendant commits
-    Working copy  (@) now at: xznxytkn fdeb070b f | f
-    Parent commit (@-)      : nkmrtpmo f1b259b2 e | e
+    Working copy  (@) now at: mznxytkn 3a0f2a4c f | f
+    Parent commit (@-)      : ukmrtpmo 3d196a08 e | e
     Added 1 files, modified 0 files, removed 0 files
     [EOF]
     ");
@@ -1722,8 +1722,8 @@ fn test_rebase_after() {
     ------- stderr -------
     Rebased 2 commits to destination
     Rebased 3 descendant commits
-    Working copy  (@) now at: xznxytkn c8ba9324 f | f
-    Parent commit (@-)      : kmkuslsw 0bd3b3d1 c | c
+    Working copy  (@) now at: mznxytkn 4640c66e f | f
+    Parent commit (@-)      : wmkuslsw c06f67e9 c | c
     Added 0 files, modified 0 files, removed 2 files
     [EOF]
     ");
@@ -1777,8 +1777,8 @@ fn test_rebase_after() {
     ------- stderr -------
     Rebased 4 commits to destination
     Rebased 2 descendant commits
-    Working copy  (@) now at: xznxytkn 9ea28699 f | f
-    Parent commit (@-)      : nkmrtpmo 989281ba e | e
+    Working copy  (@) now at: mznxytkn 68a7e117 f | f
+    Parent commit (@-)      : ukmrtpmo cd418fb4 e | e
     Added 0 files, modified 0 files, removed 2 files
     [EOF]
     ");
@@ -1810,8 +1810,8 @@ fn test_rebase_after() {
     ------- stderr -------
     Rebased 6 commits to destination
     Rebased 1 descendant commits
-    Working copy  (@) now at: xznxytkn 63860138 f | f
-    Parent commit (@-)      : nkmrtpmo cc7e9907 e | e
+    Working copy  (@) now at: mznxytkn cbb45c01 f | f
+    Parent commit (@-)      : ukmrtpmo e33f8015 e | e
     Added 0 files, modified 0 files, removed 1 files
     [EOF]
     ");
@@ -1836,7 +1836,7 @@ fn test_rebase_after() {
     let output = work_dir.run_jj(["rebase", "-r", "e", "--after", "a", "--after", "b2"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Error: Refusing to create a loop: commit 40646d195680 would be both an ancestor and a descendant of the rebased commits
+    Error: Refusing to create a loop: commit 45d26d47b68e would be both an ancestor and a descendant of the rebased commits
     [EOF]
     [exit status: 1]
     ");
@@ -1942,8 +1942,8 @@ fn test_rebase_before() {
     ------- stderr -------
     Rebased 1 commits to destination
     Rebased 8 descendant commits
-    Working copy  (@) now at: xznxytkn ff62b7d5 f | f
-    Parent commit (@-)      : nkmrtpmo b007a305 e | e
+    Working copy  (@) now at: mznxytkn 9ad72921 f | f
+    Parent commit (@-)      : ukmrtpmo 8a9188c6 e | e
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
@@ -1970,8 +1970,8 @@ fn test_rebase_before() {
     ------- stderr -------
     Rebased 1 commits to destination
     Rebased 1 descendant commits
-    Working copy  (@) now at: xznxytkn d8eb20c6 f | f
-    Parent commit (@-)      : kmkuslsw ed86d82a c | c
+    Working copy  (@) now at: mznxytkn 2efa7fc1 f | f
+    Parent commit (@-)      : wmkuslsw 4ced35a9 c | c
     Added 0 files, modified 0 files, removed 1 files
     [EOF]
     ");
@@ -1999,8 +1999,8 @@ fn test_rebase_before() {
     ------- stderr -------
     Rebased 1 commits to destination
     Rebased 4 descendant commits
-    Working copy  (@) now at: xznxytkn 5fd4cd2f f | f
-    Parent commit (@-)      : zsuskuln 62634b59 b1 | b1
+    Working copy  (@) now at: mznxytkn a26aa5fc f | f
+    Parent commit (@-)      : psuskuln f25fb4a7 b1 | b1
     Added 0 files, modified 0 files, removed 5 files
     [EOF]
     ");
@@ -2028,8 +2028,8 @@ fn test_rebase_before() {
     ------- stderr -------
     Rebased 1 commits to destination
     Rebased 5 descendant commits
-    Working copy  (@) now at: xznxytkn 4bb8afb7 f | f
-    Parent commit (@-)      : rlvkpnrz 7d980be7 a | a
+    Working copy  (@) now at: mznxytkn f61575c2 f | f
+    Parent commit (@-)      : ylvkpnrz a1afb583 a | a
     Added 0 files, modified 0 files, removed 6 files
     [EOF]
     ");
@@ -2059,9 +2059,9 @@ fn test_rebase_before() {
     ------- stderr -------
     Rebased 1 commits to destination
     Rebased 3 descendant commits
-    Working copy  (@) now at: xznxytkn b1d5040b f | f
-    Parent commit (@-)      : royxmykx 40646d19 b2 | b2
-    Parent commit (@-)      : znkkpsqq 256ac307 b4 | b4
+    Working copy  (@) now at: mznxytkn 47568833 f | f
+    Parent commit (@-)      : ooyxmykx 45d26d47 b2 | b2
+    Parent commit (@-)      : nnkkpsqq dbdc90ad b4 | b4
     Added 0 files, modified 0 files, removed 2 files
     [EOF]
     ");
@@ -2089,8 +2089,8 @@ fn test_rebase_before() {
     ------- stderr -------
     Rebased 1 commits to destination
     Rebased 5 descendant commits
-    Working copy  (@) now at: xznxytkn 9ce35fe1 f | f
-    Parent commit (@-)      : nkmrtpmo 95558239 e | e
+    Working copy  (@) now at: mznxytkn 12850b5a f | f
+    Parent commit (@-)      : ukmrtpmo 77d27d96 e | e
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
@@ -2118,9 +2118,9 @@ fn test_rebase_before() {
     ------- stderr -------
     Rebased 1 commits to destination
     Rebased 5 descendant commits
-    Working copy  (@) now at: xznxytkn b984057d f | f
-    Parent commit (@-)      : zsuskuln 62634b59 b1 | b1
-    Parent commit (@-)      : vruxwmqv a1d9eeb3 b3 | b3
+    Working copy  (@) now at: mznxytkn 7f7076b2 f | f
+    Parent commit (@-)      : psuskuln f25fb4a7 b1 | b1
+    Parent commit (@-)      : truxwmqv f4e418ee b3 | b3
     Added 0 files, modified 0 files, removed 4 files
     [EOF]
     ");
@@ -2151,8 +2151,8 @@ fn test_rebase_before() {
     ------- stderr -------
     Rebased 2 commits to destination
     Rebased 7 descendant commits
-    Working copy  (@) now at: xznxytkn 13214a9a f | f
-    Parent commit (@-)      : nkmrtpmo 257f541d e | e
+    Working copy  (@) now at: mznxytkn d91de079 f | f
+    Parent commit (@-)      : ukmrtpmo f4496ded e | e
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
@@ -2181,8 +2181,8 @@ fn test_rebase_before() {
     ------- stderr -------
     Rebased 3 commits to destination
     Rebased 3 descendant commits
-    Working copy  (@) now at: xznxytkn 903781e1 f | f
-    Parent commit (@-)      : nkmrtpmo 2a0542d6 e | e
+    Working copy  (@) now at: mznxytkn 9b9d3e65 f | f
+    Parent commit (@-)      : ukmrtpmo 5df1a0f3 e | e
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
@@ -2212,8 +2212,8 @@ fn test_rebase_before() {
     ------- stderr -------
     Rebased 2 commits to destination
     Rebased 7 descendant commits
-    Working copy  (@) now at: xznxytkn 9d5abf25 f | f
-    Parent commit (@-)      : kmkuslsw ecde78f5 c | c
+    Working copy  (@) now at: mznxytkn 7324154c f | f
+    Parent commit (@-)      : wmkuslsw b16d99f4 c | c
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
@@ -2242,8 +2242,8 @@ fn test_rebase_before() {
     ------- stderr -------
     Rebased 3 commits to destination
     Rebased 6 descendant commits
-    Working copy  (@) now at: xznxytkn 912af1a2 f | f
-    Parent commit (@-)      : nkmrtpmo 4e8eabcc e | e
+    Working copy  (@) now at: mznxytkn 10241544 f | f
+    Parent commit (@-)      : ukmrtpmo 6ad210f0 e | e
     Added 1 files, modified 0 files, removed 0 files
     [EOF]
     ");
@@ -2272,8 +2272,8 @@ fn test_rebase_before() {
     ------- stderr -------
     Rebased 3 commits to destination
     Rebased 6 descendant commits
-    Working copy  (@) now at: xznxytkn a2ed33ff f | f
-    Parent commit (@-)      : nkmrtpmo b69d0e4b e | e
+    Working copy  (@) now at: mznxytkn 0e72fc2a f | f
+    Parent commit (@-)      : ukmrtpmo 1cd0849d e | e
     Added 1 files, modified 0 files, removed 0 files
     [EOF]
     ");
@@ -2327,8 +2327,8 @@ fn test_rebase_before() {
     ------- stderr -------
     Rebased 4 commits to destination
     Rebased 2 descendant commits
-    Working copy  (@) now at: xznxytkn 5fe09799 f | f
-    Parent commit (@-)      : nkmrtpmo ee33f6f1 e | e
+    Working copy  (@) now at: mznxytkn e66b4e24 f | f
+    Parent commit (@-)      : ukmrtpmo b53bae5c e | e
     Added 0 files, modified 0 files, removed 2 files
     [EOF]
     ");
@@ -2361,8 +2361,8 @@ fn test_rebase_before() {
     Skipped rebase of 2 commits that were already in place
     Rebased 4 commits to destination
     Rebased 2 descendant commits
-    Working copy  (@) now at: xznxytkn d1c73b11 f | f
-    Parent commit (@-)      : nkmrtpmo 53fc68f7 e | e
+    Working copy  (@) now at: mznxytkn 47cd1279 f | f
+    Parent commit (@-)      : ukmrtpmo 30126eda e | e
     Added 0 files, modified 0 files, removed 2 files
     [EOF]
     ");
@@ -2387,7 +2387,7 @@ fn test_rebase_before() {
     let output = work_dir.run_jj(["rebase", "-r", "e", "--before", "b2", "--before", "c"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Error: Refusing to create a loop: commit 40646d195680 would be both an ancestor and a descendant of the rebased commits
+    Error: Refusing to create a loop: commit 45d26d47b68e would be both an ancestor and a descendant of the rebased commits
     [EOF]
     [exit status: 1]
     ");
@@ -2437,8 +2437,8 @@ fn test_rebase_after_before() {
     ------- stderr -------
     Rebased 1 commits to destination
     Rebased 1 descendant commits
-    Working copy  (@) now at: nmzmmopx 321e1d40 f | f
-    Parent commit (@-)      : nkmrtpmo 7d7b0aec d | d
+    Working copy  (@) now at: rmzmmopx 75afe005 f | f
+    Parent commit (@-)      : ukmrtpmo 2a7788db d | d
     Added 1 files, modified 0 files, removed 0 files
     [EOF]
     ");
@@ -2468,9 +2468,9 @@ fn test_rebase_after_before() {
     ------- stderr -------
     Rebased 1 commits to destination
     Rebased 1 descendant commits
-    Working copy  (@) now at: nmzmmopx a12b0ae1 f | f
-    Parent commit (@-)      : xznxytkn d4334f29 e | e
-    Parent commit (@-)      : nkmrtpmo a3204f2a d | d
+    Working copy  (@) now at: rmzmmopx 1d306167 f | f
+    Parent commit (@-)      : mznxytkn 7cf7536e e | e
+    Parent commit (@-)      : ukmrtpmo cbc96295 d | d
     Added 1 files, modified 0 files, removed 0 files
     [EOF]
     ");
@@ -2504,8 +2504,8 @@ fn test_rebase_after_before() {
     ------- stderr -------
     Rebased 1 commits to destination
     Rebased 3 descendant commits
-    Working copy  (@) now at: nmzmmopx 97ebbe11 f | f
-    Parent commit (@-)      : xznxytkn e53a8360 e | e
+    Working copy  (@) now at: rmzmmopx 5aefadf1 f | f
+    Parent commit (@-)      : mznxytkn 044c18c0 e | e
     Added 1 files, modified 0 files, removed 0 files
     [EOF]
     ");
@@ -2540,11 +2540,11 @@ fn test_rebase_after_before() {
     ------- stderr -------
     Rebased 3 commits to destination
     Rebased 1 descendant commits
-    Working copy  (@) now at: nmzmmopx 5a27aa46 f | f
-    Parent commit (@-)      : znkkpsqq 0780cdfa b1 | b1
-    Parent commit (@-)      : kmkuslsw 0692c8ed b2 | b2
-    Parent commit (@-)      : nkmrtpmo 07028fe4 d | d
-    Parent commit (@-)      : xznxytkn 1aa724f0 e | e
+    Working copy  (@) now at: rmzmmopx ca5eea1b f | f
+    Parent commit (@-)      : nnkkpsqq 8d926ed2 b1 | b1
+    Parent commit (@-)      : wmkuslsw 5ad2ce01 b2 | b2
+    Parent commit (@-)      : ukmrtpmo 77dc7a23 d | d
+    Parent commit (@-)      : mznxytkn 191822b8 e | e
     Added 1 files, modified 0 files, removed 0 files
     [EOF]
     ");
@@ -2575,8 +2575,8 @@ fn test_rebase_after_before() {
     ------- stderr -------
     Rebased 4 commits to destination
     Rebased 1 descendant commits
-    Working copy  (@) now at: nmzmmopx 5b68ace7 f | f
-    Parent commit (@-)      : xznxytkn 8bfa4c49 e | e
+    Working copy  (@) now at: rmzmmopx 48416ff2 f | f
+    Parent commit (@-)      : mznxytkn bb9a5da7 e | e
     Added 0 files, modified 0 files, removed 1 files
     [EOF]
     ");
@@ -2608,8 +2608,8 @@ fn test_rebase_after_before() {
     ------- stderr -------
     Rebased 3 commits to destination
     Rebased 4 descendant commits
-    Working copy  (@) now at: nmzmmopx 68713d9d f | f
-    Parent commit (@-)      : xznxytkn d4bcbcd4 e | e
+    Working copy  (@) now at: rmzmmopx 01ca8d88 f | f
+    Parent commit (@-)      : mznxytkn f0d2ea8a e | e
     Added 3 files, modified 0 files, removed 0 files
     [EOF]
     ");
@@ -2637,7 +2637,7 @@ fn test_rebase_after_before() {
     let output = work_dir.run_jj(["rebase", "-r", "e", "--after", "c", "--before", "a"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Error: Refusing to create a loop: commit 0c9da0df7f7c would be both an ancestor and a descendant of the rebased commits
+    Error: Refusing to create a loop: commit d7c690483f8f would be both an ancestor and a descendant of the rebased commits
     [EOF]
     [exit status: 1]
     ");
@@ -2678,8 +2678,8 @@ fn test_rebase_skip_emptied() {
     ------- stderr -------
     Rebased 2 commits to destination
     Abandoned 1 newly emptied commits
-    Working copy  (@) now at: yostqsxw 6b46781e (empty) also already empty
-    Parent commit (@-)      : vruxwmqv 4861a0a8 (empty) already empty
+    Working copy  (@) now at: rostqsxw 473f1afe (empty) also already empty
+    Parent commit (@-)      : truxwmqv 5c9b67d6 (empty) already empty
     [EOF]
     ");
 
@@ -2717,8 +2717,8 @@ fn test_rebase_skip_emptied() {
     ------- stderr -------
     Rebased 2 descendant commits
     Abandoned 1 newly emptied commits
-    Working copy  (@) now at: yostqsxw bbfc2a27 (empty) also already empty
-    Parent commit (@-)      : vruxwmqv 1b8c46b3 (empty) already empty
+    Working copy  (@) now at: rostqsxw 9699c50e (empty) also already empty
+    Parent commit (@-)      : truxwmqv 900cf9c9 (empty) already empty
     Added 0 files, modified 0 files, removed 1 files
     [EOF]
     ");
@@ -2773,8 +2773,8 @@ fn test_rebase_skip_emptied_descendants() {
     ------- stderr -------
     Skipped rebase of 1 commits that were already in place
     Rebased 3 descendant commits
-    Working copy  (@) now at: znkkpsqq 6d024ab4 (empty) also already empty
-    Parent commit (@-)      : yostqsxw bb87e185 (empty) already empty
+    Working copy  (@) now at: nnkkpsqq 5e95fd69 (empty) also already empty
+    Parent commit (@-)      : rostqsxw bdfdcd74 (empty) already empty
     [EOF]
     ");
 
@@ -2806,16 +2806,16 @@ fn test_rebase_skip_if_on_destination() {
     create_commit(&work_dir, "f", &["e"]);
     // Test the setup
     insta::assert_snapshot!(get_long_log_output(&work_dir), @"
-    @  f  lylxulpl  cf8edc20:  e
-    ○  e  kmkuslsw  65f1083b:  c
-    │ ○  d  znkkpsqq  f91a8202:  c
+    @  f  lylxulpl  e3d4541d:  e
+    ○  e  wmkuslsw  b5d5eea1:  c
+    │ ○  d  nnkkpsqq  ecd2023a:  c
     ├─╯
-    ○    c  vruxwmqv  86997ac2:  b1 b2
+    ○    c  truxwmqv  e6f915d4:  b1 b2
     ├─╮
-    │ ○  b2  royxmykx  1d9f22d8:  a
-    ○ │  b1  zsuskuln  62634b59:  a
+    │ ○  b2  ooyxmykx  92cf5426:  a
+    ○ │  b1  psuskuln  f25fb4a7:  a
     ├─╯
-    ○  a  rlvkpnrz  7d980be7
+    ○  a  ylvkpnrz  a1afb583
     ◆    zzzzzzzz  00000000
     [EOF]
     ");
@@ -2829,16 +2829,16 @@ fn test_rebase_skip_if_on_destination() {
     [EOF]
     ");
     insta::assert_snapshot!(get_long_log_output(&work_dir), @"
-    @  f  lylxulpl  cf8edc20:  e
-    ○  e  kmkuslsw  65f1083b:  c
-    │ ○  d  znkkpsqq  f91a8202:  c
+    @  f  lylxulpl  e3d4541d:  e
+    ○  e  wmkuslsw  b5d5eea1:  c
+    │ ○  d  nnkkpsqq  ecd2023a:  c
     ├─╯
-    ○    c  vruxwmqv  86997ac2:  b1 b2
+    ○    c  truxwmqv  e6f915d4:  b1 b2
     ├─╮
-    │ ○  b2  royxmykx  1d9f22d8:  a
-    ○ │  b1  zsuskuln  62634b59:  a
+    │ ○  b2  ooyxmykx  92cf5426:  a
+    ○ │  b1  psuskuln  f25fb4a7:  a
     ├─╯
-    ○  a  rlvkpnrz  7d980be7
+    ○  a  ylvkpnrz  a1afb583
     ◆    zzzzzzzz  00000000
     [EOF]
     ");
@@ -2852,16 +2852,16 @@ fn test_rebase_skip_if_on_destination() {
     [EOF]
     ");
     insta::assert_snapshot!(get_long_log_output(&work_dir), @"
-    @  f  lylxulpl  cf8edc20:  e
-    ○  e  kmkuslsw  65f1083b:  c
-    │ ○  d  znkkpsqq  f91a8202:  c
+    @  f  lylxulpl  e3d4541d:  e
+    ○  e  wmkuslsw  b5d5eea1:  c
+    │ ○  d  nnkkpsqq  ecd2023a:  c
     ├─╯
-    ○    c  vruxwmqv  86997ac2:  b1 b2
+    ○    c  truxwmqv  e6f915d4:  b1 b2
     ├─╮
-    │ ○  b2  royxmykx  1d9f22d8:  a
-    ○ │  b1  zsuskuln  62634b59:  a
+    │ ○  b2  ooyxmykx  92cf5426:  a
+    ○ │  b1  psuskuln  f25fb4a7:  a
     ├─╯
-    ○  a  rlvkpnrz  7d980be7
+    ○  a  ylvkpnrz  a1afb583
     ◆    zzzzzzzz  00000000
     [EOF]
     ");
@@ -2875,16 +2875,16 @@ fn test_rebase_skip_if_on_destination() {
     [EOF]
     ");
     insta::assert_snapshot!(get_long_log_output(&work_dir), @"
-    @  f  lylxulpl  cf8edc20:  e
-    ○  e  kmkuslsw  65f1083b:  c
-    │ ○  d  znkkpsqq  f91a8202:  c
+    @  f  lylxulpl  e3d4541d:  e
+    ○  e  wmkuslsw  b5d5eea1:  c
+    │ ○  d  nnkkpsqq  ecd2023a:  c
     ├─╯
-    ○    c  vruxwmqv  86997ac2:  b1 b2
+    ○    c  truxwmqv  e6f915d4:  b1 b2
     ├─╮
-    │ ○  b2  royxmykx  1d9f22d8:  a
-    ○ │  b1  zsuskuln  62634b59:  a
+    │ ○  b2  ooyxmykx  92cf5426:  a
+    ○ │  b1  psuskuln  f25fb4a7:  a
     ├─╯
-    ○  a  rlvkpnrz  7d980be7
+    ○  a  ylvkpnrz  a1afb583
     ◆    zzzzzzzz  00000000
     [EOF]
     ");
@@ -2895,23 +2895,23 @@ fn test_rebase_skip_if_on_destination() {
     ------- stderr -------
     Skipped rebase of 1 commits that were already in place
     Rebased 1 descendant commits
-    Working copy  (@) now at: lylxulpl f2015644 f | f
-    Parent commit (@-)      : vruxwmqv 86997ac2 c | c
+    Working copy  (@) now at: lylxulpl f85207d4 f | f
+    Parent commit (@-)      : truxwmqv e6f915d4 c | c
     Added 0 files, modified 0 files, removed 1 files
     [EOF]
     ");
     insta::assert_snapshot!(get_long_log_output(&work_dir), @"
-    @  f  lylxulpl  f2015644:  c
-    │ ○  e  kmkuslsw  65f1083b:  c
+    @  f  lylxulpl  f85207d4:  c
+    │ ○  e  wmkuslsw  b5d5eea1:  c
     ├─╯
-    │ ○  d  znkkpsqq  f91a8202:  c
+    │ ○  d  nnkkpsqq  ecd2023a:  c
     ├─╯
-    ○    c  vruxwmqv  86997ac2:  b1 b2
+    ○    c  truxwmqv  e6f915d4:  b1 b2
     ├─╮
-    │ ○  b2  royxmykx  1d9f22d8:  a
-    ○ │  b1  zsuskuln  62634b59:  a
+    │ ○  b2  ooyxmykx  92cf5426:  a
+    ○ │  b1  psuskuln  f25fb4a7:  a
     ├─╯
-    ○  a  rlvkpnrz  7d980be7
+    ○  a  ylvkpnrz  a1afb583
     ◆    zzzzzzzz  00000000
     [EOF]
     ");
@@ -2935,12 +2935,12 @@ fn test_rebase_skip_duplicate_divergent() {
 
     // Test the setup (commit B is duplicated)
     insta::assert_snapshot!(get_long_log_output(&work_dir), @"
-    @  d  znkkpsqq  ecbe1d2f:  b1
-    ○  b1  zsuskuln  48bf33ab:  a
-    │ ○  b2  zsuskuln  3f194323:  c
-    │ ○  c  royxmykx  0fdb9e5a:  a
+    @  d  qnkkpsqq  176a675a:  b1
+    ○  b1  psuskuln  62c0c393:  a
+    │ ○  b2  psuskuln  9f995fe1:  c
+    │ ○  c  ooyxmykx  01c753d5:  a
     ├─╯
-    ○  a  rlvkpnrz  08789390
+    ○  a  ylvkpnrz  b09f5d37
     ◆    zzzzzzzz  00000000
     [EOF]
     ");
@@ -2950,15 +2950,15 @@ fn test_rebase_skip_duplicate_divergent() {
     insta::assert_snapshot!(work_dir.run_jj(["rebase", "-r", "c::", "-o", "d"]), @"
     ------- stderr -------
     Abandoned 1 divergent commits that were already present in the destination:
-      zsuskuln/0 3f194323 b2 | (divergent) b2
+      psuskuln/0 9f995fe1 b2 | (divergent) b2
     Rebased 1 commits to destination
     [EOF]
     ");
     insta::assert_snapshot!(get_long_log_output(&work_dir), @"
-    ○  b2 c  royxmykx  56740329:  d
-    @  d  znkkpsqq  ecbe1d2f:  b1
-    ○  b1  zsuskuln  48bf33ab:  a
-    ○  a  rlvkpnrz  08789390
+    ○  b2 c  ooyxmykx  9addd745:  d
+    @  d  qnkkpsqq  176a675a:  b1
+    ○  b1  psuskuln  62c0c393:  a
+    ○  a  ylvkpnrz  b09f5d37
     ◆    zzzzzzzz  00000000
     [EOF]
     ");
@@ -2968,19 +2968,19 @@ fn test_rebase_skip_duplicate_divergent() {
     insta::assert_snapshot!(work_dir.run_jj(["rebase", "-s", "b1", "-o", "b2"]), @"
     ------- stderr -------
     Abandoned 1 divergent commits that were already present in the destination:
-      zsuskuln/1 48bf33ab b1 | (divergent) b2
+      psuskuln/1 62c0c393 b1 | (divergent) b2
     Rebased 1 commits to destination
-    Working copy  (@) now at: znkkpsqq 81e83d0f d | d
-    Parent commit (@-)      : zsuskuln 3f194323 b1 b2 | b2
+    Working copy  (@) now at: qnkkpsqq fcb2c657 d | d
+    Parent commit (@-)      : psuskuln 9f995fe1 b1 b2 | b2
     Added 1 files, modified 0 files, removed 0 files
     [EOF]
     ");
     // BUG: "d" should be on top of "b2", but it wasn't rebased
     insta::assert_snapshot!(get_long_log_output(&work_dir), @"
-    @  d  znkkpsqq  81e83d0f:  b1 b2
-    ○  b1 b2  zsuskuln  3f194323:  c
-    ○  c  royxmykx  0fdb9e5a:  a
-    ○  a  rlvkpnrz  08789390
+    @  d  qnkkpsqq  fcb2c657:  b1 b2
+    ○  b1 b2  psuskuln  9f995fe1:  c
+    ○  c  ooyxmykx  01c753d5:  a
+    ○  a  ylvkpnrz  b09f5d37
     ◆    zzzzzzzz  00000000
     [EOF]
     ");
@@ -2993,11 +2993,11 @@ fn test_rebase_skip_duplicate_divergent() {
     [EOF]
     ");
     insta::assert_snapshot!(get_long_log_output(&work_dir), @"
-    ○  b2  zsuskuln  f8e418c5:  c
-    ○  c  royxmykx  e232ead1:  d
-    @  d  znkkpsqq  ecbe1d2f:  b1
-    ○  b1  zsuskuln  48bf33ab:  a
-    ○  a  rlvkpnrz  08789390
+    ○  b2  psuskuln  6938ed92:  c
+    ○  c  ooyxmykx  9a1d551e:  d
+    @  d  qnkkpsqq  176a675a:  b1
+    ○  b1  psuskuln  62c0c393:  a
+    ○  a  ylvkpnrz  b09f5d37
     ◆    zzzzzzzz  00000000
     [EOF]
     ");
@@ -3015,13 +3015,13 @@ fn test_rebase_simplify_parents() {
     create_commit(&work_dir, "a3", &["a2", "a1"]);
     create_commit(&work_dir, "b", &[]);
     insta::assert_snapshot!(get_long_log_output(&work_dir), @"
-    @  b  znkkpsqq  3df16d78
-    │ ○    a3  vruxwmqv  cf72a356:  a2 a1
+    @  b  nnkkpsqq  f7b4d1b6
+    │ ○    a3  truxwmqv  c64a94f8:  a2 a1
     │ ├─╮
-    │ ○ │  a2  royxmykx  1f35d069:  a1
+    │ ○ │  a2  ooyxmykx  e09d3a5d:  a1
     │ ├─╯
-    │ ○  a1  zsuskuln  dce85039:  a
-    │ ○  a  rlvkpnrz  7d980be7
+    │ ○  a1  psuskuln  ea8ceb1c:  a
+    │ ○  a  ylvkpnrz  a1afb583
     ├─╯
     ◆    zzzzzzzz  00000000
     [EOF]
@@ -3031,13 +3031,13 @@ fn test_rebase_simplify_parents() {
     // without --simplify-parents, should transplant the whole tree structure
     work_dir.run_jj(["rebase", "-s", "a", "-o", "b"]).success();
     insta::assert_snapshot!(get_long_log_output(&work_dir), @"
-    ○    a3  vruxwmqv  b15b79bb:  a2 a1
+    ○    a3  truxwmqv  79dc04ed:  a2 a1
     ├─╮
-    ○ │  a2  royxmykx  06a5cde7:  a1
+    ○ │  a2  ooyxmykx  8e6523c9:  a1
     ├─╯
-    ○  a1  zsuskuln  16af6bbe:  a
-    ○  a  rlvkpnrz  69d157bb:  b
-    @  b  znkkpsqq  3df16d78
+    ○  a1  psuskuln  f1ee7969:  a
+    ○  a  ylvkpnrz  fcca0365:  b
+    @  b  nnkkpsqq  f7b4d1b6
     ◆    zzzzzzzz  00000000
     [EOF]
     ");
@@ -3048,11 +3048,11 @@ fn test_rebase_simplify_parents() {
         .run_jj(["rebase", "-s", "a", "-o", "b", "--simplify-parents"])
         .success();
     insta::assert_snapshot!(get_long_log_output(&work_dir), @"
-    ○  a3  vruxwmqv  867b901e:  a2
-    ○  a2  royxmykx  ecaa9fe7:  a1
-    ○  a1  zsuskuln  88fc1ed4:  a
-    ○  a  rlvkpnrz  c23ea181:  b
-    @  b  znkkpsqq  3df16d78
+    ○  a3  truxwmqv  60c499ca:  a2
+    ○  a2  ooyxmykx  1a830140:  a1
+    ○  a1  psuskuln  cd265e09:  a
+    ○  a  ylvkpnrz  38a98cae:  b
+    @  b  nnkkpsqq  f7b4d1b6
     ◆    zzzzzzzz  00000000
     [EOF]
     ");
@@ -3063,13 +3063,13 @@ fn test_rebase_simplify_parents() {
         .run_jj(["rebase", "-r", "a", "-o", "b", "--simplify-parents"])
         .success();
     insta::assert_snapshot!(get_long_log_output(&work_dir), @"
-    ○  a  rlvkpnrz  0e4898d1:  b
-    @  b  znkkpsqq  3df16d78
-    │ ○    a3  vruxwmqv  92c40092:  a2 a1
+    ○  a  ylvkpnrz  7407d5f2:  b
+    @  b  nnkkpsqq  f7b4d1b6
+    │ ○    a3  truxwmqv  eba1aca8:  a2 a1
     │ ├─╮
-    │ ○ │  a2  royxmykx  4bed9069:  a1
+    │ ○ │  a2  ooyxmykx  586aa140:  a1
     │ ├─╯
-    │ ○  a1  zsuskuln  98a31b4f
+    │ ○  a1  psuskuln  5e779699
     ├─╯
     ◆    zzzzzzzz  00000000
     [EOF]

--- a/cli/tests/test_repo_change_report.rs
+++ b/cli/tests/test_repo_change_report.rs
@@ -87,7 +87,7 @@ fn test_report_conflicts() {
     let output = work_dir.run_jj(["new", "rlvkpnrzqnoo"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: vruxwmqv 94208127 (conflict) (empty) (no description set)
+    Working copy  (@) now at: uruxwmqv 7ca1fc76 (conflict) (empty) (no description set)
     Parent commit (@-)      : rlvkpnrz 894d709e (conflict) B
     Added 0 files, modified 1 files, removed 0 files
     Warning: There are unresolved conflicts at these paths:
@@ -127,18 +127,18 @@ fn test_report_conflicts_with_divergent_commits() {
     ------- stderr -------
     Concurrent modification detected, resolving automatically.
     Rebased 3 commits to destination
-    Working copy  (@) now at: zsuskuln/1 f3e2e0a2 (divergent) (conflict) C2
-    Parent commit (@-)      : kkmpptxz c6237d2f (conflict) B
+    Working copy  (@) now at: psuskuln/1 3b041d51 (divergent) (conflict) C2
+    Parent commit (@-)      : nkmpptxz f6781998 (conflict) B
     Added 0 files, modified 1 files, removed 0 files
     Warning: There are unresolved conflicts at these paths:
     file    2-sided conflict including 1 deletion
     New conflicts appeared in 3 commits:
-      zsuskuln/0 9432879f (divergent) (conflict) C3
-      zsuskuln/1 f3e2e0a2 (divergent) (conflict) C2
-      kkmpptxz c6237d2f (conflict) B
+      psuskuln/0 a0ddb9f2 (divergent) (conflict) C3
+      psuskuln/1 3b041d51 (divergent) (conflict) C2
+      nkmpptxz f6781998 (conflict) B
     Hint: To resolve the conflicts, start by creating a commit on top of
     the first conflicted commit:
-      jj new kkmpptxz
+      jj new nkmpptxz
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you can inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
@@ -149,8 +149,8 @@ fn test_report_conflicts_with_divergent_commits() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Rebased 3 commits to destination
-    Working copy  (@) now at: zsuskuln/1 27ef05d9 (divergent) C2
-    Parent commit (@-)      : kkmpptxz 9039ed49 B
+    Working copy  (@) now at: psuskuln/1 2eda3066 (divergent) C2
+    Parent commit (@-)      : nkmpptxz d275d6d3 B
     Added 0 files, modified 1 files, removed 0 files
     Existing conflicts were resolved or abandoned from 3 commits.
     [EOF]
@@ -161,16 +161,16 @@ fn test_report_conflicts_with_divergent_commits() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Rebased 1 commits to destination
-    Working copy  (@) now at: zsuskuln/0 aa95f2b1 (divergent) (conflict) C2
+    Working copy  (@) now at: psuskuln/0 3b964481 (divergent) (conflict) C2
     Parent commit (@-)      : zzzzzzzz 00000000 (empty) (no description set)
     Added 0 files, modified 1 files, removed 0 files
     Warning: There are unresolved conflicts at these paths:
     file    2-sided conflict including 1 deletion
     New conflicts appeared in 1 commits:
-      zsuskuln/0 aa95f2b1 (divergent) (conflict) C2
+      psuskuln/0 3b964481 (divergent) (conflict) C2
     Hint: To resolve the conflicts, start by creating a commit on top of
     the conflicted commit:
-      jj new zsuskuln/0
+      jj new psuskuln/0
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you can inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
@@ -182,10 +182,10 @@ fn test_report_conflicts_with_divergent_commits() {
     ------- stderr -------
     Rebased 1 commits to destination
     New conflicts appeared in 1 commits:
-      zsuskuln/0 733a79ca (divergent) (conflict) C3
+      psuskuln/0 e54aa196 (divergent) (conflict) C3
     Hint: To resolve the conflicts, start by creating a commit on top of
     the conflicted commit:
-      jj new zsuskuln/0
+      jj new psuskuln/0
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you can inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
@@ -196,8 +196,8 @@ fn test_report_conflicts_with_divergent_commits() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Rebased 1 commits to destination
-    Working copy  (@) now at: zsuskuln/0 3fcf2fd2 (divergent) C2
-    Parent commit (@-)      : kkmpptxz 9039ed49 B
+    Working copy  (@) now at: psuskuln/0 2dc2bdd2 (divergent) C2
+    Parent commit (@-)      : nkmpptxz d275d6d3 B
     Added 0 files, modified 1 files, removed 0 files
     Existing conflicts were resolved or abandoned from 1 commits.
     [EOF]

--- a/cli/tests/test_resolve_command.rs
+++ b/cli/tests/test_resolve_command.rs
@@ -55,11 +55,11 @@ fn test_resolution() -> TestResult {
     ");
     insta::assert_snapshot!(work_dir.read_file("file"), @r#"
     <<<<<<< conflict 1 of 1
-    %%%%%%% diff from: rlvkpnrz 1792382a "base"
-    \\\\\\\        to: zsuskuln 45537d53 "a"
+    %%%%%%% diff from: ylvkpnrz b3d9a894 "base"
+    \\\\\\\        to: psuskuln 5abf80b5 "a"
     -base
     +a
-    +++++++ royxmykx 89d1b299 "b"
+    +++++++ ooyxmykx 61d89756 "b"
     b
     >>>>>>> conflict 1 of 1 ends
     "#);
@@ -74,9 +74,9 @@ fn test_resolution() -> TestResult {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Resolving conflicts in: file
-    Working copy  (@) now at: vruxwmqv 741263c9 conflict | conflict
-    Parent commit (@-)      : zsuskuln 45537d53 a | a
-    Parent commit (@-)      : royxmykx 89d1b299 b | b
+    Working copy  (@) now at: truxwmqv 47303865 conflict | conflict
+    Parent commit (@-)      : psuskuln 5abf80b5 a | a
+    Parent commit (@-)      : ooyxmykx 61d89756 b | b
     Added 0 files, modified 1 files, removed 0 files
     [EOF]
     ");
@@ -89,11 +89,11 @@ fn test_resolution() -> TestResult {
     +++ b/file
     @@ -1,8 +1,1 @@
     -<<<<<<< conflict 1 of 1
-    -%%%%%%% diff from: rlvkpnrz 1792382a "base"
-    -\\\\\\\        to: zsuskuln 45537d53 "a"
+    -%%%%%%% diff from: ylvkpnrz b3d9a894 "base"
+    -\\\\\\\        to: psuskuln 5abf80b5 "a"
     --base
     -+a
-    -+++++++ royxmykx 89d1b299 "b"
+    -+++++++ ooyxmykx 61d89756 "b"
     -b
     ->>>>>>> conflict 1 of 1 ends
     +resolution
@@ -117,9 +117,9 @@ fn test_resolution() -> TestResult {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Resolving conflicts in: file
-    Working copy  (@) now at: vruxwmqv 1f8a36f7 conflict | conflict
-    Parent commit (@-)      : zsuskuln 45537d53 a | a
-    Parent commit (@-)      : royxmykx 89d1b299 b | b
+    Working copy  (@) now at: truxwmqv cd51d72a conflict | conflict
+    Parent commit (@-)      : psuskuln 5abf80b5 a | a
+    Parent commit (@-)      : ooyxmykx 61d89756 b | b
     Added 0 files, modified 1 files, removed 0 files
     [EOF]
     ");
@@ -130,11 +130,11 @@ fn test_resolution() -> TestResult {
     +++ b/file
     @@ -1,8 +1,1 @@
     -<<<<<<< conflict 1 of 1
-    -%%%%%%% diff from: rlvkpnrz 1792382a "base"
-    -\\\\\\\        to: zsuskuln 45537d53 "a"
+    -%%%%%%% diff from: ylvkpnrz b3d9a894 "base"
+    -\\\\\\\        to: psuskuln 5abf80b5 "a"
     --base
     -+a
-    -+++++++ royxmykx 89d1b299 "b"
+    -+++++++ ooyxmykx 61d89756 "b"
     -b
     ->>>>>>> conflict 1 of 1 ends
     +resolution
@@ -164,11 +164,11 @@ fn test_resolution() -> TestResult {
     insta::assert_snapshot!(
         std::fs::read_to_string(test_env.env_root().join("editor1"))?, @r#"
     <<<<<<< conflict 1 of 1
-    %%%%%%% diff from: rlvkpnrz 1792382a "base"
-    \\\\\\\        to: zsuskuln 45537d53 "a"
+    %%%%%%% diff from: ylvkpnrz b3d9a894 "base"
+    \\\\\\\        to: psuskuln 5abf80b5 "a"
     -base
     +a
-    +++++++ royxmykx 89d1b299 "b"
+    +++++++ ooyxmykx 61d89756 "b"
     b
     >>>>>>> conflict 1 of 1 ends
     "#);
@@ -179,11 +179,11 @@ fn test_resolution() -> TestResult {
     +++ b/file
     @@ -1,8 +1,1 @@
     -<<<<<<< conflict 1 of 1
-    -%%%%%%% diff from: rlvkpnrz 1792382a "base"
-    -\\\\\\\        to: zsuskuln 45537d53 "a"
+    -%%%%%%% diff from: ylvkpnrz b3d9a894 "base"
+    -\\\\\\\        to: psuskuln 5abf80b5 "a"
     --base
     -+a
-    -+++++++ royxmykx 89d1b299 "b"
+    -+++++++ ooyxmykx 61d89756 "b"
     -b
     ->>>>>>> conflict 1 of 1 ends
     +resolution
@@ -218,17 +218,17 @@ fn test_resolution() -> TestResult {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Resolving conflicts in: file
-    Working copy  (@) now at: vruxwmqv a9cb79b1 conflict | (conflict) conflict
-    Parent commit (@-)      : zsuskuln 45537d53 a | a
-    Parent commit (@-)      : royxmykx 89d1b299 b | b
+    Working copy  (@) now at: truxwmqv 63d109c0 conflict | (conflict) conflict
+    Parent commit (@-)      : psuskuln 5abf80b5 a | a
+    Parent commit (@-)      : ooyxmykx 61d89756 b | b
     Added 0 files, modified 1 files, removed 0 files
     Warning: There are unresolved conflicts at these paths:
     file    2-sided conflict
     New conflicts appeared in 1 commits:
-      vruxwmqv a9cb79b1 conflict | (conflict) conflict
+      truxwmqv 63d109c0 conflict | (conflict) conflict
     Hint: To resolve the conflicts, start by creating a commit on top of
     the conflicted commit:
-      jj new vruxwmqv
+      jj new truxwmqv
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you can inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
@@ -237,11 +237,11 @@ fn test_resolution() -> TestResult {
     insta::assert_snapshot!(
         std::fs::read_to_string(test_env.env_root().join("editor2"))?, @r#"
     <<<<<<< conflict 1 of 1
-    %%%%%%% diff from: rlvkpnrz 1792382a "base"
-    \\\\\\\        to: zsuskuln 45537d53 "a"
+    %%%%%%% diff from: ylvkpnrz b3d9a894 "base"
+    \\\\\\\        to: psuskuln 5abf80b5 "a"
     -base
     +a
-    +++++++ royxmykx 89d1b299 "b"
+    +++++++ ooyxmykx 61d89756 "b"
     b
     >>>>>>> conflict 1 of 1 ends
     "#);
@@ -252,13 +252,13 @@ fn test_resolution() -> TestResult {
     +++ b/file
     @@ -1,8 +1,8 @@
      <<<<<<< conflict 1 of 1
-     %%%%%%% diff from: rlvkpnrz 1792382a "base"
-     \\\\\\\        to: zsuskuln 45537d53 "a"
+     %%%%%%% diff from: ylvkpnrz b3d9a894 "base"
+     \\\\\\\        to: psuskuln 5abf80b5 "a"
     --base
     -+a
     +-some
     ++fake
-     +++++++ royxmykx 89d1b299 "b"
+     +++++++ ooyxmykx 61d89756 "b"
     -b
     +conflict
      >>>>>>> conflict 1 of 1 ends
@@ -295,9 +295,9 @@ fn test_resolution() -> TestResult {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Resolving conflicts in: file
-    Working copy  (@) now at: vruxwmqv 2cc7f5e3 conflict | conflict
-    Parent commit (@-)      : zsuskuln 45537d53 a | a
-    Parent commit (@-)      : royxmykx 89d1b299 b | b
+    Working copy  (@) now at: truxwmqv 05430198 conflict | conflict
+    Parent commit (@-)      : psuskuln 5abf80b5 a | a
+    Parent commit (@-)      : ooyxmykx 61d89756 b | b
     Added 0 files, modified 1 files, removed 0 files
     [EOF]
     ");
@@ -311,11 +311,11 @@ fn test_resolution() -> TestResult {
     +++ b/file
     @@ -1,8 +1,7 @@
     -<<<<<<< conflict 1 of 1
-    -%%%%%%% diff from: rlvkpnrz 1792382a "base"
-    -\\\\\\\        to: zsuskuln 45537d53 "a"
+    -%%%%%%% diff from: ylvkpnrz b3d9a894 "base"
+    -\\\\\\\        to: psuskuln 5abf80b5 "a"
     --base
     -+a
-    -+++++++ royxmykx 89d1b299 "b"
+    -+++++++ ooyxmykx 61d89756 "b"
     -b
     ->>>>>>> conflict 1 of 1 ends
     +<<<<<<<
@@ -363,17 +363,17 @@ fn test_resolution() -> TestResult {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Resolving conflicts in: file
-    Working copy  (@) now at: vruxwmqv cd45e3c2 conflict | (conflict) conflict
-    Parent commit (@-)      : zsuskuln 45537d53 a | a
-    Parent commit (@-)      : royxmykx 89d1b299 b | b
+    Working copy  (@) now at: truxwmqv c2f03b4e conflict | (conflict) conflict
+    Parent commit (@-)      : psuskuln 5abf80b5 a | a
+    Parent commit (@-)      : ooyxmykx 61d89756 b | b
     Added 0 files, modified 1 files, removed 0 files
     Warning: There are unresolved conflicts at these paths:
     file    2-sided conflict
     New conflicts appeared in 1 commits:
-      vruxwmqv cd45e3c2 conflict | (conflict) conflict
+      truxwmqv c2f03b4e conflict | (conflict) conflict
     Hint: To resolve the conflicts, start by creating a commit on top of
     the conflicted commit:
-      jj new vruxwmqv
+      jj new truxwmqv
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you can inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
@@ -381,13 +381,13 @@ fn test_resolution() -> TestResult {
     ");
     insta::assert_snapshot!(
         std::fs::read_to_string(test_env.env_root().join("editor4"))?, @r#"
-    <<<<<<< zsuskuln 45537d53 "a"
+    <<<<<<< psuskuln 5abf80b5 "a"
     a
-    ||||||| rlvkpnrz 1792382a "base"
+    ||||||| ylvkpnrz b3d9a894 "base"
     base
     =======
     b
-    >>>>>>> royxmykx 89d1b299 "b"
+    >>>>>>> ooyxmykx 61d89756 "b"
     "#);
     insta::assert_snapshot!(work_dir.run_jj(["diff", "--git"]), @r#"
     diff --git a/file b/file
@@ -395,13 +395,13 @@ fn test_resolution() -> TestResult {
     +++ b/file
     @@ -1,8 +1,8 @@
      <<<<<<< conflict 1 of 1
-     %%%%%%% diff from: rlvkpnrz 1792382a "base"
-     \\\\\\\        to: zsuskuln 45537d53 "a"
+     %%%%%%% diff from: ylvkpnrz b3d9a894 "base"
+     \\\\\\\        to: psuskuln 5abf80b5 "a"
     --base
     -+a
     +-fake
     ++some
-     +++++++ royxmykx 89d1b299 "b"
+     +++++++ ooyxmykx 61d89756 "b"
     -b
     +conflict
      >>>>>>> conflict 1 of 1 ends
@@ -442,17 +442,17 @@ fn test_resolution() -> TestResult {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Resolving conflicts in: file
-    Working copy  (@) now at: vruxwmqv 097d6249 conflict | (conflict) conflict
-    Parent commit (@-)      : zsuskuln 45537d53 a | a
-    Parent commit (@-)      : royxmykx 89d1b299 b | b
+    Working copy  (@) now at: truxwmqv f5d5c990 conflict | (conflict) conflict
+    Parent commit (@-)      : psuskuln 5abf80b5 a | a
+    Parent commit (@-)      : ooyxmykx 61d89756 b | b
     Added 0 files, modified 1 files, removed 0 files
     Warning: There are unresolved conflicts at these paths:
     file    2-sided conflict
     New conflicts appeared in 1 commits:
-      vruxwmqv 097d6249 conflict | (conflict) conflict
+      truxwmqv f5d5c990 conflict | (conflict) conflict
     Hint: To resolve the conflicts, start by creating a commit on top of
     the conflicted commit:
-      jj new vruxwmqv
+      jj new truxwmqv
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you can inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
@@ -466,13 +466,13 @@ fn test_resolution() -> TestResult {
     +++ b/file
     @@ -1,8 +1,8 @@
      <<<<<<< conflict 1 of 1
-     %%%%%%% diff from: rlvkpnrz 1792382a "base"
-     \\\\\\\        to: zsuskuln 45537d53 "a"
+     %%%%%%% diff from: ylvkpnrz b3d9a894 "base"
+     \\\\\\\        to: psuskuln 5abf80b5 "a"
     --base
     -+a
     +-fake
     ++some
-     +++++++ royxmykx 89d1b299 "b"
+     +++++++ ooyxmykx 61d89756 "b"
     -b
     +conflict
      >>>>>>> conflict 1 of 1 ends
@@ -576,7 +576,7 @@ fn test_files_still_have_conflicts() -> TestResult {
     Resolving conflicts in: file1
     Rebased 1 descendant commits
     New conflicts appeared in 1 commits:
-      vruxwmqv b7972990 conflict | (conflict) conflict
+      truxwmqv 3ddf863f conflict | (conflict) conflict
     Warning: After this operation, some files at this revision still have conflicts:
     file2    2-sided conflict
     [EOF]
@@ -597,13 +597,13 @@ fn test_files_still_have_conflicts() -> TestResult {
     ------- stderr -------
     Resolving conflicts in: file1
     Rebased 1 descendant commits
-    Working copy  (@) now at: znkkpsqq b97a283e c | (conflict) (empty) c
-    Parent commit (@-)      : vruxwmqv e97ef12c conflict | (conflict) conflict
+    Working copy  (@) now at: nnkkpsqq 1a5759a0 c | (conflict) (empty) c
+    Parent commit (@-)      : truxwmqv 24c7d55a conflict | (conflict) conflict
     Added 0 files, modified 1 files, removed 0 files
     Warning: There are unresolved conflicts at these paths:
     file2    2-sided conflict
     New conflicts appeared in 1 commits:
-      vruxwmqv e97ef12c conflict | (conflict) conflict
+      truxwmqv 24c7d55a conflict | (conflict) conflict
     Warning: After this operation, some files at this revision still have conflicts:
     file2    2-sided conflict
     [EOF]
@@ -666,11 +666,11 @@ fn test_normal_conflict_input_files() -> TestResult {
     ");
     insta::assert_snapshot!(work_dir.read_file("file"), @r#"
     <<<<<<< conflict 1 of 1
-    %%%%%%% diff from: rlvkpnrz 1792382a "base"
-    \\\\\\\        to: zsuskuln 45537d53 "a"
+    %%%%%%% diff from: ylvkpnrz b3d9a894 "base"
+    \\\\\\\        to: psuskuln 5abf80b5 "a"
     -base
     +a
-    +++++++ royxmykx 89d1b299 "b"
+    +++++++ ooyxmykx 61d89756 "b"
     b
     >>>>>>> conflict 1 of 1 ends
     "#);
@@ -708,10 +708,10 @@ fn test_baseless_conflict_input_files() -> TestResult {
     ");
     insta::assert_snapshot!(work_dir.read_file("file"), @r#"
     <<<<<<< conflict 1 of 1
-    %%%%%%% diff from: rlvkpnrz 2308e5a2 "base"
-    \\\\\\\        to: zsuskuln e3c7222d "a"
+    %%%%%%% diff from: ylvkpnrz a59b45ec "base"
+    \\\\\\\        to: psuskuln 9a157d09 "a"
     +a
-    +++++++ royxmykx 1f2c13ec "b"
+    +++++++ ooyxmykx 7627a24f "b"
     b
     >>>>>>> conflict 1 of 1 ends
     "#);
@@ -793,21 +793,21 @@ fn test_simplify_conflict_sides() -> TestResult {
     ");
     insta::assert_snapshot!(work_dir.read_file("fileA"), @r#"
     <<<<<<< conflict 1 of 1
-    %%%%%%% diff from: rlvkpnrz ca4643d3 "base"
-    \\\\\\\        to: zsuskuln f302fbd1 "a1"
+    %%%%%%% diff from: ylvkpnrz 1f92f61e "base"
+    \\\\\\\        to: psuskuln 8baf9862 "a1"
     -base
     +1
-    +++++++ royxmykx 128a2559 "a2"
+    +++++++ ooyxmykx 2d3b32c1 "a2"
     2
     >>>>>>> conflict 1 of 1 ends
     "#);
     insta::assert_snapshot!(work_dir.read_file("fileB"), @r#"
     <<<<<<< conflict 1 of 1
-    %%%%%%% diff from: rlvkpnrz ca4643d3 "base"
-    \\\\\\\        to: vruxwmqv 5be2d37a "b1"
+    %%%%%%% diff from: ylvkpnrz 1f92f61e "base"
+    \\\\\\\        to: truxwmqv 5f6f742c "b1"
     -base
     +1
-    +++++++ znkkpsqq bd8e6328 "b2"
+    +++++++ nnkkpsqq 2fc64bd3 "b2"
     2
     >>>>>>> conflict 1 of 1 ends
     "#);
@@ -845,18 +845,18 @@ fn test_simplify_conflict_sides() -> TestResult {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Resolving conflicts in: fileB
-    Working copy  (@) now at: nkmrtpmo e3edd72f conflict | (conflict) conflict
-    Parent commit (@-)      : kmkuslsw fb05b298 conflictA | (conflict) (empty) conflictA
-    Parent commit (@-)      : lylxulpl c680c6d6 conflictB | (conflict) (empty) conflictB
+    Working copy  (@) now at: ukmrtpmo 8bc443de conflict | (conflict) conflict
+    Parent commit (@-)      : wmkuslsw 2d461824 conflictA | (conflict) (empty) conflictA
+    Parent commit (@-)      : lylxulpl 6522bfe5 conflictB | (conflict) (empty) conflictB
     Added 0 files, modified 1 files, removed 0 files
     Warning: There are unresolved conflicts at these paths:
     fileA    2-sided conflict
     fileB    2-sided conflict
     New conflicts appeared in 1 commits:
-      nkmrtpmo e3edd72f conflict | (conflict) conflict
+      ukmrtpmo 8bc443de conflict | (conflict) conflict
     Hint: To resolve the conflicts, start by creating a commit on top of
     the conflicted commit:
-      jj new nkmrtpmo
+      jj new ukmrtpmo
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you can inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
@@ -864,11 +864,11 @@ fn test_simplify_conflict_sides() -> TestResult {
     ");
     insta::assert_snapshot!(work_dir.read_file("fileB"), @r#"
     <<<<<<< conflict 1 of 1
-    %%%%%%% diff from: rlvkpnrz ca4643d3 "base"
-    \\\\\\\        to: vruxwmqv 5be2d37a "b1"
+    %%%%%%% diff from: ylvkpnrz 1f92f61e "base"
+    \\\\\\\        to: truxwmqv 5f6f742c "b1"
     -base_edited
     +1_edited
-    +++++++ znkkpsqq bd8e6328 "b2"
+    +++++++ nnkkpsqq 2fc64bd3 "b2"
     2_edited
     >>>>>>> conflict 1 of 1 ends
     "#);
@@ -908,10 +908,10 @@ fn test_edit_delete_conflict_input_files() -> TestResult {
     ");
     insta::assert_snapshot!(work_dir.read_file("file"), @r#"
     <<<<<<< conflict 1 of 1
-    +++++++ zsuskuln 45537d53 "a"
+    +++++++ psuskuln 5abf80b5 "a"
     a
-    %%%%%%% diff from: rlvkpnrz 1792382a "base"
-    \\\\\\\        to: royxmykx d213fd81 "b"
+    %%%%%%% diff from: ylvkpnrz b3d9a894 "base"
+    \\\\\\\        to: ooyxmykx 51db153c "b"
     -base
     >>>>>>> conflict 1 of 1 ends
     "#);
@@ -958,9 +958,9 @@ fn test_file_vs_dir() -> TestResult {
     Error: Failed to resolve conflicts
     Caused by: Only conflicts that involve normal files (not symlinks, etc.) are supported. Conflict summary for "file":
     Conflict:
-      Removing file with id df967b96a579e45a18b8251732d16804b2e56a55 (rlvkpnrz 1792382a "base")
-      Adding file with id 78981922613b2afb6025042ff6bd878ac1994e85 (zsuskuln 45537d53 "a")
-      Adding tree with id 133bb38fc4e4bf6b551f1f04db7e48f04cac2877 (royxmykx 0950b959 "b")
+      Removing file with id df967b96a579e45a18b8251732d16804b2e56a55 (ylvkpnrz b3d9a894 "base")
+      Adding file with id 78981922613b2afb6025042ff6bd878ac1994e85 (psuskuln 5abf80b5 "a")
+      Adding tree with id 133bb38fc4e4bf6b551f1f04db7e48f04cac2877 (ooyxmykx 05f1dc2e "b")
     [EOF]
     [exit status: 1]
     "#);
@@ -1012,10 +1012,10 @@ fn test_description_with_dir_and_deletion() -> TestResult {
     Error: Failed to resolve conflicts
     Caused by: Only conflicts that involve normal files (not symlinks, etc.) are supported. Conflict summary for "file":
     Conflict:
-      Removing file with id df967b96a579e45a18b8251732d16804b2e56a55 (rlvkpnrz 1792382a "base")
-      Removing file with id df967b96a579e45a18b8251732d16804b2e56a55 (rlvkpnrz 1792382a "base")
-      Adding file with id 61780798228d17af2d34fce4cfbdf35556832472 (zsuskuln 6c74ed1d "edit")
-      Adding tree with id 133bb38fc4e4bf6b551f1f04db7e48f04cac2877 (royxmykx 09c02334 "dir")
+      Removing file with id df967b96a579e45a18b8251732d16804b2e56a55 (ylvkpnrz b3d9a894 "base")
+      Removing file with id df967b96a579e45a18b8251732d16804b2e56a55 (ylvkpnrz b3d9a894 "base")
+      Adding file with id 61780798228d17af2d34fce4cfbdf35556832472 (psuskuln 842d93f0 "edit")
+      Adding tree with id 133bb38fc4e4bf6b551f1f04db7e48f04cac2877 (ooyxmykx 07a13466 "dir")
     [EOF]
     [exit status: 1]
     "#);
@@ -1059,22 +1059,22 @@ fn test_resolve_conflicts_with_executable() -> TestResult {
     ");
     insta::assert_snapshot!(work_dir.read_file("file1"), @r#"
     <<<<<<< conflict 1 of 1
-    %%%%%%% diff from: rlvkpnrz b90abfa7 "base"
-    \\\\\\\        to: mzvwutvl 86f7f0e3 "a"
+    %%%%%%% diff from: ylvkpnrz 055afe4f "base"
+    \\\\\\\        to: pzvwutvl 465187a3 "a"
     -base1
     +a1
-    +++++++ yqosqzyt 36361412 "b"
+    +++++++ nqosqzyt bd53f9da "b"
     b1
     >>>>>>> conflict 1 of 1 ends
     "#
     );
     insta::assert_snapshot!(work_dir.read_file("file2"), @r#"
     <<<<<<< conflict 1 of 1
-    %%%%%%% diff from: rlvkpnrz b90abfa7 "base"
-    \\\\\\\        to: mzvwutvl 86f7f0e3 "a"
+    %%%%%%% diff from: ylvkpnrz 055afe4f "base"
+    \\\\\\\        to: pzvwutvl 465187a3 "a"
     -base2
     +a2
-    +++++++ yqosqzyt 36361412 "b"
+    +++++++ nqosqzyt bd53f9da "b"
     b2
     >>>>>>> conflict 1 of 1 ends
     "#
@@ -1087,17 +1087,17 @@ fn test_resolve_conflicts_with_executable() -> TestResult {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Resolving conflicts in: file1
-    Working copy  (@) now at: znkkpsqq 59e1d672 conflict | (conflict) conflict
-    Parent commit (@-)      : mzvwutvl 86f7f0e3 a | a
-    Parent commit (@-)      : yqosqzyt 36361412 b | b
+    Working copy  (@) now at: qnkkpsqq bf1b6662 conflict | (conflict) conflict
+    Parent commit (@-)      : pzvwutvl 465187a3 a | a
+    Parent commit (@-)      : nqosqzyt bd53f9da b | b
     Added 0 files, modified 1 files, removed 0 files
     Warning: There are unresolved conflicts at these paths:
     file2    2-sided conflict including an executable
     New conflicts appeared in 1 commits:
-      znkkpsqq 59e1d672 conflict | (conflict) conflict
+      qnkkpsqq bf1b6662 conflict | (conflict) conflict
     Hint: To resolve the conflicts, start by creating a commit on top of
     the conflicted commit:
-      jj new znkkpsqq
+      jj new qnkkpsqq
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you can inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
@@ -1110,11 +1110,11 @@ fn test_resolve_conflicts_with_executable() -> TestResult {
     +++ b/file1
     @@ -1,8 +1,1 @@
     -<<<<<<< conflict 1 of 1
-    -%%%%%%% diff from: rlvkpnrz b90abfa7 "base"
-    -\\\\\\\        to: mzvwutvl 86f7f0e3 "a"
+    -%%%%%%% diff from: ylvkpnrz 055afe4f "base"
+    -\\\\\\\        to: pzvwutvl 465187a3 "a"
     --base1
     -+a1
-    -+++++++ yqosqzyt 36361412 "b"
+    -+++++++ nqosqzyt bd53f9da "b"
     -b1
     ->>>>>>> conflict 1 of 1 ends
     +resolution1
@@ -1132,17 +1132,17 @@ fn test_resolve_conflicts_with_executable() -> TestResult {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Resolving conflicts in: file2
-    Working copy  (@) now at: znkkpsqq d3f09ac5 conflict | (conflict) conflict
-    Parent commit (@-)      : mzvwutvl 86f7f0e3 a | a
-    Parent commit (@-)      : yqosqzyt 36361412 b | b
+    Working copy  (@) now at: qnkkpsqq b5d91ee8 conflict | (conflict) conflict
+    Parent commit (@-)      : pzvwutvl 465187a3 a | a
+    Parent commit (@-)      : nqosqzyt bd53f9da b | b
     Added 0 files, modified 1 files, removed 0 files
     Warning: There are unresolved conflicts at these paths:
     file1    2-sided conflict including an executable
     New conflicts appeared in 1 commits:
-      znkkpsqq d3f09ac5 conflict | (conflict) conflict
+      qnkkpsqq b5d91ee8 conflict | (conflict) conflict
     Hint: To resolve the conflicts, start by creating a commit on top of
     the conflicted commit:
-      jj new znkkpsqq
+      jj new qnkkpsqq
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you can inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
@@ -1155,11 +1155,11 @@ fn test_resolve_conflicts_with_executable() -> TestResult {
     +++ b/file2
     @@ -1,8 +1,1 @@
     -<<<<<<< conflict 1 of 1
-    -%%%%%%% diff from: rlvkpnrz b90abfa7 "base"
-    -\\\\\\\        to: mzvwutvl 86f7f0e3 "a"
+    -%%%%%%% diff from: ylvkpnrz 055afe4f "base"
+    -\\\\\\\        to: pzvwutvl 465187a3 "a"
     --base2
     -+a2
-    -+++++++ yqosqzyt 36361412 "b"
+    -+++++++ nqosqzyt bd53f9da "b"
     -b2
     ->>>>>>> conflict 1 of 1 ends
     +resolution2
@@ -1175,9 +1175,9 @@ fn test_resolve_conflicts_with_executable() -> TestResult {
     let output = work_dir.run_jj(["resolve", "--tool=:ours"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: znkkpsqq d902c14b conflict | conflict
-    Parent commit (@-)      : mzvwutvl 86f7f0e3 a | a
-    Parent commit (@-)      : yqosqzyt 36361412 b | b
+    Working copy  (@) now at: qnkkpsqq 4104c320 conflict | conflict
+    Parent commit (@-)      : pzvwutvl 465187a3 a | a
+    Parent commit (@-)      : nqosqzyt bd53f9da b | b
     Added 0 files, modified 2 files, removed 0 files
     [EOF]
     ");
@@ -1188,11 +1188,11 @@ fn test_resolve_conflicts_with_executable() -> TestResult {
     +++ b/file1
     @@ -1,8 +1,1 @@
     -<<<<<<< conflict 1 of 1
-    -%%%%%%% diff from: rlvkpnrz b90abfa7 "base"
-    -\\\\\\\        to: mzvwutvl 86f7f0e3 "a"
+    -%%%%%%% diff from: ylvkpnrz 055afe4f "base"
+    -\\\\\\\        to: pzvwutvl 465187a3 "a"
     --base1
     -+a1
-    -+++++++ yqosqzyt 36361412 "b"
+    -+++++++ nqosqzyt bd53f9da "b"
     -b1
     ->>>>>>> conflict 1 of 1 ends
     +a1
@@ -1202,11 +1202,11 @@ fn test_resolve_conflicts_with_executable() -> TestResult {
     +++ b/file2
     @@ -1,8 +1,1 @@
     -<<<<<<< conflict 1 of 1
-    -%%%%%%% diff from: rlvkpnrz b90abfa7 "base"
-    -\\\\\\\        to: mzvwutvl 86f7f0e3 "a"
+    -%%%%%%% diff from: ylvkpnrz 055afe4f "base"
+    -\\\\\\\        to: pzvwutvl 465187a3 "a"
     --base2
     -+a2
-    -+++++++ yqosqzyt 36361412 "b"
+    -+++++++ nqosqzyt bd53f9da "b"
     -b2
     ->>>>>>> conflict 1 of 1 ends
     +a2
@@ -1218,9 +1218,9 @@ fn test_resolve_conflicts_with_executable() -> TestResult {
     let output = work_dir.run_jj(["resolve", "--tool=:theirs"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: znkkpsqq a340ca5f conflict | conflict
-    Parent commit (@-)      : mzvwutvl 86f7f0e3 a | a
-    Parent commit (@-)      : yqosqzyt 36361412 b | b
+    Working copy  (@) now at: qnkkpsqq bea1fb1a conflict | conflict
+    Parent commit (@-)      : pzvwutvl 465187a3 a | a
+    Parent commit (@-)      : nqosqzyt bd53f9da b | b
     Added 0 files, modified 2 files, removed 0 files
     [EOF]
     ");
@@ -1231,11 +1231,11 @@ fn test_resolve_conflicts_with_executable() -> TestResult {
     +++ b/file1
     @@ -1,8 +1,1 @@
     -<<<<<<< conflict 1 of 1
-    -%%%%%%% diff from: rlvkpnrz b90abfa7 "base"
-    -\\\\\\\        to: mzvwutvl 86f7f0e3 "a"
+    -%%%%%%% diff from: ylvkpnrz 055afe4f "base"
+    -\\\\\\\        to: pzvwutvl 465187a3 "a"
     --base1
     -+a1
-    -+++++++ yqosqzyt 36361412 "b"
+    -+++++++ nqosqzyt bd53f9da "b"
      b1
     ->>>>>>> conflict 1 of 1 ends
     diff --git a/file2 b/file2
@@ -1244,11 +1244,11 @@ fn test_resolve_conflicts_with_executable() -> TestResult {
     +++ b/file2
     @@ -1,8 +1,1 @@
     -<<<<<<< conflict 1 of 1
-    -%%%%%%% diff from: rlvkpnrz b90abfa7 "base"
-    -\\\\\\\        to: mzvwutvl 86f7f0e3 "a"
+    -%%%%%%% diff from: ylvkpnrz 055afe4f "base"
+    -\\\\\\\        to: pzvwutvl 465187a3 "a"
     --base2
     -+a2
-    -+++++++ yqosqzyt 36361412 "b"
+    -+++++++ nqosqzyt bd53f9da "b"
      b2
     ->>>>>>> conflict 1 of 1 ends
     [EOF]
@@ -1321,9 +1321,9 @@ fn test_resolve_change_delete_executable() -> TestResult {
     [EOF]
     ");
     insta::assert_snapshot!(work_dir.run_jj(["log", "--git"]), @"
-    @    kmkuslsw test.user@example.com 2001-02-03 08:05:18 conflict 1196e800 (conflict)
+    @    wmkuslsw test.user@example.com 2001-02-03 08:05:18 conflict bc0f8019 (conflict)
     ├─╮  (empty) conflict
-    │ ○  vruxwmqv test.user@example.com 2001-02-03 08:05:17 b 888b6cc3
+    │ ○  truxwmqv test.user@example.com 2001-02-03 08:05:17 b f857c29e
     │ │  b
     │ │  diff --git a/file1 b/file1
     │ │  deleted file mode 100644
@@ -1348,7 +1348,7 @@ fn test_resolve_change_delete_executable() -> TestResult {
     │ │  +++ b/file5
     │ │  @@ -0,0 +1,1 @@
     │ │  +b5
-    ○ │  mzvwutvl test.user@example.com 2001-02-03 08:05:13 a e2d3924b
+    ○ │  pzvwutvl test.user@example.com 2001-02-03 08:05:13 a 9210f32d
     ├─╯  a
     │    diff --git a/file1 b/file1
     │    old mode 100644
@@ -1368,7 +1368,7 @@ fn test_resolve_change_delete_executable() -> TestResult {
     │    diff --git a/file5 b/file5
     │    deleted file mode 100755
     │    index e69de29bb2..0000000000
-    ○  rlvkpnrz test.user@example.com 2001-02-03 08:05:10 base f747aa1f
+    ○  ylvkpnrz test.user@example.com 2001-02-03 08:05:10 base 96504832
     │  base
     │  diff --git a/file1 b/file1
     │  new file mode 100644
@@ -1393,8 +1393,8 @@ fn test_resolve_change_delete_executable() -> TestResult {
     Error: Failed to resolve conflicts
     Caused by: "file1" has conflicts in executable bit
     Conflict:
-      Removing file with id e69de29bb2d1d6434b8b29ae775ad8c2e48c5391 (rlvkpnrz f747aa1f "base")
-      Adding executable file with id e69de29bb2d1d6434b8b29ae775ad8c2e48c5391 (mzvwutvl e2d3924b "a")
+      Removing file with id e69de29bb2d1d6434b8b29ae775ad8c2e48c5391 (ylvkpnrz 96504832 "base")
+      Adding executable file with id e69de29bb2d1d6434b8b29ae775ad8c2e48c5391 (pzvwutvl 9210f32d "a")
     Hint: Use `jj file chmod` to update the executable bit.
     [EOF]
     [exit status: 1]
@@ -1409,8 +1409,8 @@ fn test_resolve_change_delete_executable() -> TestResult {
     Error: Failed to resolve conflicts
     Caused by: "file2" has conflicts in executable bit
     Conflict:
-      Removing executable file with id e69de29bb2d1d6434b8b29ae775ad8c2e48c5391 (rlvkpnrz f747aa1f "base")
-      Adding file with id e6bfff5c1d0f0ecd501552b43a1e13d8008abc31 (vruxwmqv 888b6cc3 "b")
+      Removing executable file with id e69de29bb2d1d6434b8b29ae775ad8c2e48c5391 (ylvkpnrz 96504832 "base")
+      Adding file with id e6bfff5c1d0f0ecd501552b43a1e13d8008abc31 (truxwmqv f857c29e "b")
     Hint: Use `jj file chmod` to update the executable bit.
     [EOF]
     [exit status: 1]
@@ -1422,9 +1422,9 @@ fn test_resolve_change_delete_executable() -> TestResult {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Resolving conflicts in: file2
-    Working copy  (@) now at: kmkuslsw 3f8814ba conflict | (conflict) conflict
-    Parent commit (@-)      : mzvwutvl e2d3924b a | a
-    Parent commit (@-)      : vruxwmqv 888b6cc3 b | b
+    Working copy  (@) now at: wmkuslsw 9505e9ce conflict | (conflict) conflict
+    Parent commit (@-)      : pzvwutvl 9210f32d a | a
+    Parent commit (@-)      : truxwmqv f857c29e b | b
     Added 0 files, modified 1 files, removed 0 files
     Warning: There are unresolved conflicts at these paths:
     file3    2-sided conflict including an executable
@@ -1440,8 +1440,8 @@ fn test_resolve_change_delete_executable() -> TestResult {
     Error: Failed to resolve conflicts
     Caused by: "file3" has conflicts in executable bit
     Conflict:
-      Adding file with id e69de29bb2d1d6434b8b29ae775ad8c2e48c5391 (mzvwutvl e2d3924b "a")
-      Adding executable file with id e69de29bb2d1d6434b8b29ae775ad8c2e48c5391 (vruxwmqv 888b6cc3 "b")
+      Adding file with id e69de29bb2d1d6434b8b29ae775ad8c2e48c5391 (pzvwutvl 9210f32d "a")
+      Adding executable file with id e69de29bb2d1d6434b8b29ae775ad8c2e48c5391 (truxwmqv f857c29e "b")
     Hint: Use `jj file chmod` to update the executable bit.
     [EOF]
     [exit status: 1]
@@ -1453,9 +1453,9 @@ fn test_resolve_change_delete_executable() -> TestResult {
     let output = work_dir.run_jj(["resolve", "file4", "--tool=:ours"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: kmkuslsw 0810a8d2 conflict | (conflict) conflict
-    Parent commit (@-)      : mzvwutvl e2d3924b a | a
-    Parent commit (@-)      : vruxwmqv 888b6cc3 b | b
+    Working copy  (@) now at: wmkuslsw 67cbd89d conflict | (conflict) conflict
+    Parent commit (@-)      : pzvwutvl 9210f32d a | a
+    Parent commit (@-)      : truxwmqv f857c29e b | b
     Added 0 files, modified 1 files, removed 0 files
     Warning: There are unresolved conflicts at these paths:
     file5    2-sided conflict including 1 deletion and an executable
@@ -1466,9 +1466,9 @@ fn test_resolve_change_delete_executable() -> TestResult {
     let output = work_dir.run_jj(["resolve", "file5", "--tool=:theirs"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: kmkuslsw 7337267a conflict | conflict
-    Parent commit (@-)      : mzvwutvl e2d3924b a | a
-    Parent commit (@-)      : vruxwmqv 888b6cc3 b | b
+    Working copy  (@) now at: wmkuslsw 10eeaf9c conflict | conflict
+    Parent commit (@-)      : pzvwutvl 9210f32d a | a
+    Parent commit (@-)      : truxwmqv f857c29e b | b
     Added 0 files, modified 1 files, removed 0 files
     Existing conflicts were resolved or abandoned from 1 commits.
     [EOF]
@@ -1505,11 +1505,11 @@ fn test_pass_path_argument() -> TestResult {
     ");
     insta::assert_snapshot!(work_dir.read_file("file"), @r#"
     <<<<<<< conflict 1 of 1
-    +++++++ zsuskuln 45537d53 "a"
+    +++++++ psuskuln 5abf80b5 "a"
     a
-    ------- rlvkpnrz 1792382a "base"
+    ------- ylvkpnrz b3d9a894 "base"
     base
-    +++++++ royxmykx 89d1b299 "b"
+    +++++++ ooyxmykx 61d89756 "b"
     b
     >>>>>>> conflict 1 of 1 ends
     "#
@@ -1532,9 +1532,9 @@ fn test_pass_path_argument() -> TestResult {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Resolving conflicts in: file
-    Working copy  (@) now at: vruxwmqv 682816de conflict | conflict
-    Parent commit (@-)      : zsuskuln 45537d53 a | a
-    Parent commit (@-)      : royxmykx 89d1b299 b | b
+    Working copy  (@) now at: truxwmqv 69976ae7 conflict | conflict
+    Parent commit (@-)      : psuskuln 5abf80b5 a | a
+    Parent commit (@-)      : ooyxmykx 61d89756 b | b
     Added 0 files, modified 1 files, removed 0 files
     [EOF]
     ");
@@ -1545,11 +1545,11 @@ fn test_pass_path_argument() -> TestResult {
     +++ b/file
     @@ -1,8 +1,1 @@
     -<<<<<<< conflict 1 of 1
-    -+++++++ zsuskuln 45537d53 "a"
+    -+++++++ psuskuln 5abf80b5 "a"
     -a
-    -------- rlvkpnrz 1792382a "base"
+    -------- ylvkpnrz b3d9a894 "base"
     -base
-    -+++++++ royxmykx 89d1b299 "b"
+    -+++++++ ooyxmykx 61d89756 "b"
     -b
     ->>>>>>> conflict 1 of 1 ends
     +resolution
@@ -1594,11 +1594,11 @@ fn test_resolve_long_conflict_markers() -> TestResult {
     ");
     insta::assert_snapshot!(work_dir.read_file("file"), @r#"
     <<<<<<<<<<< conflict 1 of 1
-    +++++++++++ zsuskuln 10d994ef "a"
+    +++++++++++ psuskuln 5c324f76 "a"
     <<<<<<< a
-    ----------- rlvkpnrz 04dceede "base"
+    ----------- ylvkpnrz a45327ad "base"
     ======= base
-    +++++++++++ royxmykx 7f215575 "b"
+    +++++++++++ ooyxmykx c66f0188 "b"
     >>>>>>> b
     >>>>>>>>>>> conflict 1 of 1 ends
     "#
@@ -1628,17 +1628,17 @@ fn test_resolve_long_conflict_markers() -> TestResult {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Resolving conflicts in: file
-    Working copy  (@) now at: vruxwmqv ad16cc38 conflict | (conflict) conflict
-    Parent commit (@-)      : zsuskuln 10d994ef a | a
-    Parent commit (@-)      : royxmykx 7f215575 b | b
+    Working copy  (@) now at: truxwmqv d36e7352 conflict | (conflict) conflict
+    Parent commit (@-)      : psuskuln 5c324f76 a | a
+    Parent commit (@-)      : ooyxmykx c66f0188 b | b
     Added 0 files, modified 1 files, removed 0 files
     Warning: There are unresolved conflicts at these paths:
     file    2-sided conflict
     New conflicts appeared in 1 commits:
-      vruxwmqv ad16cc38 conflict | (conflict) conflict
+      truxwmqv d36e7352 conflict | (conflict) conflict
     Hint: To resolve the conflicts, start by creating a commit on top of
     the conflicted commit:
-      jj new vruxwmqv
+      jj new truxwmqv
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you can inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
@@ -1650,19 +1650,19 @@ fn test_resolve_long_conflict_markers() -> TestResult {
     +++ b/file
     @@ -1,8 +1,8 @@
     -<<<<<<<<<<< conflict 1 of 1
-    -+++++++++++ zsuskuln 10d994ef "a"
+    -+++++++++++ psuskuln 5c324f76 "a"
     -<<<<<<< a
-    ------------ rlvkpnrz 04dceede "base"
+    ------------ ylvkpnrz a45327ad "base"
     -======= base
-    -+++++++++++ royxmykx 7f215575 "b"
+    -+++++++++++ ooyxmykx c66f0188 "b"
     ->>>>>>> b
     ->>>>>>>>>>> conflict 1 of 1 ends
     +<<<<<<< conflict 1 of 1
-    ++++++++ zsuskuln 10d994ef "a"
+    ++++++++ psuskuln 5c324f76 "a"
     +A
-    +------- rlvkpnrz 04dceede "base"
+    +------- ylvkpnrz a45327ad "base"
     +BASE
-    ++++++++ royxmykx 7f215575 "b"
+    ++++++++ ooyxmykx c66f0188 "b"
     +B
     +>>>>>>> conflict 1 of 1 ends
     [EOF]
@@ -1697,17 +1697,17 @@ fn test_resolve_long_conflict_markers() -> TestResult {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Resolving conflicts in: file
-    Working copy  (@) now at: vruxwmqv bbbee812 conflict | (conflict) conflict
-    Parent commit (@-)      : zsuskuln 10d994ef a | a
-    Parent commit (@-)      : royxmykx 7f215575 b | b
+    Working copy  (@) now at: truxwmqv dacc031f conflict | (conflict) conflict
+    Parent commit (@-)      : psuskuln 5c324f76 a | a
+    Parent commit (@-)      : ooyxmykx c66f0188 b | b
     Added 0 files, modified 1 files, removed 0 files
     Warning: There are unresolved conflicts at these paths:
     file    2-sided conflict
     New conflicts appeared in 1 commits:
-      vruxwmqv bbbee812 conflict | (conflict) conflict
+      truxwmqv dacc031f conflict | (conflict) conflict
     Hint: To resolve the conflicts, start by creating a commit on top of
     the conflicted commit:
-      jj new vruxwmqv
+      jj new truxwmqv
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you can inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
@@ -1716,11 +1716,11 @@ fn test_resolve_long_conflict_markers() -> TestResult {
     insta::assert_snapshot!(
         std::fs::read_to_string(test_env.env_root().join("editor"))?, @r#"
     <<<<<<<<<<< conflict 1 of 1
-    +++++++++++ zsuskuln 10d994ef "a"
+    +++++++++++ psuskuln 5c324f76 "a"
     <<<<<<< a
-    ----------- rlvkpnrz 04dceede "base"
+    ----------- ylvkpnrz a45327ad "base"
     ======= base
-    +++++++++++ royxmykx 7f215575 "b"
+    +++++++++++ ooyxmykx c66f0188 "b"
     >>>>>>> b
     >>>>>>>>>>> conflict 1 of 1 ends
     "#);
@@ -1730,13 +1730,13 @@ fn test_resolve_long_conflict_markers() -> TestResult {
     +++ b/file
     @@ -1,8 +1,8 @@
      <<<<<<<<<<< conflict 1 of 1
-     +++++++++++ zsuskuln 10d994ef "a"
+     +++++++++++ psuskuln 5c324f76 "a"
     -<<<<<<< a
     +<<<<<<< A
-     ----------- rlvkpnrz 04dceede "base"
+     ----------- ylvkpnrz a45327ad "base"
     -======= base
     +======= BASE
-     +++++++++++ royxmykx 7f215575 "b"
+     +++++++++++ ooyxmykx c66f0188 "b"
     ->>>>>>> b
     +>>>>>>> B
      >>>>>>>>>>> conflict 1 of 1 ends
@@ -1772,17 +1772,17 @@ fn test_resolve_long_conflict_markers() -> TestResult {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Resolving conflicts in: file
-    Working copy  (@) now at: vruxwmqv 4405a045 conflict | (conflict) conflict
-    Parent commit (@-)      : zsuskuln 10d994ef a | a
-    Parent commit (@-)      : royxmykx 7f215575 b | b
+    Working copy  (@) now at: truxwmqv 2c926b04 conflict | (conflict) conflict
+    Parent commit (@-)      : psuskuln 5c324f76 a | a
+    Parent commit (@-)      : ooyxmykx c66f0188 b | b
     Added 0 files, modified 1 files, removed 0 files
     Warning: There are unresolved conflicts at these paths:
     file    2-sided conflict
     New conflicts appeared in 1 commits:
-      vruxwmqv 4405a045 conflict | (conflict) conflict
+      truxwmqv 2c926b04 conflict | (conflict) conflict
     Hint: To resolve the conflicts, start by creating a commit on top of
     the conflicted commit:
-      jj new vruxwmqv
+      jj new truxwmqv
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you can inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
@@ -1794,13 +1794,13 @@ fn test_resolve_long_conflict_markers() -> TestResult {
     +++ b/file
     @@ -1,8 +1,8 @@
      <<<<<<<<<<< conflict 1 of 1
-     +++++++++++ zsuskuln 10d994ef "a"
+     +++++++++++ psuskuln 5c324f76 "a"
     -<<<<<<< a
     +<<<<<<< A
-     ----------- rlvkpnrz 04dceede "base"
+     ----------- ylvkpnrz a45327ad "base"
     -======= base
     +======= BASE
-     +++++++++++ royxmykx 7f215575 "b"
+     +++++++++++ ooyxmykx c66f0188 "b"
     ->>>>>>> b
     +>>>>>>> B
      >>>>>>>>>>> conflict 1 of 1 ends
@@ -1871,21 +1871,21 @@ fn test_multiple_conflicts() -> TestResult {
     insta::assert_snapshot!(
         work_dir.read_file("this_file_has_a_very_long_name_to_test_padding"), @r#"
     <<<<<<< conflict 1 of 1
-    %%%%%%% diff from: rlvkpnrz fa081b8c "base"
-    \\\\\\\        to: zsuskuln 2c821f70 "a"
+    %%%%%%% diff from: ylvkpnrz 1eb8762d "base"
+    \\\\\\\        to: psuskuln 63ed2965 "a"
     -first base
     +first a
-    +++++++ royxmykx 4c2029de "b"
+    +++++++ ooyxmykx fe3c2e32 "b"
     first b
     >>>>>>> conflict 1 of 1 ends
     "#);
     insta::assert_snapshot!(work_dir.read_file("another_file"), @r#"
     <<<<<<< conflict 1 of 1
-    %%%%%%% diff from: rlvkpnrz fa081b8c "base"
-    \\\\\\\        to: zsuskuln 2c821f70 "a"
+    %%%%%%% diff from: ylvkpnrz 1eb8762d "base"
+    \\\\\\\        to: psuskuln 63ed2965 "a"
     -second base
     +second a
-    +++++++ royxmykx 4c2029de "b"
+    +++++++ ooyxmykx fe3c2e32 "b"
     second b
     >>>>>>> conflict 1 of 1 ends
     "#);
@@ -1908,17 +1908,17 @@ fn test_multiple_conflicts() -> TestResult {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Resolving conflicts in: another_file
-    Working copy  (@) now at: vruxwmqv 90639b66 conflict | (conflict) conflict
-    Parent commit (@-)      : zsuskuln 2c821f70 a | a
-    Parent commit (@-)      : royxmykx 4c2029de b | b
+    Working copy  (@) now at: truxwmqv 507dd7e0 conflict | (conflict) conflict
+    Parent commit (@-)      : psuskuln 63ed2965 a | a
+    Parent commit (@-)      : ooyxmykx fe3c2e32 b | b
     Added 0 files, modified 1 files, removed 0 files
     Warning: There are unresolved conflicts at these paths:
     this_file_has_a_very_long_name_to_test_padding 2-sided conflict
     New conflicts appeared in 1 commits:
-      vruxwmqv 90639b66 conflict | (conflict) conflict
+      truxwmqv 507dd7e0 conflict | (conflict) conflict
     Hint: To resolve the conflicts, start by creating a commit on top of
     the conflicted commit:
-      jj new vruxwmqv
+      jj new truxwmqv
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you can inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
@@ -1931,11 +1931,11 @@ fn test_multiple_conflicts() -> TestResult {
     +++ b/another_file
     @@ -1,8 +1,1 @@
     -<<<<<<< conflict 1 of 1
-    -%%%%%%% diff from: rlvkpnrz fa081b8c "base"
-    -\\\\\\\        to: zsuskuln 2c821f70 "a"
+    -%%%%%%% diff from: ylvkpnrz 1eb8762d "base"
+    -\\\\\\\        to: psuskuln 63ed2965 "a"
     --second base
     -+second a
-    -+++++++ royxmykx 4c2029de "b"
+    -+++++++ ooyxmykx fe3c2e32 "b"
     -second b
     ->>>>>>> conflict 1 of 1 ends
     +resolution another_file
@@ -1974,11 +1974,11 @@ fn test_multiple_conflicts() -> TestResult {
     +++ b/another_file
     @@ -1,8 +1,1 @@
     -<<<<<<< conflict 1 of 1
-    -%%%%%%% diff from: rlvkpnrz fa081b8c "base"
-    -\\\\\\\        to: zsuskuln 2c821f70 "a"
+    -%%%%%%% diff from: ylvkpnrz 1eb8762d "base"
+    -\\\\\\\        to: psuskuln 63ed2965 "a"
     --second base
     -+second a
-    -+++++++ royxmykx 4c2029de "b"
+    -+++++++ ooyxmykx fe3c2e32 "b"
     -second b
     ->>>>>>> conflict 1 of 1 ends
     +first resolution for auto-chosen file
@@ -1988,11 +1988,11 @@ fn test_multiple_conflicts() -> TestResult {
     +++ b/this_file_has_a_very_long_name_to_test_padding
     @@ -1,8 +1,1 @@
     -<<<<<<< conflict 1 of 1
-    -%%%%%%% diff from: rlvkpnrz fa081b8c "base"
-    -\\\\\\\        to: zsuskuln 2c821f70 "a"
+    -%%%%%%% diff from: ylvkpnrz 1eb8762d "base"
+    -\\\\\\\        to: psuskuln 63ed2965 "a"
     --first base
     -+first a
-    -+++++++ royxmykx 4c2029de "b"
+    -+++++++ ooyxmykx fe3c2e32 "b"
     -first b
     ->>>>>>> conflict 1 of 1 ends
     +second resolution for auto-chosen file
@@ -2052,22 +2052,22 @@ fn test_multiple_conflicts_with_error() -> TestResult {
     ");
     insta::assert_snapshot!(work_dir.read_file("file1"), @r#"
     <<<<<<< conflict 1 of 1
-    %%%%%%% diff from: rlvkpnrz 6591ac1d "base"
-    \\\\\\\        to: zsuskuln 6c31698c "a"
+    %%%%%%% diff from: ylvkpnrz b4d7eeb2 "base"
+    \\\\\\\        to: psuskuln 8bea729b "a"
     -base1
     +a1
-    +++++++ royxmykx ba0a5538 "b"
+    +++++++ ooyxmykx c9c84710 "b"
     b1
     >>>>>>> conflict 1 of 1 ends
     "#
     );
     insta::assert_snapshot!(work_dir.read_file("file2"), @r#"
     <<<<<<< conflict 1 of 1
-    %%%%%%% diff from: rlvkpnrz 6591ac1d "base"
-    \\\\\\\        to: zsuskuln 6c31698c "a"
+    %%%%%%% diff from: ylvkpnrz b4d7eeb2 "base"
+    \\\\\\\        to: psuskuln 8bea729b "a"
     -base2
     +a2
-    +++++++ royxmykx ba0a5538 "b"
+    +++++++ ooyxmykx c9c84710 "b"
     b2
     >>>>>>> conflict 1 of 1 ends
     "#
@@ -2084,17 +2084,17 @@ fn test_multiple_conflicts_with_error() -> TestResult {
     ------- stderr -------
     Resolving conflicts in: file1
     Resolving conflicts in: file2
-    Working copy  (@) now at: vruxwmqv e2442c8d conflict | (conflict) conflict
-    Parent commit (@-)      : zsuskuln 6c31698c a | a
-    Parent commit (@-)      : royxmykx ba0a5538 b | b
+    Working copy  (@) now at: truxwmqv 76c497d5 conflict | (conflict) conflict
+    Parent commit (@-)      : psuskuln 8bea729b a | a
+    Parent commit (@-)      : ooyxmykx c9c84710 b | b
     Added 0 files, modified 1 files, removed 0 files
     Warning: There are unresolved conflicts at these paths:
     file2    2-sided conflict
     New conflicts appeared in 1 commits:
-      vruxwmqv e2442c8d conflict | (conflict) conflict
+      truxwmqv 76c497d5 conflict | (conflict) conflict
     Hint: To resolve the conflicts, start by creating a commit on top of
     the conflicted commit:
-      jj new vruxwmqv
+      jj new truxwmqv
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you can inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
@@ -2110,11 +2110,11 @@ fn test_multiple_conflicts_with_error() -> TestResult {
     +++ b/file1
     @@ -1,8 +1,1 @@
     -<<<<<<< conflict 1 of 1
-    -%%%%%%% diff from: rlvkpnrz 6591ac1d "base"
-    -\\\\\\\        to: zsuskuln 6c31698c "a"
+    -%%%%%%% diff from: ylvkpnrz b4d7eeb2 "base"
+    -\\\\\\\        to: psuskuln 8bea729b "a"
     --base1
     -+a1
-    -+++++++ royxmykx ba0a5538 "b"
+    -+++++++ ooyxmykx c9c84710 "b"
     -b1
     ->>>>>>> conflict 1 of 1 ends
     +resolution1
@@ -2136,17 +2136,17 @@ fn test_multiple_conflicts_with_error() -> TestResult {
     ------- stderr -------
     Resolving conflicts in: file1
     Resolving conflicts in: file2
-    Working copy  (@) now at: vruxwmqv fa64d807 conflict | (conflict) conflict
-    Parent commit (@-)      : zsuskuln 6c31698c a | a
-    Parent commit (@-)      : royxmykx ba0a5538 b | b
+    Working copy  (@) now at: truxwmqv 48663ccd conflict | (conflict) conflict
+    Parent commit (@-)      : psuskuln 8bea729b a | a
+    Parent commit (@-)      : ooyxmykx c9c84710 b | b
     Added 0 files, modified 1 files, removed 0 files
     Warning: There are unresolved conflicts at these paths:
     file2    2-sided conflict
     New conflicts appeared in 1 commits:
-      vruxwmqv fa64d807 conflict | (conflict) conflict
+      truxwmqv 48663ccd conflict | (conflict) conflict
     Hint: To resolve the conflicts, start by creating a commit on top of
     the conflicted commit:
-      jj new vruxwmqv
+      jj new truxwmqv
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you can inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
@@ -2162,11 +2162,11 @@ fn test_multiple_conflicts_with_error() -> TestResult {
     +++ b/file1
     @@ -1,8 +1,1 @@
     -<<<<<<< conflict 1 of 1
-    -%%%%%%% diff from: rlvkpnrz 6591ac1d "base"
-    -\\\\\\\        to: zsuskuln 6c31698c "a"
+    -%%%%%%% diff from: ylvkpnrz b4d7eeb2 "base"
+    -\\\\\\\        to: psuskuln 8bea729b "a"
     --base1
     -+a1
-    -+++++++ royxmykx ba0a5538 "b"
+    -+++++++ ooyxmykx c9c84710 "b"
     -b1
     ->>>>>>> conflict 1 of 1 ends
     +resolution1
@@ -2252,21 +2252,21 @@ fn test_resolve_with_contents_of_side() -> TestResult {
     ");
     insta::assert_snapshot!(work_dir.read_file("file"), @r#"
     <<<<<<< conflict 1 of 1
-    %%%%%%% diff from: rlvkpnrz ed3e06b2 "base"
-    \\\\\\\        to: zsuskuln 72dced6e "a"
+    %%%%%%% diff from: ylvkpnrz d74361a7 "base"
+    \\\\\\\        to: psuskuln 51af6f58 "a"
     -base
     +a
-    +++++++ vruxwmqv dd35236a "c"
+    +++++++ truxwmqv bbc7c0fa "c"
     b
     >>>>>>> conflict 1 of 1 ends
     "#);
     insta::assert_snapshot!(work_dir.read_file("other"), @r#"
     <<<<<<< conflict 1 of 1
-    %%%%%%% diff from: rlvkpnrz ed3e06b2 "base"
-    \\\\\\\        to: royxmykx e5747f42 "b"
+    %%%%%%% diff from: ylvkpnrz d74361a7 "base"
+    \\\\\\\        to: ooyxmykx 9e58c346 "b"
     -base
     +left
-    +++++++ vruxwmqv dd35236a "c"
+    +++++++ truxwmqv bbc7c0fa "c"
     right
     >>>>>>> conflict 1 of 1 ends
     "#);
@@ -2278,8 +2278,8 @@ fn test_resolve_with_contents_of_side() -> TestResult {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Rebased 1 descendant commits
-    Working copy  (@) now at: kmkuslsw 6cca6d79 tip | (empty) tip
-    Parent commit (@-)      : znkkpsqq b84d5da4 conflict | conflict
+    Working copy  (@) now at: wmkuslsw edbea569 tip | (empty) tip
+    Parent commit (@-)      : nnkkpsqq 66cba3d7 conflict | conflict
     Added 0 files, modified 2 files, removed 0 files
     [EOF]
     ");
@@ -2299,8 +2299,8 @@ fn test_resolve_with_contents_of_side() -> TestResult {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Rebased 1 descendant commits
-    Working copy  (@) now at: kmkuslsw 4a54e224 tip | (empty) tip
-    Parent commit (@-)      : znkkpsqq ffd341c7 conflict | conflict
+    Working copy  (@) now at: wmkuslsw b0da03c9 tip | (empty) tip
+    Parent commit (@-)      : nnkkpsqq fd0a8bd8 conflict | conflict
     Added 0 files, modified 2 files, removed 0 files
     [EOF]
     ");

--- a/cli/tests/test_restore_command.rs
+++ b/cli/tests/test_restore_command.rs
@@ -50,8 +50,8 @@ fn test_restore() {
     let output = work_dir.run_jj(["restore"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: kkmpptxz ff7ef1df (empty) (no description set)
-    Parent commit (@-)      : rlvkpnrz 1d3e40a3 (no description set)
+    Working copy  (@) now at: nkmpptxz 832acf55 (empty) (no description set)
+    Parent commit (@-)      : ylvkpnrz a269d8b1 (no description set)
     Added 1 files, modified 1 files, removed 1 files
     [EOF]
     ");
@@ -69,16 +69,16 @@ fn test_restore() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Rebased 1 descendant commits
-    Working copy  (@) now at: kkmpptxz faa5911c (conflict) (no description set)
-    Parent commit (@-)      : rlvkpnrz 67841e01 (empty) (no description set)
+    Working copy  (@) now at: nkmpptxz 9e0f77d3 (conflict) (no description set)
+    Parent commit (@-)      : ylvkpnrz e0e22d71 (empty) (no description set)
     Added 0 files, modified 1 files, removed 0 files
     Warning: There are unresolved conflicts at these paths:
     file2    2-sided conflict including 1 deletion
     New conflicts appeared in 1 commits:
-      kkmpptxz faa5911c (conflict) (no description set)
+      nkmpptxz 9e0f77d3 (conflict) (no description set)
     Hint: To resolve the conflicts, start by creating a commit on top of
     the conflicted commit:
-      jj new kkmpptxz
+      jj new nkmpptxz
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you can inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
@@ -92,8 +92,8 @@ fn test_restore() {
     let output = work_dir.run_jj(["restore", "--from", "@--"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: kkmpptxz 3beda426 (no description set)
-    Parent commit (@-)      : rlvkpnrz 1d3e40a3 (no description set)
+    Working copy  (@) now at: nkmpptxz 91fcc892 (no description set)
+    Parent commit (@-)      : ylvkpnrz a269d8b1 (no description set)
     Added 1 files, modified 0 files, removed 2 files
     [EOF]
     ");
@@ -109,8 +109,8 @@ fn test_restore() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Rebased 1 descendant commits
-    Working copy  (@) now at: kkmpptxz 5edd8125 (empty) (no description set)
-    Parent commit (@-)      : rlvkpnrz e01fe0b9 (no description set)
+    Working copy  (@) now at: nkmpptxz f9666e30 (empty) (no description set)
+    Parent commit (@-)      : ylvkpnrz 8354362b (no description set)
     [EOF]
     ");
     let output = work_dir.run_jj(["diff", "-s"]);
@@ -129,8 +129,8 @@ fn test_restore() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Rebased 1 descendant commits
-    Working copy  (@) now at: kkmpptxz 9807d79b (empty) (no description set)
-    Parent commit (@-)      : rlvkpnrz f3774db8 (no description set)
+    Working copy  (@) now at: nkmpptxz 7fe29877 (empty) (no description set)
+    Parent commit (@-)      : ylvkpnrz 4d917d02 (no description set)
     [EOF]
     ");
     let output = work_dir.run_jj(["diff", "-s"]);
@@ -148,8 +148,8 @@ fn test_restore() {
     let output = work_dir.run_jj(["restore", "file2", "file3"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: kkmpptxz 08b04134 (no description set)
-    Parent commit (@-)      : rlvkpnrz 1d3e40a3 (no description set)
+    Working copy  (@) now at: nkmpptxz ca63cc90 (no description set)
+    Parent commit (@-)      : ylvkpnrz a269d8b1 (no description set)
     Added 0 files, modified 1 files, removed 1 files
     [EOF]
     ");
@@ -193,11 +193,11 @@ fn test_restore_conflicted_merge() {
     ");
     insta::assert_snapshot!(work_dir.read_file("file"), @r#"
     <<<<<<< conflict 1 of 1
-    %%%%%%% diff from: rlvkpnrz 1792382a "base"
-    \\\\\\\        to: zsuskuln 45537d53 "a"
+    %%%%%%% diff from: ylvkpnrz b3d9a894 "base"
+    \\\\\\\        to: psuskuln 5abf80b5 "a"
     -base
     +a
-    +++++++ royxmykx 89d1b299 "b"
+    +++++++ ooyxmykx 61d89756 "b"
     b
     >>>>>>> conflict 1 of 1 ends
     "#);
@@ -207,11 +207,11 @@ fn test_restore_conflicted_merge() {
     insta::assert_snapshot!(work_dir.run_jj(["diff"]), @r#"
     Resolved conflict in file:
        1     : <<<<<<< conflict 1 of 1
-       2     : %%%%%%% diff from: rlvkpnrz 1792382a "base"
-       3     : \\\\\\\        to: zsuskuln 45537d53 "a"
+       2     : %%%%%%% diff from: ylvkpnrz b3d9a894 "base"
+       3     : \\\\\\\        to: psuskuln 5abf80b5 "a"
        4     : -base
        5     : +a
-       6     : +++++++ royxmykx 89d1b299 "b"
+       6     : +++++++ ooyxmykx 61d89756 "b"
        7     : b
        8     : >>>>>>> conflict 1 of 1 ends
             1: resolution
@@ -222,9 +222,9 @@ fn test_restore_conflicted_merge() {
     let output = work_dir.run_jj(["restore", "file"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: vruxwmqv 7efcd5f8 conflict | (conflict) (empty) conflict
-    Parent commit (@-)      : zsuskuln 45537d53 a | a
-    Parent commit (@-)      : royxmykx 89d1b299 b | b
+    Working copy  (@) now at: truxwmqv 4d95688b conflict | (conflict) (empty) conflict
+    Parent commit (@-)      : psuskuln 5abf80b5 a | a
+    Parent commit (@-)      : ooyxmykx 61d89756 b | b
     Added 0 files, modified 1 files, removed 0 files
     Warning: There are unresolved conflicts at these paths:
     file    2-sided conflict
@@ -232,11 +232,11 @@ fn test_restore_conflicted_merge() {
     ");
     insta::assert_snapshot!(work_dir.read_file("file"), @r#"
     <<<<<<< conflict 1 of 1
-    %%%%%%% diff from: rlvkpnrz 1792382a "base"
-    \\\\\\\        to: zsuskuln 45537d53 "a"
+    %%%%%%% diff from: ylvkpnrz b3d9a894 "base"
+    \\\\\\\        to: psuskuln 5abf80b5 "a"
     -base
     +a
-    +++++++ royxmykx 89d1b299 "b"
+    +++++++ ooyxmykx 61d89756 "b"
     b
     >>>>>>> conflict 1 of 1 ends
     "#);
@@ -248,11 +248,11 @@ fn test_restore_conflicted_merge() {
     insta::assert_snapshot!(work_dir.run_jj(["diff"]), @r#"
     Resolved conflict in file:
        1     : <<<<<<< conflict 1 of 1
-       2     : %%%%%%% diff from: rlvkpnrz 1792382a "base"
-       3     : \\\\\\\        to: zsuskuln 45537d53 "a"
+       2     : %%%%%%% diff from: ylvkpnrz b3d9a894 "base"
+       3     : \\\\\\\        to: psuskuln 5abf80b5 "a"
        4     : -base
        5     : +a
-       6     : +++++++ royxmykx 89d1b299 "b"
+       6     : +++++++ ooyxmykx 61d89756 "b"
        7     : b
        8     : >>>>>>> conflict 1 of 1 ends
             1: resolution
@@ -263,9 +263,9 @@ fn test_restore_conflicted_merge() {
     let output = work_dir.run_jj(["restore"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: vruxwmqv e0c3b307 conflict | (conflict) (empty) conflict
-    Parent commit (@-)      : zsuskuln 45537d53 a | a
-    Parent commit (@-)      : royxmykx 89d1b299 b | b
+    Working copy  (@) now at: truxwmqv 0eeb82d9 conflict | (conflict) (empty) conflict
+    Parent commit (@-)      : psuskuln 5abf80b5 a | a
+    Parent commit (@-)      : ooyxmykx 61d89756 b | b
     Added 0 files, modified 1 files, removed 0 files
     Warning: There are unresolved conflicts at these paths:
     file    2-sided conflict
@@ -273,11 +273,11 @@ fn test_restore_conflicted_merge() {
     ");
     insta::assert_snapshot!(work_dir.read_file("file"), @r#"
     <<<<<<< conflict 1 of 1
-    %%%%%%% diff from: rlvkpnrz 1792382a "base"
-    \\\\\\\        to: zsuskuln 45537d53 "a"
+    %%%%%%% diff from: ylvkpnrz b3d9a894 "base"
+    \\\\\\\        to: psuskuln 5abf80b5 "a"
     -base
     +a
-    +++++++ royxmykx 89d1b299 "b"
+    +++++++ ooyxmykx 61d89756 "b"
     b
     >>>>>>> conflict 1 of 1 ends
     "#);
@@ -317,9 +317,9 @@ fn test_restore_restore_descendants() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Rebased 1 descendant commits (while preserving their content)
-    Working copy  (@) now at: vruxwmqv 14c0c336 ab | ab
-    Parent commit (@-)      : zsuskuln 45537d53 a | a
-    Parent commit (@-)      : royxmykx 5fd3f8c5 b | b
+    Working copy  (@) now at: truxwmqv 575551cd ab | ab
+    Parent commit (@-)      : psuskuln 5abf80b5 a | a
+    Parent commit (@-)      : ooyxmykx f600c654 b | b
     [EOF]
     ");
 
@@ -370,12 +370,12 @@ fn test_restore_interactive() -> TestResult {
     );
     let output = work_dir.run_jj(["log", "--summary"]);
     insta::assert_snapshot!(output, @"
-    @  zsuskuln test.user@example.com 2001-02-03 08:05:11 b 38153274
+    @  psuskuln test.user@example.com 2001-02-03 08:05:11 b c7b5747e
     │  b
     │  M file1
     │  M file2
     │  A file3
-    ○  rlvkpnrz test.user@example.com 2001-02-03 08:05:09 a 6c8d5b87
+    ○  ylvkpnrz test.user@example.com 2001-02-03 08:05:09 a f59a9f62
     │  a
     │  A file1
     │  A file2
@@ -397,16 +397,16 @@ fn test_restore_interactive() -> TestResult {
     let output = work_dir.run_jj(["restore", "-i", "--from=@-"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: zsuskuln 7cd0a341 b | b
-    Parent commit (@-)      : rlvkpnrz 6c8d5b87 a | a
+    Working copy  (@) now at: psuskuln 7d59f635 b | b
+    Parent commit (@-)      : ylvkpnrz f59a9f62 a | a
     Added 0 files, modified 1 files, removed 1 files
     [EOF]
     ");
 
     insta::assert_snapshot!(
         std::fs::read_to_string(test_env.env_root().join("instrs"))?, @"
-    You are restoring changes from: rlvkpnrz 6c8d5b87 a | a
-    to commit: zsuskuln 38153274 b | b
+    You are restoring changes from: ylvkpnrz f59a9f62 a | a
+    to commit: psuskuln c7b5747e b | b
 
     The diff initially shows all changes restored. Adjust the right side until it
     shows the contents you want for the destination commit.
@@ -414,10 +414,10 @@ fn test_restore_interactive() -> TestResult {
 
     let output = work_dir.run_jj(["log", "--summary"]);
     insta::assert_snapshot!(output, @"
-    @  zsuskuln test.user@example.com 2001-02-03 08:05:13 b 7cd0a341
+    @  psuskuln test.user@example.com 2001-02-03 08:05:13 b 7d59f635
     │  b
     │  M file2
-    ○  rlvkpnrz test.user@example.com 2001-02-03 08:05:09 a 6c8d5b87
+    ○  ylvkpnrz test.user@example.com 2001-02-03 08:05:09 a f59a9f62
     │  a
     │  A file1
     │  A file2
@@ -430,18 +430,18 @@ fn test_restore_interactive() -> TestResult {
     let output = work_dir.run_jj(["restore", "--tool=fake-diff-editor"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: zsuskuln 0f1263f5 b | b
-    Parent commit (@-)      : rlvkpnrz 6c8d5b87 a | a
+    Working copy  (@) now at: psuskuln 841dc4a5 b | b
+    Parent commit (@-)      : ylvkpnrz f59a9f62 a | a
     Added 0 files, modified 1 files, removed 1 files
     [EOF]
     ");
 
     let output = work_dir.run_jj(["log", "--summary"]);
     insta::assert_snapshot!(output, @"
-    @  zsuskuln test.user@example.com 2001-02-03 08:05:16 b 0f1263f5
+    @  psuskuln test.user@example.com 2001-02-03 08:05:16 b 841dc4a5
     │  b
     │  M file2
-    ○  rlvkpnrz test.user@example.com 2001-02-03 08:05:09 a 6c8d5b87
+    ○  ylvkpnrz test.user@example.com 2001-02-03 08:05:09 a f59a9f62
     │  a
     │  A file1
     │  A file2
@@ -468,15 +468,15 @@ fn test_restore_interactive_merge() -> TestResult {
     );
     let output = work_dir.run_jj(["log", "--summary"]);
     insta::assert_snapshot!(output, @"
-    @    royxmykx test.user@example.com 2001-02-03 08:05:13 c e37470c3
+    @    ooyxmykx test.user@example.com 2001-02-03 08:05:13 c 8afa2187
     ├─╮  c
     │ │  M file1
     │ │  M file2
     │ │  A file3
-    │ ○  zsuskuln test.user@example.com 2001-02-03 08:05:11 b ca7e57cd
+    │ ○  psuskuln test.user@example.com 2001-02-03 08:05:11 b 17727ad7
     │ │  b
     │ │  A file2
-    ○ │  rlvkpnrz test.user@example.com 2001-02-03 08:05:09 a 78059355
+    ○ │  ylvkpnrz test.user@example.com 2001-02-03 08:05:09 a 37794b1b
     ├─╯  a
     │    A file1
     ◆  zzzzzzzz root() 00000000
@@ -496,18 +496,18 @@ fn test_restore_interactive_merge() -> TestResult {
     let output = work_dir.run_jj(["restore", "-i"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: royxmykx 196af27b c | c
-    Parent commit (@-)      : rlvkpnrz 78059355 a | a
-    Parent commit (@-)      : zsuskuln ca7e57cd b | b
+    Working copy  (@) now at: ooyxmykx 4b4af08b c | c
+    Parent commit (@-)      : ylvkpnrz 37794b1b a | a
+    Parent commit (@-)      : psuskuln 17727ad7 b | b
     Added 0 files, modified 1 files, removed 1 files
     [EOF]
     ");
 
     insta::assert_snapshot!(
         std::fs::read_to_string(test_env.env_root().join("instrs"))?, @"
-    You are restoring changes from: rlvkpnrz 78059355 a | a
-                                    zsuskuln ca7e57cd b | b
-    to commit: royxmykx e37470c3 c | c
+    You are restoring changes from: ylvkpnrz 37794b1b a | a
+                                    psuskuln 17727ad7 b | b
+    to commit: ooyxmykx 8afa2187 c | c
 
     The diff initially shows all changes restored. Adjust the right side until it
     shows the contents you want for the destination commit.
@@ -515,13 +515,13 @@ fn test_restore_interactive_merge() -> TestResult {
 
     let output = work_dir.run_jj(["log", "--summary"]);
     insta::assert_snapshot!(output, @"
-    @    royxmykx test.user@example.com 2001-02-03 08:05:15 c 196af27b
+    @    ooyxmykx test.user@example.com 2001-02-03 08:05:15 c 4b4af08b
     ├─╮  c
     │ │  M file2
-    │ ○  zsuskuln test.user@example.com 2001-02-03 08:05:11 b ca7e57cd
+    │ ○  psuskuln test.user@example.com 2001-02-03 08:05:11 b 17727ad7
     │ │  b
     │ │  A file2
-    ○ │  rlvkpnrz test.user@example.com 2001-02-03 08:05:09 a 78059355
+    ○ │  ylvkpnrz test.user@example.com 2001-02-03 08:05:09 a 37794b1b
     ├─╯  a
     │    A file1
     ◆  zzzzzzzz root() 00000000
@@ -546,12 +546,12 @@ fn test_restore_interactive_with_paths() -> TestResult {
     );
     let output = work_dir.run_jj(["log", "--summary"]);
     insta::assert_snapshot!(output, @"
-    @  zsuskuln test.user@example.com 2001-02-03 08:05:11 b 38153274
+    @  psuskuln test.user@example.com 2001-02-03 08:05:11 b c7b5747e
     │  b
     │  M file1
     │  M file2
     │  A file3
-    ○  rlvkpnrz test.user@example.com 2001-02-03 08:05:09 a 6c8d5b87
+    ○  ylvkpnrz test.user@example.com 2001-02-03 08:05:09 a f59a9f62
     │  a
     │  A file1
     │  A file2
@@ -571,19 +571,19 @@ fn test_restore_interactive_with_paths() -> TestResult {
     let output = work_dir.run_jj(["restore", "-i", "file1", "file2"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: zsuskuln 8b2f997d b | b
-    Parent commit (@-)      : rlvkpnrz 6c8d5b87 a | a
+    Working copy  (@) now at: psuskuln 953b9039 b | b
+    Parent commit (@-)      : ylvkpnrz f59a9f62 a | a
     Added 0 files, modified 1 files, removed 0 files
     [EOF]
     ");
 
     let output = work_dir.run_jj(["log", "--summary"]);
     insta::assert_snapshot!(output, @"
-    @  zsuskuln test.user@example.com 2001-02-03 08:05:13 b 8b2f997d
+    @  psuskuln test.user@example.com 2001-02-03 08:05:13 b 953b9039
     │  b
     │  M file2
     │  A file3
-    ○  rlvkpnrz test.user@example.com 2001-02-03 08:05:09 a 6c8d5b87
+    ○  ylvkpnrz test.user@example.com 2001-02-03 08:05:09 a f59a9f62
     │  a
     │  A file1
     │  A file2

--- a/cli/tests/test_revert_command.rs
+++ b/cli/tests/test_revert_command.rs
@@ -29,10 +29,10 @@ fn test_revert() {
     create_commit_with_files(&work_dir, "d", &["c"], &[]);
     // Test the setup
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  98fb6151f954 d
-    ○  96ff42270bbc c
-    ○  58aaf278bf58 b
-    ○  7d980be7a1d4 a
+    @  fa26c55c301b d
+    ○  3ba70189111d c
+    ○  b2f482be4c08 b
+    ○  a1afb5834d8e a
     ◆  000000000000
     [EOF]
     ");
@@ -62,17 +62,17 @@ fn test_revert() {
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Reverted 1 commits as follows:
-      wqnwkozp 64910788 Revert "a"
+      wqnwkozp b0012bfd Revert "a"
     [EOF]
     "#);
     insta::assert_snapshot!(get_log_output(&work_dir), @r#"
-    ○  64910788f8a5 Revert "a"
+    ○  b0012bfd21de Revert "a"
     │
-    │  This reverts commit 7d980be7a1d499e4d316ab4c01242885032f7eaf.
-    @  98fb6151f954 d
-    ○  96ff42270bbc c
-    ○  58aaf278bf58 b
-    ○  7d980be7a1d4 a
+    │  This reverts commit a1afb5834d8ee4dcb61b59db0f682c7a53f96f53.
+    @  fa26c55c301b d
+    ○  3ba70189111d c
+    ○  b2f482be4c08 b
+    ○  a1afb5834d8e a
     ◆  000000000000
     [EOF]
     "#);
@@ -87,20 +87,20 @@ fn test_revert() {
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Reverted 1 commits as follows:
-      nkmrtpmo 90d12316 Revert "Revert "a""
+      nkmrtpmo 4deb57e3 Revert "Revert "a""
     [EOF]
     "#);
     insta::assert_snapshot!(get_log_output(&work_dir), @r#"
-    ○  90d123162199 Revert "Revert "a""
+    ○  4deb57e3940a Revert "Revert "a""
     │
-    │  This reverts commit 64910788f8a5d322739e1e38ef35f7d06ea4b38d.
-    ○  64910788f8a5 Revert "a"
+    │  This reverts commit b0012bfd21de6b73af1ca81b9e1a3dc6b605ab37.
+    ○  b0012bfd21de Revert "a"
     │
-    │  This reverts commit 7d980be7a1d499e4d316ab4c01242885032f7eaf.
-    @  98fb6151f954 d
-    ○  96ff42270bbc c
-    ○  58aaf278bf58 b
-    ○  7d980be7a1d4 a
+    │  This reverts commit a1afb5834d8ee4dcb61b59db0f682c7a53f96f53.
+    @  fa26c55c301b d
+    ○  3ba70189111d c
+    ○  b2f482be4c08 b
+    ○  a1afb5834d8e a
     ◆  000000000000
     [EOF]
     "#);
@@ -116,21 +116,21 @@ fn test_revert() {
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Reverted 1 commits as follows:
-      nmzmmopx 9e7b8585 Revert "a"
+      nmzmmopx fc5e66c4 Revert "a"
     Rebased 2 descendant commits
-    Working copy  (@) now at: vruxwmqv b1885396 d | (empty) d
-    Parent commit (@-)      : royxmykx efc4bd83 c | (empty) c
+    Working copy  (@) now at: truxwmqv bb9e400f d | (empty) d
+    Parent commit (@-)      : ooyxmykx 5b8a9403 c | (empty) c
     Added 0 files, modified 0 files, removed 1 files
     [EOF]
     "#);
     insta::assert_snapshot!(get_log_output(&work_dir), @r#"
-    @  b18853966f79 d
-    ○  efc4bd83159f c
-    ○  9e7b85853718 Revert "a"
+    @  bb9e400fb73e d
+    ○  5b8a9403cdc5 c
+    ○  fc5e66c47827 Revert "a"
     │
-    │  This reverts commit 7d980be7a1d499e4d316ab4c01242885032f7eaf.
-    ○  58aaf278bf58 b
-    ○  7d980be7a1d4 a
+    │  This reverts commit a1afb5834d8ee4dcb61b59db0f682c7a53f96f53.
+    ○  b2f482be4c08 b
+    ○  a1afb5834d8e a
     ◆  000000000000
     [EOF]
     "#);
@@ -146,21 +146,21 @@ fn test_revert() {
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Reverted 1 commits as follows:
-      pzsxstzt d51ea564 Revert "a"
+      pzsxstzt 8c22ca4f Revert "a"
     Rebased 1 descendant commits
-    Working copy  (@) now at: vruxwmqv 5c5d60a6 d | (empty) d
-    Parent commit (@-)      : pzsxstzt d51ea564 Revert "a"
+    Working copy  (@) now at: truxwmqv 309be317 d | (empty) d
+    Parent commit (@-)      : pzsxstzt 8c22ca4f Revert "a"
     Added 0 files, modified 0 files, removed 1 files
     [EOF]
     "#);
     insta::assert_snapshot!(get_log_output(&work_dir), @r#"
-    @  5c5d60a69afd d
-    ○  d51ea56444ce Revert "a"
+    @  309be317775a d
+    ○  8c22ca4f224e Revert "a"
     │
-    │  This reverts commit 7d980be7a1d499e4d316ab4c01242885032f7eaf.
-    ○  96ff42270bbc c
-    ○  58aaf278bf58 b
-    ○  7d980be7a1d4 a
+    │  This reverts commit a1afb5834d8ee4dcb61b59db0f682c7a53f96f53.
+    ○  3ba70189111d c
+    ○  b2f482be4c08 b
+    ○  a1afb5834d8e a
     ◆  000000000000
     [EOF]
     "#);
@@ -176,24 +176,24 @@ fn test_revert() {
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Reverted 1 commits as follows:
-      oupztwtk d311a8f0 Revert "a"
+      oupztwtk d3f03fa4 Revert "a"
     Rebased 1 descendant commits
-    Working copy  (@) now at: vruxwmqv 5b97d572 d | (empty) d
-    Parent commit (@-)      : royxmykx 96ff4227 c | (empty) c
-    Parent commit (@-)      : oupztwtk d311a8f0 Revert "a"
+    Working copy  (@) now at: truxwmqv 9347ae05 d | (empty) d
+    Parent commit (@-)      : ooyxmykx 3ba70189 c | (empty) c
+    Parent commit (@-)      : oupztwtk d3f03fa4 Revert "a"
     Added 0 files, modified 0 files, removed 1 files
     [EOF]
     "#);
     insta::assert_snapshot!(get_log_output(&work_dir), @r#"
-    @    5b97d572e457 d
+    @    9347ae05d47e d
     ├─╮
-    │ ○  d311a8f0c13f Revert "a"
+    │ ○  d3f03fa45cfa Revert "a"
     │ │
-    │ │  This reverts commit 7d980be7a1d499e4d316ab4c01242885032f7eaf.
-    ○ │  96ff42270bbc c
-    ○ │  58aaf278bf58 b
+    │ │  This reverts commit a1afb5834d8ee4dcb61b59db0f682c7a53f96f53.
+    ○ │  3ba70189111d c
+    ○ │  b2f482be4c08 b
     ├─╯
-    ○  7d980be7a1d4 a
+    ○  a1afb5834d8e a
     ◆  000000000000
     [EOF]
     "#);
@@ -227,11 +227,11 @@ fn test_revert_multiple() {
 
     // Test the setup
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  51a01d6d8cc4 e
-    ○  4b9d123d3b33 d
-    ○  05e1f540476f c
-    ○  f93a910dbdf0 b
-    ○  7d980be7a1d4 a
+    @  cf24eb81f036 e
+    ○  73a51527a9fe d
+    ○  38264d21e3d7 c
+    ○  0b942411d277 b
+    ○  a1afb5834d8e a
     ◆  000000000000
     [EOF]
     ");
@@ -241,40 +241,40 @@ fn test_revert_multiple() {
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Reverted 3 commits as follows:
-      wqnwkozp 4329cf72 Revert "e"
-      mouksmqu 092f722e Revert "c"
-      tqvpomtp c90eef02 Revert "b"
+      wqnwkozp a6081eb6 Revert "e"
+      mouksmqu 51cda3bf Revert "c"
+      tqvpomtp a468f0ad Revert "b"
     [EOF]
     "#);
     insta::assert_snapshot!(get_log_output(&work_dir), @r#"
-    ○  c90eef022369 Revert "b"
+    ○  a468f0ad978e Revert "b"
     │
-    │  This reverts commit f93a910dbdf0f841e6cf2bc0ab0ba4c336d6f436.
-    ○  092f722e521f Revert "c"
+    │  This reverts commit 0b942411d277054caabbaf1e9dc62f368d73bb66.
+    ○  51cda3bfcc54 Revert "c"
     │
-    │  This reverts commit 05e1f540476f8c4207ff44febbe2ce6e6696dc4b.
-    ○  4329cf7230d7 Revert "e"
+    │  This reverts commit 38264d21e3d79a70e31740bd1cd21201c4d6281f.
+    ○  a6081eb6a3ab Revert "e"
     │
-    │  This reverts commit 51a01d6d8cc48a296cb87f8383b34ade3c050363.
-    @  51a01d6d8cc4 e
-    ○  4b9d123d3b33 d
-    ○  05e1f540476f c
-    ○  f93a910dbdf0 b
-    ○  7d980be7a1d4 a
+    │  This reverts commit cf24eb81f036ebed82802cd38b4ad9189208fa6a.
+    @  cf24eb81f036 e
+    ○  73a51527a9fe d
+    ○  38264d21e3d7 c
+    ○  0b942411d277 b
+    ○  a1afb5834d8e a
     ◆  000000000000
     [EOF]
     "#);
     // View the output of each reverted commit
     let output = work_dir.run_jj(["show", "@+"]);
     insta::assert_snapshot!(output, @r#"
-    Commit ID: 4329cf7230d7b8229e9c88087cfa2f8aa13a1317
+    Commit ID: a6081eb6a3abffb261f2f8eb6a700e34068a0ed8
     Change ID: wqnwkozpkustnxypnnntnykwrqrkrpvv
     Author   : Test User <test.user@example.com> (2001-02-03 08:05:19)
     Committer: Test User <test.user@example.com> (2001-02-03 08:05:19)
 
         Revert "e"
 
-        This reverts commit 51a01d6d8cc48a296cb87f8383b34ade3c050363.
+        This reverts commit cf24eb81f036ebed82802cd38b4ad9189208fa6a.
 
     Modified regular file a:
        1    1: a
@@ -284,14 +284,14 @@ fn test_revert_multiple() {
     "#);
     let output = work_dir.run_jj(["show", "@++"]);
     insta::assert_snapshot!(output, @r#"
-    Commit ID: 092f722e521fe49fde5a3830568fe1c51b8f2f5f
+    Commit ID: 51cda3bfcc541a752f9001aac1ef15d33dc95f8d
     Change ID: mouksmquosnpvwqrpsvvxtxpywpnxlss
     Author   : Test User <test.user@example.com> (2001-02-03 08:05:19)
     Committer: Test User <test.user@example.com> (2001-02-03 08:05:19)
 
         Revert "c"
 
-        This reverts commit 05e1f540476f8c4207ff44febbe2ce6e6696dc4b.
+        This reverts commit 38264d21e3d79a70e31740bd1cd21201c4d6281f.
 
     Removed regular file b:
        1     : b
@@ -299,14 +299,14 @@ fn test_revert_multiple() {
     "#);
     let output = work_dir.run_jj(["show", "@+++"]);
     insta::assert_snapshot!(output, @r#"
-    Commit ID: c90eef022369d43d5eae8303101b5889b4b73963
+    Commit ID: a468f0ad978eee5b2ae0c73f23c82c9480c0bce7
     Change ID: tqvpomtpwrqsylrpsxknultrymmqxmxv
     Author   : Test User <test.user@example.com> (2001-02-03 08:05:19)
     Committer: Test User <test.user@example.com> (2001-02-03 08:05:19)
 
         Revert "b"
 
-        This reverts commit f93a910dbdf0f841e6cf2bc0ab0ba4c336d6f436.
+        This reverts commit 0b942411d277054caabbaf1e9dc62f368d73bb66.
 
     Modified regular file a:
        1    1: a
@@ -336,7 +336,7 @@ fn test_revert_description_template() {
 
     // Test the setup
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  7d980be7a1d4 a
+    @  a1afb5834d8e a
     ◆  000000000000
     [EOF]
     ");
@@ -351,12 +351,12 @@ fn test_revert_description_template() {
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Reverted 1 commits as follows:
-      royxmykx 6bfb98a3 Revert commit 7d980be7a1d4 "a"
+      royxmykx 2fbadb7a Revert commit a1afb5834d8e "a"
     [EOF]
     "#);
     insta::assert_snapshot!(get_log_output(&work_dir), @r#"
-    ○  6bfb98a33f58 Revert commit 7d980be7a1d4 "a"
-    @  7d980be7a1d4 a
+    ○  2fbadb7a5a37 Revert commit a1afb5834d8e "a"
+    @  a1afb5834d8e a
     ◆  000000000000
     [EOF]
     "#);
@@ -374,9 +374,9 @@ fn test_revert_with_conflict() {
 
     // Test the setup
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  48b910edc43e c
-    ○  f93a910dbdf0 b
-    ○  7d980be7a1d4 a
+    @  3def7730ce49 c
+    ○  0b942411d277 b
+    ○  a1afb5834d8e a
     ◆  000000000000
     [EOF]
     ");
@@ -386,9 +386,9 @@ fn test_revert_with_conflict() {
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Reverted 1 commits as follows:
-      yostqsxw eadfde9a (conflict) Revert "b"
+      yostqsxw db4fbaf3 (conflict) Revert "b"
     New conflicts appeared in 1 commits:
-      yostqsxw eadfde9a (conflict) Revert "b"
+      yostqsxw db4fbaf3 (conflict) Revert "b"
     Hint: To resolve the conflicts, start by creating a commit on top of
     the conflicted commit:
       jj new yostqsxw
@@ -398,12 +398,12 @@ fn test_revert_with_conflict() {
     [EOF]
     "#);
     insta::assert_snapshot!(get_log_output(&work_dir), @r#"
-    ×  eadfde9a48f3 Revert "b"
+    ×  db4fbaf3663c Revert "b"
     │
-    │  This reverts commit f93a910dbdf0f841e6cf2bc0ab0ba4c336d6f436.
-    @  48b910edc43e c
-    ○  f93a910dbdf0 b
-    ○  7d980be7a1d4 a
+    │  This reverts commit 0b942411d277054caabbaf1e9dc62f368d73bb66.
+    @  3def7730ce49 c
+    ○  0b942411d277 b
+    ○  a1afb5834d8e a
     ◆  000000000000
     [EOF]
     "#);
@@ -412,11 +412,11 @@ fn test_revert_with_conflict() {
     insta::assert_snapshot!(output, @r#"
     a
     <<<<<<< conflict 1 of 1
-    %%%%%%% diff from: zsuskuln f93a910d "b" (reverted revision)
-    \\\\\\\        to: royxmykx 48b910ed "c" (revert destination)
+    %%%%%%% diff from: psuskuln 0b942411 "b" (reverted revision)
+    \\\\\\\        to: ooyxmykx 3def7730 "c" (revert destination)
      b
     +c
-    +++++++ rlvkpnrz 7d980be7 "a" (parents of reverted revision)
+    +++++++ ylvkpnrz a1afb583 "a" (parents of reverted revision)
     >>>>>>> conflict 1 of 1 ends
     [EOF]
     "#);

--- a/cli/tests/test_revset_output.rs
+++ b/cli/tests/test_revset_output.rs
@@ -965,7 +965,7 @@ fn test_user_trunk_absent_or_conflicted() {
     Warning: Failed to resolve `revset-aliases.trunk()`: Revision `main` doesn't exist
     The `trunk()` alias is temporarily set to `root()`.
     Hint: Use `jj config edit --repo` to adjust the `trunk()` alias.
-    Created 1 bookmarks pointing to rlvkpnrz 095dbd02 main | (empty) A
+    Created 1 bookmarks pointing to ylvkpnrz fca1427e main | (empty) A
     [EOF]
     ");
 
@@ -974,9 +974,9 @@ fn test_user_trunk_absent_or_conflicted() {
     insta::assert_snapshot!(output, @"
     @  qpvuntsm test.user@example.com 2001-02-03 08:05:07 e8849ae1
     │  (empty) (no description set)
-    │ ○  kkmpptxz test.user@example.com 2001-02-03 08:05:09 e3ebbfd5
+    │ ○  nkmpptxz test.user@example.com 2001-02-03 08:05:09 5405bc83
     ├─╯  (empty) B
-    │ ◆  rlvkpnrz test.user@example.com 2001-02-03 08:05:08 main 095dbd02
+    │ ◆  ylvkpnrz test.user@example.com 2001-02-03 08:05:08 main fca1427e
     ├─╯  (empty) A
     ◆  zzzzzzzz root() 00000000
     [EOF]
@@ -989,7 +989,7 @@ fn test_user_trunk_absent_or_conflicted() {
     Warning: Failed to resolve `revset-aliases.trunk()`: Revision `main` doesn't exist
     The `trunk()` alias is temporarily set to `root()`.
     Hint: Use `jj config edit --repo` to adjust the `trunk()` alias.
-    Created 1 bookmarks pointing to kkmpptxz e3ebbfd5 main | (empty) B
+    Created 1 bookmarks pointing to nkmpptxz 5405bc83 main | (empty) B
     [EOF]
     ");
 
@@ -998,9 +998,9 @@ fn test_user_trunk_absent_or_conflicted() {
     insta::assert_snapshot!(output, @"
     @  qpvuntsm test.user@example.com 2001-02-03 08:05:07 e8849ae1
     │  (empty) (no description set)
-    │ ○  kkmpptxz test.user@example.com 2001-02-03 08:05:09 main?? e3ebbfd5
+    │ ○  nkmpptxz test.user@example.com 2001-02-03 08:05:09 main?? 5405bc83
     ├─╯  (empty) B
-    │ ○  rlvkpnrz test.user@example.com 2001-02-03 08:05:08 main?? 095dbd02
+    │ ○  ylvkpnrz test.user@example.com 2001-02-03 08:05:08 main?? fca1427e
     ├─╯  (empty) A
     ◆  zzzzzzzz root() 00000000
     [EOF]

--- a/cli/tests/test_show_command.rs
+++ b/cli/tests/test_show_command.rs
@@ -89,8 +89,8 @@ fn test_show_basic() {
 
     let output = work_dir.run_jj(["show"]);
     insta::assert_snapshot!(output, @"
-    Commit ID: 92e687faa4e5b681937f5a9c47feaa33e6b4892c
-    Change ID: rlvkpnrzqnoowoytxnquwvuryrwnrmlp
+    Commit ID: f6e1748b258ddd40af6a6c67dc1a770432004b06
+    Change ID: ylvkpnrzqnoowoytxnquwvuryrwnrmlp
     Author   : Test User <test.user@example.com> (2001-02-03 08:05:09)
     Committer: Test User <test.user@example.com> (2001-02-03 08:05:09)
 
@@ -107,8 +107,8 @@ fn test_show_basic() {
 
     let output = work_dir.run_jj(["show", "--context=0"]);
     insta::assert_snapshot!(output, @"
-    Commit ID: 92e687faa4e5b681937f5a9c47feaa33e6b4892c
-    Change ID: rlvkpnrzqnoowoytxnquwvuryrwnrmlp
+    Commit ID: f6e1748b258ddd40af6a6c67dc1a770432004b06
+    Change ID: ylvkpnrzqnoowoytxnquwvuryrwnrmlp
     Author   : Test User <test.user@example.com> (2001-02-03 08:05:09)
     Committer: Test User <test.user@example.com> (2001-02-03 08:05:09)
 
@@ -125,8 +125,8 @@ fn test_show_basic() {
 
     let output = work_dir.run_jj(["show", "--color=debug"]);
     insta::assert_snapshot!(output, @"
-    <<show commit::Commit ID: >>[38;5;4m<<show commit commit_id::92e687faa4e5b681937f5a9c47feaa33e6b4892c>>[39m<<show commit::>>
-    <<show commit::Change ID: >>[38;5;5m<<show commit change_id::rlvkpnrzqnoowoytxnquwvuryrwnrmlp>>[39m<<show commit::>>
+    <<show commit::Commit ID: >>[38;5;4m<<show commit commit_id::f6e1748b258ddd40af6a6c67dc1a770432004b06>>[39m<<show commit::>>
+    <<show commit::Change ID: >>[38;5;5m<<show commit change_id::ylvkpnrzqnoowoytxnquwvuryrwnrmlp>>[39m<<show commit::>>
     <<show commit::Author   : >>[38;5;3m<<show commit author name::Test User>>[39m<<show commit:: <>>[38;5;3m<<show commit author email local::test.user>><<show commit author email::@>><<show commit author email domain::example.com>>[39m<<show commit::> (>>[38;5;6m<<show commit author timestamp local format::2001-02-03 08:05:09>>[39m<<show commit::)>>
     <<show commit::Committer: >>[38;5;3m<<show commit committer name::Test User>>[39m<<show commit:: <>>[38;5;3m<<show commit committer email local::test.user>><<show commit committer email::@>><<show commit committer email domain::example.com>>[39m<<show commit::> (>>[38;5;6m<<show commit committer timestamp local format::2001-02-03 08:05:09>>[39m<<show commit::)>>
     <<show commit::>>
@@ -142,8 +142,8 @@ fn test_show_basic() {
 
     let output = work_dir.run_jj(["show", "-s"]);
     insta::assert_snapshot!(output, @"
-    Commit ID: 92e687faa4e5b681937f5a9c47feaa33e6b4892c
-    Change ID: rlvkpnrzqnoowoytxnquwvuryrwnrmlp
+    Commit ID: f6e1748b258ddd40af6a6c67dc1a770432004b06
+    Change ID: ylvkpnrzqnoowoytxnquwvuryrwnrmlp
     Author   : Test User <test.user@example.com> (2001-02-03 08:05:09)
     Committer: Test User <test.user@example.com> (2001-02-03 08:05:09)
 
@@ -156,8 +156,8 @@ fn test_show_basic() {
 
     let output = work_dir.run_jj(["show", "--types"]);
     insta::assert_snapshot!(output, @"
-    Commit ID: 92e687faa4e5b681937f5a9c47feaa33e6b4892c
-    Change ID: rlvkpnrzqnoowoytxnquwvuryrwnrmlp
+    Commit ID: f6e1748b258ddd40af6a6c67dc1a770432004b06
+    Change ID: ylvkpnrzqnoowoytxnquwvuryrwnrmlp
     Author   : Test User <test.user@example.com> (2001-02-03 08:05:09)
     Committer: Test User <test.user@example.com> (2001-02-03 08:05:09)
 
@@ -170,8 +170,8 @@ fn test_show_basic() {
 
     let output = work_dir.run_jj(["show", "--git"]);
     insta::assert_snapshot!(output, @"
-    Commit ID: 92e687faa4e5b681937f5a9c47feaa33e6b4892c
-    Change ID: rlvkpnrzqnoowoytxnquwvuryrwnrmlp
+    Commit ID: f6e1748b258ddd40af6a6c67dc1a770432004b06
+    Change ID: ylvkpnrzqnoowoytxnquwvuryrwnrmlp
     Author   : Test User <test.user@example.com> (2001-02-03 08:05:09)
     Committer: Test User <test.user@example.com> (2001-02-03 08:05:09)
 
@@ -194,8 +194,8 @@ fn test_show_basic() {
 
     let output = work_dir.run_jj(["show", "--git", "--context=0"]);
     insta::assert_snapshot!(output, @"
-    Commit ID: 92e687faa4e5b681937f5a9c47feaa33e6b4892c
-    Change ID: rlvkpnrzqnoowoytxnquwvuryrwnrmlp
+    Commit ID: f6e1748b258ddd40af6a6c67dc1a770432004b06
+    Change ID: ylvkpnrzqnoowoytxnquwvuryrwnrmlp
     Author   : Test User <test.user@example.com> (2001-02-03 08:05:09)
     Committer: Test User <test.user@example.com> (2001-02-03 08:05:09)
 
@@ -217,8 +217,8 @@ fn test_show_basic() {
 
     let output = work_dir.run_jj(["show", "--git", "--color=debug"]);
     insta::assert_snapshot!(output, @"
-    <<show commit::Commit ID: >>[38;5;4m<<show commit commit_id::92e687faa4e5b681937f5a9c47feaa33e6b4892c>>[39m<<show commit::>>
-    <<show commit::Change ID: >>[38;5;5m<<show commit change_id::rlvkpnrzqnoowoytxnquwvuryrwnrmlp>>[39m<<show commit::>>
+    <<show commit::Commit ID: >>[38;5;4m<<show commit commit_id::f6e1748b258ddd40af6a6c67dc1a770432004b06>>[39m<<show commit::>>
+    <<show commit::Change ID: >>[38;5;5m<<show commit change_id::ylvkpnrzqnoowoytxnquwvuryrwnrmlp>>[39m<<show commit::>>
     <<show commit::Author   : >>[38;5;3m<<show commit author name::Test User>>[39m<<show commit:: <>>[38;5;3m<<show commit author email local::test.user>><<show commit author email::@>><<show commit author email domain::example.com>>[39m<<show commit::> (>>[38;5;6m<<show commit author timestamp local format::2001-02-03 08:05:09>>[39m<<show commit::)>>
     <<show commit::Committer: >>[38;5;3m<<show commit committer name::Test User>>[39m<<show commit:: <>>[38;5;3m<<show commit committer email local::test.user>><<show commit committer email::@>><<show commit committer email domain::example.com>>[39m<<show commit::> (>>[38;5;6m<<show commit committer timestamp local format::2001-02-03 08:05:09>>[39m<<show commit::)>>
     <<show commit::>>
@@ -241,8 +241,8 @@ fn test_show_basic() {
 
     let output = work_dir.run_jj(["show", "-s", "--git"]);
     insta::assert_snapshot!(output, @"
-    Commit ID: 92e687faa4e5b681937f5a9c47feaa33e6b4892c
-    Change ID: rlvkpnrzqnoowoytxnquwvuryrwnrmlp
+    Commit ID: f6e1748b258ddd40af6a6c67dc1a770432004b06
+    Change ID: ylvkpnrzqnoowoytxnquwvuryrwnrmlp
     Author   : Test User <test.user@example.com> (2001-02-03 08:05:09)
     Committer: Test User <test.user@example.com> (2001-02-03 08:05:09)
 
@@ -267,8 +267,8 @@ fn test_show_basic() {
 
     let output = work_dir.run_jj(["show", "--stat"]);
     insta::assert_snapshot!(output, @"
-    Commit ID: 92e687faa4e5b681937f5a9c47feaa33e6b4892c
-    Change ID: rlvkpnrzqnoowoytxnquwvuryrwnrmlp
+    Commit ID: f6e1748b258ddd40af6a6c67dc1a770432004b06
+    Change ID: ylvkpnrzqnoowoytxnquwvuryrwnrmlp
     Author   : Test User <test.user@example.com> (2001-02-03 08:05:09)
     Committer: Test User <test.user@example.com> (2001-02-03 08:05:09)
 
@@ -323,8 +323,8 @@ fn test_show_with_no_patch() {
     let output = work_dir.run_jj(["show", "--no-patch"]);
 
     insta::assert_snapshot!(output, @"
-    Commit ID: 86d5fa72f4ecc6d51478941ee9160db9c52b842e
-    Change ID: rlvkpnrzqnoowoytxnquwvuryrwnrmlp
+    Commit ID: ffb25e8b8466ef7eadc0a4afc37ec7707e2f67e2
+    Change ID: ylvkpnrzqnoowoytxnquwvuryrwnrmlp
     Author   : Test User <test.user@example.com> (2001-02-03 08:05:08)
     Committer: Test User <test.user@example.com> (2001-02-03 08:05:09)
 

--- a/cli/tests/test_simplify_parents_command.rs
+++ b/cli/tests/test_simplify_parents_command.rs
@@ -147,8 +147,8 @@ fn test_simplify_parents_redundant_parent(args: &[&str]) {
         insta::assert_snapshot!(output, @"
         ------- stderr -------
         Removed 1 edges from 1 out of 3 commits.
-        Working copy  (@) now at: royxmykx 265f0407 c | c
-        Parent commit (@-)      : zsuskuln 123b4d91 b | b
+        Working copy  (@) now at: ooyxmykx c5640718 c | c
+        Parent commit (@-)      : psuskuln dd148a1b b | b
         [EOF]
         ");
     }
@@ -200,8 +200,8 @@ fn test_simplify_parents_multiple_redundant_parents() {
     ------- stderr -------
     Removed 2 edges from 2 out of 2 commits.
     Rebased 2 descendant commits
-    Working copy  (@) now at: kmkuslsw 5ad764e9 f | f
-    Parent commit (@-)      : znkkpsqq 9102487c e | e
+    Working copy  (@) now at: wmkuslsw 3ae1614a f | f
+    Parent commit (@-)      : nnkkpsqq 8869333d e | e
     [EOF]
     ");
 
@@ -224,8 +224,8 @@ fn test_simplify_parents_multiple_redundant_parents() {
     ------- stderr -------
     Removed 2 edges from 2 out of 4 commits.
     Rebased 2 descendant commits
-    Working copy  (@) now at: kmkuslsw 2b2c1c63 f | f
-    Parent commit (@-)      : znkkpsqq 9142e3bb e | e
+    Working copy  (@) now at: wmkuslsw 9ce6006d f | f
+    Parent commit (@-)      : nnkkpsqq 0da473f6 e | e
     [EOF]
     ");
 
@@ -276,8 +276,8 @@ fn test_simplify_parents_no_args() {
     ------- stderr -------
     Removed 2 edges from 2 out of 6 commits.
     Rebased 2 descendant commits
-    Working copy  (@) now at: kmkuslsw 5ad764e9 f | f
-    Parent commit (@-)      : znkkpsqq 9102487c e | e
+    Working copy  (@) now at: wmkuslsw 3ae1614a f | f
+    Parent commit (@-)      : nnkkpsqq 8869333d e | e
     [EOF]
     ");
 
@@ -300,8 +300,8 @@ fn test_simplify_parents_no_args() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Removed 1 edges from 1 out of 3 commits.
-    Working copy  (@) now at: kmkuslsw 1180d0f5 f | f
-    Parent commit (@-)      : znkkpsqq 009aef72 e | e
+    Working copy  (@) now at: wmkuslsw 8f8b8a90 f | f
+    Parent commit (@-)      : nnkkpsqq 4a1f9030 e | e
     [EOF]
     ");
 

--- a/cli/tests/test_split_command.rs
+++ b/cli/tests/test_split_command.rs
@@ -202,10 +202,10 @@ fn test_split_by_paths() -> TestResult {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Warning: All changes have been selected, so the original revision will become empty
-    Selected changes : uyznsvlq 971ccc0b (no description set)
-    Remaining changes: xznxytkn a267cd96 (empty) (no description set)
-    Working copy  (@) now at: smwtzssm 6715dc2c (empty) (no description set)
-    Parent commit (@-)      : uyznsvlq 971ccc0b (no description set)
+    Selected changes : wyznsvlq 00edb089 (no description set)
+    Remaining changes: xznxytkn 1586a25c (empty) (no description set)
+    Working copy  (@) now at: smwtzssm 6a201512 (empty) (no description set)
+    Parent commit (@-)      : wyznsvlq 00edb089 (no description set)
     [EOF]
     ");
     Ok(())
@@ -469,9 +469,9 @@ fn test_split_with_merge_child() -> TestResult {
         .run_jj(["new", "subject(1)", "subject(a)", "-m=2"])
         .success();
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @    zsuskulnrvyr true 2
+    @    psuskulnrvyr true 2
     ├─╮
-    │ ○  kkmpptxzrspx false a
+    │ ○  nkmpptxzrspx false a
     ○ │  qpvuntsmwlqt true 1
     ├─╯
     ◆  zzzzzzzzzzzz true
@@ -487,18 +487,18 @@ fn test_split_with_merge_child() -> TestResult {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Rebased 1 descendant commits
-    Selected changes : kkmpptxz cc199567 Add file1
-    Remaining changes: royxmykx e488409f Add file2
-    Working copy  (@) now at: zsuskuln ace61421 (empty) 2
+    Selected changes : nkmpptxz 7220d39e Add file1
+    Remaining changes: royxmykx b340d326 Add file2
+    Working copy  (@) now at: psuskuln 71f32120 (empty) 2
     Parent commit (@-)      : qpvuntsm 884fe9b9 (empty) 1
-    Parent commit (@-)      : royxmykx e488409f Add file2
+    Parent commit (@-)      : royxmykx b340d326 Add file2
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @    zsuskulnrvyr true 2
+    @    psuskulnrvyr true 2
     ├─╮
     │ ○  royxmykxtrkr false Add file2
-    │ ○  kkmpptxzrspx false Add file1
+    │ ○  nkmpptxzrspx false Add file1
     ○ │  qpvuntsmwlqt true 1
     ├─╯
     ◆  zzzzzzzzzzzz true
@@ -712,9 +712,9 @@ fn test_split_parallel_with_merge_child() -> TestResult {
         .run_jj(["new", "subject(1)", "subject(a)", "-m=2"])
         .success();
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @    zsuskulnrvyr true 2
+    @    psuskulnrvyr true 2
     ├─╮
-    │ ○  kkmpptxzrspx false a
+    │ ○  nkmpptxzrspx false a
     ○ │  qpvuntsmwlqt true 1
     ├─╯
     ◆  zzzzzzzzzzzz true
@@ -730,19 +730,19 @@ fn test_split_parallel_with_merge_child() -> TestResult {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Rebased 1 descendant commits
-    Selected changes : kkmpptxz cc199567 Add file1
+    Selected changes : nkmpptxz 7220d39e Add file1
     Remaining changes: royxmykx 82a5c527 Add file2
-    Working copy  (@) now at: zsuskuln b7cdcdec (empty) 2
+    Working copy  (@) now at: psuskuln 8466ccec (empty) 2
     Parent commit (@-)      : qpvuntsm 884fe9b9 (empty) 1
-    Parent commit (@-)      : kkmpptxz cc199567 Add file1
+    Parent commit (@-)      : nkmpptxz 7220d39e Add file1
     Parent commit (@-)      : royxmykx 82a5c527 Add file2
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @      zsuskulnrvyr true 2
+    @      psuskulnrvyr true 2
     ├─┬─╮
     │ │ ○  royxmykxtrkr false Add file2
-    │ ○ │  kkmpptxzrspx false Add file1
+    │ ○ │  nkmpptxzrspx false Add file1
     │ ├─╯
     ○ │  qpvuntsmwlqt true 1
     ├─╯
@@ -766,8 +766,8 @@ fn test_split_parallel_with_conflict() -> TestResult {
     work_dir.write_file("file", "line 1\nline 3\n");
     work_dir.run_jj(["prev", "--edit"]).success();
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    ○  kkmpptxzrspx false
-    @  rlvkpnrzqnoo false
+    ○  nkmpptxzrspx false
+    @  ylvkpnrzqnoo false
     ○  qpvuntsmwlqt false
     ◆  zzzzzzzzzzzz true
     [EOF]
@@ -782,15 +782,15 @@ fn test_split_parallel_with_conflict() -> TestResult {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Rebased 1 descendant commits
-    Selected changes : rlvkpnrz abe15fea (no description set)
-    Remaining changes: royxmykx 4bbc5826 (conflict) (no description set)
-    Working copy  (@) now at: royxmykx 4bbc5826 (conflict) (no description set)
+    Selected changes : ylvkpnrz 6e8f31ba (no description set)
+    Remaining changes: royxmykx ebc03619 (conflict) (no description set)
+    Working copy  (@) now at: royxmykx ebc03619 (conflict) (no description set)
     Parent commit (@-)      : qpvuntsm ee8e9376 (no description set)
     Added 0 files, modified 1 files, removed 0 files
     Warning: There are unresolved conflicts at these paths:
     file    2-sided conflict
     New conflicts appeared in 1 commits:
-      royxmykx 4bbc5826 (conflict) (no description set)
+      royxmykx ebc03619 (conflict) (no description set)
     Hint: To resolve the conflicts, start by creating a commit on top of
     the conflicted commit:
       jj new royxmykx
@@ -800,10 +800,10 @@ fn test_split_parallel_with_conflict() -> TestResult {
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    ○    kkmpptxzrspx false
+    ○    nkmpptxzrspx false
     ├─╮
     │ @  royxmykxtrkr false
-    ○ │  rlvkpnrzqnoo false
+    ○ │  ylvkpnrzqnoo false
     ├─╯
     ○  qpvuntsmwlqt false
     ◆  zzzzzzzzzzzz true
@@ -814,8 +814,8 @@ fn test_split_parallel_with_conflict() -> TestResult {
     insta::assert_snapshot!(work_dir.read_file("file"), @r"
     line 1
     <<<<<<< conflict 1 of 1
-    %%%%%%% diff from: selected changes for split (from rlvkpnrz 35382813)
-    \\\\\\\        to: split revision (rlvkpnrz 35382813)
+    %%%%%%% diff from: selected changes for split (from ylvkpnrz 81ae5d1f)
+    \\\\\\\        to: split revision (ylvkpnrz 81ae5d1f)
      line 2.1
     +line 2.2
     +++++++ qpvuntsm ee8e9376 (parents of split revision)
@@ -997,10 +997,10 @@ fn test_split_interactive_with_paths() -> TestResult {
     let output = work_dir.run_jj(["split", "-i", "file1", "file2"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Selected changes : rlvkpnrz cdc9960a (no description set)
-    Remaining changes: kkmpptxz 7255f070 (no description set)
-    Working copy  (@) now at: kkmpptxz 7255f070 (no description set)
-    Parent commit (@-)      : rlvkpnrz cdc9960a (no description set)
+    Selected changes : ylvkpnrz d4e0b1c4 (no description set)
+    Remaining changes: kkmpptxz 2294686f (no description set)
+    Working copy  (@) now at: kkmpptxz 2294686f (no description set)
+    Parent commit (@-)      : ylvkpnrz d4e0b1c4 (no description set)
     [EOF]
     ");
 
@@ -1009,7 +1009,7 @@ fn test_split_interactive_with_paths() -> TestResult {
     JJ: Enter a description for the selected changes.
 
 
-    JJ: Change ID: rlvkpnrz
+    JJ: Change ID: ylvkpnrz
     JJ: This commit contains the following changes:
     JJ:     A file1
     JJ:
@@ -1018,11 +1018,11 @@ fn test_split_interactive_with_paths() -> TestResult {
 
     let output = work_dir.run_jj(["log", "--summary"]);
     insta::assert_snapshot!(output, @"
-    @  kkmpptxz test.user@example.com 2001-02-03 08:05:09 7255f070
+    @  kkmpptxz test.user@example.com 2001-02-03 08:05:09 2294686f
     │  (no description set)
     │  M file2
     │  M file3
-    ○  rlvkpnrz test.user@example.com 2001-02-03 08:05:09 cdc9960a
+    ○  ylvkpnrz test.user@example.com 2001-02-03 08:05:09 d4e0b1c4
     │  (no description set)
     │  A file1
     ○  qpvuntsm test.user@example.com 2001-02-03 08:05:08 ff687a2f
@@ -1312,7 +1312,7 @@ fn test_split_move_first_commit() -> TestResult {
 
     insta::assert_snapshot!(get_log_with_summary(&work_dir), @"
     @  royxmykxtrkr
-    ○  mzvwutvlkqwt file5
+    ○  pzvwutvlkqwt file5
     │  A file5
     │ ○  kkmpptxzrspx file4
     │ │  A file4
@@ -1347,7 +1347,7 @@ fn test_split_move_first_commit() -> TestResult {
 
     insta::assert_snapshot!(get_log_with_summary(&work_dir), @"
     @  royxmykxtrkr
-    ○  mzvwutvlkqwt file5
+    ○  pzvwutvlkqwt file5
     │  A file5
     │ ○  kkmpptxzrspx file4
     │ │  A file4
@@ -1383,7 +1383,7 @@ fn test_split_move_first_commit() -> TestResult {
 
     insta::assert_snapshot!(get_log_with_summary(&work_dir), @"
     @  royxmykxtrkr
-    ○  mzvwutvlkqwt file5
+    ○  pzvwutvlkqwt file5
     │  A file5
     │ ○  kkmpptxzrspx file4
     │ │  A file4
@@ -1419,7 +1419,7 @@ fn test_split_move_first_commit() -> TestResult {
 
     insta::assert_snapshot!(get_log_with_summary(&work_dir), @"
     @  royxmykxtrkr
-    ○  mzvwutvlkqwt file5
+    ○  pzvwutvlkqwt file5
     │  A file5
     │ ○  kkmpptxzrspx file4
     │ │  A file4
@@ -1457,7 +1457,7 @@ fn test_split_move_first_commit() -> TestResult {
 
     insta::assert_snapshot!(get_log_with_summary(&work_dir), @"
     @  royxmykxtrkr
-    ○  mzvwutvlkqwt file5
+    ○  pzvwutvlkqwt file5
     │  A file5
     │ ○    kkmpptxzrspx file4
     │ ├─╮  A file4
@@ -1486,10 +1486,10 @@ fn test_split_move_first_commit() -> TestResult {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Rebased 3 descendant commits
-    Selected changes : nmzmmopx 72225233 file1
+    Selected changes : nmzmmopx 051042c8 file1
     Remaining changes: qpvuntsm 98b70782 file2
-    Working copy  (@) now at: royxmykx c3dd10b0 (empty) (no description set)
-    Parent commit (@-)      : nmzmmopx 72225233 file1
+    Working copy  (@) now at: royxmykx 0dc866c6 (empty) (no description set)
+    Parent commit (@-)      : nmzmmopx 051042c8 file1
     Added 1 files, modified 0 files, removed 0 files
     [EOF]
     ");
@@ -1498,7 +1498,7 @@ fn test_split_move_first_commit() -> TestResult {
     @  royxmykxtrkr
     ○  nmzmmopxokps file1
     │  A file1
-    ○  mzvwutvlkqwt file5
+    ○  pzvwutvlkqwt file5
     │  A file5
     │ ○  kkmpptxzrspx file4
     │ │  A file4
@@ -1519,7 +1519,7 @@ fn test_split_move_first_commit() -> TestResult {
         "-r",
         "qpvuntsmwlqt",
         "--after",
-        "mzvwutvlkqwt",
+        "pzvwutvlkqwt",
         "--after",
         "kkmpptxzrspx",
         "file1",
@@ -1527,10 +1527,10 @@ fn test_split_move_first_commit() -> TestResult {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Rebased 3 descendant commits
-    Selected changes : nlrtlrxv 1b6975b0 file1
+    Selected changes : nlrtlrxv bf4bce56 file1
     Remaining changes: qpvuntsm 905586dd file2
-    Working copy  (@) now at: royxmykx 85be9860 (empty) (no description set)
-    Parent commit (@-)      : nlrtlrxv 1b6975b0 file1
+    Working copy  (@) now at: royxmykx b7151d84 (empty) (no description set)
+    Parent commit (@-)      : nlrtlrxv bf4bce56 file1
     Added 4 files, modified 0 files, removed 0 files
     [EOF]
     ");
@@ -1545,7 +1545,7 @@ fn test_split_move_first_commit() -> TestResult {
     │ │  A file3
     │ ○  qpvuntsmwlqt file2
     │ │  A file2
-    ○ │  mzvwutvlkqwt file5
+    ○ │  pzvwutvlkqwt file5
     ├─╯  A file5
     ◆  zzzzzzzzzzzz
     [EOF]

--- a/cli/tests/test_squash_command.rs
+++ b/cli/tests/test_squash_command.rs
@@ -42,8 +42,8 @@ fn test_squash() {
     work_dir.write_file("file1", "c\n");
     // Test the setup
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  22be6c4e01da c
-    ○  75591b1896b4 b
+    @  1cc10709fbc0 c
+    ○  099a44efcab4 b
     ○  e6086990958c a
     ◆  000000000000 (empty)
     [EOF]
@@ -54,13 +54,13 @@ fn test_squash() {
     let output = work_dir.run_jj(["squash"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: vruxwmqv 2cf02eb8 (empty) (no description set)
-    Parent commit (@-)      : kkmpptxz 9422c8d6 b c | (no description set)
+    Working copy  (@) now at: vruxwmqv 48829820 (empty) (no description set)
+    Parent commit (@-)      : nkmpptxz 818fe366 b c | (no description set)
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  2cf02eb82d82 (empty)
-    ○  9422c8d6f294 b c
+    @  48829820e303 (empty)
+    ○  818fe3660cdf b c
     ○  e6086990958c a
     ◆  000000000000 (empty)
     [EOF]
@@ -77,12 +77,12 @@ fn test_squash() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Rebased 1 descendant commits
-    Working copy  (@) now at: mzvwutvl 441a7a3a c | (no description set)
+    Working copy  (@) now at: pzvwutvl 6d920b60 c | (no description set)
     Parent commit (@-)      : qpvuntsm 105931bf a b | (no description set)
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  441a7a3a17b0 c
+    @  6d920b60d0c3 c
     ○  105931bfedad a b
     ◆  000000000000 (empty)
     [EOF]
@@ -112,12 +112,12 @@ fn test_squash() {
         .run_jj(["bookmark", "create", "-r@", "e"])
         .success();
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @    e05d4caaf6ce e (empty)
+    @    85b0f46cfb80 e (empty)
     ├─╮
-    │ ○  9bb7863cfc78 d
-    ○ │  22be6c4e01da c
+    │ ○  f8340c58ec2d d
+    ○ │  1cc10709fbc0 c
     ├─╯
-    ○  75591b1896b4 b
+    ○  099a44efcab4 b
     ○  e6086990958c a
     ◆  000000000000 (empty)
     [EOF]
@@ -137,18 +137,18 @@ fn test_squash() {
     let output = work_dir.run_jj(["squash"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: xlzxqlsl 91a81249 (empty) (no description set)
-    Parent commit (@-)      : nmzmmopx 9155baf5 e | (no description set)
+    Working copy  (@) now at: xlzxqlsl 48f45181 (empty) (no description set)
+    Parent commit (@-)      : rmzmmopx e07a7b7e e | (no description set)
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  91a81249954f (empty)
-    ○    9155baf5ced1 e
+    @  48f451818309 (empty)
+    ○    e07a7b7e496d e
     ├─╮
-    │ ○  9bb7863cfc78 d
-    ○ │  22be6c4e01da c
+    │ ○  f8340c58ec2d d
+    ○ │  1cc10709fbc0 c
     ├─╯
-    ○  75591b1896b4 b
+    ○  099a44efcab4 b
     ○  e6086990958c a
     ◆  000000000000 (empty)
     [EOF]
@@ -186,8 +186,8 @@ fn test_squash_partial() -> TestResult {
     work_dir.write_file("file2", "c\n");
     // Test the setup
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  87059ac9657b c
-    ○  f2c9709f39e9 b
+    @  e385ba6aaff1 c
+    ○  39826f7cef30 b
     ○  64ea60be8d77 a
     ◆  000000000000 (empty)
     [EOF]
@@ -202,7 +202,7 @@ fn test_squash_partial() -> TestResult {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Rebased 1 descendant commits
-    Working copy  (@) now at: mzvwutvl 34484d82 c | (no description set)
+    Working copy  (@) now at: pzvwutvl d79ac05a c | (no description set)
     Parent commit (@-)      : qpvuntsm 3141e675 a b | (no description set)
     [EOF]
     ");
@@ -210,7 +210,7 @@ fn test_squash_partial() -> TestResult {
     let instrs = std::fs::read_to_string(test_env.env_root().join("instrs"))?;
     insta::assert_snapshot!(
         instrs, @"
-    You are moving changes from: kkmpptxz f2c9709f b | (no description set)
+    You are moving changes from: nkmpptxz 39826f7c b | (no description set)
     into commit: qpvuntsm 64ea60be a | (no description set)
 
     The left side of the diff shows the contents of the parent commit. The
@@ -223,7 +223,7 @@ fn test_squash_partial() -> TestResult {
     ");
 
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  34484d825f47 c
+    @  d79ac05a29d6 c
     ○  3141e67514f6 a b
     ◆  000000000000 (empty)
     [EOF]
@@ -241,13 +241,13 @@ fn test_squash_partial() -> TestResult {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Rebased 2 descendant commits
-    Working copy  (@) now at: mzvwutvl 37e1a0ef c | (no description set)
-    Parent commit (@-)      : kkmpptxz b41e789d b | (no description set)
+    Working copy  (@) now at: pzvwutvl ecd03a71 c | (no description set)
+    Parent commit (@-)      : nkmpptxz bb59a2d2 b | (no description set)
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  37e1a0ef57ff c
-    ○  b41e789df71c b
+    @  ecd03a711173 c
+    ○  bb59a2d20bab b
     ○  3af17565155e a
     ◆  000000000000 (empty)
     [EOF]
@@ -281,13 +281,13 @@ fn test_squash_partial() -> TestResult {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Rebased 2 descendant commits
-    Working copy  (@) now at: mzvwutvl 72ff256c c | (no description set)
-    Parent commit (@-)      : kkmpptxz dd056a92 b | (no description set)
+    Working copy  (@) now at: pzvwutvl 58a2bd33 c | (no description set)
+    Parent commit (@-)      : nkmpptxz a643b929 b | (no description set)
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  72ff256cd290 c
-    ○  dd056a925eb3 b
+    @  58a2bd33e7b4 c
+    ○  a643b929b068 b
     ○  cf083f1d9ccf a
     ◆  000000000000 (empty)
     [EOF]
@@ -352,17 +352,17 @@ fn test_squash_partial() -> TestResult {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Rebased 1 descendant commits
-    Working copy  (@) now at: mzvwutvl 3615d80e c | (no description set)
-    Parent commit (@-)      : kkmpptxz 037106c4 b | (no description set)
+    Working copy  (@) now at: pzvwutvl 72ef6df7 c | (no description set)
+    Parent commit (@-)      : nkmpptxz 4c315a39 b | (no description set)
     [EOF]
     ");
     let output = work_dir.run_jj(["log", "-s"]);
     insta::assert_snapshot!(output, @"
-    @  mzvwutvl test.user@example.com 2001-02-03 08:05:38 c 3615d80e
+    @  pzvwutvl test.user@example.com 2001-02-03 08:05:38 c 72ef6df7
     │  (no description set)
     │  M file1
     │  M file2
-    ○  kkmpptxz test.user@example.com 2001-02-03 08:05:38 b 037106c4
+    ○  nkmpptxz test.user@example.com 2001-02-03 08:05:38 b 4c315a39
     │  (no description set)
     │  M file1
     │  M file2
@@ -386,8 +386,8 @@ fn test_squash_partial() -> TestResult {
     [exit status: 1]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  87059ac9657b c
-    ○  f2c9709f39e9 b
+    @  e385ba6aaff1 c
+    ○  39826f7cef30 b
     ○  64ea60be8d77 a
     ◆  000000000000 (empty)
     [EOF]
@@ -418,8 +418,8 @@ fn test_squash_keep_emptied() {
     // Test the setup
 
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  22be6c4e01da c
-    ○  75591b1896b4 b
+    @  1cc10709fbc0 c
+    ○  099a44efcab4 b
     ○  e6086990958c a
     ◆  000000000000 (empty)
     [EOF]
@@ -429,14 +429,14 @@ fn test_squash_keep_emptied() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Rebased 2 descendant commits
-    Working copy  (@) now at: mzvwutvl 093590e0 c | (no description set)
-    Parent commit (@-)      : kkmpptxz 357946cf b | (empty) (no description set)
+    Working copy  (@) now at: pzvwutvl 01e25431 c | (no description set)
+    Parent commit (@-)      : nkmpptxz 0b7d47c7 b | (empty) (no description set)
     [EOF]
     ");
     // With --keep-emptied, b remains even though it is now empty.
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  093590e044bd c
-    ○  357946cf85df b (empty)
+    @  01e2543152dd c
+    ○  0b7d47c7d9a8 b (empty)
     ○  2269fb3b12f5 a
     ◆  000000000000 (empty)
     [EOF]
@@ -499,11 +499,11 @@ fn test_squash_from_to() {
     work_dir.write_file("file2", "f\n");
     // Test the setup
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  0fac1124d1ad f
-    ○  4ebe104a0e4e e
-    ○  dc71a460d5d6 d
-    │ ○  ee0b260ffc44 c
-    │ ○  e31bf988d7c9 b
+    @  c3f05ef6d541 f
+    ○  2d65a93c1fff e
+    ○  1178bb01a390 d
+    │ ○  2e0a6f0e80af c
+    │ ○  7d81fc05a211 b
     ├─╯
     ○  e3e04beaf7d3 a
     ◆  000000000000 (empty)
@@ -523,16 +523,16 @@ fn test_squash_from_to() {
     let output = work_dir.run_jj(["squash", "--from", "c"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: kmkuslsw 941ab024 f | (no description set)
-    Parent commit (@-)      : znkkpsqq 4ebe104a e | (no description set)
+    Working copy  (@) now at: xmkuslsw 4dcae49d f | (no description set)
+    Parent commit (@-)      : onkkpsqq 2d65a93c e | (no description set)
     Added 0 files, modified 1 files, removed 0 files
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  941ab024b3f8 f
-    ○  4ebe104a0e4e e
-    ○  dc71a460d5d6 d
-    │ ○  e31bf988d7c9 b c
+    @  4dcae49dd4b5 f
+    ○  2d65a93c1fff e
+    ○  1178bb01a390 d
+    │ ○  7d81fc05a211 b c
     ├─╯
     ○  e3e04beaf7d3 a
     ◆  000000000000 (empty)
@@ -556,17 +556,17 @@ fn test_squash_from_to() {
     let output = work_dir.run_jj(["squash", "--from", "@--"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: kmkuslsw c102d2c4 f | (no description set)
-    Parent commit (@-)      : znkkpsqq beb7c033 e | (no description set)
+    Working copy  (@) now at: xmkuslsw fe225f90 f | (no description set)
+    Parent commit (@-)      : onkkpsqq 8f1397ec e | (no description set)
     [EOF]
     ");
     // The change has been removed from the source (the change pointed to by 'd'
     // became empty and was abandoned)
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  c102d2c4e165 f
-    ○  beb7c0338f7c e
-    │ ○  ee0b260ffc44 c
-    │ ○  e31bf988d7c9 b
+    @  fe225f90bb8e f
+    ○  8f1397ec3c64 e
+    │ ○  2e0a6f0e80af c
+    │ ○  7d81fc05a211 b
     ├─╯
     ○  e3e04beaf7d3 a d
     ◆  000000000000 (empty)
@@ -586,17 +586,17 @@ fn test_squash_from_to() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Rebased 1 descendant commits
-    Working copy  (@) now at: kmkuslsw 1bc21d4e f | (no description set)
-    Parent commit (@-)      : vruxwmqv 8b6b080a d e | (no description set)
+    Working copy  (@) now at: xmkuslsw d9c58db7 f | (no description set)
+    Parent commit (@-)      : uruxwmqv 28db7434 d e | (no description set)
     [EOF]
     ");
     // The change has been removed from the source (the change pointed to by 'e'
     // became empty and was abandoned)
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  1bc21d4e92d6 f
-    ○  8b6b080ab587 d e
-    │ ○  ee0b260ffc44 c
-    │ ○  e31bf988d7c9 b
+    @  d9c58db7d356 f
+    ○  28db743473ba d e
+    │ ○  2e0a6f0e80af c
+    │ ○  7d81fc05a211 b
     ├─╯
     ○  e3e04beaf7d3 a
     ◆  000000000000 (empty)
@@ -614,17 +614,17 @@ fn test_squash_from_to() {
     let output = work_dir.run_jj(["squash", "--from", "e::f", "--into", "d"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: pkstwlsy 76baa567 (empty) (no description set)
-    Parent commit (@-)      : vruxwmqv 415e4069 d e f | (no description set)
+    Working copy  (@) now at: pkstwlsy d9f582e2 (empty) (no description set)
+    Parent commit (@-)      : uruxwmqv 09d81031 d e f | (no description set)
     [EOF]
     ");
     // The change has been removed from the source (the change pointed to by 'e'
     // became empty and was abandoned)
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  76baa567ed0a (empty)
-    ○  415e40694e88 d e f
-    │ ○  ee0b260ffc44 c
-    │ ○  e31bf988d7c9 b
+    @  d9f582e2ae5a (empty)
+    ○  09d810311cd0 d e f
+    │ ○  2e0a6f0e80af c
+    │ ○  7d81fc05a211 b
     ├─╯
     ○  e3e04beaf7d3 a
     ◆  000000000000 (empty)
@@ -676,9 +676,9 @@ fn test_squash_from_to_partial() -> TestResult {
     work_dir.write_file("file3", "d\n");
     // Test the setup
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  dc71a460d5d6 d
-    │ ○  499d601f6046 c
-    │ ○  e31bf988d7c9 b
+    @  1178bb01a390 d
+    │ ○  b602c842be32 c
+    │ ○  7d81fc05a211 b
     ├─╯
     ○  e3e04beaf7d3 a
     ◆  000000000000 (empty)
@@ -690,14 +690,14 @@ fn test_squash_from_to_partial() -> TestResult {
     let output = work_dir.run_jj(["squash", "-i", "--from", "c"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: vruxwmqv 85589465 d | (no description set)
+    Working copy  (@) now at: uruxwmqv caa38690 d | (no description set)
     Parent commit (@-)      : qpvuntsm e3e04bea a | (no description set)
     Added 0 files, modified 2 files, removed 0 files
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  85589465a5f7 d
-    │ ○  e31bf988d7c9 b c
+    @  caa3869056b3 d
+    │ ○  7d81fc05a211 b c
     ├─╯
     ○  e3e04beaf7d3 a
     ◆  000000000000 (empty)
@@ -727,15 +727,15 @@ fn test_squash_from_to_partial() -> TestResult {
     let output = work_dir.run_jj(["squash", "-i", "--from", "c"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: vruxwmqv 62bd5cd9 d | (no description set)
+    Working copy  (@) now at: uruxwmqv d6d5cb6c d | (no description set)
     Parent commit (@-)      : qpvuntsm e3e04bea a | (no description set)
     Added 0 files, modified 1 files, removed 0 files
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  62bd5cd9f413 d
-    │ ○  2748f30463ed c
-    │ ○  e31bf988d7c9 b
+    @  d6d5cb6c8d88 d
+    │ ○  79776eb0ce33 c
+    │ ○  7d81fc05a211 b
     ├─╯
     ○  e3e04beaf7d3 a
     ◆  000000000000 (empty)
@@ -767,15 +767,15 @@ fn test_squash_from_to_partial() -> TestResult {
     let output = work_dir.run_jj(["squash", "--from", "c", "file1"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: vruxwmqv 76bf6139 d | (no description set)
+    Working copy  (@) now at: uruxwmqv 12b7c40d d | (no description set)
     Parent commit (@-)      : qpvuntsm e3e04bea a | (no description set)
     Added 0 files, modified 1 files, removed 0 files
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  76bf613928cf d
-    │ ○  9d4418d4828e c
-    │ ○  e31bf988d7c9 b
+    @  12b7c40d7a38 d
+    │ ○  79c8c3c1c41e c
+    │ ○  7d81fc05a211 b
     ├─╯
     ○  e3e04beaf7d3 a
     ◆  000000000000 (empty)
@@ -811,9 +811,9 @@ fn test_squash_from_to_partial() -> TestResult {
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  dc71a460d5d6 d
-    │ ○  f964ce4bca71 c
-    │ ○  e12c895adba6 b
+    @  1178bb01a390 d
+    │ ○  935243195478 c
+    │ ○  b501bf0b84fb b
     ├─╯
     ○  e3e04beaf7d3 a
     ◆  000000000000 (empty)
@@ -889,13 +889,13 @@ fn test_squash_from_multiple() {
     work_dir.write_file("file", "f\n");
     // Test the setup
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  65e53f39b4d6 f
-    ○      7dc592781647 e
+    @  753caba5242d f
+    ○      ddd0b99531ee e
     ├─┬─╮
-    │ │ ○  fed4d1a2e491 b
-    │ ○ │  d7e94ec7e73e c
+    │ │ ○  f6e7afb9574d b
+    │ ○ │  d19fb4af3952 c
     │ ├─╯
-    ○ │  8acbb71558d5 d
+    ○ │  fb329beb2b59 d
     ├─╯
     ○  e88768e65e67 a
     ◆  000000000000 (empty)
@@ -908,23 +908,23 @@ fn test_squash_from_multiple() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Rebased 2 descendant commits
-    Working copy  (@) now at: kpqxywon f584da5f f | (no description set)
-    Parent commit (@-)      : yostqsxw 6fbe5593 e | (no description set)
+    Working copy  (@) now at: kpqxywon 2b0355c6 f | (no description set)
+    Parent commit (@-)      : tostqsxw 823fe121 e | (no description set)
     New conflicts appeared in 1 commits:
-      yqosqzyt 3592e886 d | (conflict) (no description set)
+      oqosqzyt 8ac982e5 d | (conflict) (no description set)
     Hint: To resolve the conflicts, start by creating a commit on top of
     the conflicted commit:
-      jj new yqosqzyt
+      jj new oqosqzyt
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you can inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  f584da5f6b0d f
-    ○    6fbe5593f24a e
+    @  2b0355c6b989 f
+    ○    823fe1216e53 e
     ├─╮
-    × │  3592e886b254 d
+    × │  8ac982e569d1 d
     ├─╯
     ○  e88768e65e67 a b c
     ◆  000000000000 (empty)
@@ -935,14 +935,14 @@ fn test_squash_from_multiple() {
     insta::assert_snapshot!(output, @r"
     <<<<<<< conflict 1 of 1
     %%%%%%% diff from: qpvuntsm e88768e6 (parents of squashed revision)
-    \\\\\\\        to: yqosqzyt 8acbb715 (squash destination)
+    \\\\\\\        to: oqosqzyt fb329beb (squash destination)
     -a
     +d
     %%%%%%% diff from: qpvuntsm e88768e6 (parents of squashed revision)
-    \\\\\\\        to: kkmpptxz fed4d1a2 (squashed revision)
+    \\\\\\\        to: nkmpptxz f6e7afb9 (squashed revision)
     -a
     +b
-    +++++++ mzvwutvl d7e94ec7 (squashed revision)
+    +++++++ pzvwutvl d19fb4af (squashed revision)
     c
     >>>>>>> conflict 1 of 1 ends
     [EOF]
@@ -954,15 +954,15 @@ fn test_squash_from_multiple() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Rebased 1 descendant commits
-    Working copy  (@) now at: xznxytkn ec32238b (empty) (no description set)
-    Parent commit (@-)      : yostqsxw 5298eef6 e f | (no description set)
+    Working copy  (@) now at: xznxytkn 4df53997 (empty) (no description set)
+    Parent commit (@-)      : tostqsxw 158ae8fa e f | (no description set)
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  ec32238b2be5 (empty)
-    ○    5298eef6bca5 e f
+    @  4df539973717 (empty)
+    ○    158ae8fad763 e f
     ├─╮
-    ○ │  8acbb71558d5 d
+    ○ │  fb329beb2b59 d
     ├─╯
     ○  e88768e65e67 a b c
     ◆  000000000000 (empty)
@@ -1035,13 +1035,13 @@ fn test_squash_from_multiple_partial() {
     work_dir.write_file("file2", "f\n");
     // Test the setup
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  4558bd852475 f
-    ○      e2db96b2e57a e
+    @  db8e25ab40d6 f
+    ○      a21546447dd4 e
     ├─┬─╮
-    │ │ ○  f2c9709f39e9 b
-    │ ○ │  aa908686a197 c
+    │ │ ○  39826f7cef30 b
+    │ ○ │  7b9f5b9a1f25 c
     │ ├─╯
-    ○ │  f6812ff8db35 d
+    ○ │  fa497fccf4b2 d
     ├─╯
     ○  64ea60be8d77 a
     ◆  000000000000 (empty)
@@ -1054,26 +1054,26 @@ fn test_squash_from_multiple_partial() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Rebased 2 descendant commits
-    Working copy  (@) now at: kpqxywon 9113246b f | (no description set)
-    Parent commit (@-)      : yostqsxw f069c595 e | (no description set)
+    Working copy  (@) now at: kpqxywon 353aea0d f | (no description set)
+    Parent commit (@-)      : tostqsxw f116f2cc e | (no description set)
     New conflicts appeared in 1 commits:
-      yqosqzyt 35455ce2 d | (conflict) (no description set)
+      oqosqzyt debdecf0 d | (conflict) (no description set)
     Hint: To resolve the conflicts, start by creating a commit on top of
     the conflicted commit:
-      jj new yqosqzyt
+      jj new oqosqzyt
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you can inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  9113246bdbc0 f
-    ○      f069c5953603 e
+    @  353aea0d92ff f
+    ○      f116f2cc2d71 e
     ├─┬─╮
-    │ │ ○  e9db15b956c4 b
-    │ ○ │  83cbe51db94d c
+    │ │ ○  a2848adee8db b
+    │ ○ │  3008ab942232 c
     │ ├─╯
-    × │  35455ce2c7a8 d
+    × │  debdecf0b4f3 d
     ├─╯
     ○  64ea60be8d77 a
     ◆  000000000000 (empty)
@@ -1095,14 +1095,14 @@ fn test_squash_from_multiple_partial() {
     insta::assert_snapshot!(output, @r"
     <<<<<<< conflict 1 of 1
     %%%%%%% diff from: qpvuntsm 64ea60be (parents of squashed revision)
-    \\\\\\\        to: yqosqzyt f6812ff8 (squash destination)
+    \\\\\\\        to: oqosqzyt fa497fcc (squash destination)
     -a
     +d
     %%%%%%% diff from: qpvuntsm 64ea60be (parents of squashed revision)
-    \\\\\\\        to: selected changes for squash (from kkmpptxz f2c9709f)
+    \\\\\\\        to: selected changes for squash (from nkmpptxz 39826f7c)
     -a
     +b
-    +++++++ selected changes for squash (from mzvwutvl aa908686)
+    +++++++ selected changes for squash (from pzvwutvl 7b9f5b9a)
     c
     >>>>>>> conflict 1 of 1 ends
     [EOF]
@@ -1121,18 +1121,18 @@ fn test_squash_from_multiple_partial() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Rebased 1 descendant commits
-    Working copy  (@) now at: kpqxywon b5a40c15 f | (no description set)
-    Parent commit (@-)      : yostqsxw 5dea187c e | (no description set)
+    Working copy  (@) now at: kpqxywon 3cd8135b f | (no description set)
+    Parent commit (@-)      : tostqsxw 2d22fc90 e | (no description set)
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  b5a40c154611 f
-    ○      5dea187c414d e
+    @  3cd8135b107f f
+    ○      2d22fc90cdbc e
     ├─┬─╮
-    │ │ ○  8b9afc05ca07 b
-    │ ○ │  5630471a8fd5 c
+    │ │ ○  0db6e33d88e4 b
+    │ ○ │  e167a3c015bb c
     │ ├─╯
-    ○ │  f6812ff8db35 d
+    ○ │  fa497fccf4b2 d
     ├─╯
     ○  64ea60be8d77 a
     ◆  000000000000 (empty)
@@ -1188,10 +1188,10 @@ fn test_squash_from_multiple_partial_no_op() {
     work_dir.write_file("d", "d\n");
     // Test the setup
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  fdb92bc249a0 d
-    │ ○  0dc8cb72859d c
+    @  110e903b7a41 d
+    │ ○  f1ef0762d926 c
     ├─╯
-    │ ○  b1a17f79a1a5 b
+    │ ○  892a3c5f3db8 b
     ├─╯
     ○  93d495c46d89 a
     ◆  000000000000 (empty)
@@ -1203,14 +1203,14 @@ fn test_squash_from_multiple_partial_no_op() {
     let output = work_dir.run_jj(["squash", "--from=@-+ ~ @", "--into=@", "-m=d", "b"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: mzvwutvl 6dfc239e d
+    Working copy  (@) now at: rzvwutvl e0415921 d
     Parent commit (@-)      : qpvuntsm 93d495c4 a
     Added 1 files, modified 0 files, removed 0 files
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  6dfc239e2ba3 d
-    │ ○  0dc8cb72859d c
+    @  e04159212ff1 d
+    │ ○  f1ef0762d926 c
     ├─╯
     ○  93d495c46d89 a
     ◆  000000000000 (empty)
@@ -1222,12 +1222,12 @@ fn test_squash_from_multiple_partial_no_op() {
         r#"separate(" ", commit.commit_id().short(), commit.description())"#,
     ]);
     insta::assert_snapshot!(output, @"
-    @    6dfc239e2ba3 d
+    @    e04159212ff1 d
     ├─╮
-    │ ○  b1a17f79a1a5 b
-    │ ○  d8b7d57239ca b
-    ○  fdb92bc249a0 d
-    ○  af709ccc1ca9 d
+    │ ○  892a3c5f3db8 b
+    │ ○  99ac3ad52a50 b
+    ○  110e903b7a41 d
+    ○  a8fb5d054651 d
     [EOF]
     ");
 
@@ -1240,10 +1240,10 @@ fn test_squash_from_multiple_partial_no_op() {
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  fdb92bc249a0 d
-    │ ○  0dc8cb72859d c
+    @  110e903b7a41 d
+    │ ○  f1ef0762d926 c
     ├─╯
-    │ ○  b1a17f79a1a5 b
+    │ ○  892a3c5f3db8 b
     ├─╯
     ○  93d495c46d89 a
     ◆  000000000000 (empty)
@@ -1461,7 +1461,7 @@ fn test_squash_description() -> TestResult {
     work_dir.run_jj(["op", "restore", &setup_opid3]).success();
     work_dir.run_jj(["describe", "-m", ""]).success();
     insta::assert_snapshot!(get_log_output_with_description(&work_dir), @"
-    @  452e4831d64b
+    @  80ec542962c1
     ○  e650dfcd7312 destination
     ◆  000000000000
     [EOF]
@@ -1488,7 +1488,7 @@ fn test_squash_description() -> TestResult {
         .run_jj(["describe", "-r", "@-", "-m", ""])
         .success();
     insta::assert_snapshot!(get_log_output_with_description(&work_dir), @"
-    @  78e7f58582e8 source
+    @  4b20b2b6c32e source
     ○  a01e1865957e
     ◆  000000000000
     [EOF]
@@ -1513,7 +1513,7 @@ fn test_squash_description() -> TestResult {
         .run_jj(["describe", "-r", "..", "-m", ""])
         .success();
     insta::assert_snapshot!(get_log_output_with_description(&work_dir), @"
-    @  8a34624ec18b
+    @  f7af8ee727c1
     ○  2560c9e5ef72
     ◆  000000000000
     [EOF]
@@ -1534,7 +1534,7 @@ fn test_squash_description() -> TestResult {
         .run_jj(["describe", "-r", "@-", "-m", ""])
         .success();
     insta::assert_snapshot!(get_log_output_with_description(&work_dir), @"
-    @  405f52356ed5 source
+    @  b3f1ffd7d003 source
     ○  ecf32ca3d742
     ◆  000000000000
     [EOF]
@@ -1553,7 +1553,7 @@ fn test_squash_description() -> TestResult {
     // any trailer
     work_dir.run_jj(["op", "restore", &setup_opid3]).success();
     insta::assert_snapshot!(get_log_output_with_description(&work_dir), @"
-    @  2a79b102bf46 source
+    @  da682fda7323 source
     ○  e650dfcd7312 destination
     ◆  000000000000
     [EOF]
@@ -1573,7 +1573,7 @@ fn test_squash_description() -> TestResult {
     work_dir.run_jj(["op", "restore", &setup_opid3]).success();
     work_dir.write_file("data.txt", b"\xff\n");
     insta::assert_snapshot!(get_log_output_with_description(&work_dir), @"
-    @  9eec7f21360c source
+    @  57c9368a52f6 source
     ○  e650dfcd7312 destination
     ◆  000000000000
     [EOF]
@@ -2275,14 +2275,14 @@ fn test_squash_to_new_commit() -> TestResult {
     let output = work_dir.run_jj(["new", "--no-edit", "root()"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Created new commit szrrkvty f5e47d01 (empty) (no description set)
+    Created new commit ozrrkvty 2d2b113d (empty) (no description set)
     [EOF]
     ");
 
     let output = work_dir.run_jj([
         "squash",
         "-f",
-        "szrrkvty",
+        "ozrrkvty",
         "--onto",
         "root()",
         "--use-destination-message",
@@ -2313,10 +2313,10 @@ fn test_squash_to_new_commit() -> TestResult {
     insta::assert_snapshot!(output, @"
     ○  pyoswmwk test.user@example.com 2001-02-03 08:05:50 991d0644
     │  (empty) (no description set)
-    │  -- operation 587bcc3abdef squash commit f5e47d019271a392eb7f92a6b2e9f8cf41d97049
-    ○  szrrkvty/0 test.user@example.com 2001-02-03 08:05:50 f5e47d01 (hidden)
+    │  -- operation 65e6a8ee34b6 squash commit 2d2b113dbb76af23695f11dca69cc8b1be571b60
+    ○  ozrrkvty/0 test.user@example.com 2001-02-03 08:05:50 2d2b113d (hidden)
        (empty) (no description set)
-       -- operation 4096cc584a23 new empty commit
+       -- operation 2177f5bc2539 new empty commit
     [EOF]
     ");
 

--- a/cli/tests/test_status_command.rs
+++ b/cli/tests/test_status_command.rs
@@ -35,7 +35,7 @@ fn test_status_copies() {
     M copy-source
     C {copy-source => copy-target}
     R {rename-source => rename-target}
-    Working copy  (@) : rlvkpnrz c2fce842 (no description set)
+    Working copy  (@) : ylvkpnrz 767a7dbe (no description set)
     Parent commit (@-): qpvuntsm ebf799bc (no description set)
     [EOF]
     ");
@@ -61,9 +61,9 @@ fn test_status_merge() {
     let output = work_dir.run_jj(["status"]);
     insta::assert_snapshot!(output, @"
     The working copy has no changes.
-    Working copy  (@) : mzvwutvl f62dad77 (empty) (no description set)
-    Parent commit (@-): rlvkpnrz a007d87b left | (empty) left
-    Parent commit (@-): zsuskuln e6ad1952 right
+    Working copy  (@) : pzvwutvl 0cbd032b (empty) (no description set)
+    Parent commit (@-): ylvkpnrz 6f5724a9 left | (empty) left
+    Parent commit (@-): osuskuln e63278bf right
     [EOF]
     ");
 }
@@ -137,7 +137,7 @@ fn test_status_filtered() {
 
     let output = work_dir.run_jj(["status", "file_1"]);
     insta::assert_snapshot!(output, @"
-    Working copy  (@) : mzvwutvl d977fd8e (no description set)
+    Working copy  (@) : pzvwutvl ba3fdffd (no description set)
     Parent commit (@-): qpvuntsm 2f169edb (no description set)
     [EOF]
     ");
@@ -146,7 +146,7 @@ fn test_status_filtered() {
     // only the warning.
     let output = work_dir.run_jj(["status", "file_1", "nonexistent"]);
     insta::assert_snapshot!(output, @"
-    Working copy  (@) : mzvwutvl d977fd8e (no description set)
+    Working copy  (@) : pzvwutvl ba3fdffd (no description set)
     Parent commit (@-): qpvuntsm 2f169edb (no description set)
     [EOF]
     ------- stderr -------
@@ -161,8 +161,8 @@ fn test_status_filtered() {
     let output = work_dir.run_jj(["status", "nonexistent"]);
     insta::assert_snapshot!(output, @"
     The working copy has no changes.
-    Working copy  (@) : vruxwmqv bc1fcb38 (empty) (no description set)
-    Parent commit (@-): mzvwutvl d977fd8e (no description set)
+    Working copy  (@) : uruxwmqv 1cd4c35c (empty) (no description set)
+    Parent commit (@-): pzvwutvl ba3fdffd (no description set)
     [EOF]
     ------- stderr -------
     Warning: No matching entries for paths: nonexistent
@@ -293,15 +293,15 @@ fn test_status_display_relevant_working_commit_conflict_hints() {
     let output = work_dir.run_jj(["log", "-r", "::"]);
 
     insta::assert_snapshot!(output, @"
-    @  yqosqzyt test.user@example.com 2001-02-03 08:05:13 06b8a9dd (conflict)
+    @  oqosqzyt test.user@example.com 2001-02-03 08:05:13 c98164bc (conflict)
     │  (empty) boom-cont-2
-    ×  royxmykx test.user@example.com 2001-02-03 08:05:12 fc966143 (conflict)
+    ×  soyxmykx test.user@example.com 2001-02-03 08:05:12 cfd83822 (conflict)
     │  (empty) boom-cont
-    ×    mzvwutvl test.user@example.com 2001-02-03 08:05:11 7bc77be4 (conflict)
+    ×    rzvwutvl test.user@example.com 2001-02-03 08:05:11 8b7b1070 (conflict)
     ├─╮  (empty) boom
-    │ ○  kkmpptxz test.user@example.com 2001-02-03 08:05:10 7bb1724e
+    │ ○  nkmpptxz test.user@example.com 2001-02-03 08:05:10 6f709ada
     │ │  First part of conflicting change
-    ○ │  zsuskuln test.user@example.com 2001-02-03 08:05:11 263e2eb6
+    ○ │  psuskuln test.user@example.com 2001-02-03 08:05:11 5d979282
     ├─╯  Second part of conflicting change
     ○  qpvuntsm test.user@example.com 2001-02-03 08:05:08 8b2bca65
     │  Initial contents
@@ -312,14 +312,14 @@ fn test_status_display_relevant_working_commit_conflict_hints() {
     let output = work_dir.run_jj(["status"]);
     insta::assert_snapshot!(output, @"
     The working copy has no changes.
-    Working copy  (@) : yqosqzyt 06b8a9dd (conflict) (empty) boom-cont-2
-    Parent commit (@-): royxmykx fc966143 (conflict) (empty) boom-cont
+    Working copy  (@) : oqosqzyt c98164bc (conflict) (empty) boom-cont-2
+    Parent commit (@-): soyxmykx cfd83822 (conflict) (empty) boom-cont
     Warning: There are unresolved conflicts at these paths:
     conflicted1.txt    2-sided conflict
     conflicted2.txt    2-sided conflict
     Hint: To resolve the conflicts, start by creating a commit on top of
     the first conflicted commit:
-      jj new mzvwutvl
+      jj new rzvwutvl
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you can inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
@@ -330,13 +330,13 @@ fn test_status_display_relevant_working_commit_conflict_hints() {
     let output = work_dir.run_jj(["status", "conflicted1.txt"]);
     insta::assert_snapshot!(output, @"
     The working copy has no changes.
-    Working copy  (@) : yqosqzyt 06b8a9dd (conflict) (empty) boom-cont-2
-    Parent commit (@-): royxmykx fc966143 (conflict) (empty) boom-cont
+    Working copy  (@) : oqosqzyt c98164bc (conflict) (empty) boom-cont-2
+    Parent commit (@-): soyxmykx cfd83822 (conflict) (empty) boom-cont
     Warning: There are unresolved conflicts at these paths:
     conflicted1.txt    2-sided conflict
     Hint: To resolve the conflicts, start by creating a commit on top of
     the first conflicted commit:
-      jj new mzvwutvl
+      jj new rzvwutvl
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you can inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
@@ -346,14 +346,14 @@ fn test_status_display_relevant_working_commit_conflict_hints() {
     let output = work_dir.run_jj(["status", "--color=always"]);
     insta::assert_snapshot!(output, @"
     The working copy has no changes.
-    Working copy  (@) : [1m[38;5;13my[38;5;8mqosqzyt[39m [38;5;12m06[38;5;8mb8a9dd[39m [38;5;9m(conflict)[39m [38;5;10m(empty)[39m boom-cont-2[0m
-    Parent commit (@-): [1m[38;5;5mr[0m[38;5;8moyxmykx[39m [1m[38;5;4mf[0m[38;5;8mc966143[39m [38;5;1m(conflict)[39m [38;5;2m(empty)[39m boom-cont
+    Working copy  (@) : [1m[38;5;13mo[38;5;8mqosqzyt[39m [38;5;12mc9[38;5;8m8164bc[39m [38;5;9m(conflict)[39m [38;5;10m(empty)[39m boom-cont-2[0m
+    Parent commit (@-): [1m[38;5;5ms[0m[38;5;8moyxmykx[39m [1m[38;5;4mcf[0m[38;5;8md83822[39m [38;5;1m(conflict)[39m [38;5;2m(empty)[39m boom-cont
     [1m[38;5;3mWarning: [39mThere are unresolved conflicts at these paths:[0m
     conflicted1.txt    [38;5;3m2-sided conflict[39m
     conflicted2.txt    [38;5;3m2-sided conflict[39m
     [1m[38;5;6mHint: [0m[39mTo resolve the conflicts, start by creating a commit on top of[39m
     [39mthe first conflicted commit:[39m
-    [39m  jj new [1m[38;5;5mm[0m[38;5;8mzvwutvl[39m[39m
+    [39m  jj new [1m[38;5;5mr[0m[38;5;8mzvwutvl[39m[39m
     [39mThen use `jj resolve`, or edit the conflict markers in the file directly.[39m
     [39mOnce the conflicts are resolved, you can inspect the result with `jj diff`.[39m
     [39mThen run `jj squash` to move the resolution into the conflicted commit.[39m
@@ -363,8 +363,8 @@ fn test_status_display_relevant_working_commit_conflict_hints() {
     let output = work_dir.run_jj(["status", "--config=hints.resolving-conflicts=false"]);
     insta::assert_snapshot!(output, @"
     The working copy has no changes.
-    Working copy  (@) : yqosqzyt 06b8a9dd (conflict) (empty) boom-cont-2
-    Parent commit (@-): royxmykx fc966143 (conflict) (empty) boom-cont
+    Working copy  (@) : oqosqzyt c98164bc (conflict) (empty) boom-cont-2
+    Parent commit (@-): soyxmykx cfd83822 (conflict) (empty) boom-cont
     Warning: There are unresolved conflicts at these paths:
     conflicted1.txt    2-sided conflict
     conflicted2.txt    2-sided conflict
@@ -385,19 +385,19 @@ fn test_status_display_relevant_working_commit_conflict_hints() {
     let output = work_dir.run_jj(["log", "-r", "::"]);
 
     insta::assert_snapshot!(output, @"
-    @  lylxulpl test.user@example.com 2001-02-03 08:05:21 cb6faf76
+    @  lylxulpl test.user@example.com 2001-02-03 08:05:21 bfba410a
     │  fixed 2
-    ○  wqnwkozp test.user@example.com 2001-02-03 08:05:20 4ecf4b33
+    ○  xqnwkozp test.user@example.com 2001-02-03 08:05:20 cbb3170c
     │  fixed 1
-    ×  yqosqzyt test.user@example.com 2001-02-03 08:05:13 06b8a9dd (conflict)
+    ×  oqosqzyt test.user@example.com 2001-02-03 08:05:13 c98164bc (conflict)
     │  (empty) boom-cont-2
-    ×  royxmykx test.user@example.com 2001-02-03 08:05:12 fc966143 (conflict)
+    ×  soyxmykx test.user@example.com 2001-02-03 08:05:12 cfd83822 (conflict)
     │  (empty) boom-cont
-    ×    mzvwutvl test.user@example.com 2001-02-03 08:05:11 7bc77be4 (conflict)
+    ×    rzvwutvl test.user@example.com 2001-02-03 08:05:11 8b7b1070 (conflict)
     ├─╮  (empty) boom
-    │ ○  kkmpptxz test.user@example.com 2001-02-03 08:05:10 7bb1724e
+    │ ○  nkmpptxz test.user@example.com 2001-02-03 08:05:10 6f709ada
     │ │  First part of conflicting change
-    ○ │  zsuskuln test.user@example.com 2001-02-03 08:05:11 263e2eb6
+    ○ │  psuskuln test.user@example.com 2001-02-03 08:05:11 5d979282
     ├─╯  Second part of conflicting change
     ○  qpvuntsm test.user@example.com 2001-02-03 08:05:08 8b2bca65
     │  Initial contents
@@ -411,8 +411,8 @@ fn test_status_display_relevant_working_commit_conflict_hints() {
     Working copy changes:
     M conflicted1.txt
     M conflicted2.txt
-    Working copy  (@) : lylxulpl cb6faf76 fixed 2
-    Parent commit (@-): wqnwkozp 4ecf4b33 fixed 1
+    Working copy  (@) : lylxulpl bfba410a fixed 2
+    Parent commit (@-): xqnwkozp cbb3170c fixed 1
     [EOF]
     ");
 
@@ -422,19 +422,19 @@ fn test_status_display_relevant_working_commit_conflict_hints() {
     let output = work_dir.run_jj(["log", "-r", "::"]);
 
     insta::assert_snapshot!(output, @"
-    ○  lylxulpl test.user@example.com 2001-02-03 08:05:21 cb6faf76
+    ○  lylxulpl test.user@example.com 2001-02-03 08:05:21 bfba410a
     │  fixed 2
-    @  wqnwkozp test.user@example.com 2001-02-03 08:05:20 4ecf4b33
+    @  xqnwkozp test.user@example.com 2001-02-03 08:05:20 cbb3170c
     │  fixed 1
-    ×  yqosqzyt test.user@example.com 2001-02-03 08:05:13 06b8a9dd (conflict)
+    ×  oqosqzyt test.user@example.com 2001-02-03 08:05:13 c98164bc (conflict)
     │  (empty) boom-cont-2
-    ×  royxmykx test.user@example.com 2001-02-03 08:05:12 fc966143 (conflict)
+    ×  soyxmykx test.user@example.com 2001-02-03 08:05:12 cfd83822 (conflict)
     │  (empty) boom-cont
-    ×    mzvwutvl test.user@example.com 2001-02-03 08:05:11 7bc77be4 (conflict)
+    ×    rzvwutvl test.user@example.com 2001-02-03 08:05:11 8b7b1070 (conflict)
     ├─╮  (empty) boom
-    │ ○  kkmpptxz test.user@example.com 2001-02-03 08:05:10 7bb1724e
+    │ ○  nkmpptxz test.user@example.com 2001-02-03 08:05:10 6f709ada
     │ │  First part of conflicting change
-    ○ │  zsuskuln test.user@example.com 2001-02-03 08:05:11 263e2eb6
+    ○ │  psuskuln test.user@example.com 2001-02-03 08:05:11 5d979282
     ├─╯  Second part of conflicting change
     ○  qpvuntsm test.user@example.com 2001-02-03 08:05:08 8b2bca65
     │  Initial contents
@@ -448,8 +448,8 @@ fn test_status_display_relevant_working_commit_conflict_hints() {
     Working copy changes:
     M conflicted1.txt
     M conflicted2.txt
-    Working copy  (@) : wqnwkozp 4ecf4b33 fixed 1
-    Parent commit (@-): yqosqzyt 06b8a9dd (conflict) (empty) boom-cont-2
+    Working copy  (@) : xqnwkozp cbb3170c fixed 1
+    Parent commit (@-): oqosqzyt c98164bc (conflict) (empty) boom-cont-2
     Hint: Conflict in parent commit has been resolved in working copy
     [EOF]
     ");
@@ -461,19 +461,19 @@ fn test_status_display_relevant_working_commit_conflict_hints() {
     let output = work_dir.run_jj(["log", "-r", "::"]);
 
     insta::assert_snapshot!(output, @"
-    ○  lylxulpl test.user@example.com 2001-02-03 08:05:21 cb6faf76
+    ○  lylxulpl test.user@example.com 2001-02-03 08:05:21 bfba410a
     │  fixed 2
-    ○  wqnwkozp test.user@example.com 2001-02-03 08:05:20 4ecf4b33
+    ○  xqnwkozp test.user@example.com 2001-02-03 08:05:20 cbb3170c
     │  fixed 1
-    ×  yqosqzyt test.user@example.com 2001-02-03 08:05:13 06b8a9dd (conflict)
+    ×  oqosqzyt test.user@example.com 2001-02-03 08:05:13 c98164bc (conflict)
     │  (empty) boom-cont-2
-    ×  royxmykx test.user@example.com 2001-02-03 08:05:12 fc966143 (conflict)
+    ×  soyxmykx test.user@example.com 2001-02-03 08:05:12 cfd83822 (conflict)
     │  (empty) boom-cont
-    ×    mzvwutvl test.user@example.com 2001-02-03 08:05:11 7bc77be4 (conflict)
+    ×    rzvwutvl test.user@example.com 2001-02-03 08:05:11 8b7b1070 (conflict)
     ├─╮  (empty) boom
-    │ ○  kkmpptxz test.user@example.com 2001-02-03 08:05:10 7bb1724e
+    │ ○  nkmpptxz test.user@example.com 2001-02-03 08:05:10 6f709ada
     │ │  First part of conflicting change
-    ○ │  zsuskuln test.user@example.com 2001-02-03 08:05:11 263e2eb6
+    ○ │  psuskuln test.user@example.com 2001-02-03 08:05:11 5d979282
     ├─╯  Second part of conflicting change
     @  qpvuntsm test.user@example.com 2001-02-03 08:05:08 8b2bca65
     │  Initial contents
@@ -519,16 +519,16 @@ fn test_status_simplify_conflict_sides() {
     insta::assert_snapshot!(work_dir.run_jj(["status"]),
     @"
     The working copy has no changes.
-    Working copy  (@) : nkmrtpmo ae2d1b1f conflict | (conflict) (empty) conflict
-    Parent commit (@-): kmkuslsw fb05b298 conflictA | (conflict) (empty) conflictA
-    Parent commit (@-): lylxulpl c680c6d6 conflictB | (conflict) (empty) conflictB
+    Working copy  (@) : ukmrtpmo 6401768a conflict | (conflict) (empty) conflict
+    Parent commit (@-): wmkuslsw 2d461824 conflictA | (conflict) (empty) conflictA
+    Parent commit (@-): lylxulpl 6522bfe5 conflictB | (conflict) (empty) conflictB
     Warning: There are unresolved conflicts at these paths:
     fileA    2-sided conflict
     fileB    2-sided conflict
     Hint: To resolve the conflicts, start by creating a commit on top of
     one of the first conflicted commits:
       jj new lylxulpl
-      jj new kmkuslsw
+      jj new wmkuslsw
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you can inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
@@ -590,7 +590,7 @@ fn test_status_untracked_files() {
     Untracked paths:
     ? always-untracked-file
     ? sub/always-untracked
-    Working copy  (@) : mzvwutvl daa133b8 (empty) (no description set)
+    Working copy  (@) : pzvwutvl e9a246cb (empty) (no description set)
     Parent commit (@-): qpvuntsm b8c1286d (no description set)
     [EOF]
     ");
@@ -612,7 +612,7 @@ fn test_status_untracked_files() {
     ? always-untracked-file
     ? initially-untracked-file
     ? sub/
-    Working copy  (@) : mzvwutvl 240f261a (no description set)
+    Working copy  (@) : pzvwutvl d646378a (no description set)
     Parent commit (@-): qpvuntsm b8c1286d (no description set)
     [EOF]
     ");
@@ -625,8 +625,8 @@ fn test_status_untracked_files() {
     ? always-untracked-file
     ? initially-untracked-file
     ? sub/
-    Working copy  (@) : yostqsxw 50beac0d (empty) (no description set)
-    Parent commit (@-): mzvwutvl 240f261a (no description set)
+    Working copy  (@) : rostqsxw ec7264b6 (empty) (no description set)
+    Parent commit (@-): pzvwutvl d646378a (no description set)
     [EOF]
     ");
 
@@ -636,8 +636,8 @@ fn test_status_untracked_files() {
     ? ../always-untracked-file
     ? ../initially-untracked-file
     ? ./
-    Working copy  (@) : yostqsxw 50beac0d (empty) (no description set)
-    Parent commit (@-): mzvwutvl 240f261a (no description set)
+    Working copy  (@) : rostqsxw ec7264b6 (empty) (no description set)
+    Parent commit (@-): pzvwutvl d646378a (no description set)
     [EOF]
     ");
 }

--- a/cli/tests/test_tag_command.rs
+++ b/cli/tests/test_tag_command.rs
@@ -258,11 +258,11 @@ fn test_tag_list() {
 
     insta::assert_snapshot!(work_dir.run_jj(["tag", "list"]), @"
     conflicted_tag (conflicted):
-      - rlvkpnrz 893e67dc (empty) commit1
-      + zsuskuln 76abdd20 (empty) commit2
-      + royxmykx 13c4e819 (empty) commit3
-    test_tag: rlvkpnrz 893e67dc (empty) commit1
-    test_tag2: zsuskuln 76abdd20 (empty) commit2
+      - ylvkpnrz 107f7311 (empty) commit1
+      + psuskuln 0f8c3cd6 (empty) commit2
+      + qoyxmykx 448fec82 (empty) commit3
+    test_tag: ylvkpnrz 107f7311 (empty) commit1
+    test_tag2: psuskuln 0f8c3cd6 (empty) commit2
     [EOF]
     ------- stderr -------
     Concurrent modification detected, resolving automatically.
@@ -271,42 +271,42 @@ fn test_tag_list() {
 
     insta::assert_snapshot!(work_dir.run_jj(["tag", "list", "--color=always"]), @"
     [38;5;5mconflicted_tag[39m [38;5;1m(conflicted)[39m:
-      - [1m[38;5;5mrl[0m[38;5;8mvkpnrz[39m [1m[38;5;4m8[0m[38;5;8m93e67dc[39m [38;5;2m(empty)[39m commit1
-      + [1m[38;5;5mzs[0m[38;5;8muskuln[39m [1m[38;5;4m7[0m[38;5;8m6abdd20[39m [38;5;2m(empty)[39m commit2
-      + [1m[38;5;13mr[38;5;8moyxmykx[39m [38;5;12m1[38;5;8m3c4e819[39m [38;5;10m(empty)[39m commit3[0m
-    [38;5;5mtest_tag[39m: [1m[38;5;5mrl[0m[38;5;8mvkpnrz[39m [1m[38;5;4m8[0m[38;5;8m93e67dc[39m [38;5;2m(empty)[39m commit1
-    [38;5;5mtest_tag2[39m: [1m[38;5;5mzs[0m[38;5;8muskuln[39m [1m[38;5;4m7[0m[38;5;8m6abdd20[39m [38;5;2m(empty)[39m commit2
+      - [1m[38;5;5my[0m[38;5;8mlvkpnrz[39m [1m[38;5;4m1[0m[38;5;8m07f7311[39m [38;5;2m(empty)[39m commit1
+      + [1m[38;5;5mp[0m[38;5;8msuskuln[39m [1m[38;5;4m0f[0m[38;5;8m8c3cd6[39m [38;5;2m(empty)[39m commit2
+      + [1m[38;5;13mq[38;5;8moyxmykx[39m [38;5;12m4[38;5;8m48fec82[39m [38;5;10m(empty)[39m commit3[0m
+    [38;5;5mtest_tag[39m: [1m[38;5;5my[0m[38;5;8mlvkpnrz[39m [1m[38;5;4m1[0m[38;5;8m07f7311[39m [38;5;2m(empty)[39m commit1
+    [38;5;5mtest_tag2[39m: [1m[38;5;5mp[0m[38;5;8msuskuln[39m [1m[38;5;4m0f[0m[38;5;8m8c3cd6[39m [38;5;2m(empty)[39m commit2
     [EOF]
     ");
 
     // Test pattern matching.
     insta::assert_snapshot!(work_dir.run_jj(["tag", "list", "test_tag2"]), @"
-    test_tag2: zsuskuln 76abdd20 (empty) commit2
+    test_tag2: psuskuln 0f8c3cd6 (empty) commit2
     [EOF]
     ");
 
     insta::assert_snapshot!(work_dir.run_jj(["tag", "list", "'test_tag?'"]), @"
-    test_tag2: zsuskuln 76abdd20 (empty) commit2
+    test_tag2: psuskuln 0f8c3cd6 (empty) commit2
     [EOF]
     ");
 
     // Filter by revset
     insta::assert_snapshot!(work_dir.run_jj(["tag", "list", "-rsubject(commit1)"]), @"
-    test_tag: rlvkpnrz 893e67dc (empty) commit1
+    test_tag: ylvkpnrz 107f7311 (empty) commit1
     [EOF]
     ");
     insta::assert_snapshot!(work_dir.run_jj(["tag", "list", "-rsubject(commit2)"]), @"
     conflicted_tag (conflicted):
-      - rlvkpnrz 893e67dc (empty) commit1
-      + zsuskuln 76abdd20 (empty) commit2
-      + royxmykx 13c4e819 (empty) commit3
-    test_tag2: zsuskuln 76abdd20 (empty) commit2
+      - ylvkpnrz 107f7311 (empty) commit1
+      + psuskuln 0f8c3cd6 (empty) commit2
+      + qoyxmykx 448fec82 (empty) commit3
+    test_tag2: psuskuln 0f8c3cd6 (empty) commit2
     [EOF]
     ");
     // Filter by revset and name, which aren't intersected
     insta::assert_snapshot!(work_dir.run_jj(["tag", "list", "-rsubject(commit1)", "test_tag2"]), @"
-    test_tag: rlvkpnrz 893e67dc (empty) commit1
-    test_tag2: zsuskuln 76abdd20 (empty) commit2
+    test_tag: ylvkpnrz 107f7311 (empty) commit1
+    test_tag2: psuskuln 0f8c3cd6 (empty) commit2
     [EOF]
     ");
 
@@ -314,7 +314,7 @@ fn test_tag_list() {
     // isn't included in the match.
     insta::assert_snapshot!(
         work_dir.run_jj(["tag", "list", "test* & ~*2", "unknown ~ test_tag2"]), @"
-    test_tag: rlvkpnrz 893e67dc (empty) commit1
+    test_tag: ylvkpnrz 107f7311 (empty) commit1
     [EOF]
     ------- stderr -------
     Warning: No matching tags for names: unknown
@@ -323,9 +323,9 @@ fn test_tag_list() {
 
     insta::assert_snapshot!(work_dir.run_jj(["tag", "list", "--conflicted"]), @"
     conflicted_tag (conflicted):
-      - rlvkpnrz 893e67dc (empty) commit1
-      + zsuskuln 76abdd20 (empty) commit2
-      + royxmykx 13c4e819 (empty) commit3
+      - ylvkpnrz 107f7311 (empty) commit1
+      + psuskuln 0f8c3cd6 (empty) commit2
+      + qoyxmykx 448fec82 (empty) commit3
     [EOF]
     ");
 
@@ -364,23 +364,23 @@ fn test_tag_list() {
     // Sort by command argument
     insta::assert_snapshot!(work_dir.run_jj(["tag", "list", "--sort=committer-date-,name"]), @"
     conflicted_tag (conflicted):
-      - rlvkpnrz 893e67dc (empty) commit1
-      + zsuskuln 76abdd20 (empty) commit2
-      + royxmykx 13c4e819 (empty) commit3
-    test_tag2: zsuskuln 76abdd20 (empty) commit2
-    test_tag: rlvkpnrz 893e67dc (empty) commit1
+      - ylvkpnrz 107f7311 (empty) commit1
+      + psuskuln 0f8c3cd6 (empty) commit2
+      + qoyxmykx 448fec82 (empty) commit3
+    test_tag2: psuskuln 0f8c3cd6 (empty) commit2
+    test_tag: ylvkpnrz 107f7311 (empty) commit1
     [EOF]
     ");
 
     // Default sort keys in config
     let config = "--config=ui.tag-list-sort-keys=['committer-date', 'name-']";
     insta::assert_snapshot!(work_dir.run_jj(["tag", "list", config]), @"
-    test_tag: rlvkpnrz 893e67dc (empty) commit1
-    test_tag2: zsuskuln 76abdd20 (empty) commit2
+    test_tag: ylvkpnrz 107f7311 (empty) commit1
+    test_tag2: psuskuln 0f8c3cd6 (empty) commit2
     conflicted_tag (conflicted):
-      - rlvkpnrz 893e67dc (empty) commit1
-      + zsuskuln 76abdd20 (empty) commit2
-      + royxmykx 13c4e819 (empty) commit3
+      - ylvkpnrz 107f7311 (empty) commit1
+      + psuskuln 0f8c3cd6 (empty) commit2
+      + qoyxmykx 448fec82 (empty) commit3
     [EOF]
     ");
 }
@@ -403,8 +403,8 @@ fn test_tag_list_remotes() {
 
     let output = local_dir.run_jj(["tag", "list", "--all-remotes"]);
     insta::assert_snapshot!(output, @"
-    local-only: rlvkpnrz d3e8d245 (empty) local-only
-      @git: rlvkpnrz d3e8d245 (empty) local-only
+    local-only: ylvkpnrz 7652aed1 (empty) local-only
+      @git: ylvkpnrz 7652aed1 (empty) local-only
     [EOF]
     ");
 
@@ -415,8 +415,8 @@ fn test_tag_list_remotes() {
 
     let output = local_dir.run_jj(["tag", "list", "--tracked", "--remote=git"]);
     insta::assert_snapshot!(output, @"
-    local-only: rlvkpnrz d3e8d245 (empty) local-only
-      @git: rlvkpnrz d3e8d245 (empty) local-only
+    local-only: ylvkpnrz 7652aed1 (empty) local-only
+      @git: ylvkpnrz 7652aed1 (empty) local-only
     [EOF]
     ");
 
@@ -425,8 +425,8 @@ fn test_tag_list_remotes() {
 
     let output = local_dir.run_jj(["tag", "list", "--remote=git"]);
     insta::assert_snapshot!(output, @"
-    local-only: rlvkpnrz d3e8d245 (empty) local-only
-      @git: rlvkpnrz d3e8d245 (empty) local-only
+    local-only: ylvkpnrz 7652aed1 (empty) local-only
+      @git: ylvkpnrz 7652aed1 (empty) local-only
     [EOF]
     ");
 }

--- a/cli/tests/test_working_copy.rs
+++ b/cli/tests/test_working_copy.rs
@@ -143,12 +143,12 @@ fn test_snapshot_large_file_restore() {
         This will increase the maximum file size allowed for new files, in this repository only.
       * Run `jj --config snapshot.max-new-file-size=13 status`
         This will increase the maximum file size allowed for new files, for this command only.
-    Working copy  (@) now at: kkmpptxz 119f5156 (no description set)
+    Working copy  (@) now at: nkmpptxz f96924ce (no description set)
     Parent commit (@-)      : zzzzzzzz 00000000 (empty) (no description set)
     Added 1 files, modified 0 files, removed 0 files
     Warning: 1 of those updates were skipped because there were conflicting changes in the working copy.
-    Hint: Inspect the changes compared to the intended target with `jj diff --from 119f5156d330`.
-    Discard the conflicting changes with `jj restore --from 119f5156d330`.
+    Hint: Inspect the changes compared to the intended target with `jj diff --from f96924ce1457`.
+    Discard the conflicting changes with `jj restore --from f96924ce1457`.
     [EOF]
     ");
     insta::assert_snapshot!(work_dir.read_file("file"), @"a lot of text");
@@ -159,7 +159,7 @@ fn test_snapshot_large_file_restore() {
     insta::assert_snapshot!(output, @"
     Working copy changes:
     A file
-    Working copy  (@) : kkmpptxz 09eba65e (no description set)
+    Working copy  (@) : nkmpptxz c9c69e98 (no description set)
     Parent commit (@-): zzzzzzzz 00000000 (empty) (no description set)
     [EOF]
     ");
@@ -220,7 +220,7 @@ fn test_materialize_and_snapshot_different_conflict_markers() -> TestResult {
     =======
     line 2 - b
     line 3 - b
-    >>>>>>> zsuskuln 68dcce1b "side-b"
+    >>>>>>> psuskuln 0760f616 "side-b"
     "#);
 
     // Configure to use JJ-style "snapshot" conflict markers
@@ -342,7 +342,7 @@ fn test_conflict_marker_length_stored_in_working_copy() -> TestResult {
     -line 3
     +line 2 - left
     +line 3 - left
-    +++++++++++ zsuskuln d7acaf48 "side-b"
+    +++++++++++ psuskuln 1ec39521 "side-b"
     ======= fake marker
     line 2 - right
     ======= fake marker
@@ -361,8 +361,8 @@ fn test_conflict_marker_length_stored_in_working_copy() -> TestResult {
     // Working copy should contain conflict marker length
     let output = work_dir.run_jj(["debug", "local-working-copy"]);
     insta::assert_snapshot!(output.normalize_stdout_with(redact_output), @r#"
-    Current operation: OperationId("072342f0123bbb53824fe316de828240ec981d9d11608e8a31c12253e99cd504d5a0fae3851f6a83941863a85b68954c90b7d6ad2fd4f7da469b7d8a6482c003")
-    Current tree: MergedTree { tree_ids: Conflicted([TreeId("381273b50cf73f8c81b3f1502ee89e9bbd6c1518"), TreeId("771f3d31c4588ea40a8864b2a981749888e596c2"), TreeId("f56b8223da0dab22b03b8323ced4946329aeb4e0")]), labels: Labeled(["rlvkpnrz ccf9527c \"side-a\"", "qpvuntsm 2205b3ac \"base\"", "zsuskuln d7acaf48 \"side-b\""]), .. }
+    Current operation: OperationId("e5c1616befa1b0e0640a951f0bd15ea1ab57919b46d4a3b6c3b4d6d76024f14b545c33be19c91001c759dee089dbb174c8cbe8e88ad414bf95296f9bce6239d5")
+    Current tree: MergedTree { tree_ids: Conflicted([TreeId("381273b50cf73f8c81b3f1502ee89e9bbd6c1518"), TreeId("771f3d31c4588ea40a8864b2a981749888e596c2"), TreeId("f56b8223da0dab22b03b8323ced4946329aeb4e0")]), labels: Labeled(["rlvkpnrz ccf9527c \"side-a\"", "qpvuntsm 2205b3ac \"base\"", "psuskuln 1ec39521 \"side-b\""]), .. }
     Normal { exec_bit: ExecBit(false) }           313 <timestamp> Some(MaterializedConflictData { conflict_marker_len: 11 }) "file"
     [EOF]
     "#);
@@ -395,9 +395,9 @@ fn test_conflict_marker_length_stored_in_working_copy() -> TestResult {
     insta::assert_snapshot!(output, @"
     Working copy changes:
     M file
-    Working copy  (@) : mzvwutvl d31c99cf (conflict) (no description set)
+    Working copy  (@) : ozvwutvl 512be212 (conflict) (no description set)
     Parent commit (@-): rlvkpnrz ccf9527c side-a
-    Parent commit (@-): zsuskuln d7acaf48 side-b
+    Parent commit (@-): psuskuln 1ec39521 side-b
     Warning: There are unresolved conflicts at these paths:
     file    2-sided conflict
     [EOF]
@@ -409,7 +409,7 @@ fn test_conflict_marker_length_stored_in_working_copy() -> TestResult {
     @@ -7,8 +7,10 @@
      +line 2 - left
      +line 3 - left
-     +++++++++++ zsuskuln d7acaf48 "side-b"
+     +++++++++++ psuskuln 1ec39521 "side-b"
     -======= fake marker
     +<<<<<<< fake marker
     +||||||| fake marker
@@ -424,8 +424,8 @@ fn test_conflict_marker_length_stored_in_working_copy() -> TestResult {
     // Working copy should still contain conflict marker length
     let output = work_dir.run_jj(["debug", "local-working-copy"]);
     insta::assert_snapshot!(output.normalize_stdout_with(redact_output), @r#"
-    Current operation: OperationId("19bcba55afcdec47b31cf0217b2a4b20dd9d90fe7dd7b4cdf0c52b74735c5407a8fddd1d3b43f37c09223b8b8053289f49bcba58c0af68869f891f582460ad4a")
-    Current tree: MergedTree { tree_ids: Conflicted([TreeId("381273b50cf73f8c81b3f1502ee89e9bbd6c1518"), TreeId("771f3d31c4588ea40a8864b2a981749888e596c2"), TreeId("3329c18c95f7b7a55c278c2259e9c4ce711fae59")]), labels: Labeled(["rlvkpnrz ccf9527c \"side-a\"", "qpvuntsm 2205b3ac \"base\"", "zsuskuln d7acaf48 \"side-b\""]), .. }
+    Current operation: OperationId("6bd87ef9457844ec51f68f6f05ec1cdd1e2bc0d42780afc26d545bbd8833c115fd76a8816a6c416f760a1eca8c5aa35db897c7b3743a98ffc27886a83cdc1907")
+    Current tree: MergedTree { tree_ids: Conflicted([TreeId("381273b50cf73f8c81b3f1502ee89e9bbd6c1518"), TreeId("771f3d31c4588ea40a8864b2a981749888e596c2"), TreeId("3329c18c95f7b7a55c278c2259e9c4ce711fae59")]), labels: Labeled(["rlvkpnrz ccf9527c \"side-a\"", "qpvuntsm 2205b3ac \"base\"", "psuskuln 1ec39521 \"side-b\""]), .. }
     Normal { exec_bit: ExecBit(false) }           274 <timestamp> Some(MaterializedConflictData { conflict_marker_len: 11 }) "file"
     [EOF]
     "#);
@@ -449,9 +449,9 @@ fn test_conflict_marker_length_stored_in_working_copy() -> TestResult {
     insta::assert_snapshot!(output, @"
     Working copy changes:
     M file
-    Working copy  (@) : mzvwutvl 469d479f (no description set)
+    Working copy  (@) : ozvwutvl 5e65aa64 (no description set)
     Parent commit (@-): rlvkpnrz ccf9527c side-a
-    Parent commit (@-): zsuskuln d7acaf48 side-b
+    Parent commit (@-): psuskuln 1ec39521 side-b
     [EOF]
     ");
 
@@ -459,7 +459,7 @@ fn test_conflict_marker_length_stored_in_working_copy() -> TestResult {
     // working copy
     let output = work_dir.run_jj(["debug", "local-working-copy"]);
     insta::assert_snapshot!(output.normalize_stdout_with(redact_output), @r#"
-    Current operation: OperationId("ed741c71397533330b01669ac13c3407ed89ba782a65ef038cefef27f95f3e2a513f0d3b04a2f96e79ac8b9e050ea080b06dd6ad2b10fc4e3f6978100b8ec8c9")
+    Current operation: OperationId("71c4b064902fa64bdc264183a2c9a200edb3522e021c90827d0e1a6389d887e92f4f330a8d8d603b871af07fee2aeebe174b715acd4f105aea8471d34e103872")
     Current tree: MergedTree { tree_ids: Resolved(TreeId("6120567b3cb2472d549753ed3e4b84183d52a650")), labels: Unlabeled, .. }
     Normal { exec_bit: ExecBit(false) }           130 <timestamp> None "file"
     [EOF]
@@ -598,8 +598,8 @@ fn test_snapshot_jjconflict_trees() -> TestResult {
     A .jjconflict-side-1/file
     A JJ-CONFLICT-README
     M file
-    Working copy  (@) : zsuskuln 2681a418 (no description set)
-    Parent commit (@-): kkmpptxz aadeb8eb (conflict) side-b
+    Working copy  (@) : psuskuln cb0abe79 (no description set)
+    Parent commit (@-): nkmpptxz cf1c9058 (conflict) side-b
     Hint: Conflict in parent commit has been resolved in working copy
     [EOF]
     ------- stderr -------

--- a/cli/tests/test_workspaces.rs
+++ b/cli/tests/test_workspaces.rs
@@ -262,7 +262,7 @@ fn test_workspaces_add_second_workspace_on_merge() {
 
     let output = main_dir.run_jj(["workspace", "list"]);
     insta::assert_snapshot!(output, @"
-    default: zsuskuln 46ed31b6 (empty) merge
+    default: psuskuln 7f8df8b7 (empty) merge
     [EOF]
     ");
 
@@ -272,12 +272,12 @@ fn test_workspaces_add_second_workspace_on_merge() {
 
     // The new workspace's working-copy commit shares all parents with the old one.
     insta::assert_snapshot!(get_log_output(&main_dir), @r#"
-    @    46ed31b61ce9 default@ "merge"
+    @    7f8df8b70507 default@ "merge"
     ├─╮
-    │ │ ○  d23b2d4ff55c second@
+    │ │ ○  d716b707076e second@
     ╭─┬─╯
     │ ○  3c52528f5893 "left"
-    ○ │  a3155ab1bf5a "right"
+    ○ │  32de3a4c36e0 "right"
     ├─╯
     ◆  000000000000
     [EOF]
@@ -479,10 +479,10 @@ fn test_workspaces_add_workspace_multiple_revisions() {
     main_dir.run_jj(["new", "-r", "root()"]).success();
 
     insta::assert_snapshot!(get_log_output(&main_dir), @r#"
-    @  8d23abddc924
-    │ ○  eba7f49e2358 "third"
+    @  0edd0f26ec40
+    │ ○  3ce578a9f428 "third"
     ├─╯
-    │ ○  62444a45efcf "second"
+    │ ○  ff789b07c69b "second"
     ├─╯
     │ ○  27473635a942 "first"
     ├─╯
@@ -502,23 +502,23 @@ fn test_workspaces_add_workspace_multiple_revisions() {
     insta::assert_snapshot!(output.normalize_backslash(), @r#"
     ------- stderr -------
     Created workspace in "../merged"
-    Working copy  (@) now at: wmwvqwsz 2d7c9a2d (empty) (no description set)
-    Parent commit (@-)      : mzvwutvl eba7f49e third
-    Parent commit (@-)      : kkmpptxz 62444a45 second
+    Working copy  (@) now at: wmwvqwsz 91b19974 (empty) (no description set)
+    Parent commit (@-)      : pzvwutvl 3ce578a9 third
+    Parent commit (@-)      : nkmpptxz ff789b07 second
     Parent commit (@-)      : qpvuntsm 27473635 first
     Added 3 files, modified 0 files, removed 0 files
     [EOF]
     "#);
 
     insta::assert_snapshot!(get_log_output(&main_dir), @r#"
-    @  8d23abddc924 default@
-    │ ○      2d7c9a2d41dc merge@
+    @  0edd0f26ec40 default@
+    │ ○      91b199744f5e merge@
     │ ├─┬─╮
     │ │ │ ○  27473635a942 "first"
     ├─────╯
-    │ │ ○  62444a45efcf "second"
+    │ │ ○  ff789b07c69b "second"
     ├───╯
-    │ ○  eba7f49e2358 "third"
+    │ ○  3ce578a9f428 "third"
     ├─╯
     ◆  000000000000
     [EOF]
@@ -704,7 +704,7 @@ fn test_workspaces_conflicting_edits() {
         .success();
 
     insta::assert_snapshot!(get_log_output(&main_dir), @"
-    @  393250c59e39 default@
+    @  9a01e1a6ef1c default@
     │ ○  547036666102 secondary@
     ├─╯
     ○  9a462e35578a
@@ -738,7 +738,7 @@ fn test_workspaces_conflicting_edits() {
     let output = secondary_dir.run_jj(["st"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Error: The working copy is stale (not updated since operation 58f8ef773e05).
+    Error: The working copy is stale (not updated since operation 76089b82c0b6).
     Hint: Run `jj workspace update-stale` to update it.
     See https://docs.jj-vcs.dev/latest/working-copy/#stale-working-copy for more information.
     [EOF]
@@ -748,7 +748,7 @@ fn test_workspaces_conflicting_edits() {
     let output = secondary_dir.run_jj(["log"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Error: The working copy is stale (not updated since operation 58f8ef773e05).
+    Error: The working copy is stale (not updated since operation 76089b82c0b6).
     Hint: Run `jj workspace update-stale` to update it.
     See https://docs.jj-vcs.dev/latest/working-copy/#stale-working-copy for more information.
     [EOF]
@@ -808,7 +808,7 @@ fn test_workspaces_updated_by_other() {
         .success();
 
     insta::assert_snapshot!(get_log_output(&main_dir), @"
-    @  393250c59e39 default@
+    @  9a01e1a6ef1c default@
     │ ○  547036666102 secondary@
     ├─╯
     ○  9a462e35578a
@@ -839,7 +839,7 @@ fn test_workspaces_updated_by_other() {
     let output = secondary_dir.run_jj(["st"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Error: The working copy is stale (not updated since operation 58f8ef773e05).
+    Error: The working copy is stale (not updated since operation 76089b82c0b6).
     Hint: Run `jj workspace update-stale` to update it.
     See https://docs.jj-vcs.dev/latest/working-copy/#stale-working-copy for more information.
     [EOF]
@@ -885,7 +885,7 @@ fn test_workspaces_updated_by_other_automatic() {
         .success();
 
     insta::assert_snapshot!(get_log_output(&main_dir), @"
-    @  393250c59e39 default@
+    @  9a01e1a6ef1c default@
     │ ○  547036666102 secondary@
     ├─╯
     ○  9a462e35578a
@@ -958,7 +958,7 @@ fn test_workspaces_updated_by_other_with_changes_in_working_copy_automatic() {
         .success();
 
     insta::assert_snapshot!(get_log_output(&main_dir), @"
-    @  393250c59e39 default@
+    @  9a01e1a6ef1c default@
     │ ○  547036666102 secondary@
     ├─╯
     ○  9a462e35578a
@@ -1089,12 +1089,12 @@ fn test_workspaces_current_op_discarded_by_other(automatic: bool) {
     ]);
     insta::allow_duplicates! {
         insta::assert_snapshot!(output, @"
-        @  2dea766382 abandon commit de90575a14d8b9198dc0930f9de4a69f846ded36
-        ○  0d3faebd8c create initial working-copy commit in workspace secondary
-        ○  200ba564cb add workspace 'secondary'
-        ○  b34eafb924 new empty commit
-        ○  c883929a6b snapshot working copy
-        ○  bd7b1cfa98 new empty commit
+        @  f7ce0dfe58 abandon commit 8d8895c422852fa27d9c1a494755c8d337f3ed73
+        ○  1056601e2d create initial working-copy commit in workspace secondary
+        ○  168783d791 add workspace 'secondary'
+        ○  146ce9d37c new empty commit
+        ○  e43629982e snapshot working copy
+        ○  413041eaab new empty commit
         ○  4509e20d8c snapshot working copy
         ○  90267f31f9 add workspace 'default'
         ○  0000000000
@@ -1108,7 +1108,7 @@ fn test_workspaces_current_op_discarded_by_other(automatic: bool) {
 
     insta::allow_duplicates! {
         insta::assert_snapshot!(get_log_output(&main_dir), @"
-        @  320bc89effc9 default@
+        @  0b76f1a00317 default@
         │ ○  891f00062e10 secondary@
         ├─╯
         ○  367415be5b44
@@ -1131,7 +1131,7 @@ fn test_workspaces_current_op_discarded_by_other(automatic: bool) {
         Parent commit (@-): rzvqmyuk 891f0006 (empty) (no description set)
         [EOF]
         ------- stderr -------
-        Failed to read working copy's current operation; attempting recovery. Error message from read attempt: Object 0d3faebd8cf4f0e39ea3eab47f22c9cdbcdaa54d95e79a86a0dab4ebe3b0377f69e1d64fa4661913c8c6af01dc0ebb5ad7c8b2bfa3d229827b2ba756d729e0bf of type operation not found
+        Failed to read working copy's current operation; attempting recovery. Error message from read attempt: Object 1056601e2db2748b73572fb837f7ba209a0858e9e93de48a50397ec5c210433b4cfbcc1522b0ad269dab2b55f874cab7471a37d1937985fbee8f75d03d677d3e of type operation not found
         Created and checked out recovery commit 866928d1e0fd
         [EOF]
         ");
@@ -1149,7 +1149,7 @@ fn test_workspaces_current_op_discarded_by_other(automatic: bool) {
         let output = secondary_dir.run_jj(["workspace", "update-stale"]);
         insta::assert_snapshot!(output, @"
         ------- stderr -------
-        Failed to read working copy's current operation; attempting recovery. Error message from read attempt: Object 0d3faebd8cf4f0e39ea3eab47f22c9cdbcdaa54d95e79a86a0dab4ebe3b0377f69e1d64fa4661913c8c6af01dc0ebb5ad7c8b2bfa3d229827b2ba756d729e0bf of type operation not found
+        Failed to read working copy's current operation; attempting recovery. Error message from read attempt: Object 1056601e2db2748b73572fb837f7ba209a0858e9e93de48a50397ec5c210433b4cfbcc1522b0ad269dab2b55f874cab7471a37d1937985fbee8f75d03d677d3e of type operation not found
         Created and checked out recovery commit 866928d1e0fd
         [EOF]
         ");
@@ -1157,7 +1157,7 @@ fn test_workspaces_current_op_discarded_by_other(automatic: bool) {
 
     insta::allow_duplicates! {
         insta::assert_snapshot!(get_log_output(&main_dir), @r#"
-        @  320bc89effc9 default@
+        @  0b76f1a00317 default@
         │ ○  18851b397d09 secondary@ "RECOVERY COMMIT FROM `jj workspace update-stale`"
         │ ○  891f00062e10
         ├─╯
@@ -1200,20 +1200,20 @@ fn test_workspaces_current_op_discarded_by_other(automatic: bool) {
         insta::assert_snapshot!(output, @"
         @  kmkuslsw test.user@example.com 2001-02-03 08:05:18 secondary@ 18851b39
         │  RECOVERY COMMIT FROM `jj workspace update-stale`
-        │  -- operation a35d39d101f4 snapshot working copy
+        │  -- operation 47e1cdfb593a snapshot working copy
         ○  kmkuslsw/1 test.user@example.com 2001-02-03 08:05:18 866928d1 (hidden)
            (empty) RECOVERY COMMIT FROM `jj workspace update-stale`
-           -- operation 754c2986ff83 recovery commit
+           -- operation e86acc212d1e recovery commit
         [EOF]
         ");
     } else {
         insta::assert_snapshot!(output, @"
         @  kmkuslsw test.user@example.com 2001-02-03 08:05:18 secondary@ 18851b39
         │  RECOVERY COMMIT FROM `jj workspace update-stale`
-        │  -- operation 3ae899f26750 snapshot working copy
+        │  -- operation f4255ccf9eaf snapshot working copy
         ○  kmkuslsw/1 test.user@example.com 2001-02-03 08:05:18 866928d1 (hidden)
            (empty) RECOVERY COMMIT FROM `jj workspace update-stale`
-           -- operation 754c2986ff83 recovery commit
+           -- operation e86acc212d1e recovery commit
         [EOF]
         ");
     }
@@ -1271,8 +1271,8 @@ fn test_workspaces_unpublished_operation_same_tree() {
     let output = main_dir.run_jj(["status"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Internal error: The repo was loaded at operation 8627c7508be4, which seems to be a sibling of the working copy's operation eceacbdafd84
-    Hint: Run `jj op integrate eceacbdafd84` to add the working copy's operation to the operation log.
+    Internal error: The repo was loaded at operation 292f86d8ca22, which seems to be a sibling of the working copy's operation db8fce250af3
+    Hint: Run `jj op integrate db8fce250af3` to add the working copy's operation to the operation log.
     [EOF]
     [exit status: 255]
     ");
@@ -1281,9 +1281,9 @@ fn test_workspaces_unpublished_operation_same_tree() {
     let output = main_dir.run_jj(["workspace", "update-stale"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: zsuskuln 36a15ac4 (empty) C
+    Working copy  (@) now at: psuskuln 62a409aa (empty) C
     Parent commit (@-)      : qpvuntsm 8777db25 (empty) A
-    Updated working copy to fresh commit 36a15ac414e8
+    Updated working copy to fresh commit 62a409aa7bb8
     [EOF]
     ");
 }
@@ -1318,8 +1318,8 @@ fn test_workspaces_update_stale_snapshot() {
 
     insta::assert_snapshot!(get_log_output(&secondary_dir), @"
     @  35d779b3baea secondary@
-    │ ○  c9516583d53b default@
-    │ ○  f6ae7810ef56
+    │ ○  16253ab6fb36 default@
+    │ ○  2e73f76d9bad
     ├─╯
     ○  7d5738ba9943
     ◆  000000000000
@@ -1384,12 +1384,12 @@ fn test_colocated_workspace_update_stale() {
 
     insta::assert_snapshot!(get_log_output(&secondary_dir), @r#"
     @  9cb8253861b5 secondary@
-    │ ○  f562bf82f2da default@
+    │ ○  b44563d40a92 default@
     ├─╯
     ○  30ed2f28b710
-    │ ○  e97ad7861f78 book1 "new book1"
+    │ ○  d1c9e38182d5 book1 "new book1"
     ├─╯
-    │ ○  f656b467890b "old book1"
+    │ ○  cc9cc8eae747 "old book1"
     ├─╯
     ◆  000000000000
     [EOF]
@@ -1399,7 +1399,7 @@ fn test_colocated_workspace_update_stale() {
     let output = main_dir.run_jj(["st"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Error: The working copy is stale (not updated since operation 8ab980a3d398).
+    Error: The working copy is stale (not updated since operation f01296619359).
     Hint: Run `jj workspace update-stale` to update it.
     See https://docs.jj-vcs.dev/latest/working-copy/#stale-working-copy for more information.
     [EOF]
@@ -1412,10 +1412,10 @@ fn test_colocated_workspace_update_stale() {
     let output = main_dir.run_jj(["workspace", "update-stale"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: rlvkpnrz f562bf82 (empty) (no description set)
+    Working copy  (@) now at: ylvkpnrz b44563d4 (empty) (no description set)
     Parent commit (@-)      : qpvuntsm 30ed2f28 (no description set)
     Added 0 files, modified 1 files, removed 0 files
-    Updated working copy to fresh commit f562bf82f2da
+    Updated working copy to fresh commit b44563d40a92
     Done importing changes from the underlying Git repo.
     [EOF]
     ");
@@ -1425,7 +1425,7 @@ fn test_colocated_workspace_update_stale() {
     let output = main_dir.run_jj(["st"]);
     insta::assert_snapshot!(output, @"
     The working copy has no changes.
-    Working copy  (@) : rlvkpnrz f562bf82 (empty) (no description set)
+    Working copy  (@) : ylvkpnrz b44563d4 (empty) (no description set)
     Parent commit (@-): qpvuntsm 30ed2f28 (no description set)
     [EOF]
     ");
@@ -1433,15 +1433,15 @@ fn test_colocated_workspace_update_stale() {
     // The updated bookmark "book1" shouldn't be re-imported as an external
     // change. If it were, the "old book1" revision would be abandoned.
     insta::assert_snapshot!(get_log_output(&main_dir), @r#"
-    @  f562bf82f2da default@
+    @  b44563d40a92 default@
     │ ○  9cb8253861b5 secondary@
     ├─╯
     ○  30ed2f28b710
     │ ○  7fe3ff3b9a60 book2 "book2"
     ├─╯
-    │ ○  e97ad7861f78 book1 "new book1"
+    │ ○  d1c9e38182d5 book1 "new book1"
     ├─╯
-    │ ○  f656b467890b "old book1"
+    │ ○  cc9cc8eae747 "old book1"
     ├─╯
     ◆  000000000000
     [EOF]
@@ -1587,7 +1587,7 @@ fn test_workspaces_forget_multi_transaction() {
     // there should be three workspaces
     let output = main_dir.run_jj(["workspace", "list"]);
     insta::assert_snapshot!(output, @"
-    default: rlvkpnrz f6bf8819 (empty) (no description set)
+    default: ylvkpnrz 1705bc9a (empty) (no description set)
     second: pmmvwywv 31da1455 (empty) (no description set)
     third: rzvqmyuk bf5b5b4d (empty) (no description set)
     [EOF]
@@ -1599,14 +1599,14 @@ fn test_workspaces_forget_multi_transaction() {
         .success();
     let output = main_dir.run_jj(["workspace", "list"]);
     insta::assert_snapshot!(output, @"
-    default: rlvkpnrz f6bf8819 (empty) (no description set)
+    default: ylvkpnrz 1705bc9a (empty) (no description set)
     [EOF]
     ");
 
     // the op log should have the multiple valid workspaces forgotten in a single tx
     let output = main_dir.run_jj(["op", "log", "--limit", "1"]);
     insta::assert_snapshot!(output, @"
-    @  90493ae75198 test-username@host.example.com default@ 2001-02-03 04:05:12.000 +07:00 - 2001-02-03 04:05:12.000 +07:00
+    @  4c3998fced17 test-username@host.example.com default@ 2001-02-03 04:05:12.000 +07:00 - 2001-02-03 04:05:12.000 +07:00
     │  forget workspaces second, third
     │  args: jj workspace forget second third fourth
     [EOF]
@@ -1618,7 +1618,7 @@ fn test_workspaces_forget_multi_transaction() {
     // finally, there should be three workspaces at the end
     let output = main_dir.run_jj(["workspace", "list"]);
     insta::assert_snapshot!(output, @"
-    default: rlvkpnrz f6bf8819 (empty) (no description set)
+    default: ylvkpnrz 1705bc9a (empty) (no description set)
     second: pmmvwywv 31da1455 (empty) (no description set)
     third: rzvqmyuk bf5b5b4d (empty) (no description set)
     [EOF]

--- a/lib/src/id_prefix.rs
+++ b/lib/src/id_prefix.rs
@@ -38,6 +38,7 @@ use crate::revset::RevsetResolutionError;
 use crate::revset::SymbolResolver;
 use crate::revset::SymbolResolverExtension;
 use crate::revset::UserRevsetExpression;
+use crate::settings::JJRng;
 use crate::view::View;
 
 #[derive(Debug, Error)]
@@ -277,6 +278,25 @@ impl IdPrefixIndex<'_> {
         }
         repo.shortest_unique_change_id_prefix_len(change_id)
     }
+
+    /// Generates a change-ID whose prefix doesn't collide with any
+    /// existing change-ID in the disambiguation set. Uses a multi-level
+    /// bitset to find a free prefix at the shortest possible length.
+    pub fn generate_new_change_id(&self, rng: &JJRng, length: usize) -> ChangeId {
+        let prefixes: Vec<[u8; 2]> = self
+            .indexes
+            .iter()
+            .flat_map(|indexes| {
+                indexes.commit_change_ids.iter().map(|(_, change_id)| {
+                    let bytes = change_id.as_bytes();
+                    [bytes[0], bytes[1]]
+                })
+            })
+            .collect();
+        let mut bytes = rng.new_change_id(length).to_bytes();
+        find_free_prefix(&mut bytes, &prefixes, rng);
+        ChangeId::new(bytes)
+    }
 }
 
 fn disambiguate_prefix_with_refs(view: &View, id_sym: &str, min_len: usize) -> usize {
@@ -292,6 +312,52 @@ fn disambiguate_prefix_with_refs(view: &View, id_sym: &str, min_len: usize) -> u
         // No need to test conflicts with the full ID. We have to return some
         // valid length anyway.
         .unwrap_or(id_sym.len())
+}
+
+pub(crate) fn prefix_key(bytes: &[u8], len: usize) -> usize {
+    let mut val = 0usize;
+    for i in 0..len {
+        let byte_idx = i / 2;
+        let digit = if i % 2 == 0 {
+            bytes[byte_idx] >> 4
+        } else {
+            bytes[byte_idx] & 0x0f
+        };
+        val = (val << 4) | (digit as usize);
+    }
+    val
+}
+
+/// Modifies the leading hex digits of `bytes` to avoid collision with any
+/// prefix in `prefixes`. Picks uniformly at random among free slots at
+/// the shortest available prefix length (1-4). If all slots are exhausted
+/// at every length, leaves `bytes` unchanged.
+pub(crate) fn find_free_prefix(bytes: &mut [u8], prefixes: &[[u8; 2]], rng: &JJRng) {
+    for len in 1..=4 {
+        let slots: usize = 1usize << (4 * len);
+        let mut taken = vec![false; slots];
+        for p in prefixes {
+            taken[prefix_key(p, len)] = true;
+        }
+        let free: Vec<usize> = (0..slots).filter(|&i| !taken[i]).collect();
+        if !free.is_empty() {
+            let val = free[rng.random_index(free.len())];
+            encode_prefix(bytes, len, val);
+            return;
+        }
+    }
+}
+
+pub(crate) fn encode_prefix(bytes: &mut [u8], len: usize, val: usize) {
+    for i in 0..len {
+        let digit = (val >> (4 * (len - 1 - i))) & 0xf;
+        let byte_idx = i / 2;
+        if i % 2 == 0 {
+            bytes[byte_idx] = (bytes[byte_idx] & 0x0f) | ((digit as u8) << 4);
+        } else {
+            bytes[byte_idx] = (bytes[byte_idx] & 0xf0) | (digit as u8);
+        }
+    }
 }
 
 /// In-memory immutable index to do prefix lookup of key `K` through `P`.

--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -389,7 +389,7 @@ pub type OpStoreInitializer<'a> =
     dyn Fn(&UserSettings, &Path, RootOperationData) -> Result<Box<dyn OpStore>, BackendInitError>
     + 'a;
 #[rustfmt::skip] // auto-formatted line would exceed the maximum width
-pub type OpHeadsStoreInitializer<'a> = 
+pub type OpHeadsStoreInitializer<'a> =
     dyn Fn(&UserSettings, &Path, &OperationId)
     -> Result<Box<dyn OpHeadsStore>, BackendInitError>
     + 'a;

--- a/lib/src/settings.rs
+++ b/lib/src/settings.rs
@@ -304,6 +304,11 @@ impl JJRng {
         ChangeId::new(random_bytes)
     }
 
+    /// Returns a random index in `[0, len)`. Panics if `len == 0`.
+    pub fn random_index(&self, len: usize) -> usize {
+        self.0.lock().unwrap().random_range(0..len)
+    }
+
     /// Creates a new RNGs. Could be made public, but we'd like to encourage all
     /// RNGs references to point to the same RNG.
     fn new(seed: Option<u64>) -> Self {

--- a/lib/tests/test_id_prefix.rs
+++ b/lib/tests/test_id_prefix.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use itertools::Itertools as _;
 use jj_lib::backend::ChangeId;
 use jj_lib::backend::CommitId;
@@ -32,6 +34,7 @@ use jj_lib::op_store::RefTarget;
 use jj_lib::repo::MutableRepo;
 use jj_lib::repo::Repo as _;
 use jj_lib::revset::RevsetExpression;
+use jj_lib::revset::RevsetExtensions;
 use jj_lib::settings::UserSettings;
 use pollster::FutureExt as _;
 use testutils::CommitBuilderExt as _;
@@ -622,4 +625,75 @@ fn test_id_prefix_shadowed_by_ref() {
         shortest_change_prefix_len(tx.repo(), commit.change_id()),
         change_id_sym.len()
     );
+}
+
+fn prefix_key(bytes: &[u8], len: usize) -> usize {
+    let mut val = 0usize;
+    for i in 0..len {
+        let byte_idx = i / 2;
+        let digit = if i % 2 == 0 {
+            bytes[byte_idx] >> 4
+        } else {
+            bytes[byte_idx] & 0x0f
+        };
+        val = (val << 4) | (digit as usize);
+    }
+    val
+}
+
+#[test]
+fn test_generate_new_change_id() -> TestResult {
+    let test_repo = TestRepo::init_with_backend(TestRepoBackend::Git);
+    let repo = &test_repo.repo;
+    let settings = stable_settings();
+    let rng = settings.get_rng();
+    let root_commit_id = repo.store().root_commit_id();
+
+    // Create commits so the disambiguation set has entries
+    let mut tx = repo.start_transaction();
+    let signature = Signature {
+        name: "Some One".to_string(),
+        email: "some.one@example.com".to_string(),
+        timestamp: Timestamp {
+            timestamp: MillisSinceEpoch(0),
+            tz_offset: 0,
+        },
+    };
+    let mut existing = vec![repo.store().root_change_id().clone()];
+    for _ in 0..10 {
+        let commit = tx
+            .repo_mut()
+            .new_commit(
+                vec![root_commit_id.clone()],
+                repo.store().empty_merged_tree(),
+            )
+            .set_author(signature.clone())
+            .set_committer(signature.clone())
+            .write_unwrap();
+        existing.push(commit.change_id().clone());
+    }
+    let repo = tx.commit("test").block_on()?;
+
+    // Build an IdPrefixContext with a disambiguation revset that covers
+    // all existing commits.
+    let id_prefix_context = IdPrefixContext::new(Arc::new(RevsetExtensions::default()))
+        .disambiguate_within(RevsetExpression::all());
+    let index = id_prefix_context.populate(repo.as_ref())?;
+    let length = repo.store().change_id_length();
+
+    // Generate a change-ID and verify it doesn't collide with any existing
+    // ID at prefix lengths 1 through 4.
+    let change_id = index.generate_new_change_id(&rng, length);
+    assert_eq!(change_id.as_bytes().len(), length);
+    for (j, other) in existing.iter().enumerate() {
+        for len in 1..=4 {
+            assert_ne!(
+                prefix_key(change_id.as_bytes(), len),
+                prefix_key(other.as_bytes(), len),
+                "len={len} prefix collision with existing entry {j}",
+            );
+        }
+    }
+
+    Ok(())
 }


### PR DESCRIPTION

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
