### PR TITLE
run: Remove unnecessarily verbose summary output

### DIFF
--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -704,7 +704,6 @@ pub async fn cmd_run(
         auto_tracking_matcher,
         args.clean,
     )?);
-    let stored_len = resolved_commits.len();
 
     let spec = Arc::new(CommandSpec {
         program: args.command.clone(),
@@ -716,7 +715,7 @@ pub async fn cmd_run(
     // Drive the producer (run_inner) and consumer (receive loop) concurrently
     // so that each subprocess's output is emitted as soon as it finishes rather
     // than after all subprocesses complete.
-    let ((), visited) = futures::try_join!(
+    futures::try_join!(
         async {
             run_inner(
                 &tx,
@@ -731,7 +730,6 @@ pub async fn cmd_run(
             .map_err(CommandError::from)
         },
         async {
-            let mut visited = 0;
             while let Some(res) = receiver.recv().await {
                 if res.skipped {
                     writeln!(
@@ -770,23 +768,14 @@ pub async fn cmd_run(
                         rewritten_commits.insert(res.old_id.clone(), (res.old_tree, new_tree));
                     }
                 }
-                visited += 1;
-                if visited == stored_len {
-                    break;
-                }
             }
-            Ok::<_, CommandError>(visited)
+            Ok::<_, CommandError>(())
         },
     )?;
 
     // The operation was a no-op, bail.
     if rewritten_commits.is_empty() {
-        writeln!(
-            ui.stderr(),
-            "No commits were rewritten as the command did not modify any tracked files"
-        )?;
-        tx.finish(ui, format!("run: No-op on {visited} commits with {spec}"))
-            .await?;
+        tx.finish(ui, "run: nothing changed").await?;
         return Ok(());
     }
 
@@ -826,8 +815,8 @@ pub async fn cmd_run(
             },
         )
         .await?;
-    writeln!(ui.stderr(), "Rewrote {count} commits with {spec}")?;
-    tx.finish(ui, format!("run: rewrite {count} commits with {spec}"))
+    writeln!(ui.stderr(), "Rewrote {count} commits")?;
+    tx.finish(ui, format!("run: rewrite {count} commits"))
         .await?;
 
     Ok(())

--- a/cli/tests/test_run_command.rs
+++ b/cli/tests/test_run_command.rs
@@ -150,7 +150,6 @@ fn test_run_noop() {
         .success();
     insta::assert_snapshot!(output.stdout, @"foofoofoofoo[EOF]");
     insta::assert_snapshot!(output.stderr, @r"
-    No commits were rewritten as the command did not modify any tracked files
     Nothing changed.
     [EOF]
     ");
@@ -270,7 +269,7 @@ fn test_run_from_subdir_skips_commits_without_it() {
         .normalize_backslash();
     insta::assert_snapshot!(output.stderr, @r"
     Skipped commit 3bb1f1ca3c09a8e6be46ef48515803464b16b426: directory does not exist: sub
-    Rewrote 1 commits with $FAKE_FORMATTER_PATH --tee ran.txt
+    Rewrote 1 commits
     Working copy  (@) now at: kkmpptxz 3548431a (empty) (no description set)
     Parent commit (@-)      : rlvkpnrz 3aa9a235 with-sub
     Added 1 files, modified 0 files, removed 0 files


### PR DESCRIPTION
This message is unnecessary because the usual "Nothing changed" message is also printed. It's also not necessary to output the command when summarizing what changed.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [ ] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
