### PR TITLE
dependabot: Fix npm manifest directory to adjust commit messages prefix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,8 +39,9 @@ updates:
     nix-dependencies:
       patterns:
       - "*"
+# Docs website
 - package-ecosystem: "npm"
-  directory: "/"
+  directory: "/web/docs"
   schedule:
     interval: "weekly"
   cooldown:


### PR DESCRIPTION
This should fix the problem that npm bumps still use default prefix [1], relates to [2].

Post-action: check that no error should be raised in dependabot [recent jobs dashboard](https://github.com/jj-vcs/jj/network/updates).

reference: [Dependabot options reference](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#directories-or-directory--)

cc: @PhilipMetzger 

[1]: https://github.com/jj-vcs/jj/pull/9192#issuecomment-4130486347
[2]: https://github.com/jj-vcs/jj/pull/9158

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [ ] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
