### PR TITLE
cli: improve deprecated command hints

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -4507,6 +4507,16 @@ fn map_clap_cli_error(err: clap::Error, ui: &Ui, config: &StackedConfig) -> Comm
             }
             _ => {}
         }
+        // Only rewrite messages for commands clap has already rejected. Soft
+        // deprecations still dispatch normally and print their command warning.
+        if let Some(hint) = removed_subcommand_hint(&err, cmd) {
+            return CommandError::from(remove_misleading_suggestion(err)).hinted(hint);
+        }
+    }
+    if let Some(ContextValue::String(arg)) = err.get(ContextKind::InvalidArg)
+        && let Some(hint) = removed_arg_hint(&err, arg)
+    {
+        return CommandError::from(remove_misleading_arg_suggestion(err)).hinted(hint);
     }
     if let (Some(ContextValue::String(arg)), Some(ContextValue::String(value))) = (
         err.get(ContextKind::InvalidArg),
@@ -4520,6 +4530,188 @@ fn map_clap_cli_error(err: clap::Error, ui: &Ui, config: &StackedConfig) -> Comm
         }
     }
     CommandError::from(err)
+}
+
+/// Removes clap's fuzzy suggestions when a removed subcommand has a more
+/// accurate recovery hint.
+///
+/// A removed jj command can be close to a live but semantically unrelated
+/// command. Keep the original clap error and usage text, but replace fuzzy
+/// suggestions with the recovery path from jj's removal history.
+fn remove_misleading_suggestion(mut err: clap::Error) -> clap::Error {
+    err.remove(ContextKind::SuggestedArg);
+    err.remove(ContextKind::SuggestedSubcommand);
+    err.remove(ContextKind::Suggested);
+    err
+}
+
+/// Removes clap's fuzzy suggestions and usage text for removed flags.
+///
+/// For removed flags, clap's suggested usage is often the usage of the
+/// similar-looking live flag rather than the command the user ran.
+fn remove_misleading_arg_suggestion(mut err: clap::Error) -> clap::Error {
+    err.remove(ContextKind::SuggestedArg);
+    err.remove(ContextKind::Suggested);
+    err.remove(ContextKind::Usage);
+    err
+}
+
+/// Returns recovery advice for removed subcommands after clap has rejected the
+/// command line.
+///
+/// These are not deprecation warnings. The command has already failed clap
+/// parsing as an invalid subcommand, and this table only replaces the recovery
+/// advice. The usage check scopes ambiguous names to the command family where
+/// the removed spelling used to exist.
+///
+/// Keep these breadcrumbs aligned with the corresponding removal entries in
+/// CHANGELOG.md so the recovery advice stays tied to the historical change.
+fn removed_subcommand_hint(err: &clap::Error, command_name: &str) -> Option<&'static str> {
+    let usage = error_usage(err)?;
+    let usage = usage.as_str();
+    match command_name {
+        // Removed in 0.33.0 after being deprecated in 0.28.0.
+        "backout" if usage_is_top_level(usage) => Some("Use `jj revert` instead."),
+        // Removed in 0.30.0 after the 0.22.0 branch/bookmark rename.
+        "branch" if usage_is_top_level(usage) => {
+            Some("Use `jj bookmark` and its subcommands instead.")
+        }
+        // Removed in 0.26.0 after the file-command migration.
+        "cat" if usage_is_top_level(usage) => Some("Use `jj file show` instead."),
+        "chmod" if usage_is_top_level(usage) => Some("Use `jj file chmod` instead."),
+        "files" if usage_is_top_level(usage) => Some("Use `jj file list` instead."),
+        // Removed in 0.22.0 after being deprecated in 0.14.0.
+        "checkout" | "co" if usage_is_top_level(usage) => Some("Use `jj new` instead."),
+        "merge" if usage_is_top_level(usage) => Some("Use `jj new` instead."),
+        // Removed in 0.22.0 after being deprecated in 0.16.0.
+        "move" if usage_is_top_level(usage) => Some("Use `jj squash` instead."),
+        // Removed in 0.26.0.
+        "mangen" if usage_starts_with(usage, "jj util") => {
+            Some("Use `jj util install-man-pages` instead.")
+        }
+        // Removed in 0.28.0 after being renamed in 0.20.0.
+        "untrack" if usage_is_top_level(usage) => Some("Use `jj file untrack` instead."),
+        // Removed in 0.28.0 after being deprecated in 0.22.0.
+        "unsquash" if usage_is_top_level(usage) => {
+            Some("Use `jj squash` or `jj diffedit --restore-descendants` instead.")
+        }
+        // Removed in 0.40.0 after being deprecated in 0.33.0.
+        "undo" if usage_starts_with_any(usage, &["jj operation", "jj op"]) => Some(
+            "Use `jj undo` to undo the latest operation. Use `jj op revert` to revert a specific \
+             operation.",
+        ),
+        // `jj op redo` never existed; keep the recovery next to the removed
+        // `jj op undo` mapping because users commonly try them together.
+        "redo" if usage_starts_with_any(usage, &["jj operation", "jj op"]) => {
+            Some("Use `jj redo` instead.")
+        }
+        _ => None,
+    }
+}
+
+/// Returns recovery advice for removed flags after clap has rejected the
+/// command line.
+///
+/// These are not deprecation warnings. The flag has already failed clap parsing
+/// as an invalid argument, and this table only replaces the recovery advice.
+/// The usage check avoids changing unrelated commands that happen to reject the
+/// same flag spelling.
+///
+/// Keep these breadcrumbs aligned with the corresponding removal entries in
+/// CHANGELOG.md so the recovery advice stays tied to the historical change.
+fn removed_arg_hint(err: &clap::Error, arg: &str) -> Option<&'static str> {
+    let usage = error_usage(err)?;
+    let usage = usage.as_str();
+    match arg {
+        // Removed in 0.26.0.
+        "-l" if usage_starts_with(usage, "jj log")
+            || usage_starts_with_any(usage, &["jj operation log", "jj op log"]) =>
+        {
+            Some("Use `-n` instead.")
+        }
+        // Removed in 0.42.0.
+        "--allow-new" if usage_starts_with(usage, "jj git push") => {
+            Some("Push a specific bookmark with `jj git push --bookmark <name>` instead.")
+        }
+        // Removed in 0.42.0 after being deprecated in 0.34.0.
+        "--author"
+            if usage_starts_with(usage, "jj commit") || usage_starts_with(usage, "jj describe") =>
+        {
+            Some("Use `jj metaedit --author <author>` instead.")
+        }
+        // Removed in 0.42.0 after being deprecated in 0.36.0.
+        "--edit" if usage_starts_with(usage, "jj describe") => {
+            Some("Use `jj describe --editor` instead.")
+        }
+        // Removed in 0.42.0 after being deprecated in 0.34.0.
+        "--no-edit" if usage_starts_with(usage, "jj describe") => Some(
+            "Omit `--no-edit`; `jj describe --message <message>` already avoids opening an editor.",
+        ),
+        // Removed in 0.42.0 after being deprecated in 0.34.0.
+        "--reset-author"
+            if usage_starts_with(usage, "jj commit") || usage_starts_with(usage, "jj describe") =>
+        {
+            Some("Use `jj metaedit --update-author` instead.")
+        }
+        // Removed in 0.30.0 after being renamed in 0.20.0.
+        "--skip-empty" if usage_starts_with(usage, "jj rebase") => {
+            Some("Use `jj rebase --skip-emptied` instead.")
+        }
+        // Removed in 0.26.0 after being deprecated in 0.23.0.
+        "--siblings" if usage_starts_with(usage, "jj split") => {
+            Some("Use `jj split --parallel` instead.")
+        }
+        // Removed in 0.33.0.
+        "--summary" if usage_starts_with(usage, "jj abandon") => Some(
+            "Omit `--summary`; `jj abandon` now limits the abandoned commit list automatically.",
+        ),
+        // Removed in 0.42.0 after being renamed in 0.33.0.
+        "--update-committer-timestamp" if usage_starts_with(usage, "jj metaedit") => {
+            Some("Use `jj metaedit --force-rewrite` instead.")
+        }
+        _ => None,
+    }
+}
+
+/// Returns clap's rendered usage text from the structured error context.
+///
+/// The removed-command hint tables use this to identify which command family
+/// rejected the spelling.
+fn error_usage(err: &clap::Error) -> Option<String> {
+    err.get(ContextKind::Usage).map(ToString::to_string)
+}
+
+/// Checks whether clap's rendered usage starts with the given command prefix.
+///
+/// Matching the rendered command prefix is enough to scope removed spellings
+/// without threading command metadata through this error-mapping layer. clap
+/// renders the Windows binary name as `jj.exe`, so accept both binary spellings
+/// here while keeping the hint tables in normal `jj ...` form.
+fn usage_starts_with(usage: &str, command: &str) -> bool {
+    let Some(command_suffix) = command.strip_prefix("jj") else {
+        return usage.starts_with(&format!("Usage: {command} "));
+    };
+    usage.starts_with(&format!("Usage: jj{command_suffix} "))
+        || usage.starts_with(&format!("Usage: jj.exe{command_suffix} "))
+}
+
+/// Checks whether clap's rendered usage starts with any of the given command
+/// prefixes.
+///
+/// This keeps canonical command names and visible aliases together when both
+/// can appear in the usage text.
+fn usage_starts_with_any(usage: &str, commands: &[&str]) -> bool {
+    commands
+        .iter()
+        .any(|command| usage_starts_with(usage, command))
+}
+
+/// Checks whether clap's rendered usage is for the top-level jj command.
+///
+/// This scopes removed top-level command spellings without matching nested
+/// subcommands that happen to share the same name.
+fn usage_is_top_level(usage: &str) -> bool {
+    usage_starts_with(usage, "jj [OPTIONS]")
 }
 
 fn format_template_aliases_hint(template_aliases: &TemplateAliasesMap) -> String {

--- a/cli/tests/test_global_opts.rs
+++ b/cli/tests/test_global_opts.rs
@@ -209,11 +209,10 @@ fn test_deprecated_removed_command_hints() {
     ------- stderr -------
     error: unrecognized subcommand 'undo'
 
-      tip: a similar subcommand exists: 'abandon'
-
     Usage: jj operation [OPTIONS] <COMMAND>
 
     For more information, try '--help'.
+    Hint: Use `jj undo` to undo the latest operation. Use `jj op revert` to revert a specific operation.
     [EOF]
     [exit status: 2]
     ");
@@ -223,11 +222,10 @@ fn test_deprecated_removed_command_hints() {
     ------- stderr -------
     error: unrecognized subcommand 'redo'
 
-      tip: a similar subcommand exists: 'restore'
-
     Usage: jj operation [OPTIONS] <COMMAND>
 
     For more information, try '--help'.
+    Hint: Use `jj redo` instead.
     [EOF]
     [exit status: 2]
     ");
@@ -240,6 +238,7 @@ fn test_deprecated_removed_command_hints() {
     Usage: jj [OPTIONS] <COMMAND>
 
     For more information, try '--help'.
+    Hint: Use `jj revert` instead.
     [EOF]
     [exit status: 2]
     ");
@@ -252,6 +251,7 @@ fn test_deprecated_removed_command_hints() {
     Usage: jj [OPTIONS] <COMMAND>
 
     For more information, try '--help'.
+    Hint: Use `jj bookmark` and its subcommands instead.
     [EOF]
     [exit status: 2]
     ");
@@ -264,6 +264,7 @@ fn test_deprecated_removed_command_hints() {
     Usage: jj [OPTIONS] <COMMAND>
 
     For more information, try '--help'.
+    Hint: Use `jj file show` instead.
     [EOF]
     [exit status: 2]
     ");
@@ -276,6 +277,7 @@ fn test_deprecated_removed_command_hints() {
     Usage: jj [OPTIONS] <COMMAND>
 
     For more information, try '--help'.
+    Hint: Use `jj file chmod` instead.
     [EOF]
     [exit status: 2]
     ");
@@ -288,6 +290,7 @@ fn test_deprecated_removed_command_hints() {
     Usage: jj [OPTIONS] <COMMAND>
 
     For more information, try '--help'.
+    Hint: Use `jj new` instead.
     [EOF]
     [exit status: 2]
     ");
@@ -297,11 +300,10 @@ fn test_deprecated_removed_command_hints() {
     ------- stderr -------
     error: unrecognized subcommand 'co'
 
-      tip: some similar subcommands exist: 'commit', 'config'
-
     Usage: jj [OPTIONS] <COMMAND>
 
     For more information, try '--help'.
+    Hint: Use `jj new` instead.
     [EOF]
     [exit status: 2]
     ");
@@ -311,11 +313,10 @@ fn test_deprecated_removed_command_hints() {
     ------- stderr -------
     error: unrecognized subcommand 'files'
 
-      tip: a similar subcommand exists: 'file'
-
     Usage: jj [OPTIONS] <COMMAND>
 
     For more information, try '--help'.
+    Hint: Use `jj file list` instead.
     [EOF]
     [exit status: 2]
     ");
@@ -328,6 +329,7 @@ fn test_deprecated_removed_command_hints() {
     Usage: jj [OPTIONS] <COMMAND>
 
     For more information, try '--help'.
+    Hint: Use `jj new` instead.
     [EOF]
     [exit status: 2]
     ");
@@ -340,6 +342,7 @@ fn test_deprecated_removed_command_hints() {
     Usage: jj [OPTIONS] <COMMAND>
 
     For more information, try '--help'.
+    Hint: Use `jj squash` instead.
     [EOF]
     [exit status: 2]
     ");
@@ -352,6 +355,7 @@ fn test_deprecated_removed_command_hints() {
     Usage: jj util [OPTIONS] <COMMAND>
 
     For more information, try '--help'.
+    Hint: Use `jj util install-man-pages` instead.
     [EOF]
     [exit status: 2]
     ");
@@ -364,6 +368,7 @@ fn test_deprecated_removed_command_hints() {
     Usage: jj [OPTIONS] <COMMAND>
 
     For more information, try '--help'.
+    Hint: Use `jj file untrack` instead.
     [EOF]
     [exit status: 2]
     ");
@@ -373,11 +378,10 @@ fn test_deprecated_removed_command_hints() {
     ------- stderr -------
     error: unrecognized subcommand 'unsquash'
 
-      tip: a similar subcommand exists: 'squash'
-
     Usage: jj [OPTIONS] <COMMAND>
 
     For more information, try '--help'.
+    Hint: Use `jj squash` or `jj diffedit --restore-descendants` instead.
     [EOF]
     [exit status: 2]
     ");
@@ -387,11 +391,8 @@ fn test_deprecated_removed_command_hints() {
     ------- stderr -------
     error: unexpected argument '-l' found
 
-      tip: to pass '-l' as a value, use '-- -l'
-
-    Usage: jj log [OPTIONS] [FILESETS]...
-
     For more information, try '--help'.
+    Hint: Use `-n` instead.
     [EOF]
     [exit status: 2]
     ");
@@ -401,9 +402,8 @@ fn test_deprecated_removed_command_hints() {
     ------- stderr -------
     error: unexpected argument '-l' found
 
-    Usage: jj operation log [OPTIONS]
-
     For more information, try '--help'.
+    Hint: Use `-n` instead.
     [EOF]
     [exit status: 2]
     ");
@@ -413,11 +413,8 @@ fn test_deprecated_removed_command_hints() {
     ------- stderr -------
     error: unexpected argument '--allow-new' found
 
-      tip: a similar argument exists: '--all'
-
-    Usage: jj git push --all
-
     For more information, try '--help'.
+    Hint: Push a specific bookmark with `jj git push --bookmark <name>` instead.
     [EOF]
     [exit status: 2]
     ");
@@ -427,11 +424,8 @@ fn test_deprecated_removed_command_hints() {
     ------- stderr -------
     error: unexpected argument '--reset-author' found
 
-      tip: a similar argument exists: '--repository'
-
-    Usage: jj commit --repository <REPOSITORY> [FILESETS]...
-
     For more information, try '--help'.
+    Hint: Use `jj metaedit --update-author` instead.
     [EOF]
     [exit status: 2]
     ");
@@ -441,11 +435,8 @@ fn test_deprecated_removed_command_hints() {
     ------- stderr -------
     error: unexpected argument '--author' found
 
-      tip: a similar argument exists: '--at-op'
-
-    Usage: jj commit --at-operation <AT_OPERATION> [FILESETS]...
-
     For more information, try '--help'.
+    Hint: Use `jj metaedit --author <author>` instead.
     [EOF]
     [exit status: 2]
     ");
@@ -455,11 +446,8 @@ fn test_deprecated_removed_command_hints() {
     ------- stderr -------
     error: unexpected argument '--edit' found
 
-      tip: a similar argument exists: '--editor'
-
-    Usage: jj describe --editor [REVSETS]...
-
     For more information, try '--help'.
+    Hint: Use `jj describe --editor` instead.
     [EOF]
     [exit status: 2]
     ");
@@ -469,11 +457,8 @@ fn test_deprecated_removed_command_hints() {
     ------- stderr -------
     error: unexpected argument '--no-edit' found
 
-      tip: to pass '--no-edit' as a value, use '-- --no-edit'
-
-    Usage: jj describe [OPTIONS] [REVSETS]...
-
     For more information, try '--help'.
+    Hint: Omit `--no-edit`; `jj describe --message <message>` already avoids opening an editor.
     [EOF]
     [exit status: 2]
     ");
@@ -483,11 +468,8 @@ fn test_deprecated_removed_command_hints() {
     ------- stderr -------
     error: unexpected argument '--skip-empty' found
 
-      tip: a similar argument exists: '--skip-emptied'
-
-    Usage: jj rebase --skip-emptied <--onto <REVSETS>|--insert-after <REVSETS>|--insert-before <REVSETS>>
-
     For more information, try '--help'.
+    Hint: Use `jj rebase --skip-emptied` instead.
     [EOF]
     [exit status: 2]
     ");
@@ -497,11 +479,8 @@ fn test_deprecated_removed_command_hints() {
     ------- stderr -------
     error: unexpected argument '--siblings' found
 
-      tip: to pass '--siblings' as a value, use '-- --siblings'
-
-    Usage: jj split [OPTIONS] [FILESETS]...
-
     For more information, try '--help'.
+    Hint: Use `jj split --parallel` instead.
     [EOF]
     [exit status: 2]
     ");
@@ -511,11 +490,8 @@ fn test_deprecated_removed_command_hints() {
     ------- stderr -------
     error: unexpected argument '--summary' found
 
-      tip: to pass '--summary' as a value, use '-- --summary'
-
-    Usage: jj abandon [OPTIONS] [REVSETS]...
-
     For more information, try '--help'.
+    Hint: Omit `--summary`; `jj abandon` now limits the abandoned commit list automatically.
     [EOF]
     [exit status: 2]
     ");
@@ -525,11 +501,8 @@ fn test_deprecated_removed_command_hints() {
     ------- stderr -------
     error: unexpected argument '--update-committer-timestamp' found
 
-      tip: a similar argument exists: '--update-author-timestamp'
-
-    Usage: jj metaedit --update-author-timestamp [REVSETS]...
-
     For more information, try '--help'.
+    Hint: Use `jj metaedit --force-rewrite` instead.
     [EOF]
     [exit status: 2]
     ");
@@ -539,11 +512,8 @@ fn test_deprecated_removed_command_hints() {
     ------- stderr -------
     error: unexpected argument '--reset-author' found
 
-      tip: a similar argument exists: '--repository'
-
-    Usage: jj describe --repository <REPOSITORY> [REVSETS]...
-
     For more information, try '--help'.
+    Hint: Use `jj metaedit --update-author` instead.
     [EOF]
     [exit status: 2]
     ");
@@ -553,11 +523,8 @@ fn test_deprecated_removed_command_hints() {
     ------- stderr -------
     error: unexpected argument '--author' found
 
-      tip: a similar argument exists: '--at-op'
-
-    Usage: jj describe --at-operation <AT_OPERATION> [REVSETS]...
-
     For more information, try '--help'.
+    Hint: Use `jj metaedit --author <author>` instead.
     [EOF]
     [exit status: 2]
     ");

--- a/cli/tests/test_global_opts.rs
+++ b/cli/tests/test_global_opts.rs
@@ -199,6 +199,385 @@ fn test_no_subcommand() {
 }
 
 #[test]
+fn test_deprecated_removed_command_hints() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    let output = work_dir.run_jj(["op", "undo"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    error: unrecognized subcommand 'undo'
+
+      tip: a similar subcommand exists: 'abandon'
+
+    Usage: jj operation [OPTIONS] <COMMAND>
+
+    For more information, try '--help'.
+    [EOF]
+    [exit status: 2]
+    ");
+
+    let output = work_dir.run_jj(["op", "redo"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    error: unrecognized subcommand 'redo'
+
+      tip: a similar subcommand exists: 'restore'
+
+    Usage: jj operation [OPTIONS] <COMMAND>
+
+    For more information, try '--help'.
+    [EOF]
+    [exit status: 2]
+    ");
+
+    let output = work_dir.run_jj(["backout"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    error: unrecognized subcommand 'backout'
+
+    Usage: jj [OPTIONS] <COMMAND>
+
+    For more information, try '--help'.
+    [EOF]
+    [exit status: 2]
+    ");
+
+    let output = work_dir.run_jj(["branch", "list"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    error: unrecognized subcommand 'branch'
+
+    Usage: jj [OPTIONS] <COMMAND>
+
+    For more information, try '--help'.
+    [EOF]
+    [exit status: 2]
+    ");
+
+    let output = work_dir.run_jj(["cat", "file"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    error: unrecognized subcommand 'cat'
+
+    Usage: jj [OPTIONS] <COMMAND>
+
+    For more information, try '--help'.
+    [EOF]
+    [exit status: 2]
+    ");
+
+    let output = work_dir.run_jj(["chmod", "x", "file"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    error: unrecognized subcommand 'chmod'
+
+    Usage: jj [OPTIONS] <COMMAND>
+
+    For more information, try '--help'.
+    [EOF]
+    [exit status: 2]
+    ");
+
+    let output = work_dir.run_jj(["checkout"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    error: unrecognized subcommand 'checkout'
+
+    Usage: jj [OPTIONS] <COMMAND>
+
+    For more information, try '--help'.
+    [EOF]
+    [exit status: 2]
+    ");
+
+    let output = work_dir.run_jj(["co"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    error: unrecognized subcommand 'co'
+
+      tip: some similar subcommands exist: 'commit', 'config'
+
+    Usage: jj [OPTIONS] <COMMAND>
+
+    For more information, try '--help'.
+    [EOF]
+    [exit status: 2]
+    ");
+
+    let output = work_dir.run_jj(["files"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    error: unrecognized subcommand 'files'
+
+      tip: a similar subcommand exists: 'file'
+
+    Usage: jj [OPTIONS] <COMMAND>
+
+    For more information, try '--help'.
+    [EOF]
+    [exit status: 2]
+    ");
+
+    let output = work_dir.run_jj(["merge"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    error: unrecognized subcommand 'merge'
+
+    Usage: jj [OPTIONS] <COMMAND>
+
+    For more information, try '--help'.
+    [EOF]
+    [exit status: 2]
+    ");
+
+    let output = work_dir.run_jj(["move"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    error: unrecognized subcommand 'move'
+
+    Usage: jj [OPTIONS] <COMMAND>
+
+    For more information, try '--help'.
+    [EOF]
+    [exit status: 2]
+    ");
+
+    let output = work_dir.run_jj(["util", "mangen"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    error: unrecognized subcommand 'mangen'
+
+    Usage: jj util [OPTIONS] <COMMAND>
+
+    For more information, try '--help'.
+    [EOF]
+    [exit status: 2]
+    ");
+
+    let output = work_dir.run_jj(["untrack", "file"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    error: unrecognized subcommand 'untrack'
+
+    Usage: jj [OPTIONS] <COMMAND>
+
+    For more information, try '--help'.
+    [EOF]
+    [exit status: 2]
+    ");
+
+    let output = work_dir.run_jj(["unsquash"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    error: unrecognized subcommand 'unsquash'
+
+      tip: a similar subcommand exists: 'squash'
+
+    Usage: jj [OPTIONS] <COMMAND>
+
+    For more information, try '--help'.
+    [EOF]
+    [exit status: 2]
+    ");
+
+    let output = work_dir.run_jj(["log", "-l", "5"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    error: unexpected argument '-l' found
+
+      tip: to pass '-l' as a value, use '-- -l'
+
+    Usage: jj log [OPTIONS] [FILESETS]...
+
+    For more information, try '--help'.
+    [EOF]
+    [exit status: 2]
+    ");
+
+    let output = work_dir.run_jj(["op", "log", "-l", "5"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    error: unexpected argument '-l' found
+
+    Usage: jj operation log [OPTIONS]
+
+    For more information, try '--help'.
+    [EOF]
+    [exit status: 2]
+    ");
+
+    let output = work_dir.run_jj(["git", "push", "--allow-new"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    error: unexpected argument '--allow-new' found
+
+      tip: a similar argument exists: '--all'
+
+    Usage: jj git push --all
+
+    For more information, try '--help'.
+    [EOF]
+    [exit status: 2]
+    ");
+
+    let output = work_dir.run_jj(["commit", "--reset-author"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    error: unexpected argument '--reset-author' found
+
+      tip: a similar argument exists: '--repository'
+
+    Usage: jj commit --repository <REPOSITORY> [FILESETS]...
+
+    For more information, try '--help'.
+    [EOF]
+    [exit status: 2]
+    ");
+
+    let output = work_dir.run_jj(["commit", "--author", "A. U. Thor <author@example.com>"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    error: unexpected argument '--author' found
+
+      tip: a similar argument exists: '--at-op'
+
+    Usage: jj commit --at-operation <AT_OPERATION> [FILESETS]...
+
+    For more information, try '--help'.
+    [EOF]
+    [exit status: 2]
+    ");
+
+    let output = work_dir.run_jj(["describe", "--edit"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    error: unexpected argument '--edit' found
+
+      tip: a similar argument exists: '--editor'
+
+    Usage: jj describe --editor [REVSETS]...
+
+    For more information, try '--help'.
+    [EOF]
+    [exit status: 2]
+    ");
+
+    let output = work_dir.run_jj(["describe", "--no-edit"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    error: unexpected argument '--no-edit' found
+
+      tip: to pass '--no-edit' as a value, use '-- --no-edit'
+
+    Usage: jj describe [OPTIONS] [REVSETS]...
+
+    For more information, try '--help'.
+    [EOF]
+    [exit status: 2]
+    ");
+
+    let output = work_dir.run_jj(["rebase", "--skip-empty"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    error: unexpected argument '--skip-empty' found
+
+      tip: a similar argument exists: '--skip-emptied'
+
+    Usage: jj rebase --skip-emptied <--onto <REVSETS>|--insert-after <REVSETS>|--insert-before <REVSETS>>
+
+    For more information, try '--help'.
+    [EOF]
+    [exit status: 2]
+    ");
+
+    let output = work_dir.run_jj(["split", "--siblings"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    error: unexpected argument '--siblings' found
+
+      tip: to pass '--siblings' as a value, use '-- --siblings'
+
+    Usage: jj split [OPTIONS] [FILESETS]...
+
+    For more information, try '--help'.
+    [EOF]
+    [exit status: 2]
+    ");
+
+    let output = work_dir.run_jj(["abandon", "--summary"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    error: unexpected argument '--summary' found
+
+      tip: to pass '--summary' as a value, use '-- --summary'
+
+    Usage: jj abandon [OPTIONS] [REVSETS]...
+
+    For more information, try '--help'.
+    [EOF]
+    [exit status: 2]
+    ");
+
+    let output = work_dir.run_jj(["metaedit", "--update-committer-timestamp"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    error: unexpected argument '--update-committer-timestamp' found
+
+      tip: a similar argument exists: '--update-author-timestamp'
+
+    Usage: jj metaedit --update-author-timestamp [REVSETS]...
+
+    For more information, try '--help'.
+    [EOF]
+    [exit status: 2]
+    ");
+
+    let output = work_dir.run_jj(["describe", "--reset-author"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    error: unexpected argument '--reset-author' found
+
+      tip: a similar argument exists: '--repository'
+
+    Usage: jj describe --repository <REPOSITORY> [REVSETS]...
+
+    For more information, try '--help'.
+    [EOF]
+    [exit status: 2]
+    ");
+
+    let output = work_dir.run_jj(["describe", "--author", "A. U. Thor <author@example.com>"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    error: unexpected argument '--author' found
+
+      tip: a similar argument exists: '--at-op'
+
+    Usage: jj describe --at-operation <AT_OPERATION> [REVSETS]...
+
+    For more information, try '--help'.
+    [EOF]
+    [exit status: 2]
+    ");
+}
+
+#[test]
+fn test_soft_deprecated_command_still_runs() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    let output = work_dir.run_jj(["debug", "snapshot"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    Warning: `jj debug snapshot` is deprecated; use `jj util snapshot` instead
+    [EOF]
+    ");
+}
+
+#[test]
 fn test_ignore_working_copy() {
     let test_env = TestEnvironment::default();
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();


### PR DESCRIPTION
The motivating example is `jj op undo`, which currently suggests `jj op abandon` because it is textually similar. The useful recovery is `jj undo` for undoing the latest operation, or `jj op revert` for reverting a specific operation.

I noticed this by spinning up a bare Claude Code instance to see what it inherently knew from its knowledge cutoff. It tried the old `jj op undo` spelling and got the misleading `jj op abandon` suggestion. This patch addresses that class of failure by grounding recovery hints in jj's actual deprecation/removal history instead of relying only on clap's fuzzy string matching.

The stack is split to make the behavior clear:

- `cli: characterize removed command errors` copies the test cases and records the current messages for commands and flags that are already invalid.
- `cli: improve deprecated command hints` changes only those error messages, replacing misleading fuzzy suggestions with targeted recovery hints.

This should not make any soft-deprecated command or flag start failing. The new hinting path only runs after clap has already rejected an invalid subcommand or argument, and the characterization layer includes a guard that a still-supported deprecated command (`jj debug snapshot`) continues to run successfully with its warning.

# Checklist

If applicable:

- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does, how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with an eye towards deleting anything that is irrelevant, clarifying anything that is confusing, and adding details that are relevant. This includes, for example, commit descriptions, PR descriptions, and code comments.
