### PR TITLE
docs: document templates.workspace_list default-template config

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -614,6 +614,7 @@ needing the original behavior.
 You can configure the template used when no `-T` is specified.
 
 - `templates.config_list` for `jj config list`
+- `templates.workspace_list` for `jj workspace list`
 
 ```toml
 [templates]
@@ -627,6 +628,13 @@ you can add this to your config:
 ```toml
 [templates]
 config_list = "builtin_config_list_detailed"
+```
+
+You can include the workspace root path when you do `jj workspace list`:
+
+```toml
+[templates]
+workspace_list = "name ++ \": \" ++ root ++ \"\\n\""
 ```
 
 ## Log


### PR DESCRIPTION
The configuration docs already explain that `templates.config_list` sets the default template for `jj config list` when no `-T` is given. The parallel option for `jj workspace list`, `templates.workspace_list`, exists in the CLI and the config schema but is never mentioned in the docs.

That gap is what #9428 reports: there is no discoverable way to customize `jj workspace list` output (for example, to include each workspace's root path) without passing `-T` every time. This adds `templates.workspace_list` to the default-template list alongside `config_list` and shows a root-path example, matching the existing documentation style. No code or behavior changes; the option already works.

Fixes #9428

AI was used for assistance.

# Checklist

- [x] I have updated `CHANGELOG.md` (n/a: documents an existing option; no behavior change)
- [x] I have updated the documentation (`docs/config.md`)
- [x] I have updated the config schema (`cli/src/config-schema.json`) (n/a: option already present at line 1098)
- [x] I have added/updated tests to cover my changes (n/a: docs-only change)
- [x] I fully understand the code that I am submitting, including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited it for relevance and clarity.
