### PR TITLE
cli: show a user error with a hint on concurrent working-copy checkout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,12 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   aliases of the reserved `.git` and `.jj` directories.
   [#8924](https://github.com/jj-vcs/jj/issues/8924)
 
+* Concurrent working-copy checkout races (e.g. a snapshot from another process
+  while an editor is open) now produce a user-facing warning explaining that the
+  operation was recorded and how to refresh the working copy, instead of an
+  internal error.
+  [#9408](https://github.com/jj-vcs/jj/issues/9408)
+
 * `jj` now creates a new working-copy revision during snapshotting if the
   working copy was immutable. Previously, the new revision was created
   immediately after the working copy became immutable.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   aliases that are simply repeated. For example, with the alias `jj = []`, the
   command `jj jj jj log` will resolve to `jj log` as expected.
 
+* Concurrent working-copy checkout races (e.g. a snapshot from another process
+  while an editor is open) now produce a user-facing warning explaining that the
+  operation was recorded and how to refresh the working copy, instead of an
+  internal error.
+  [#9408](https://github.com/jj-vcs/jj/issues/9408)
+
 ## [0.43.0] - 2026-07-01
 
 ### Release highlights
@@ -86,12 +92,6 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   file. This identity check is used when writing the working copy to detect
   aliases of the reserved `.git` and `.jj` directories.
   [#8924](https://github.com/jj-vcs/jj/issues/8924)
-
-* Concurrent working-copy checkout races (e.g. a snapshot from another process
-  while an editor is open) now produce a user-facing warning explaining that the
-  operation was recorded and how to refresh the working copy, instead of an
-  internal error.
-  [#9408](https://github.com/jj-vcs/jj/issues/9408)
 
 * `jj` now creates a new working-copy revision during snapshotting if the
   working copy was immutable. Previously, the new revision was created

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -131,6 +131,7 @@ use jj_lib::str_util::StringMatcher;
 use jj_lib::transaction::Transaction;
 use jj_lib::transaction::TransactionCommitError;
 use jj_lib::working_copy;
+use jj_lib::working_copy::CheckoutError;
 use jj_lib::working_copy::CheckoutStats;
 use jj_lib::working_copy::LockedWorkingCopy;
 use jj_lib::working_copy::SnapshotOptions;
@@ -2161,13 +2162,17 @@ to the current parents may contain changes from multiple commits.
     ) -> Result<(), CommandError> {
         assert!(self.may_update_working_copy);
         let stats = update_working_copy(
+            ui,
             &self.user_repo.repo,
             &mut self.workspace,
             maybe_old_commit,
             new_commit,
         )
         .await?;
-        self.print_updated_working_copy_stats(ui, maybe_old_commit, new_commit, &stats)
+        if let Some(stats) = stats {
+            self.print_updated_working_copy_stats(ui, maybe_old_commit, new_commit, &stats)?;
+        }
+        Ok(())
     }
 
     fn print_updated_working_copy_stats(
@@ -3213,24 +3218,37 @@ pub fn print_unmatched_explicit_paths<'a>(
 }
 
 pub async fn update_working_copy(
+    ui: &Ui,
     repo: &Arc<ReadonlyRepo>,
     workspace: &mut Workspace,
     old_commit: Option<&Commit>,
     new_commit: &Commit,
-) -> Result<CheckoutStats, CommandError> {
+) -> Result<Option<CheckoutStats>, CommandError> {
     let old_tree = old_commit.map(|commit| commit.tree());
-    // TODO: CheckoutError::ConcurrentCheckout should probably just result in a
-    // warning for most commands (but be an error for the checkout command)
-    let stats = workspace
+    match workspace
         .check_out(repo.op_id().clone(), old_tree.as_ref(), new_commit)
         .await
-        .map_err(|err| {
-            internal_error_with_message(
-                format!("Failed to check out commit {}", new_commit.id().hex()),
-                err,
-            )
-        })?;
-    Ok(stats)
+    {
+        Ok(stats) => Ok(Some(stats)),
+        // TODO: This should probably be an error for the checkout command.
+        Err(CheckoutError::ConcurrentCheckout) => {
+            writeln!(
+                ui.warning_default(),
+                "The working copy was concurrently modified while this command was running."
+            )?;
+            writeln!(
+                ui.hint_default(),
+                "The operation's result was recorded, but the working copy was not updated. \
+                 Re-run the command if needed, or run `jj status` to update the working copy on \
+                 the next snapshot."
+            )?;
+            Ok(None)
+        }
+        Err(err) => Err(internal_error_with_message(
+            format!("Failed to check out commit {}", new_commit.id().hex()),
+            err,
+        )),
+    }
 }
 
 /// Returns the special remote name that should be ignored by default.

--- a/cli/tests/test_concurrent_operations.rs
+++ b/cli/tests/test_concurrent_operations.rs
@@ -151,6 +151,36 @@ fn test_concurrent_operations_wc_modified() {
 }
 
 #[test]
+#[cfg_attr(windows, ignore = "uses POSIX sh")]
+fn test_concurrent_checkout_after_operation_recorded() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    work_dir.write_file("file", "contents\n");
+    work_dir
+        .run_jj(["describe", "-m", "old description"])
+        .success();
+
+    let jj_bin = assert_cmd::cargo::cargo_bin!("jj");
+    let output = work_dir.run_jj_with(|cmd| {
+        cmd.env("JJ_BIN", jj_bin).args([
+            "describe",
+            "-m",
+            "new description",
+            "--editor",
+            r#"--config=ui.editor=['sh', '-c', '"$JJ_BIN" new "root()" >/dev/null 2>&1 && printf "%s\n" "new description" > "$1"', 'editor']"#,
+        ])
+    });
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    Warning: The working copy was concurrently modified while this command was running.
+    Hint: The operation's result was recorded, but the working copy was not updated. Re-run the command if needed, or run `jj status` to update the working copy on the next snapshot.
+    [EOF]
+    ");
+}
+
+#[test]
 fn test_concurrent_snapshot_wc_reloadable() -> TestResult {
     let test_env = TestEnvironment::default();
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();


### PR DESCRIPTION
## Summary
Converts the `CheckoutError::ConcurrentCheckout` case in `update_working_copy` from an opaque internal error into a clear user error with an actionable hint.

## Why this matters
Reproducing #9408: start `jj describe` (editor opens), concurrently change the working copy in another process so a snapshot happens (e.g. `jj status`), then finish the edit. Today jj prints `Internal error: Failed to check out commit ...`, which reads like a bug even though nothing went wrong: the operation's result was recorded, only the working copy was not updated to match. In the issue thread the maintainers agreed not to auto-resolve the divergence but that making the message precise is worthwhile, and pointed at exactly this code in `cli/src/cli_util.rs`.

## What changed
- `cli/src/cli_util.rs`: match on the checkout error in `update_working_copy`; for `ConcurrentCheckout`, return a `user_error` explaining the operation was recorded and `.hinted(...)` to re-run the command or run `jj status` to update the working copy on the next snapshot. All other checkout errors keep the existing internal-error path.
- `cli/tests/test_concurrent_operations.rs`: a test exercising the concurrent-checkout path and asserting the user-facing error and hint (no internal error).
- `CHANGELOG.md`: a fixed entry.

Closes #9408

# Checklist

- [x] I have updated `CHANGELOG.md`
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does, how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited it.
- [x] Documentation (`README.md`, `docs/`, `demos/`) and config schema (`cli/src/config-schema.json`): no changes needed for this fix.

AI was used for assistance.
