### PR TITLE
cli: improve additional rejected-command hints

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -4509,12 +4509,12 @@ fn map_clap_cli_error(err: clap::Error, ui: &Ui, config: &StackedConfig) -> Comm
         }
         // Only rewrite messages for commands clap has already rejected. Soft
         // deprecations still dispatch normally and print their command warning.
-        if let Some(hint) = removed_subcommand_hint(&err, cmd) {
+        if let Some(hint) = curated_subcommand_hint(&err, cmd) {
             return CommandError::from(remove_misleading_suggestion(err)).hinted(hint);
         }
     }
     if let Some(ContextValue::String(arg)) = err.get(ContextKind::InvalidArg)
-        && let Some(hint) = removed_arg_hint(&err, arg)
+        && let Some(hint) = curated_arg_hint(&err, arg)
     {
         return CommandError::from(remove_misleading_arg_suggestion(err)).hinted(hint);
     }
@@ -4532,12 +4532,12 @@ fn map_clap_cli_error(err: clap::Error, ui: &Ui, config: &StackedConfig) -> Comm
     CommandError::from(err)
 }
 
-/// Removes clap's fuzzy suggestions when a removed subcommand has a more
+/// Removes clap's fuzzy suggestions when a rejected subcommand has a more
 /// accurate recovery hint.
 ///
-/// A removed jj command can be close to a live but semantically unrelated
+/// A rejected jj command can be close to a live but semantically unrelated
 /// command. Keep the original clap error and usage text, but replace fuzzy
-/// suggestions with the recovery path from jj's removal history.
+/// suggestions with a known recovery path.
 fn remove_misleading_suggestion(mut err: clap::Error) -> clap::Error {
     err.remove(ContextKind::SuggestedArg);
     err.remove(ContextKind::SuggestedSubcommand);
@@ -4545,10 +4545,10 @@ fn remove_misleading_suggestion(mut err: clap::Error) -> clap::Error {
     err
 }
 
-/// Removes clap's fuzzy suggestions and usage text for removed flags.
+/// Removes clap's fuzzy suggestions and usage text for curated argument hints.
 ///
-/// For removed flags, clap's suggested usage is often the usage of the
-/// similar-looking live flag rather than the command the user ran.
+/// For removed or git-shaped flags, clap's suggested usage is often the usage
+/// of the similar-looking live flag rather than the command the user ran.
 fn remove_misleading_arg_suggestion(mut err: clap::Error) -> clap::Error {
     err.remove(ContextKind::SuggestedArg);
     err.remove(ContextKind::Suggested);
@@ -4556,20 +4556,43 @@ fn remove_misleading_arg_suggestion(mut err: clap::Error) -> clap::Error {
     err
 }
 
-/// Returns recovery advice for removed subcommands after clap has rejected the
+/// Returns recovery advice for selected subcommands after clap has rejected the
 /// command line.
 ///
 /// These are not deprecation warnings. The command has already failed clap
 /// parsing as an invalid subcommand, and this table only replaces the recovery
-/// advice. The usage check scopes ambiguous names to the command family where
-/// the removed spelling used to exist.
+/// advice. The usage check scopes ambiguous names to the command family where a
+/// replacement is known.
 ///
 /// Keep these breadcrumbs aligned with the corresponding removal entries in
 /// CHANGELOG.md so the recovery advice stays tied to the historical change.
-fn removed_subcommand_hint(err: &clap::Error, command_name: &str) -> Option<&'static str> {
+fn curated_subcommand_hint(err: &clap::Error, command_name: &str) -> Option<&'static str> {
     let usage = error_usage(err)?;
     let usage = usage.as_str();
     match command_name {
+        // Common Git-shaped commands with documented jj equivalents. These are
+        // rejected commands, not aliases.
+        "add" if usage_is_top_level(usage) => {
+            Some("No `jj add` is needed; new files are tracked automatically.")
+        }
+        "annotate" | "blame" if usage_is_top_level(usage) => {
+            Some("Use `jj file annotate` instead.")
+        }
+        "branches" if usage_is_top_level(usage) => Some("Use `jj bookmark list` instead."),
+        "clean" if usage_is_top_level(usage) => {
+            Some("Use `jj restore` to discard file changes or `jj abandon` to abandon a change.")
+        }
+        "fetch" if usage_is_top_level(usage) => Some("Use `jj git fetch` instead."),
+        "pull" if usage_is_top_level(usage) => {
+            Some("Use `jj git fetch`, then `jj rebase` if needed.")
+        }
+        "push" if usage_is_top_level(usage) => Some("Use `jj git push` instead."),
+        "remote" if usage_is_top_level(usage) => Some("Use `jj git remote` instead."),
+        "reset" if usage_is_top_level(usage) => {
+            Some("Use `jj abandon` to abandon a change or `jj restore` to empty it.")
+        }
+        "stash" if usage_is_top_level(usage) => Some("Use `jj new @-` instead."),
+        "switch" | "goto" | "update" if usage_is_top_level(usage) => Some("Use `jj new` instead."),
         // Removed in 0.33.0 after being deprecated in 0.28.0.
         "backout" if usage_is_top_level(usage) => Some("Use `jj revert` instead."),
         // Removed in 0.30.0 after the 0.22.0 branch/bookmark rename.
@@ -4609,7 +4632,7 @@ fn removed_subcommand_hint(err: &clap::Error, command_name: &str) -> Option<&'st
     }
 }
 
-/// Returns recovery advice for removed flags after clap has rejected the
+/// Returns recovery advice for selected flags after clap has rejected the
 /// command line.
 ///
 /// These are not deprecation warnings. The flag has already failed clap parsing
@@ -4617,9 +4640,9 @@ fn removed_subcommand_hint(err: &clap::Error, command_name: &str) -> Option<&'st
 /// The usage check avoids changing unrelated commands that happen to reject the
 /// same flag spelling.
 ///
-/// Keep these breadcrumbs aligned with the corresponding removal entries in
-/// CHANGELOG.md so the recovery advice stays tied to the historical change.
-fn removed_arg_hint(err: &clap::Error, arg: &str) -> Option<&'static str> {
+/// Keep removed-flag breadcrumbs aligned with the corresponding removal entries
+/// in CHANGELOG.md so the recovery advice stays tied to the historical change.
+fn curated_arg_hint(err: &clap::Error, arg: &str) -> Option<&'static str> {
     let usage = error_usage(err)?;
     let usage = usage.as_str();
     match arg {
@@ -4628,6 +4651,14 @@ fn removed_arg_hint(err: &clap::Error, arg: &str) -> Option<&'static str> {
             || usage_starts_with_any(usage, &["jj operation log", "jj op log"]) =>
         {
             Some("Use `-n` instead.")
+        }
+        // Git-shaped log flags that currently get misleading fuzzy suggestions.
+        "--all" if usage_starts_with(usage, "jj log") => Some("Use `jj log -r 'all()'` instead."),
+        "--oneline" if usage_starts_with(usage, "jj log") => {
+            Some("Use `jj log -T builtin_log_oneline` instead.")
+        }
+        "--allow-deletes" if usage_starts_with(usage, "jj git push") => {
+            Some("Use `jj git push --deleted` instead.")
         }
         // Removed in 0.42.0.
         "--allow-new" if usage_starts_with(usage, "jj git push") => {

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -4507,6 +4507,16 @@ fn map_clap_cli_error(err: clap::Error, ui: &Ui, config: &StackedConfig) -> Comm
             }
             _ => {}
         }
+        // Only rewrite messages for commands clap has already rejected. Soft
+        // deprecations still dispatch normally and print their command warning.
+        if let Some(hint) = removed_subcommand_hint(&err, cmd) {
+            return CommandError::from(remove_misleading_suggestion(err)).hinted(hint);
+        }
+    }
+    if let Some(ContextValue::String(arg)) = err.get(ContextKind::InvalidArg)
+        && let Some(hint) = removed_arg_hint(&err, arg)
+    {
+        return CommandError::from(remove_misleading_arg_suggestion(err)).hinted(hint);
     }
     if let (Some(ContextValue::String(arg)), Some(ContextValue::String(value))) = (
         err.get(ContextKind::InvalidArg),
@@ -4520,6 +4530,188 @@ fn map_clap_cli_error(err: clap::Error, ui: &Ui, config: &StackedConfig) -> Comm
         }
     }
     CommandError::from(err)
+}
+
+/// Removes clap's fuzzy suggestions when a removed subcommand has a more
+/// accurate recovery hint.
+///
+/// A removed jj command can be close to a live but semantically unrelated
+/// command. Keep the original clap error and usage text, but replace fuzzy
+/// suggestions with the recovery path from jj's removal history.
+fn remove_misleading_suggestion(mut err: clap::Error) -> clap::Error {
+    err.remove(ContextKind::SuggestedArg);
+    err.remove(ContextKind::SuggestedSubcommand);
+    err.remove(ContextKind::Suggested);
+    err
+}
+
+/// Removes clap's fuzzy suggestions and usage text for removed flags.
+///
+/// For removed flags, clap's suggested usage is often the usage of the
+/// similar-looking live flag rather than the command the user ran.
+fn remove_misleading_arg_suggestion(mut err: clap::Error) -> clap::Error {
+    err.remove(ContextKind::SuggestedArg);
+    err.remove(ContextKind::Suggested);
+    err.remove(ContextKind::Usage);
+    err
+}
+
+/// Returns recovery advice for removed subcommands after clap has rejected the
+/// command line.
+///
+/// These are not deprecation warnings. The command has already failed clap
+/// parsing as an invalid subcommand, and this table only replaces the recovery
+/// advice. The usage check scopes ambiguous names to the command family where
+/// the removed spelling used to exist.
+///
+/// Keep these breadcrumbs aligned with the corresponding removal entries in
+/// CHANGELOG.md so the recovery advice stays tied to the historical change.
+fn removed_subcommand_hint(err: &clap::Error, command_name: &str) -> Option<&'static str> {
+    let usage = error_usage(err)?;
+    let usage = usage.as_str();
+    match command_name {
+        // Removed in 0.33.0 after being deprecated in 0.28.0.
+        "backout" if usage_is_top_level(usage) => Some("Use `jj revert` instead."),
+        // Removed in 0.30.0 after the 0.22.0 branch/bookmark rename.
+        "branch" if usage_is_top_level(usage) => {
+            Some("Use `jj bookmark` and its subcommands instead.")
+        }
+        // Removed in 0.26.0 after the file-command migration.
+        "cat" if usage_is_top_level(usage) => Some("Use `jj file show` instead."),
+        "chmod" if usage_is_top_level(usage) => Some("Use `jj file chmod` instead."),
+        "files" if usage_is_top_level(usage) => Some("Use `jj file list` instead."),
+        // Removed in 0.22.0 after being deprecated in 0.14.0.
+        "checkout" | "co" if usage_is_top_level(usage) => Some("Use `jj new` instead."),
+        "merge" if usage_is_top_level(usage) => Some("Use `jj new` instead."),
+        // Removed in 0.22.0 after being deprecated in 0.16.0.
+        "move" if usage_is_top_level(usage) => Some("Use `jj squash` instead."),
+        // Removed in 0.26.0.
+        "mangen" if usage_starts_with(usage, "jj util") => {
+            Some("Use `jj util install-man-pages` instead.")
+        }
+        // Removed in 0.28.0 after being renamed in 0.20.0.
+        "untrack" if usage_is_top_level(usage) => Some("Use `jj file untrack` instead."),
+        // Removed in 0.28.0 after being deprecated in 0.22.0.
+        "unsquash" if usage_is_top_level(usage) => {
+            Some("Use `jj squash` or `jj diffedit --restore-descendants` instead.")
+        }
+        // Removed in 0.40.0 after being deprecated in 0.33.0.
+        "undo" if usage_starts_with_any(usage, &["jj operation", "jj op"]) => Some(
+            "Use `jj undo` to undo the latest operation. Use `jj op revert` to revert a specific \
+             operation.",
+        ),
+        // `jj op redo` never existed; keep the recovery next to the removed
+        // `jj op undo` mapping because users commonly try them together.
+        "redo" if usage_starts_with_any(usage, &["jj operation", "jj op"]) => {
+            Some("Use `jj redo` instead.")
+        }
+        _ => None,
+    }
+}
+
+/// Returns recovery advice for removed flags after clap has rejected the
+/// command line.
+///
+/// These are not deprecation warnings. The flag has already failed clap parsing
+/// as an invalid argument, and this table only replaces the recovery advice.
+/// The usage check avoids changing unrelated commands that happen to reject the
+/// same flag spelling.
+///
+/// Keep these breadcrumbs aligned with the corresponding removal entries in
+/// CHANGELOG.md so the recovery advice stays tied to the historical change.
+fn removed_arg_hint(err: &clap::Error, arg: &str) -> Option<&'static str> {
+    let usage = error_usage(err)?;
+    let usage = usage.as_str();
+    match arg {
+        // Removed in 0.26.0.
+        "-l" if usage_starts_with(usage, "jj log")
+            || usage_starts_with_any(usage, &["jj operation log", "jj op log"]) =>
+        {
+            Some("Use `-n` instead.")
+        }
+        // Removed in 0.42.0.
+        "--allow-new" if usage_starts_with(usage, "jj git push") => {
+            Some("Push a specific bookmark with `jj git push --bookmark <name>` instead.")
+        }
+        // Removed in 0.42.0 after being deprecated in 0.34.0.
+        "--author"
+            if usage_starts_with(usage, "jj commit") || usage_starts_with(usage, "jj describe") =>
+        {
+            Some("Use `jj metaedit --author <author>` instead.")
+        }
+        // Removed in 0.42.0 after being deprecated in 0.36.0.
+        "--edit" if usage_starts_with(usage, "jj describe") => {
+            Some("Use `jj describe --editor` instead.")
+        }
+        // Removed in 0.42.0 after being deprecated in 0.34.0.
+        "--no-edit" if usage_starts_with(usage, "jj describe") => Some(
+            "Omit `--no-edit`; `jj describe --message <message>` already avoids opening an editor.",
+        ),
+        // Removed in 0.42.0 after being deprecated in 0.34.0.
+        "--reset-author"
+            if usage_starts_with(usage, "jj commit") || usage_starts_with(usage, "jj describe") =>
+        {
+            Some("Use `jj metaedit --update-author` instead.")
+        }
+        // Removed in 0.30.0 after being renamed in 0.20.0.
+        "--skip-empty" if usage_starts_with(usage, "jj rebase") => {
+            Some("Use `jj rebase --skip-emptied` instead.")
+        }
+        // Removed in 0.26.0 after being deprecated in 0.23.0.
+        "--siblings" if usage_starts_with(usage, "jj split") => {
+            Some("Use `jj split --parallel` instead.")
+        }
+        // Removed in 0.33.0.
+        "--summary" if usage_starts_with(usage, "jj abandon") => Some(
+            "Omit `--summary`; `jj abandon` now limits the abandoned commit list automatically.",
+        ),
+        // Removed in 0.42.0 after being renamed in 0.33.0.
+        "--update-committer-timestamp" if usage_starts_with(usage, "jj metaedit") => {
+            Some("Use `jj metaedit --force-rewrite` instead.")
+        }
+        _ => None,
+    }
+}
+
+/// Returns clap's rendered usage text from the structured error context.
+///
+/// The removed-command hint tables use this to identify which command family
+/// rejected the spelling.
+fn error_usage(err: &clap::Error) -> Option<String> {
+    err.get(ContextKind::Usage).map(ToString::to_string)
+}
+
+/// Checks whether clap's rendered usage starts with the given command prefix.
+///
+/// Matching the rendered command prefix is enough to scope removed spellings
+/// without threading command metadata through this error-mapping layer. clap
+/// renders the Windows binary name as `jj.exe`, so accept both binary spellings
+/// here while keeping the hint tables in normal `jj ...` form.
+fn usage_starts_with(usage: &str, command: &str) -> bool {
+    let Some(command_suffix) = command.strip_prefix("jj") else {
+        return usage.starts_with(&format!("Usage: {command} "));
+    };
+    usage.starts_with(&format!("Usage: jj{command_suffix} "))
+        || usage.starts_with(&format!("Usage: jj.exe{command_suffix} "))
+}
+
+/// Checks whether clap's rendered usage starts with any of the given command
+/// prefixes.
+///
+/// This keeps canonical command names and visible aliases together when both
+/// can appear in the usage text.
+fn usage_starts_with_any(usage: &str, commands: &[&str]) -> bool {
+    commands
+        .iter()
+        .any(|command| usage_starts_with(usage, command))
+}
+
+/// Checks whether clap's rendered usage is for the top-level jj command.
+///
+/// This scopes removed top-level command spellings without matching nested
+/// subcommands that happen to share the same name.
+fn usage_is_top_level(usage: &str) -> bool {
+    usage_starts_with(usage, "jj [OPTIONS]")
 }
 
 fn format_template_aliases_hint(template_aliases: &TemplateAliasesMap) -> String {

--- a/cli/tests/test_global_opts.rs
+++ b/cli/tests/test_global_opts.rs
@@ -209,11 +209,10 @@ fn test_deprecated_removed_command_hints() {
     ------- stderr -------
     error: unrecognized subcommand 'undo'
 
-      tip: a similar subcommand exists: 'abandon'
-
     Usage: jj operation [OPTIONS] <COMMAND>
 
     For more information, try '--help'.
+    Hint: Use `jj undo` to undo the latest operation. Use `jj op revert` to revert a specific operation.
     [EOF]
     [exit status: 2]
     ");
@@ -223,11 +222,10 @@ fn test_deprecated_removed_command_hints() {
     ------- stderr -------
     error: unrecognized subcommand 'redo'
 
-      tip: a similar subcommand exists: 'restore'
-
     Usage: jj operation [OPTIONS] <COMMAND>
 
     For more information, try '--help'.
+    Hint: Use `jj redo` instead.
     [EOF]
     [exit status: 2]
     ");
@@ -240,6 +238,7 @@ fn test_deprecated_removed_command_hints() {
     Usage: jj [OPTIONS] <COMMAND>
 
     For more information, try '--help'.
+    Hint: Use `jj revert` instead.
     [EOF]
     [exit status: 2]
     ");
@@ -252,6 +251,7 @@ fn test_deprecated_removed_command_hints() {
     Usage: jj [OPTIONS] <COMMAND>
 
     For more information, try '--help'.
+    Hint: Use `jj bookmark` and its subcommands instead.
     [EOF]
     [exit status: 2]
     ");
@@ -264,6 +264,7 @@ fn test_deprecated_removed_command_hints() {
     Usage: jj [OPTIONS] <COMMAND>
 
     For more information, try '--help'.
+    Hint: Use `jj file show` instead.
     [EOF]
     [exit status: 2]
     ");
@@ -276,6 +277,7 @@ fn test_deprecated_removed_command_hints() {
     Usage: jj [OPTIONS] <COMMAND>
 
     For more information, try '--help'.
+    Hint: Use `jj file chmod` instead.
     [EOF]
     [exit status: 2]
     ");
@@ -288,6 +290,7 @@ fn test_deprecated_removed_command_hints() {
     Usage: jj [OPTIONS] <COMMAND>
 
     For more information, try '--help'.
+    Hint: Use `jj new` instead.
     [EOF]
     [exit status: 2]
     ");
@@ -297,11 +300,10 @@ fn test_deprecated_removed_command_hints() {
     ------- stderr -------
     error: unrecognized subcommand 'co'
 
-      tip: some similar subcommands exist: 'commit', 'config'
-
     Usage: jj [OPTIONS] <COMMAND>
 
     For more information, try '--help'.
+    Hint: Use `jj new` instead.
     [EOF]
     [exit status: 2]
     ");
@@ -311,11 +313,10 @@ fn test_deprecated_removed_command_hints() {
     ------- stderr -------
     error: unrecognized subcommand 'files'
 
-      tip: a similar subcommand exists: 'file'
-
     Usage: jj [OPTIONS] <COMMAND>
 
     For more information, try '--help'.
+    Hint: Use `jj file list` instead.
     [EOF]
     [exit status: 2]
     ");
@@ -328,6 +329,7 @@ fn test_deprecated_removed_command_hints() {
     Usage: jj [OPTIONS] <COMMAND>
 
     For more information, try '--help'.
+    Hint: Use `jj new` instead.
     [EOF]
     [exit status: 2]
     ");
@@ -340,6 +342,7 @@ fn test_deprecated_removed_command_hints() {
     Usage: jj [OPTIONS] <COMMAND>
 
     For more information, try '--help'.
+    Hint: Use `jj squash` instead.
     [EOF]
     [exit status: 2]
     ");
@@ -352,6 +355,7 @@ fn test_deprecated_removed_command_hints() {
     Usage: jj util [OPTIONS] <COMMAND>
 
     For more information, try '--help'.
+    Hint: Use `jj util install-man-pages` instead.
     [EOF]
     [exit status: 2]
     ");
@@ -364,6 +368,7 @@ fn test_deprecated_removed_command_hints() {
     Usage: jj [OPTIONS] <COMMAND>
 
     For more information, try '--help'.
+    Hint: Use `jj file untrack` instead.
     [EOF]
     [exit status: 2]
     ");
@@ -373,11 +378,10 @@ fn test_deprecated_removed_command_hints() {
     ------- stderr -------
     error: unrecognized subcommand 'unsquash'
 
-      tip: a similar subcommand exists: 'squash'
-
     Usage: jj [OPTIONS] <COMMAND>
 
     For more information, try '--help'.
+    Hint: Use `jj squash` or `jj diffedit --restore-descendants` instead.
     [EOF]
     [exit status: 2]
     ");
@@ -387,11 +391,8 @@ fn test_deprecated_removed_command_hints() {
     ------- stderr -------
     error: unexpected argument '-l' found
 
-      tip: to pass '-l' as a value, use '-- -l'
-
-    Usage: jj log [OPTIONS] [FILESETS]...
-
     For more information, try '--help'.
+    Hint: Use `-n` instead.
     [EOF]
     [exit status: 2]
     ");
@@ -401,9 +402,8 @@ fn test_deprecated_removed_command_hints() {
     ------- stderr -------
     error: unexpected argument '-l' found
 
-    Usage: jj operation log [OPTIONS]
-
     For more information, try '--help'.
+    Hint: Use `-n` instead.
     [EOF]
     [exit status: 2]
     ");
@@ -413,11 +413,8 @@ fn test_deprecated_removed_command_hints() {
     ------- stderr -------
     error: unexpected argument '--allow-new' found
 
-      tip: a similar argument exists: '--all'
-
-    Usage: jj git push --all
-
     For more information, try '--help'.
+    Hint: Push a specific bookmark with `jj git push --bookmark <name>` instead.
     [EOF]
     [exit status: 2]
     ");
@@ -427,11 +424,8 @@ fn test_deprecated_removed_command_hints() {
     ------- stderr -------
     error: unexpected argument '--reset-author' found
 
-      tip: a similar argument exists: '--repository'
-
-    Usage: jj commit --repository <REPOSITORY> [FILESETS]...
-
     For more information, try '--help'.
+    Hint: Use `jj metaedit --update-author` instead.
     [EOF]
     [exit status: 2]
     ");
@@ -441,11 +435,8 @@ fn test_deprecated_removed_command_hints() {
     ------- stderr -------
     error: unexpected argument '--author' found
 
-      tip: a similar argument exists: '--at-op'
-
-    Usage: jj commit --at-operation <AT_OPERATION> [FILESETS]...
-
     For more information, try '--help'.
+    Hint: Use `jj metaedit --author <author>` instead.
     [EOF]
     [exit status: 2]
     ");
@@ -455,11 +446,8 @@ fn test_deprecated_removed_command_hints() {
     ------- stderr -------
     error: unexpected argument '--edit' found
 
-      tip: a similar argument exists: '--editor'
-
-    Usage: jj describe --editor [REVSETS]...
-
     For more information, try '--help'.
+    Hint: Use `jj describe --editor` instead.
     [EOF]
     [exit status: 2]
     ");
@@ -469,11 +457,8 @@ fn test_deprecated_removed_command_hints() {
     ------- stderr -------
     error: unexpected argument '--no-edit' found
 
-      tip: to pass '--no-edit' as a value, use '-- --no-edit'
-
-    Usage: jj describe [OPTIONS] [REVSETS]...
-
     For more information, try '--help'.
+    Hint: Omit `--no-edit`; `jj describe --message <message>` already avoids opening an editor.
     [EOF]
     [exit status: 2]
     ");
@@ -483,11 +468,8 @@ fn test_deprecated_removed_command_hints() {
     ------- stderr -------
     error: unexpected argument '--skip-empty' found
 
-      tip: a similar argument exists: '--skip-emptied'
-
-    Usage: jj rebase --skip-emptied <--onto <REVSETS>|--insert-after <REVSETS>|--insert-before <REVSETS>>
-
     For more information, try '--help'.
+    Hint: Use `jj rebase --skip-emptied` instead.
     [EOF]
     [exit status: 2]
     ");
@@ -497,11 +479,8 @@ fn test_deprecated_removed_command_hints() {
     ------- stderr -------
     error: unexpected argument '--siblings' found
 
-      tip: to pass '--siblings' as a value, use '-- --siblings'
-
-    Usage: jj split [OPTIONS] [FILESETS]...
-
     For more information, try '--help'.
+    Hint: Use `jj split --parallel` instead.
     [EOF]
     [exit status: 2]
     ");
@@ -511,11 +490,8 @@ fn test_deprecated_removed_command_hints() {
     ------- stderr -------
     error: unexpected argument '--summary' found
 
-      tip: to pass '--summary' as a value, use '-- --summary'
-
-    Usage: jj abandon [OPTIONS] [REVSETS]...
-
     For more information, try '--help'.
+    Hint: Omit `--summary`; `jj abandon` now limits the abandoned commit list automatically.
     [EOF]
     [exit status: 2]
     ");
@@ -525,11 +501,8 @@ fn test_deprecated_removed_command_hints() {
     ------- stderr -------
     error: unexpected argument '--update-committer-timestamp' found
 
-      tip: a similar argument exists: '--update-author-timestamp'
-
-    Usage: jj metaedit --update-author-timestamp [REVSETS]...
-
     For more information, try '--help'.
+    Hint: Use `jj metaedit --force-rewrite` instead.
     [EOF]
     [exit status: 2]
     ");
@@ -539,11 +512,8 @@ fn test_deprecated_removed_command_hints() {
     ------- stderr -------
     error: unexpected argument '--reset-author' found
 
-      tip: a similar argument exists: '--repository'
-
-    Usage: jj describe --repository <REPOSITORY> [REVSETS]...
-
     For more information, try '--help'.
+    Hint: Use `jj metaedit --update-author` instead.
     [EOF]
     [exit status: 2]
     ");
@@ -553,11 +523,8 @@ fn test_deprecated_removed_command_hints() {
     ------- stderr -------
     error: unexpected argument '--author' found
 
-      tip: a similar argument exists: '--at-op'
-
-    Usage: jj describe --at-operation <AT_OPERATION> [REVSETS]...
-
     For more information, try '--help'.
+    Hint: Use `jj metaedit --author <author>` instead.
     [EOF]
     [exit status: 2]
     ");

--- a/cli/tests/test_global_opts.rs
+++ b/cli/tests/test_global_opts.rs
@@ -544,6 +544,7 @@ fn test_additional_rejected_command_hints() {
     Usage: jj [OPTIONS] <COMMAND>
 
     For more information, try '--help'.
+    Hint: No `jj add` is needed; new files are tracked automatically.
     [EOF]
     [exit status: 2]
     ");
@@ -556,6 +557,7 @@ fn test_additional_rejected_command_hints() {
     Usage: jj [OPTIONS] <COMMAND>
 
     For more information, try '--help'.
+    Hint: Use `jj file annotate` instead.
     [EOF]
     [exit status: 2]
     ");
@@ -565,11 +567,10 @@ fn test_additional_rejected_command_hints() {
     ------- stderr -------
     error: unrecognized subcommand 'blame'
 
-      tip: a similar subcommand exists: 'rebase'
-
     Usage: jj [OPTIONS] <COMMAND>
 
     For more information, try '--help'.
+    Hint: Use `jj file annotate` instead.
     [EOF]
     [exit status: 2]
     ");
@@ -582,6 +583,7 @@ fn test_additional_rejected_command_hints() {
     Usage: jj [OPTIONS] <COMMAND>
 
     For more information, try '--help'.
+    Hint: Use `jj bookmark list` instead.
     [EOF]
     [exit status: 2]
     ");
@@ -594,6 +596,7 @@ fn test_additional_rejected_command_hints() {
     Usage: jj [OPTIONS] <COMMAND>
 
     For more information, try '--help'.
+    Hint: Use `jj restore` to discard file changes or `jj abandon` to abandon a change.
     [EOF]
     [exit status: 2]
     ");
@@ -606,6 +609,7 @@ fn test_additional_rejected_command_hints() {
     Usage: jj [OPTIONS] <COMMAND>
 
     For more information, try '--help'.
+    Hint: Use `jj git fetch` instead.
     [EOF]
     [exit status: 2]
     ");
@@ -615,11 +619,10 @@ fn test_additional_rejected_command_hints() {
     ------- stderr -------
     error: unrecognized subcommand 'goto'
 
-      tip: some similar subcommands exist: 'git', 'root'
-
     Usage: jj [OPTIONS] <COMMAND>
 
     For more information, try '--help'.
+    Hint: Use `jj new` instead.
     [EOF]
     [exit status: 2]
     ");
@@ -632,6 +635,7 @@ fn test_additional_rejected_command_hints() {
     Usage: jj [OPTIONS] <COMMAND>
 
     For more information, try '--help'.
+    Hint: Use `jj git fetch`, then `jj rebase` if needed.
     [EOF]
     [exit status: 2]
     ");
@@ -644,6 +648,7 @@ fn test_additional_rejected_command_hints() {
     Usage: jj [OPTIONS] <COMMAND>
 
     For more information, try '--help'.
+    Hint: Use `jj git push` instead.
     [EOF]
     [exit status: 2]
     ");
@@ -653,11 +658,10 @@ fn test_additional_rejected_command_hints() {
     ------- stderr -------
     error: unrecognized subcommand 'remote'
 
-      tip: some similar subcommands exist: 'resolve', 'redo', 'root', 'restore'
-
     Usage: jj [OPTIONS] <COMMAND>
 
     For more information, try '--help'.
+    Hint: Use `jj git remote` instead.
     [EOF]
     [exit status: 2]
     ");
@@ -667,11 +671,10 @@ fn test_additional_rejected_command_hints() {
     ------- stderr -------
     error: unrecognized subcommand 'reset'
 
-      tip: some similar subcommands exist: 'restore', 'rebase', 'revert'
-
     Usage: jj [OPTIONS] <COMMAND>
 
     For more information, try '--help'.
+    Hint: Use `jj abandon` to abandon a change or `jj restore` to empty it.
     [EOF]
     [exit status: 2]
     ");
@@ -681,11 +684,10 @@ fn test_additional_rejected_command_hints() {
     ------- stderr -------
     error: unrecognized subcommand 'stash'
 
-      tip: some similar subcommands exist: 'sparse', 'squash', 'status'
-
     Usage: jj [OPTIONS] <COMMAND>
 
     For more information, try '--help'.
+    Hint: Use `jj new @-` instead.
     [EOF]
     [exit status: 2]
     ");
@@ -695,11 +697,10 @@ fn test_additional_rejected_command_hints() {
     ------- stderr -------
     error: unrecognized subcommand 'switch'
 
-      tip: a similar subcommand exists: 'split'
-
     Usage: jj [OPTIONS] <COMMAND>
 
     For more information, try '--help'.
+    Hint: Use `jj new` instead.
     [EOF]
     [exit status: 2]
     ");
@@ -709,11 +710,10 @@ fn test_additional_rejected_command_hints() {
     ------- stderr -------
     error: unrecognized subcommand 'update'
 
-      tip: a similar subcommand exists: 'duplicate'
-
     Usage: jj [OPTIONS] <COMMAND>
 
     For more information, try '--help'.
+    Hint: Use `jj new` instead.
     [EOF]
     [exit status: 2]
     ");
@@ -723,11 +723,8 @@ fn test_additional_rejected_command_hints() {
     ------- stderr -------
     error: unexpected argument '--all' found
 
-      tip: a similar argument exists: '--ignore-all-space'
-
-    Usage: jj log --ignore-all-space [FILESETS]...
-
     For more information, try '--help'.
+    Hint: Use `jj log -r 'all()'` instead.
     [EOF]
     [exit status: 2]
     ");
@@ -737,11 +734,8 @@ fn test_additional_rejected_command_hints() {
     ------- stderr -------
     error: unexpected argument '--oneline' found
 
-      tip: to pass '--oneline' as a value, use '-- --oneline'
-
-    Usage: jj log [OPTIONS] [FILESETS]...
-
     For more information, try '--help'.
+    Hint: Use `jj log -T builtin_log_oneline` instead.
     [EOF]
     [exit status: 2]
     ");
@@ -751,11 +745,8 @@ fn test_additional_rejected_command_hints() {
     ------- stderr -------
     error: unexpected argument '--allow-deletes' found
 
-      tip: a similar argument exists: '--all'
-
-    Usage: jj git push --all
-
     For more information, try '--help'.
+    Hint: Use `jj git push --deleted` instead.
     [EOF]
     [exit status: 2]
     ");

--- a/cli/tests/test_global_opts.rs
+++ b/cli/tests/test_global_opts.rs
@@ -531,6 +531,237 @@ fn test_deprecated_removed_command_hints() {
 }
 
 #[test]
+fn test_additional_rejected_command_hints() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    let output = work_dir.run_jj(["add", "file"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    error: unrecognized subcommand 'add'
+
+    Usage: jj [OPTIONS] <COMMAND>
+
+    For more information, try '--help'.
+    [EOF]
+    [exit status: 2]
+    ");
+
+    let output = work_dir.run_jj(["annotate", "file"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    error: unrecognized subcommand 'annotate'
+
+    Usage: jj [OPTIONS] <COMMAND>
+
+    For more information, try '--help'.
+    [EOF]
+    [exit status: 2]
+    ");
+
+    let output = work_dir.run_jj(["blame", "file"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    error: unrecognized subcommand 'blame'
+
+      tip: a similar subcommand exists: 'rebase'
+
+    Usage: jj [OPTIONS] <COMMAND>
+
+    For more information, try '--help'.
+    [EOF]
+    [exit status: 2]
+    ");
+
+    let output = work_dir.run_jj(["branches"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    error: unrecognized subcommand 'branches'
+
+    Usage: jj [OPTIONS] <COMMAND>
+
+    For more information, try '--help'.
+    [EOF]
+    [exit status: 2]
+    ");
+
+    let output = work_dir.run_jj(["clean"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    error: unrecognized subcommand 'clean'
+
+    Usage: jj [OPTIONS] <COMMAND>
+
+    For more information, try '--help'.
+    [EOF]
+    [exit status: 2]
+    ");
+
+    let output = work_dir.run_jj(["fetch"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    error: unrecognized subcommand 'fetch'
+
+    Usage: jj [OPTIONS] <COMMAND>
+
+    For more information, try '--help'.
+    [EOF]
+    [exit status: 2]
+    ");
+
+    let output = work_dir.run_jj(["goto"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    error: unrecognized subcommand 'goto'
+
+      tip: some similar subcommands exist: 'git', 'root'
+
+    Usage: jj [OPTIONS] <COMMAND>
+
+    For more information, try '--help'.
+    [EOF]
+    [exit status: 2]
+    ");
+
+    let output = work_dir.run_jj(["pull"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    error: unrecognized subcommand 'pull'
+
+    Usage: jj [OPTIONS] <COMMAND>
+
+    For more information, try '--help'.
+    [EOF]
+    [exit status: 2]
+    ");
+
+    let output = work_dir.run_jj(["push"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    error: unrecognized subcommand 'push'
+
+    Usage: jj [OPTIONS] <COMMAND>
+
+    For more information, try '--help'.
+    [EOF]
+    [exit status: 2]
+    ");
+
+    let output = work_dir.run_jj(["remote", "add", "origin", "example"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    error: unrecognized subcommand 'remote'
+
+      tip: some similar subcommands exist: 'resolve', 'redo', 'root', 'restore'
+
+    Usage: jj [OPTIONS] <COMMAND>
+
+    For more information, try '--help'.
+    [EOF]
+    [exit status: 2]
+    ");
+
+    let output = work_dir.run_jj(["reset"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    error: unrecognized subcommand 'reset'
+
+      tip: some similar subcommands exist: 'restore', 'rebase', 'revert'
+
+    Usage: jj [OPTIONS] <COMMAND>
+
+    For more information, try '--help'.
+    [EOF]
+    [exit status: 2]
+    ");
+
+    let output = work_dir.run_jj(["stash"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    error: unrecognized subcommand 'stash'
+
+      tip: some similar subcommands exist: 'sparse', 'squash', 'status'
+
+    Usage: jj [OPTIONS] <COMMAND>
+
+    For more information, try '--help'.
+    [EOF]
+    [exit status: 2]
+    ");
+
+    let output = work_dir.run_jj(["switch"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    error: unrecognized subcommand 'switch'
+
+      tip: a similar subcommand exists: 'split'
+
+    Usage: jj [OPTIONS] <COMMAND>
+
+    For more information, try '--help'.
+    [EOF]
+    [exit status: 2]
+    ");
+
+    let output = work_dir.run_jj(["update"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    error: unrecognized subcommand 'update'
+
+      tip: a similar subcommand exists: 'duplicate'
+
+    Usage: jj [OPTIONS] <COMMAND>
+
+    For more information, try '--help'.
+    [EOF]
+    [exit status: 2]
+    ");
+
+    let output = work_dir.run_jj(["log", "--all"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    error: unexpected argument '--all' found
+
+      tip: a similar argument exists: '--ignore-all-space'
+
+    Usage: jj log --ignore-all-space [FILESETS]...
+
+    For more information, try '--help'.
+    [EOF]
+    [exit status: 2]
+    ");
+
+    let output = work_dir.run_jj(["log", "--oneline"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    error: unexpected argument '--oneline' found
+
+      tip: to pass '--oneline' as a value, use '-- --oneline'
+
+    Usage: jj log [OPTIONS] [FILESETS]...
+
+    For more information, try '--help'.
+    [EOF]
+    [exit status: 2]
+    ");
+
+    let output = work_dir.run_jj(["git", "push", "--allow-deletes"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    error: unexpected argument '--allow-deletes' found
+
+      tip: a similar argument exists: '--all'
+
+    Usage: jj git push --all
+
+    For more information, try '--help'.
+    [EOF]
+    [exit status: 2]
+    ");
+}
+
+#[test]
 fn test_soft_deprecated_command_still_runs() {
     let test_env = TestEnvironment::default();
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();

--- a/cli/tests/test_global_opts.rs
+++ b/cli/tests/test_global_opts.rs
@@ -199,6 +199,385 @@ fn test_no_subcommand() {
 }
 
 #[test]
+fn test_deprecated_removed_command_hints() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    let output = work_dir.run_jj(["op", "undo"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    error: unrecognized subcommand 'undo'
+
+      tip: a similar subcommand exists: 'abandon'
+
+    Usage: jj operation [OPTIONS] <COMMAND>
+
+    For more information, try '--help'.
+    [EOF]
+    [exit status: 2]
+    ");
+
+    let output = work_dir.run_jj(["op", "redo"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    error: unrecognized subcommand 'redo'
+
+      tip: a similar subcommand exists: 'restore'
+
+    Usage: jj operation [OPTIONS] <COMMAND>
+
+    For more information, try '--help'.
+    [EOF]
+    [exit status: 2]
+    ");
+
+    let output = work_dir.run_jj(["backout"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    error: unrecognized subcommand 'backout'
+
+    Usage: jj [OPTIONS] <COMMAND>
+
+    For more information, try '--help'.
+    [EOF]
+    [exit status: 2]
+    ");
+
+    let output = work_dir.run_jj(["branch", "list"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    error: unrecognized subcommand 'branch'
+
+    Usage: jj [OPTIONS] <COMMAND>
+
+    For more information, try '--help'.
+    [EOF]
+    [exit status: 2]
+    ");
+
+    let output = work_dir.run_jj(["cat", "file"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    error: unrecognized subcommand 'cat'
+
+    Usage: jj [OPTIONS] <COMMAND>
+
+    For more information, try '--help'.
+    [EOF]
+    [exit status: 2]
+    ");
+
+    let output = work_dir.run_jj(["chmod", "x", "file"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    error: unrecognized subcommand 'chmod'
+
+    Usage: jj [OPTIONS] <COMMAND>
+
+    For more information, try '--help'.
+    [EOF]
+    [exit status: 2]
+    ");
+
+    let output = work_dir.run_jj(["checkout"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    error: unrecognized subcommand 'checkout'
+
+    Usage: jj [OPTIONS] <COMMAND>
+
+    For more information, try '--help'.
+    [EOF]
+    [exit status: 2]
+    ");
+
+    let output = work_dir.run_jj(["co"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    error: unrecognized subcommand 'co'
+
+      tip: some similar subcommands exist: 'commit', 'config'
+
+    Usage: jj [OPTIONS] <COMMAND>
+
+    For more information, try '--help'.
+    [EOF]
+    [exit status: 2]
+    ");
+
+    let output = work_dir.run_jj(["files"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    error: unrecognized subcommand 'files'
+
+      tip: a similar subcommand exists: 'file'
+
+    Usage: jj [OPTIONS] <COMMAND>
+
+    For more information, try '--help'.
+    [EOF]
+    [exit status: 2]
+    ");
+
+    let output = work_dir.run_jj(["merge"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    error: unrecognized subcommand 'merge'
+
+    Usage: jj [OPTIONS] <COMMAND>
+
+    For more information, try '--help'.
+    [EOF]
+    [exit status: 2]
+    ");
+
+    let output = work_dir.run_jj(["move"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    error: unrecognized subcommand 'move'
+
+    Usage: jj [OPTIONS] <COMMAND>
+
+    For more information, try '--help'.
+    [EOF]
+    [exit status: 2]
+    ");
+
+    let output = work_dir.run_jj(["util", "mangen"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    error: unrecognized subcommand 'mangen'
+
+    Usage: jj util [OPTIONS] <COMMAND>
+
+    For more information, try '--help'.
+    [EOF]
+    [exit status: 2]
+    ");
+
+    let output = work_dir.run_jj(["untrack", "file"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    error: unrecognized subcommand 'untrack'
+
+    Usage: jj [OPTIONS] <COMMAND>
+
+    For more information, try '--help'.
+    [EOF]
+    [exit status: 2]
+    ");
+
+    let output = work_dir.run_jj(["unsquash"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    error: unrecognized subcommand 'unsquash'
+
+      tip: a similar subcommand exists: 'squash'
+
+    Usage: jj [OPTIONS] <COMMAND>
+
+    For more information, try '--help'.
+    [EOF]
+    [exit status: 2]
+    ");
+
+    let output = work_dir.run_jj(["log", "-l", "5"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    error: unexpected argument '-l' found
+
+      tip: to pass '-l' as a value, use '-- -l'
+
+    Usage: jj log [OPTIONS] [FILESETS]...
+
+    For more information, try '--help'.
+    [EOF]
+    [exit status: 2]
+    ");
+
+    let output = work_dir.run_jj(["op", "log", "-l", "5"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    error: unexpected argument '-l' found
+
+    Usage: jj operation log [OPTIONS]
+
+    For more information, try '--help'.
+    [EOF]
+    [exit status: 2]
+    ");
+
+    let output = work_dir.run_jj(["git", "push", "--allow-new"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    error: unexpected argument '--allow-new' found
+
+      tip: a similar argument exists: '--all'
+
+    Usage: jj git push --all
+
+    For more information, try '--help'.
+    [EOF]
+    [exit status: 2]
+    ");
+
+    let output = work_dir.run_jj(["commit", "--reset-author"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    error: unexpected argument '--reset-author' found
+
+      tip: a similar argument exists: '--repository'
+
+    Usage: jj commit --repository <REPOSITORY> [FILESETS]...
+
+    For more information, try '--help'.
+    [EOF]
+    [exit status: 2]
+    ");
+
+    let output = work_dir.run_jj(["commit", "--author", "A. U. Thor <author@example.com>"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    error: unexpected argument '--author' found
+
+      tip: a similar argument exists: '--at-op'
+
+    Usage: jj commit --at-operation <AT_OPERATION> [FILESETS]...
+
+    For more information, try '--help'.
+    [EOF]
+    [exit status: 2]
+    ");
+
+    let output = work_dir.run_jj(["describe", "--edit"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    error: unexpected argument '--edit' found
+
+      tip: a similar argument exists: '--editor'
+
+    Usage: jj describe --editor [REVSETS]...
+
+    For more information, try '--help'.
+    [EOF]
+    [exit status: 2]
+    ");
+
+    let output = work_dir.run_jj(["describe", "--no-edit"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    error: unexpected argument '--no-edit' found
+
+      tip: to pass '--no-edit' as a value, use '-- --no-edit'
+
+    Usage: jj describe [OPTIONS] [REVSETS]...
+
+    For more information, try '--help'.
+    [EOF]
+    [exit status: 2]
+    ");
+
+    let output = work_dir.run_jj(["rebase", "--skip-empty"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    error: unexpected argument '--skip-empty' found
+
+      tip: a similar argument exists: '--skip-emptied'
+
+    Usage: jj rebase --skip-emptied <--onto <REVSETS>|--insert-after <REVSETS>|--insert-before <REVSETS>>
+
+    For more information, try '--help'.
+    [EOF]
+    [exit status: 2]
+    ");
+
+    let output = work_dir.run_jj(["split", "--siblings"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    error: unexpected argument '--siblings' found
+
+      tip: to pass '--siblings' as a value, use '-- --siblings'
+
+    Usage: jj split [OPTIONS] [FILESETS]...
+
+    For more information, try '--help'.
+    [EOF]
+    [exit status: 2]
+    ");
+
+    let output = work_dir.run_jj(["abandon", "--summary"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    error: unexpected argument '--summary' found
+
+      tip: to pass '--summary' as a value, use '-- --summary'
+
+    Usage: jj abandon [OPTIONS] [REVSETS]...
+
+    For more information, try '--help'.
+    [EOF]
+    [exit status: 2]
+    ");
+
+    let output = work_dir.run_jj(["metaedit", "--update-committer-timestamp"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    error: unexpected argument '--update-committer-timestamp' found
+
+      tip: a similar argument exists: '--update-author-timestamp'
+
+    Usage: jj metaedit --update-author-timestamp [REVSETS]...
+
+    For more information, try '--help'.
+    [EOF]
+    [exit status: 2]
+    ");
+
+    let output = work_dir.run_jj(["describe", "--reset-author"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    error: unexpected argument '--reset-author' found
+
+      tip: a similar argument exists: '--repository'
+
+    Usage: jj describe --repository <REPOSITORY> [REVSETS]...
+
+    For more information, try '--help'.
+    [EOF]
+    [exit status: 2]
+    ");
+
+    let output = work_dir.run_jj(["describe", "--author", "A. U. Thor <author@example.com>"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    error: unexpected argument '--author' found
+
+      tip: a similar argument exists: '--at-op'
+
+    Usage: jj describe --at-operation <AT_OPERATION> [REVSETS]...
+
+    For more information, try '--help'.
+    [EOF]
+    [exit status: 2]
+    ");
+}
+
+#[test]
+fn test_soft_deprecated_command_still_runs() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    let output = work_dir.run_jj(["debug", "snapshot"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    Warning: `jj debug snapshot` is deprecated; use `jj util snapshot` instead
+    [EOF]
+    ");
+}
+
+#[test]
 fn test_ignore_working_copy() {
     let test_env = TestEnvironment::default();
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();


### PR DESCRIPTION
## Summary

Extend the rejected-command hint work from #9700 with the remaining high-confidence cases
from items 1-3 of the [prioritized improvements note][prioritized-note].

This keeps the same boundary as #9700: these inputs still fail parsing, are not accepted
aliases, and are not added to help output. The only change is the recovery text shown
after clap has already rejected the command or flag.

## Why

The characterization commit records the current failure mode before changing behavior.
These are examples where jj currently gives no direct recovery path or points users at
unrelated string matches:

- `jj log --all` suggests `--ignore-all-space`
- `jj log --oneline` suggests passing `--oneline` as a fileset
- `jj git push --allow-deletes` suggests `--all`
- `jj remote ...`, `jj reset`, `jj stash`, `jj switch`, and similar git-shaped commands
  suggest unrelated live jj subcommands or no hint at all

Those errors are user-facing affordances. When jj already has a clear documented
equivalent, it is more useful to point at that than to rely on string similarity.

This also addresses the hint-only cases requested in #4813: `jj annotate`, `jj blame`,
`jj push`, `jj fetch`, and `jj remote`. `jj clone` is handled by #9700.

## Shape

This is stacked on top of #9700:

1. Characterize the current bad/no-help stderr for the additional rejected inputs.
2. Extend the hint table and update only those snapshots.

@steveklabnik, requesting your review since you called out items 1-3 as looking good in
the Discord thread.

## Validation

`cargo test -p jj-cli --test runner test_global_opts`

[prioritized-note]: https://github.com/joshka/jj-claude-skill/blob/main/docs/14-jj-improvements-prioritized.md
