### PR TITLE
git: drop stale cache-tree before writing colocated index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,12 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed bugs
 
+* In colocated repos, `jj` no longer leaves a stale cache-tree in `.git/index`, which could
+  make a later external `git add` produce a tree with duplicate entries
+  (`git fsck: duplicateEntries`).
+  [#9711](https://github.com/jj-vcs/jj/issues/9711)
+
+
 * `jj` now creates a new working-copy revision during snapshotting if the
   working copy was immutable. Previously, the new revision was created
   immediately after the working copy became immutable.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,13 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `log-graph-prioritize` revset.
   [#9975](https://github.com/jj-vcs/jj/issues/9975)
 
+* In colocated repos, an external `git add` after a `jj` command no longer
+  produces a tree with duplicate entries (`git fsck: duplicateEntries`). `jj`
+  was leaving a stale cache-tree behind in `.git/index`. Repositories already
+  corrupted this way are not repaired by the fix.
+  [#9711](https://github.com/jj-vcs/jj/issues/9711)
+  [#8884](https://github.com/jj-vcs/jj/issues/8884)
+
 ## [0.44.0] - 2026-08-05
 
 ### Release highlights

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -2102,6 +2102,15 @@ async fn update_intent_to_add_impl(
 
     index.sort_entries();
 
+    // The entry mutations above (`dangerously_push_entry`, `remove_entries`,
+    // `sort_entries`) do not invalidate the cache-tree (TREE) extension loaded
+    // from disk (gitoxide#2421), so writing the index back would re-emit a
+    // now-stale, under-counted cache-tree. An external `git add` that later
+    // rebuilds the cache-tree trusts those stale child counts and emits a
+    // doubled subtree entry -> `git fsck` duplicateEntries. Drop the stale
+    // cache-tree so git regenerates it.
+    index.remove_tree();
+
     Ok(())
 }
 

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -2190,6 +2190,17 @@ async fn update_intent_to_add_impl(
 
     index.sort_entries();
 
+    // The entry mutations above (`dangerously_push_entry`, `remove_entries`,
+    // `sort_entries`) do not invalidate the cache-tree (TREE) extension loaded
+    // from disk, and `gix::index::File::write()` re-emits it as-is. Its own
+    // docs prescribe this discard: "Until the tree-cache is updated on write
+    // (see gitoxide#2421), remove it with `State::remove_tree()` before writing
+    // whenever entries were changed." Otherwise the written index carries a
+    // stale, under-counted cache-tree; an external `git add` that later
+    // rebuilds it trusts those child counts and emits a doubled subtree entry,
+    // which `git fsck` reports as duplicateEntries.
+    index.remove_tree();
+
     Ok(())
 }
 

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -98,6 +98,7 @@ use testutils::TestResult;
 use testutils::base_user_config;
 use testutils::commit_transactions;
 use testutils::create_random_commit;
+use testutils::create_tree;
 use testutils::repo_path;
 use testutils::write_random_commit;
 use testutils::write_random_commit_with_parents;
@@ -7222,6 +7223,117 @@ fn test_remote_name_validation() -> TestResult {
         Err(git::GitRemoteManagementError::RemoteName(
             git::GitRemoteNameError::ReservedForLocalGitRepo
         ))
+    );
+
+    Ok(())
+}
+
+// Regression test for the colocated cache-tree corruption
+// (jj-vcs/jj#8884 family / GitoxideLabs/gitoxide#2421).
+//
+// Mechanism: in a colocated repo, `jj_lib::git::update_intent_to_add` loads the
+// on-disk `.git/index` via gix `index_or_empty()` -- which deserializes git's
+// previously-written cache-tree (TREE) extension into `State.tree` -- then
+// pushes a new intent-to-add entry into an EXISTING subtree via gix's
+// "dangerous" mutators, which DO NOT invalidate `State.tree`, and writes the
+// index back with `Extensions::All`. The written index now carries a stale,
+// under-counted cache-tree node. An external `git add` of an UNRELATED
+// sibling path invalidates only the root, leaving the stale subtree node in
+// place; the next `git write-tree` rebuilds the root while trusting the stale
+// child count and emits the same subtree directory entry TWICE -> `git fsck`
+// duplicateEntries.
+//
+// Fix: `index.remove_tree()` after the entry mutations in
+// `update_intent_to_add_impl` (lib/src/git.rs), so the discard happens only
+// when entries were actually added/removed. This test FAILS on stock main and
+// PASSES with the fix.
+
+/// Run `git <args>` in `dir`, returning combined stdout+stderr. Does NOT assert
+/// success: `git fsck` intentionally returns non-zero when it finds the
+/// corruption under test.
+fn run_git(dir: &Path, args: &[&str]) -> String {
+    let out = std::process::Command::new("git")
+        .current_dir(dir)
+        .args(args)
+        .output()
+        .unwrap_or_else(|e| panic!("failed to spawn git {args:?}: {e}"));
+    let mut s = String::from_utf8_lossy(&out.stdout).into_owned();
+    s.push_str(&String::from_utf8_lossy(&out.stderr));
+    s
+}
+
+#[test]
+fn test_update_intent_to_add_drops_stale_cache_tree() -> TestResult {
+    let settings = testutils::user_settings();
+    let temp_dir = testutils::new_temp_dir();
+    let workspace_root = temp_dir.path().join("repo");
+    testutils::git::init(&workspace_root);
+    let (_workspace, repo) =
+        Workspace::init_external_git(&settings, &workspace_root, &workspace_root.join(".git"))
+            .block_on()?;
+
+    // old_tree: a nested subtree d/e/f/ plus an UNRELATED sibling tree sib/.
+    let old_tree = create_tree(
+        &repo,
+        &[
+            (repo_path("d/e/f/w0.txt"), "0\n"),
+            (repo_path("d/e/y.txt"), "y\n"),
+            (repo_path("sib/seed.txt"), "s\n"),
+        ],
+    );
+    // new_tree: add a NEW file into the EXISTING nested subtree d/e/f/.
+    let new_tree = create_tree(
+        &repo,
+        &[
+            (repo_path("d/e/f/w0.txt"), "0\n"),
+            (repo_path("d/e/f/w1.txt"), "1\n"),
+            (repo_path("d/e/y.txt"), "y\n"),
+            (repo_path("sib/seed.txt"), "s\n"),
+        ],
+    );
+
+    // Materialize old_tree in the workdir and bake a VALID, fully-populated git
+    // cache-tree into .git/index using the real git binary -- this is the
+    // "git's earlier cache-tree" the bug depends on (jj's own index writes use
+    // tree:None and would not trigger it).
+    for (path, content) in [
+        ("d/e/f/w0.txt", "0\n"),
+        ("d/e/y.txt", "y\n"),
+        ("sib/seed.txt", "s\n"),
+    ] {
+        let p = workspace_root.join(path);
+        fs::create_dir_all(p.parent().unwrap())?;
+        fs::write(p, content)?;
+    }
+    run_git(
+        &workspace_root,
+        &["add", "d/e/f/w0.txt", "d/e/y.txt", "sib/seed.txt"],
+    );
+    run_git(&workspace_root, &["write-tree"]); // bakes a valid cache-tree onto disk
+
+    // The jj snapshot path under test: add the new file into d/e/f as
+    // intent-to-add.
+    fs::write(workspace_root.join("d/e/f/w1.txt"), "1\n")?;
+    git::update_intent_to_add(repo.as_ref(), &old_tree, &new_tree).block_on()?;
+
+    // External git op touching an UNRELATED sibling -> invalidates only the root,
+    // leaving the stale d/ subtree cache-tree node in place. (A `git add` of a
+    // file *under* d/, or `git add -A`, would invalidate d/ too and force a
+    // correct recompute -- it must be a sibling.)
+    fs::write(workspace_root.join("sib/g1.txt"), "g\n")?;
+    run_git(&workspace_root, &["add", "sib/g1.txt"]);
+
+    // Force the cache-tree rebuild + materialize the resulting tree objects in the
+    // ODB.
+    let root_tree = run_git(&workspace_root, &["write-tree"]);
+
+    // End-to-end assertion: the resulting tree must be fsck-clean.
+    let fsck = run_git(&workspace_root, &["fsck", "--no-dangling", "--no-reflogs"]);
+    assert!(
+        !fsck.contains("duplicateEntries"),
+        "colocated snapshot left a stale cache-tree that git turned into a corrupt \
+         (doubled-subtree) root tree {root}:\n{fsck}",
+        root = root_tree.trim(),
     );
 
     Ok(())

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -101,6 +101,7 @@ use testutils::TestWorkspace;
 use testutils::base_user_config;
 use testutils::commit_transactions;
 use testutils::create_random_commit;
+use testutils::create_tree;
 use testutils::repo_path;
 use testutils::write_random_commit;
 use testutils::write_random_commit_with_parents;
@@ -4024,6 +4025,124 @@ fn test_reset_head_with_index_file_directory_conflict() -> TestResult {
 
     // Only the file should be added to the index (the tree should be skipped).
     insta::assert_snapshot!(get_index_state(workspace_root), @"Theirs test Mode(FILE)");
+    Ok(())
+}
+
+/// Run `git <args>` in `dir`, asserting success and returning combined
+/// stdout+stderr.
+fn run_git(dir: &Path, args: &[&str]) -> String {
+    let (output, success) = run_git_allow_failure(dir, args);
+    assert!(success, "git {args:?} failed:\n{output}");
+    output
+}
+
+/// Like `run_git`, but reports the exit status instead of asserting it, for
+/// `git fsck`, which exits non-zero when it finds the corruption under test.
+fn run_git_allow_failure(dir: &Path, args: &[&str]) -> (String, bool) {
+    let output = std::process::Command::new("git")
+        .current_dir(dir)
+        .args(args)
+        .output()
+        .unwrap_or_else(|e| panic!("failed to spawn git {args:?}: {e}"));
+    let mut combined = String::from_utf8_lossy(&output.stdout).into_owned();
+    combined.push_str(&String::from_utf8_lossy(&output.stderr));
+    (combined, output.status.success())
+}
+
+/// Whether `.git/index` currently carries a cache-tree (TREE) extension.
+fn index_has_cache_tree(workspace_root: &Path) -> bool {
+    testutils::git::open(workspace_root)
+        .index()
+        .unwrap()
+        .tree()
+        .is_some()
+}
+
+/// Regression test for colocated cache-tree corruption (#9711, one cause of
+/// #8884): `update_intent_to_add` mutates entries in an index that git wrote,
+/// whose cache-tree (TREE) extension stays loaded and valid-looking, so writing
+/// it back leaves stale subtree counts that a later external `git add` turns
+/// into a doubled subtree entry (`git fsck: duplicateEntries`).
+#[test]
+fn test_update_intent_to_add_drops_stale_cache_tree() -> TestResult {
+    let settings = testutils::user_settings();
+    let temp_dir = testutils::new_temp_dir();
+    let workspace_root = temp_dir.path().join("repo");
+    testutils::git::init(&workspace_root);
+    let (_workspace, repo) =
+        Workspace::init_external_git(&settings, &workspace_root, &workspace_root.join(".git"))
+            .block_on()?;
+
+    // A nested subtree d/e/f/ plus an unrelated sibling tree sib/.
+    let old_files = [
+        ("d/e/f/w0.txt", "0\n"),
+        ("d/e/y.txt", "y\n"),
+        ("sib/seed.txt", "s\n"),
+    ];
+    let old_tree = create_tree(
+        &repo,
+        &old_files.map(|(path, content)| (repo_path(path), content)),
+    );
+    // new_tree adds a new file inside the existing nested subtree d/e/f/.
+    let new_tree = create_tree(
+        &repo,
+        &[
+            (repo_path("d/e/f/w0.txt"), "0\n"),
+            (repo_path("d/e/f/w1.txt"), "1\n"),
+            (repo_path("d/e/y.txt"), "y\n"),
+            (repo_path("sib/seed.txt"), "s\n"),
+        ],
+    );
+
+    // Materialize old_tree in the workdir and bake a valid, fully-populated
+    // cache-tree into .git/index using the real git binary. jj's own index
+    // writes use tree:None and would not produce one.
+    for (path, content) in old_files {
+        let p = workspace_root.join(path);
+        fs::create_dir_all(p.parent().unwrap())?;
+        fs::write(p, content)?;
+    }
+    run_git(
+        &workspace_root,
+        &["add", "d/e/f/w0.txt", "d/e/y.txt", "sib/seed.txt"],
+    );
+    run_git(&workspace_root, &["write-tree"]);
+    assert!(
+        index_has_cache_tree(&workspace_root),
+        "setup did not bake a cache-tree into .git/index, so the corruption this test checks for \
+         could never be produced",
+    );
+
+    // The jj snapshot path under test: add the new file into d/e/f as
+    // intent-to-add.
+    fs::write(workspace_root.join("d/e/f/w1.txt"), "1\n")?;
+    git::update_intent_to_add(repo.as_ref(), &workspace_root, &old_tree, &new_tree).block_on()?;
+    assert!(
+        !index_has_cache_tree(&workspace_root),
+        "update_intent_to_add wrote back a cache-tree that its own entry mutations had already \
+         invalidated",
+    );
+
+    // An external git op touching an unrelated sibling invalidates only the
+    // root, leaving any stale d/ subtree node in place. (A `git add` of a file
+    // under d/, or `git add -A`, would invalidate d/ too and force a correct
+    // recompute, so it has to be a sibling.)
+    fs::write(workspace_root.join("sib/g1.txt"), "g\n")?;
+    run_git(&workspace_root, &["add", "sib/g1.txt"]);
+
+    // Force the cache-tree rebuild and materialize the tree objects in the ODB.
+    let root_tree = run_git(&workspace_root, &["write-tree"]);
+
+    // End-to-end backstop: the resulting tree must be fsck-clean.
+    let (fsck, _) =
+        run_git_allow_failure(&workspace_root, &["fsck", "--no-dangling", "--no-reflogs"]);
+    assert!(
+        !fsck.contains("duplicateEntries"),
+        "colocated snapshot left a stale cache-tree that git turned into a corrupt \
+         (doubled-subtree) root tree {root}:\n{fsck}",
+        root = root_tree.trim(),
+    );
+
     Ok(())
 }
 

--- a/lib/testutils/src/git.rs
+++ b/lib/testutils/src/git.rs
@@ -344,6 +344,10 @@ impl<'a> IndexManager<'a> {
     pub fn sync_index(&mut self) {
         self.index.sort_entries();
         self.index.verify_entries().unwrap();
+        // Same contract as `update_intent_to_add_impl` in lib/src/git.rs: the
+        // entry mutations above leave any loaded cache-tree stale, and
+        // `write()` would re-emit it as-is.
+        self.index.remove_tree();
         self.index
             .write(gix::index::write::Options::default())
             .unwrap();


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

Fixes the chronic colocated `duplicateEntries` corruption — full mechanism is in the commit message. Root cause is gitoxide#2421; this is the jj-side fix (`remove_tree()` before the index write). The added regression test trips on stock `main` and passes with the fix.

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
