### PR TITLE
cli: Add workspace list root template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * New `merge_point()` revset function which (similar to `fork_point`) finds the
   point where multiple branches merge.
 
+* New `builtin_workspace_list` and `builtin_workspace_list_with_root` template
+  aliases are available for `jj workspace list`, and `WorkspaceRef.root()` now
+  returns an optional `FsPath` value.
+
 ### Fixed bugs
 
 * Recursive alias definitions are detected more precisely. jj can now expand

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -882,6 +882,11 @@ impl WorkspaceCommandEnvironment {
         &self.path_converter
     }
 
+    pub(crate) fn cwd(&self) -> &Path {
+        let RepoPathUiConverter::Fs { cwd, base: _ } = &self.path_converter;
+        cwd
+    }
+
     pub fn workspace_name(&self) -> &WorkspaceName {
         &self.workspace_name
     }
@@ -1889,6 +1894,7 @@ to the current parents may contain changes from multiple commits.
         OperationTemplateLanguage::new(
             self.workspace.repo_loader(),
             Some(self.repo().op_id()),
+            self.env.cwd(),
             self.env.operation_template_extensions(),
         )
     }

--- a/cli/src/commands/config/list.rs
+++ b/cli/src/commands/config/list.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::path::Path;
+
 use clap_complete::ArgValueCandidates;
 use jj_lib::config::ConfigNamePathBuf;
 use jj_lib::config::ConfigSource;
@@ -81,7 +83,7 @@ pub async fn cmd_config_list(
     args: &ConfigListArgs,
 ) -> Result<(), CommandError> {
     let template: TemplateRenderer<AnnotatedValue> = {
-        let language = config_template_language(command.settings());
+        let language = config_template_language(command.settings(), command.cwd());
         let text = match &args.template {
             Some(value) => value.to_owned(),
             None => command.settings().get_string("templates.config_list")?,
@@ -128,8 +130,8 @@ generic_templater::impl_self_property_wrapper!(AnnotatedValue);
 
 // AnnotatedValue will be cloned internally in the templater. If the cloning
 // cost matters, wrap it with Rc.
-fn config_template_language(settings: &UserSettings) -> ConfigTemplateLanguage {
-    let mut language = ConfigTemplateLanguage::new(settings);
+fn config_template_language(settings: &UserSettings, current_dir: &Path) -> ConfigTemplateLanguage {
+    let mut language = ConfigTemplateLanguage::new(settings, current_dir);
     language.add_keyword("name", |self_property| {
         let out_property = self_property.map(|annotated| annotated.name.to_string());
         Ok(out_property.into_dyn_wrapped())

--- a/cli/src/commands/operation/log.rs
+++ b/cli/src/commands/operation/log.rs
@@ -143,6 +143,7 @@ async fn do_op_log(
         let language = OperationTemplateLanguage::new(
             repo_loader,
             Some(current_op.id()),
+            workspace_env.cwd(),
             workspace_env.operation_template_extensions(),
         );
         let text = match &args.template {

--- a/cli/src/commands/workspace/list.rs
+++ b/cli/src/commands/workspace/list.rs
@@ -35,6 +35,9 @@ pub struct WorkspaceListArgs {
     /// The default template can be set by the `templates.workspace_list`
     /// setting.
     ///
+    /// Use `-T builtin_workspace_list_with_root` to include workspace root
+    /// paths.
+    ///
     /// [`WorkspaceRef` type]:
     ///     https://docs.jj-vcs.dev/latest/templates/#workspaceref-type
     ///

--- a/cli/src/commit_templater.rs
+++ b/cli/src/commit_templater.rs
@@ -22,6 +22,7 @@ use std::fmt;
 use std::fmt::Display;
 use std::io;
 use std::path::Path;
+use std::path::PathBuf;
 use std::rc::Rc;
 use std::sync::Arc;
 
@@ -1754,40 +1755,26 @@ impl WorkspaceRef {
         &self.target
     }
 
-    /// Returns the root path of the workspace.
-    fn root(&self, path_converter: &RepoPathUiConverter) -> Result<String, TemplatePropertyError> {
+    /// Returns the root path of the workspace if it is recorded and can be
+    /// resolved.
+    fn root(
+        &self,
+        path_converter: &RepoPathUiConverter,
+    ) -> Result<Option<PathBuf>, TemplatePropertyError> {
         let RepoPathUiConverter::Fs { cwd: _, base } = path_converter;
         // TODO: Stop reconstructing the workspace loader here once we've
         // decided which object should own the workspace store.
         let workspace_loader = DefaultWorkspaceLoaderFactory.create(base)?;
         let repo_path = workspace_loader.repo_path().to_owned();
         let workspace_store = SimpleWorkspaceStore::load(&repo_path)?;
-        let workspace_path = workspace_store
+        // Workspaces created before jj 0.38.0 may not have a recorded path. List
+        // templates should also keep rendering if a recorded path is stale or
+        // unavailable. Use `jj workspace root --name` for strict path diagnostics.
+        let path = workspace_store
             .get_workspace_path(self.name())?
-            .ok_or_else(|| {
-                TemplatePropertyError(
-                    format!(
-                        "Workspace has no recorded path: {}",
-                        self.name().as_symbol()
-                    )
-                    .into(),
-                )
-            })?;
-        let full_path = repo_path.join(workspace_path);
-        let path = dunce::canonicalize(&full_path).map_err(|err| {
-            TemplatePropertyError(
-                format!(
-                    "Failed to resolve workspace root: {}: {}: {err}",
-                    self.name().as_symbol(),
-                    full_path.display()
-                )
-                .into(),
-            )
-        })?;
-        // TODO: Return PathBuf once the templater has a filesystem path type.
-        path.into_os_string()
-            .into_string()
-            .map_err(|_| TemplatePropertyError("Invalid UTF-8 sequence in path".into()))
+            .map(|workspace_path| repo_path.join(workspace_path))
+            .and_then(|path| dunce::canonicalize(path).ok());
+        Ok(path)
     }
 }
 
@@ -3018,7 +3005,6 @@ fn builtin_trailer_list_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo
 #[cfg(test)]
 mod tests {
     use std::path::Component;
-    use std::path::PathBuf;
 
     use jj_lib::config::ConfigLayer;
     use jj_lib::config::ConfigSource;

--- a/cli/src/commit_templater.rs
+++ b/cli/src/commit_templater.rs
@@ -21,6 +21,7 @@ use std::collections::HashMap;
 use std::fmt;
 use std::fmt::Display;
 use std::io;
+use std::path::Path;
 use std::rc::Rc;
 use std::sync::Arc;
 
@@ -205,6 +206,11 @@ impl<'repo> TemplateLanguage<'repo> for CommitTemplateLanguage<'repo> {
 
     fn settings(&self) -> &UserSettings {
         self.repo.base_repo().settings()
+    }
+
+    fn current_dir(&self) -> &Path {
+        let RepoPathUiConverter::Fs { cwd, base: _ } = self.path_converter;
+        cwd
     }
 
     fn build_function(
@@ -3012,7 +3018,6 @@ fn builtin_trailer_list_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo
 #[cfg(test)]
 mod tests {
     use std::path::Component;
-    use std::path::Path;
     use std::path::PathBuf;
 
     use jj_lib::config::ConfigLayer;

--- a/cli/src/config/templates.toml
+++ b/cli/src/config/templates.toml
@@ -44,14 +44,7 @@ concat(
 
 tag_list = 'format_commit_ref(self, "tag") ++ "\n"'
 
-workspace_list = '''
-concat(
-  name,
-  ": ",
-  format_commit_summary_with_refs(target, format_commit_ref_names(target.bookmarks())),
-  "\n",
-)
-'''
+workspace_list = 'builtin_workspace_list'
 
 op_summary = '''
 separate(" ",
@@ -299,6 +292,28 @@ label(if(op.current_operation(), "current_operation"),
     if(op.root(), format_root_operation(op)),
     format_operation_redacted(op),
   )
+)
+'''
+
+builtin_workspace_list = '''
+concat(
+  name,
+  ": ",
+  format_commit_summary_with_refs(target, format_commit_ref_names(target.bookmarks())),
+  "\n",
+)
+'''
+
+builtin_workspace_list_with_root = '''
+concat(
+  name,
+  ": ",
+  separate(
+    " ",
+    if(root, root.relative()),
+    format_commit_summary_with_refs(target, format_commit_ref_names(target.bookmarks())),
+  ),
+  "\n",
 )
 '''
 

--- a/cli/src/generic_templater.rs
+++ b/cli/src/generic_templater.rs
@@ -14,6 +14,8 @@
 
 use std::cmp::Ordering;
 use std::collections::HashMap;
+use std::path::Path;
+use std::path::PathBuf;
 
 use bstr::BString;
 use jj_lib::backend::Timestamp;
@@ -43,6 +45,7 @@ use crate::templater::TemplatePropertyExt as _;
 /// registered to extract properties from the self object.
 pub struct GenericTemplateLanguage<'a, C> {
     settings: UserSettings,
+    current_dir: PathBuf,
     build_fn_table: GenericTemplateBuildFnTable<'a, C>,
 }
 
@@ -53,18 +56,20 @@ where
     /// Sets up environment with no keywords.
     ///
     /// New keyword functions can be registered by `add_keyword()`.
-    pub fn new(settings: &UserSettings) -> Self {
-        Self::with_keywords(HashMap::new(), settings)
+    pub fn new(settings: &UserSettings, current_dir: &Path) -> Self {
+        Self::with_keywords(HashMap::new(), settings, current_dir)
     }
 
     /// Sets up environment with the given `keywords` table.
     pub fn with_keywords(
         keywords: GenericTemplateBuildKeywordFnMap<'a, C>,
         settings: &UserSettings,
+        current_dir: &Path,
     ) -> Self {
         Self {
             // Clone settings to keep lifetime simple. It's cheap.
             settings: settings.clone(),
+            current_dir: current_dir.to_owned(),
             build_fn_table: GenericTemplateBuildFnTable {
                 core: CoreTemplateBuildFnTable::builtin(),
                 keywords,
@@ -103,6 +108,10 @@ where
 
     fn settings(&self) -> &UserSettings {
         &self.settings
+    }
+
+    fn current_dir(&self) -> &Path {
+        &self.current_dir
     }
 
     fn build_function(

--- a/cli/src/operation_templater.rs
+++ b/cli/src/operation_templater.rs
@@ -18,6 +18,8 @@ use std::any::Any;
 use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::io;
+use std::path::Path;
+use std::path::PathBuf;
 
 use bstr::BString;
 use itertools::Itertools as _;
@@ -67,6 +69,7 @@ pub trait OperationTemplateEnvironment {
 pub struct OperationTemplateLanguage {
     repo_loader: RepoLoader,
     current_op_id: Option<OperationId>,
+    current_dir: PathBuf,
     build_fn_table: OperationTemplateLanguageBuildFnTable,
     cache_extensions: ExtensionsMap,
 }
@@ -77,6 +80,7 @@ impl OperationTemplateLanguage {
     pub fn new(
         repo_loader: &RepoLoader,
         current_op_id: Option<&OperationId>,
+        current_dir: &Path,
         extensions: &[impl AsRef<dyn OperationTemplateLanguageExtension>],
     ) -> Self {
         let mut build_fn_table = OperationTemplateLanguageBuildFnTable::builtin();
@@ -93,6 +97,7 @@ impl OperationTemplateLanguage {
             // Clone these to keep lifetime simple
             repo_loader: repo_loader.clone(),
             current_op_id: current_op_id.cloned(),
+            current_dir: current_dir.to_owned(),
             build_fn_table,
             cache_extensions,
         }
@@ -104,6 +109,10 @@ impl TemplateLanguage<'static> for OperationTemplateLanguage {
 
     fn settings(&self) -> &UserSettings {
         self.repo_loader.settings()
+    }
+
+    fn current_dir(&self) -> &Path {
+        &self.current_dir
     }
 
     fn build_function(

--- a/cli/src/template_builder.rs
+++ b/cli/src/template_builder.rs
@@ -16,6 +16,8 @@ use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::io;
 use std::iter;
+use std::path::Path;
+use std::path::PathBuf;
 
 use bstr::BString;
 use bstr::ByteSlice as _;
@@ -26,6 +28,7 @@ use jj_lib::config::ConfigGetResultExt as _;
 use jj_lib::config::ConfigNamePathBuf;
 use jj_lib::config::ConfigValue;
 use jj_lib::content_hash::blake2b_hash;
+use jj_lib::file_util;
 use jj_lib::hex_util;
 use jj_lib::op_store::TimestampRange;
 use jj_lib::settings::UserSettings;
@@ -90,6 +93,9 @@ pub trait TemplateLanguage<'a> {
     type Property: CoreTemplatePropertyVar<'a> + 'a;
 
     fn settings(&self) -> &UserSettings;
+
+    /// Returns the working directory for filesystem path template methods.
+    fn current_dir(&self) -> &Path;
 
     /// Translates the given global `function` call to a property.
     ///
@@ -178,6 +184,8 @@ where
     Self: WrapTemplateProperty<'a, Option<i64>>,
     Self: WrapTemplateProperty<'a, ConfigValue>,
     Self: WrapTemplateProperty<'a, Option<ConfigValue>>,
+    Self: WrapTemplateProperty<'a, PathBuf>,
+    Self: WrapTemplateProperty<'a, Option<PathBuf>>,
     Self: WrapTemplateProperty<'a, Signature>,
     Self: WrapTemplateProperty<'a, Email>,
     Self: WrapTemplateProperty<'a, SizeHint>,
@@ -221,6 +229,8 @@ pub enum CoreTemplatePropertyKind<'a> {
     IntegerOpt(BoxedTemplateProperty<'a, Option<i64>>),
     ConfigValue(BoxedTemplateProperty<'a, ConfigValue>),
     ConfigValueOpt(BoxedTemplateProperty<'a, Option<ConfigValue>>),
+    FsPath(BoxedTemplateProperty<'a, PathBuf>),
+    FsPathOpt(BoxedTemplateProperty<'a, Option<PathBuf>>),
     Signature(BoxedTemplateProperty<'a, Signature>),
     Email(BoxedTemplateProperty<'a, Email>),
     SizeHint(BoxedTemplateProperty<'a, SizeHint>),
@@ -259,6 +269,8 @@ macro_rules! impl_core_property_wrappers {
             IntegerOpt(Option<i64>),
             ConfigValue(jj_lib::config::ConfigValue),
             ConfigValueOpt(Option<jj_lib::config::ConfigValue>),
+            FsPath(std::path::PathBuf),
+            FsPathOpt(Option<std::path::PathBuf>),
             Signature(jj_lib::backend::Signature),
             Email($crate::templater::Email),
             SizeHint($crate::templater::SizeHint),
@@ -297,6 +309,8 @@ impl<'a> CoreTemplatePropertyVar<'a> for CoreTemplatePropertyKind<'a> {
             Self::IntegerOpt(_) => "Option<Integer>",
             Self::ConfigValue(_) => "ConfigValue",
             Self::ConfigValueOpt(_) => "Option<ConfigValue>",
+            Self::FsPath(_) => "FsPath",
+            Self::FsPathOpt(_) => "Option<FsPath>",
             Self::Signature(_) => "Signature",
             Self::Email(_) => "Email",
             Self::SizeHint(_) => "SizeHint",
@@ -334,6 +348,8 @@ impl<'a> CoreTemplatePropertyVar<'a> for CoreTemplatePropertyKind<'a> {
             Self::IntegerOpt(property) => Ok(property.map(|opt| opt.is_some()).into_dyn()),
             Self::ConfigValue(_) => Err(self),
             Self::ConfigValueOpt(property) => Ok(property.map(|opt| opt.is_some()).into_dyn()),
+            Self::FsPath(_) => Err(self),
+            Self::FsPathOpt(property) => Ok(property.map(|opt| opt.is_some()).into_dyn()),
             Self::Signature(_) => Err(self),
             Self::Email(property) => Ok(property.map(|e| !e.0.is_empty()).into_dyn()),
             Self::SizeHint(_) => Err(self),
@@ -381,6 +397,8 @@ impl<'a> CoreTemplatePropertyVar<'a> for CoreTemplatePropertyKind<'a> {
                     .map(|opt| opt.map(config::to_serializable_value))
                     .into_serialize(),
             ),
+            Self::FsPath(property) => Some(property.into_serialize()),
+            Self::FsPathOpt(property) => Some(property.into_serialize()),
             Self::Signature(property) => Some(property.into_serialize()),
             Self::Email(property) => Some(property.into_serialize()),
             Self::SizeHint(property) => Some(property.into_serialize()),
@@ -404,6 +422,8 @@ impl<'a> CoreTemplatePropertyVar<'a> for CoreTemplatePropertyKind<'a> {
             Self::IntegerOpt(property) => Some(property.into_template()),
             Self::ConfigValue(property) => Some(property.into_template()),
             Self::ConfigValueOpt(property) => Some(property.into_template()),
+            Self::FsPath(property) => Some(property.into_template()),
+            Self::FsPathOpt(property) => Some(property.into_template()),
             Self::Signature(property) => Some(property.into_template()),
             Self::Email(property) => Some(property.into_template()),
             Self::SizeHint(_) => None,
@@ -463,6 +483,8 @@ impl<'a> CoreTemplatePropertyVar<'a> for CoreTemplatePropertyKind<'a> {
             (Self::IntegerOpt(_), _) => None,
             (Self::ConfigValue(_), _) => None,
             (Self::ConfigValueOpt(_), _) => None,
+            (Self::FsPath(_), _) => None,
+            (Self::FsPathOpt(_), _) => None,
             (Self::Signature(_), _) => None,
             (Self::Email(_), _) => None,
             (Self::SizeHint(_), _) => None,
@@ -498,6 +520,8 @@ impl<'a> CoreTemplatePropertyVar<'a> for CoreTemplatePropertyKind<'a> {
             (Self::IntegerOpt(_), _) => None,
             (Self::ConfigValue(_), _) => None,
             (Self::ConfigValueOpt(_), _) => None,
+            (Self::FsPath(_), _) => None,
+            (Self::FsPathOpt(_), _) => None,
             (Self::Signature(_), _) => None,
             (Self::Email(_), _) => None,
             (Self::SizeHint(_), _) => None,
@@ -563,6 +587,7 @@ pub struct CoreTemplateBuildFnTable<'a, L: ?Sized, P = <L as TemplateLanguage<'a
     pub boolean_methods: TemplateBuildMethodFnMap<'a, L, bool, P>,
     pub integer_methods: TemplateBuildMethodFnMap<'a, L, i64, P>,
     pub config_value_methods: TemplateBuildMethodFnMap<'a, L, ConfigValue, P>,
+    pub fs_path_methods: TemplateBuildMethodFnMap<'a, L, PathBuf, P>,
     pub email_methods: TemplateBuildMethodFnMap<'a, L, Email, P>,
     pub signature_methods: TemplateBuildMethodFnMap<'a, L, Signature, P>,
     pub size_hint_methods: TemplateBuildMethodFnMap<'a, L, SizeHint, P>,
@@ -593,6 +618,7 @@ impl<L: ?Sized, P> CoreTemplateBuildFnTable<'_, L, P> {
             boolean_methods: HashMap::new(),
             integer_methods: HashMap::new(),
             config_value_methods: HashMap::new(),
+            fs_path_methods: HashMap::new(),
             signature_methods: HashMap::new(),
             email_methods: HashMap::new(),
             size_hint_methods: HashMap::new(),
@@ -615,6 +641,7 @@ impl<L: ?Sized, P> CoreTemplateBuildFnTable<'_, L, P> {
             boolean_methods,
             integer_methods,
             config_value_methods,
+            fs_path_methods,
             signature_methods,
             email_methods,
             size_hint_methods,
@@ -634,6 +661,7 @@ impl<L: ?Sized, P> CoreTemplateBuildFnTable<'_, L, P> {
         merge_fn_map(&mut self.boolean_methods, boolean_methods);
         merge_fn_map(&mut self.integer_methods, integer_methods);
         merge_fn_map(&mut self.config_value_methods, config_value_methods);
+        merge_fn_map(&mut self.fs_path_methods, fs_path_methods);
         merge_fn_map(&mut self.signature_methods, signature_methods);
         merge_fn_map(&mut self.email_methods, email_methods);
         merge_fn_map(&mut self.size_hint_methods, size_hint_methods);
@@ -661,6 +689,7 @@ where
             boolean_methods: HashMap::new(),
             integer_methods: HashMap::new(),
             config_value_methods: builtin_config_value_methods(),
+            fs_path_methods: builtin_fs_path_methods(),
             signature_methods: builtin_signature_methods(),
             email_methods: builtin_email_methods(),
             size_hint_methods: builtin_size_hint_methods(),
@@ -743,6 +772,18 @@ where
             CoreTemplatePropertyKind::ConfigValueOpt(property) => {
                 let type_name = "ConfigValue";
                 let table = &self.config_value_methods;
+                let build = template_parser::lookup_method(type_name, table, function)?;
+                let inner_property = property.try_unwrap(type_name).into_dyn();
+                build(language, diagnostics, build_ctx, inner_property, function)
+            }
+            CoreTemplatePropertyKind::FsPath(property) => {
+                let table = &self.fs_path_methods;
+                let build = template_parser::lookup_method(type_name, table, function)?;
+                build(language, diagnostics, build_ctx, property, function)
+            }
+            CoreTemplatePropertyKind::FsPathOpt(property) => {
+                let type_name = "FsPath";
+                let table = &self.fs_path_methods;
                 let build = template_parser::lookup_method(type_name, table, function)?;
                 let inner_property = property.try_unwrap(type_name).into_dyn();
                 build(language, diagnostics, build_ctx, inner_property, function)
@@ -1645,6 +1686,32 @@ fn builtin_config_value_methods<'a, L: TemplateLanguage<'a> + ?Sized>()
     );
     // TODO: add is_<type>() -> Boolean?
     // TODO: add .get(key) -> ConfigValue or Option<ConfigValue>?
+    map
+}
+
+fn builtin_fs_path_methods<'a, L: TemplateLanguage<'a> + ?Sized>()
+-> TemplateBuildMethodFnMap<'a, L, PathBuf> {
+    // Not using maplit::hashmap!{} or custom declarative macro here because
+    // code completion inside macro is quite restricted.
+    let mut map = TemplateBuildMethodFnMap::<L, PathBuf>::new();
+    map.insert(
+        "absolute",
+        |language, _diagnostics, _build_ctx, self_property, function| {
+            function.expect_no_arguments()?;
+            let cwd = language.current_dir().to_owned();
+            let out_property = self_property.map(move |path| cwd.join(path));
+            Ok(out_property.into_dyn_wrapped())
+        },
+    );
+    map.insert(
+        "relative",
+        |language, _diagnostics, _build_ctx, self_property, function| {
+            function.expect_no_arguments()?;
+            let cwd = language.current_dir().to_owned();
+            let out_property = self_property.map(move |path| file_util::relative_path(&cwd, &path));
+            Ok(out_property.into_dyn_wrapped())
+        },
+    );
     map
 }
 
@@ -3015,6 +3082,8 @@ fn expect_expression_of_type<'a, L: TemplateLanguage<'a> + ?Sized, T>(
 
 #[cfg(test)]
 mod tests {
+    use std::path::Component;
+
     use assert_matches::assert_matches;
     use jj_lib::backend::MillisSinceEpoch;
     use jj_lib::config::StackedConfig;
@@ -3046,13 +3115,21 @@ mod tests {
         }
 
         fn with_config(config: StackedConfig) -> Self {
+            Self::with_config_and_current_dir(config, default_current_dir())
+        }
+
+        fn with_config_and_current_dir(config: StackedConfig, current_dir: PathBuf) -> Self {
             let settings = UserSettings::from_config(config).unwrap();
             Self {
-                language: TestTemplateLanguage::new(&settings),
+                language: TestTemplateLanguage::new(&settings, &current_dir),
                 aliases_map: TemplateAliasesMap::new(),
                 color_rules: Vec::new(),
             }
         }
+    }
+
+    fn default_current_dir() -> PathBuf {
+        PathBuf::from(Component::RootDir.as_os_str()).join("cwd")
     }
 
     impl TestTemplateEnv {
@@ -3496,6 +3573,23 @@ mod tests {
         insta::assert_snapshot!(env.render_ok(r#"if(sl0, true, false)"#), @"false");
         insta::assert_snapshot!(env.render_ok(r#"if(sl1, true, false)"#), @"true");
 
+        env.add_keyword("fs_path", || literal(PathBuf::from("/repo/workspace")));
+        insta::assert_snapshot!(env.parse_err(r#"if(fs_path, true, false)"#), @"
+         --> 1:4
+          |
+        1 | if(fs_path, true, false)
+          |    ^-----^
+          |
+          = Expected expression of type `Boolean`, but actual type is `FsPath`
+        ");
+
+        env.add_keyword("none_fs_path", || literal(None::<PathBuf>));
+        env.add_keyword("some_fs_path", || {
+            literal(Some(PathBuf::from("/repo/workspace")))
+        });
+        insta::assert_snapshot!(env.render_ok(r#"if(none_fs_path, true, false)"#), @"false");
+        insta::assert_snapshot!(env.render_ok(r#"if(some_fs_path, true, false)"#), @"true");
+
         // No implicit cast of integer
         insta::assert_snapshot!(env.parse_err(r#"if(0, true, false)"#), @"
          --> 1:4
@@ -3643,6 +3737,99 @@ mod tests {
         insta::assert_snapshot!(
             env.render_ok(r#"1 % 0"#),
             @"<Error: Attempt to divide by zero>");
+    }
+
+    #[test]
+    fn test_fs_path_methods() {
+        let cwd = default_current_dir();
+        let mut env = TestTemplateEnv::with_config_and_current_dir(
+            StackedConfig::with_defaults(),
+            cwd.clone(),
+        );
+        let path = cwd.join("workspace");
+        env.add_keyword("fs_path", {
+            let path = path.clone();
+            move || literal(path.clone())
+        });
+        env.add_keyword("none_fs_path", || literal(None::<PathBuf>));
+
+        assert_eq!(
+            env.render_ok("fs_path"),
+            BString::from(path.to_str().unwrap())
+        );
+        assert_eq!(
+            env.render_ok("fs_path.absolute()"),
+            BString::from(path.to_str().unwrap())
+        );
+        assert_eq!(
+            env.render_ok("fs_path.relative()"),
+            BString::from("workspace")
+        );
+        assert_eq!(
+            env.render_ok("fs_path.relative().absolute()"),
+            BString::from(path.to_str().unwrap())
+        );
+        insta::assert_snapshot!(env.render_ok("json(fs_path.relative())"), @r#""workspace""#);
+        insta::assert_snapshot!(
+            env.render_ok("none_fs_path.relative()"),
+            @"<Error: No FsPath available>"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_fs_path_methods_non_utf8() {
+        use std::ffi::OsString;
+        use std::os::unix::ffi::OsStrExt as _;
+        use std::os::unix::ffi::OsStringExt as _;
+
+        let cwd = default_current_dir();
+        let mut env = TestTemplateEnv::with_config_and_current_dir(
+            StackedConfig::with_defaults(),
+            cwd.clone(),
+        );
+        let mut path_bytes = cwd.as_os_str().as_bytes().to_vec();
+        if !path_bytes.ends_with(b"/") {
+            path_bytes.push(b'/');
+        }
+        path_bytes.extend(b"\x80workspace");
+        let path = PathBuf::from(OsString::from_vec(path_bytes.clone()));
+        env.add_keyword("fs_path", {
+            let path = path.clone();
+            move || literal(path.clone())
+        });
+        env.add_keyword("some_fs_path", {
+            let path = path.clone();
+            move || literal(Some(path.clone()))
+        });
+
+        // Direct rendering should preserve non-UTF-8 path bytes. This is the
+        // path used by templates like `workspace_list`'s `root`.
+        assert_eq!(
+            env.render_ok("fs_path"),
+            BString::from(path_bytes.as_slice()),
+            "direct FsPath rendering should not require UTF-8"
+        );
+        assert_eq!(
+            env.render_ok("some_fs_path"),
+            BString::from(path_bytes.as_slice()),
+            "direct Option<FsPath> rendering should not require UTF-8"
+        );
+        assert_eq!(
+            env.render_ok("fs_path.absolute()"),
+            BString::from(path_bytes.as_slice())
+        );
+        assert_eq!(
+            env.render_ok("fs_path.relative()"),
+            BString::from(b"\x80workspace".as_slice())
+        );
+        assert_eq!(
+            env.render_ok("fs_path.relative().absolute()"),
+            BString::from(path_bytes.as_slice())
+        );
+        insta::assert_snapshot!(
+            env.render_ok("json(fs_path)"),
+            @r#"<Error: path contains invalid UTF-8 characters>"#);
     }
 
     #[test]
@@ -5182,6 +5369,8 @@ mod tests {
         let mut env = TestTemplateEnv::new();
         env.add_keyword("none_i64", || literal(None::<i64>));
         env.add_keyword("ascii_bstr", || literal(BString::from("foo")));
+        env.add_keyword("fs_path", || literal(PathBuf::from("file")));
+        env.add_keyword("none_fs_path", || literal(None::<PathBuf>));
         env.add_keyword("string_list", || {
             literal(vec!["foo".to_owned(), "bar".to_owned()])
         });
@@ -5227,6 +5416,8 @@ mod tests {
         insta::assert_snapshot!(env.render_ok("json(false)"), @"false");
         insta::assert_snapshot!(env.render_ok("json(42)"), @"42");
         insta::assert_snapshot!(env.render_ok("json(none_i64)"), @"null");
+        insta::assert_snapshot!(env.render_ok("json(fs_path)"), @r#""file""#);
+        insta::assert_snapshot!(env.render_ok("json(none_fs_path)"), @"null");
         insta::assert_snapshot!(env.render_ok(r#"json(config_value_table)"#), @r#"{"foo":"bar"}"#);
         insta::assert_snapshot!(env.render_ok(r"json(some_cfgval)"), @"1");
         insta::assert_snapshot!(env.render_ok(r"json(none_cfgval)"), @"null");

--- a/cli/src/templater.rs
+++ b/cli/src/templater.rs
@@ -23,6 +23,7 @@ use std::io;
 use std::io::Write;
 use std::iter;
 use std::ops::Range;
+use std::path::PathBuf;
 use std::rc::Rc;
 
 use bstr::BStr;
@@ -30,6 +31,7 @@ use bstr::BString;
 use jj_lib::backend::Signature;
 use jj_lib::backend::Timestamp;
 use jj_lib::config::ConfigValue;
+use jj_lib::file_util;
 use jj_lib::op_store::TimestampRange;
 
 use crate::formatter::FormatRecorder;
@@ -78,6 +80,15 @@ impl Template for BString {
 impl Template for &BStr {
     fn format(&self, formatter: &mut TemplateFormatter) -> io::Result<()> {
         formatter.as_mut().write_all(self)
+    }
+}
+
+impl Template for PathBuf {
+    fn format(&self, formatter: &mut TemplateFormatter) -> io::Result<()> {
+        // Render native path bytes directly. Serialization still follows
+        // PathBuf's serde behavior, which can reject non-UTF-8 paths.
+        let bytes = file_util::path_to_bytes(self).map_err(io::Error::other)?;
+        formatter.as_mut().write_all(bytes)
     }
 }
 

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -3735,6 +3735,8 @@ List workspaces
 
    The default template can be set by the `templates.workspace_list` setting.
 
+   Use `-T builtin_workspace_list_with_root` to include workspace root paths.
+
    [`WorkspaceRef` type]: https://docs.jj-vcs.dev/latest/templates/#workspaceref-type
 
    [`jj help -k templates`]: https://docs.jj-vcs.dev/latest/templates/

--- a/cli/tests/test_completion.rs
+++ b/cli/tests/test_completion.rs
@@ -1581,6 +1581,8 @@ fn test_template_alias() {
     builtin_op_log_node_ascii
     builtin_op_log_oneline
     builtin_op_log_redacted
+    builtin_workspace_list
+    builtin_workspace_list_with_root
     commit_summary_separator
     default_commit_description
     description_placeholder

--- a/cli/tests/test_evolog_command.rs
+++ b/cli/tests/test_evolog_command.rs
@@ -608,6 +608,8 @@ fn test_evolog_with_no_template() {
     - builtin_op_log_node_ascii
     - builtin_op_log_oneline
     - builtin_op_log_redacted
+    - builtin_workspace_list
+    - builtin_workspace_list_with_root
     - commit_summary_separator
     - default_commit_description
     - description_placeholder

--- a/cli/tests/test_log_command.rs
+++ b/cli/tests/test_log_command.rs
@@ -64,6 +64,8 @@ fn test_log_with_no_template() {
     - builtin_op_log_node_ascii
     - builtin_op_log_oneline
     - builtin_op_log_redacted
+    - builtin_workspace_list
+    - builtin_workspace_list_with_root
     - commit_summary_separator
     - default_commit_description
     - description_placeholder

--- a/cli/tests/test_operations.rs
+++ b/cli/tests/test_operations.rs
@@ -210,6 +210,8 @@ fn test_op_log_with_no_template() {
     - builtin_op_log_node_ascii
     - builtin_op_log_oneline
     - builtin_op_log_redacted
+    - builtin_workspace_list
+    - builtin_workspace_list_with_root
     - commit_summary_separator
     - default_commit_description
     - description_placeholder

--- a/cli/tests/test_show_command.rs
+++ b/cli/tests/test_show_command.rs
@@ -366,6 +366,8 @@ fn test_show_with_no_template() {
     - builtin_op_log_node_ascii
     - builtin_op_log_oneline
     - builtin_op_log_redacted
+    - builtin_workspace_list
+    - builtin_workspace_list_with_root
     - commit_summary_separator
     - default_commit_description
     - description_placeholder

--- a/cli/tests/test_templater.rs
+++ b/cli/tests/test_templater.rs
@@ -145,7 +145,7 @@ fn test_templater_parse_error() {
       | ^-----^
       |
       = Keyword `builtin` doesn't exist
-    Hint: Did you mean `builtin_config_list`, `builtin_config_list_detailed`, `builtin_draft_commit_description`, `builtin_draft_commit_description_with_diff`, `builtin_evolog_compact`, `builtin_log_comfortable`, `builtin_log_compact`, `builtin_log_compact_full_description`, `builtin_log_detailed`, `builtin_log_node`, `builtin_log_node_ascii`, `builtin_log_oneline`, `builtin_log_redacted`, `builtin_op_log_comfortable`, `builtin_op_log_compact`, `builtin_op_log_node`, `builtin_op_log_node_ascii`, `builtin_op_log_oneline`, `builtin_op_log_redacted`?
+    Hint: Did you mean `builtin_config_list`, `builtin_config_list_detailed`, `builtin_draft_commit_description`, `builtin_draft_commit_description_with_diff`, `builtin_evolog_compact`, `builtin_log_comfortable`, `builtin_log_compact`, `builtin_log_compact_full_description`, `builtin_log_detailed`, `builtin_log_node`, `builtin_log_node_ascii`, `builtin_log_oneline`, `builtin_log_redacted`, `builtin_op_log_comfortable`, `builtin_op_log_compact`, `builtin_op_log_node`, `builtin_op_log_node_ascii`, `builtin_op_log_oneline`, `builtin_op_log_redacted`, `builtin_workspace_list`, `builtin_workspace_list_with_root`?
     [EOF]
     [exit status: 1]
     ");

--- a/cli/tests/test_workspaces.rs
+++ b/cli/tests/test_workspaces.rs
@@ -1756,6 +1756,22 @@ fn test_list_workspaces_template_root() {
     second: $TEST_ENV/secondary
     [EOF]
     ");
+
+    let template = r#"name ++ ": " ++ if(root, root ++ " " ++ root.relative()) ++ "\n""#;
+    let output = main_dir.run_jj(["workspace", "list", "-T", template]);
+    insta::assert_snapshot!(output.normalize_backslash(), @"
+    default: $TEST_ENV/main .
+    second: $TEST_ENV/secondary ../secondary
+    [EOF]
+    ");
+
+    let template = r#"name ++ ": " ++ if(root, root.relative()) ++ "\n""#;
+    let output = main_dir.run_jj(["workspace", "list", "-T", template]);
+    insta::assert_snapshot!(output.normalize_backslash(), @"
+    default: .
+    second: ../secondary
+    [EOF]
+    ");
 }
 
 #[test]
@@ -1770,18 +1786,18 @@ fn test_list_workspaces_template_root_unavailable() {
     std::fs::remove_dir_all(test_env.env_root().join("secondary")).unwrap();
 
     let template = r#"name ++ ": " ++ root ++ "\n""#;
-    let output = main_dir
-        .run_jj(["workspace", "list", "-T", template])
-        .normalize_backslash()
-        .normalize_stdout_with(|s| {
-            s.replace(
-                "The system cannot find the file specified.",
-                "No such file or directory",
-            )
-        });
-    insta::assert_snapshot!(output, @"
+    let output = main_dir.run_jj(["workspace", "list", "-T", template]);
+    insta::assert_snapshot!(output.normalize_backslash(), @"
     default: $TEST_ENV/main
-    second: <Error: Failed to resolve workspace root: second: $TEST_ENV/main/.jj/repo/../../../secondary: No such file or directory (os error 2)>
+    second: 
+    [EOF]
+    ");
+
+    let template = r#"name ++ ": " ++ if(root, root.relative()) ++ "\n""#;
+    let output = main_dir.run_jj(["workspace", "list", "-T", template]);
+    insta::assert_snapshot!(output, @"
+    default: .
+    second: 
     [EOF]
     ");
 }
@@ -2069,6 +2085,12 @@ fn test_workspaces_rename_workspace_from_before_workspace_store() {
     Error: Workspace has no recorded path: third
     [EOF]
     [exit status: 1]
+    ");
+
+    let output = main_dir.run_jj(["workspace", "list", "-T", r#"name ++ ": " ++ root ++ "\n""#]);
+    insta::assert_snapshot!(output, @"
+    third: 
+    [EOF]
     ");
 }
 

--- a/cli/tests/test_workspaces.rs
+++ b/cli/tests/test_workspaces.rs
@@ -1772,6 +1772,18 @@ fn test_list_workspaces_template_root() {
     second: ../secondary
     [EOF]
     ");
+
+    let output = main_dir.run_jj([
+        "workspace",
+        "list",
+        "-T",
+        "builtin_workspace_list_with_root",
+    ]);
+    insta::assert_snapshot!(output.normalize_backslash(), @"
+    default: . qpvuntsm e8849ae1 (empty) (no description set)
+    second: ../secondary uuqppmxq 94f41578 (empty) (no description set)
+    [EOF]
+    ");
 }
 
 #[test]
@@ -1798,6 +1810,18 @@ fn test_list_workspaces_template_root_unavailable() {
     insta::assert_snapshot!(output, @"
     default: .
     second: 
+    [EOF]
+    ");
+
+    let output = main_dir.run_jj([
+        "workspace",
+        "list",
+        "-T",
+        "builtin_workspace_list_with_root",
+    ]);
+    insta::assert_snapshot!(output, @"
+    default: . qpvuntsm e8849ae1 (empty) (no description set)
+    second: uuqppmxq 94f41578 (empty) (no description set)
     [EOF]
     ");
 }

--- a/docs/config.md
+++ b/docs/config.md
@@ -617,6 +617,7 @@ needing the original behavior.
 You can configure the template used when no `-T` is specified.
 
 - `templates.config_list` for `jj config list`
+- `templates.workspace_list` for `jj workspace list`
 
 If you want to see the config variable origin (type and path) when you do `jj config list`
 you can add this to your config:
@@ -624,6 +625,24 @@ you can add this to your config:
 ```toml
 [templates]
 config_list = "builtin_config_list_detailed"
+```
+
+If you want `jj workspace list` to show each workspace root, you can use the
+shipped root-path template:
+
+```sh
+jj workspace list -T builtin_workspace_list_with_root
+```
+
+Workspaces whose roots are not recorded or cannot be resolved are shown without
+the root path. Workspace roots are not recorded for workspaces created before jj
+0.38.0.
+
+Or make it your default:
+
+```toml
+[templates]
+workspace_list = "builtin_workspace_list_with_root"
 ```
 
 ## Log

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -428,6 +428,20 @@ The following methods are defined.
 * `.domain() -> String`: the part of the email after the first `@` or the empty
   string.
 
+### `FsPath` type
+
+_Conversion: `Boolean`: no, `Serialize`: yes, `Template`: yes_
+
+A filesystem path. Paths can contain bytes that are not valid UTF-8. Rendering
+and path formatting methods preserve those bytes. Serialization with `json()`
+follows Rust's `Path` serialization, which can reject non-UTF-8 paths.
+
+The following methods are defined.
+
+* `.absolute() -> FsPath`: Return an absolute filesystem path.
+* `.relative() -> FsPath`: Return the path relative to the current working
+  directory.
+
 ### `Integer` type
 
 _Conversion: `Boolean`: no, `Serialize`: yes, `Template`: yes_

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -802,7 +802,12 @@ The following methods are defined.
 
 * `.name() -> RefSymbol`: Returns the workspace name as a symbol.
 * `.target() -> Commit`: Returns the working-copy commit of this workspace.
-* `.root() -> Template`: Returns the absolute path to the workspace root.
+* `.root() -> Option<FsPath>`: Returns the workspace root path, if the root path
+  is recorded and can be resolved.
+
+  This is optional because workspaces created before jj 0.38.0 did not record
+  workspace root paths, and a recorded path can also become stale if the
+  workspace directory is moved or deleted.
 
 ## Color labels
 

--- a/docs/working-copy.md
+++ b/docs/working-copy.md
@@ -84,6 +84,9 @@ while you continue developing in another, for example. If needed,
 `jj workspace root --name <workspace>` prints the root path of the specified
 workspace (defaults to the current one).
 
+Use `jj workspace list -T builtin_workspace_list_with_root` to show every
+workspace together with its available root path.
+
 When you're done using a workspace, use `jj workspace forget` to make the repo
 forget about it. The files can be deleted from disk separately (either before or
 after).


### PR DESCRIPTION
Fixes #7114.

This adds a shipped template for showing workspace folders in `jj workspace list`:

```sh
jj workspace list -T builtin_workspace_list_with_root
```

The goal is discoverability: users should not have to write a custom template just to list workspaces with their associated folders. The default output is preserved through `builtin_workspace_list`, and `builtin_workspace_list_with_root` shows cwd-relative root paths when they are available.

The stack is split into three pieces:

- [`templates: Add FsPath template type`](https://github.com/jj-vcs/jj/commit/d420521db5f5f9dd121de96de74ec168f66d27b8) adds the reusable filesystem-path template type. `FsPath` renders native path bytes directly, supports `.absolute()` and `.relative()`, and uses explicit template-language cwd context for relative formatting.
- [`templates: Return optional workspace roots`](https://github.com/jj-vcs/jj/commit/6c7cfc9f8ac71ed89c5c454320e0d92e820420e5) changes `WorkspaceRef.root()` to return `Option<FsPath>`. Workspaces created before jj 0.38.0 may not have recorded roots, and recorded roots can become stale if a workspace directory is moved or deleted. In those cases, list templates render no value; `jj workspace root --name <workspace>` remains the strict diagnostic command.
- [`cli: Add workspace list root template`](https://github.com/jj-vcs/jj/commit/a2230744a8fffe96d67724d2a236f9270af0bb81) wires the optional root value into `builtin_workspace_list_with_root` and documents the shipped template.

Reviewer context:

- #7114 asks to expose workspace paths in the `workspace_list` template.
- #6858 implemented the workspace store and `jj workspace root --name`, leaving workspace-list display as follow-up work.
- #8565 changed workspace storage to relative paths; this PR keeps the raw root value absolute by default and lets the shipped list template choose cwd-relative output with `.relative()`.
- #9717 split out the broader `Option<String>` template work; this PR avoids depending on that by using `Option<FsPath>`.

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does, how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with an eye towards deleting anything that is irrelevant, clarifying anything that is confusing, and adding details that are relevant. This includes, for example, commit descriptions, PR descriptions, and code comments.
