### PR TITLE
cli: error when git clone destination equals the source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   remote's fetch URL or effective push URL.
   [#413](https://github.com/jj-vcs/jj/issues/413)
 
+* `jj git clone` now errors instead of silently creating an empty repository
+  when the destination resolves to the same local path as the source.
+  [#6918](https://github.com/jj-vcs/jj/issues/6918)
+
 * Fixed corrupt loose Git objects written through zlib-rs. Previously, jj could
   report a successful commit even though `git fsck` later failed with
   `incorrect data check`, `corrupt loose object`, or `missing blob`, and later

--- a/cli/src/commands/git/clone.rs
+++ b/cli/src/commands/git/clone.rs
@@ -168,13 +168,44 @@ pub async fn cmd_git_clone(
     if command.global_args().at_operation.is_some() {
         return Err(cli_error("--at-op is not respected"));
     }
-    let source = absolute_git_url(command.cwd(), &args.source)?;
+    let (source, source_url) = absolute_git_url(command.cwd(), &args.source)?;
     let wc_path_str = args
         .destination
         .as_deref()
         .or_else(|| clone_destination_for_source(&source))
         .ok_or_else(|| user_error("No destination specified and wasn't able to guess it"))?;
     let wc_path = command.cwd().join(wc_path_str);
+
+    // When no destination is given, it's inferred from the source. For a local
+    // source this can resolve to the same path as the source itself (#6918).
+    // With `--colocate` a valid empty `.git` is initialized at the destination
+    // *before* the fetch runs, so the fetch then reads from the empty repo we
+    // just created and silently produces an empty clone. Reject a local
+    // self-clone up front.
+    //
+    // Normalize *both* sides through `absolute_git_url` so the comparison uses
+    // identical canonicalization (gix resolves symlinks and applies unix
+    // separators on Windows). Comparing the parsed `gix::Url` paths avoids the
+    // earlier bug where the source was symlink-resolved but the destination was
+    // only logically normalized, letting an explicit destination that reaches
+    // the source through a symlink slip past the guard. Only `file:` paths can
+    // collide with a local destination. PUNTED: case-insensitive filesystem
+    // aliasing and ssh/remote self-clones are not detected here.
+    let (_, dest_url) = absolute_git_url(command.cwd(), wc_path_str)?;
+    if source_url.scheme == gix::url::Scheme::File
+        && dest_url.scheme == gix::url::Scheme::File
+        && source_url.path == dest_url.path
+    {
+        let message = if args.destination.is_some() {
+            format!("Destination directory is the same as the source: {wc_path_str:?}")
+        } else {
+            format!(
+                "Destination directory was inferred from the source and is the same path: \
+                 {wc_path_str:?}; specify a destination explicitly"
+            )
+        };
+        return Err(user_error(message));
+    }
 
     let wc_path_existed = wc_path.exists();
     if wc_path_existed && !file_util::is_empty_dir(&wc_path)? {

--- a/cli/src/commands/git/remote/add.rs
+++ b/cli/src/commands/git/remote/add.rs
@@ -54,11 +54,11 @@ pub async fn cmd_git_remote_add(
     args: &GitRemoteAddArgs,
 ) -> Result<(), CommandError> {
     let mut workspace_command = command.workspace_helper(ui).await?;
-    let url = absolute_git_url(command.cwd(), &args.url)?;
+    let (url, _) = absolute_git_url(command.cwd(), &args.url)?;
     let push_url = args
         .push_url
         .as_deref()
-        .map(|url| absolute_git_url(command.cwd(), url))
+        .map(|url| absolute_git_url(command.cwd(), url).map(|(url, _)| url))
         .transpose()?;
 
     let mut tx = workspace_command.start_transaction();

--- a/cli/src/commands/git/remote/set_url.rs
+++ b/cli/src/commands/git/remote/set_url.rs
@@ -59,7 +59,7 @@ pub async fn cmd_git_remote_set_url(
     let workspace_command = command.workspace_helper(ui).await?;
 
     let process_url = |url: Option<&String>| {
-        url.map(|url| absolute_git_url(command.cwd(), url))
+        url.map(|url| absolute_git_url(command.cwd(), url).map(|(url, _)| url))
             .transpose()
     };
 

--- a/cli/src/git_util.rs
+++ b/cli/src/git_util.rs
@@ -79,7 +79,14 @@ pub fn is_colocated_git_workspace(workspace: &Workspace, repo: &ReadonlyRepo) ->
 }
 
 /// Parses user-specified remote URL or path to absolute form.
-pub fn absolute_git_url(cwd: &Path, source: &str) -> Result<String, CommandError> {
+///
+/// Returns both the serialized string (for passing to libgit2/the remote
+/// config) and the parsed [`gix::Url`]. The string preserves the original
+/// source as a utf-8 fallback when the canonicalized URL isn't valid utf-8,
+/// while the parsed [`gix::Url`] exposes the scheme and canonicalized path,
+/// which callers need to reason about local-path semantics (e.g. detecting a
+/// source/destination collision in `git clone`).
+pub fn absolute_git_url(cwd: &Path, source: &str) -> Result<(String, gix::Url), CommandError> {
     // Git appears to turn URL-like source to absolute path if local git directory
     // exits, and fails because '$PWD/https' is unsupported protocol. Since it would
     // be tedious to copy the exact git (or libgit2) behavior, we simply let gix
@@ -92,7 +99,9 @@ pub fn absolute_git_url(cwd: &Path, source: &str) -> Result<String, CommandError
         url.path = gix::path::to_unix_separators_on_windows(mem::take(&mut url.path)).into_owned();
     }
     // It's less likely that cwd isn't utf-8, so just fall back to original source.
-    Ok(String::from_utf8(url.to_bstring().into()).unwrap_or_else(|_| source.to_owned()))
+    let url_string =
+        String::from_utf8(url.to_bstring().into()).unwrap_or_else(|_| source.to_owned());
+    Ok((url_string, url))
 }
 
 /// Converts a git remote URL to a normalized HTTPS URL for web browsing.
@@ -602,11 +611,11 @@ mod tests {
 
         // Local path
         assert_eq!(
-            absolute_git_url(&cwd, "foo").unwrap(),
+            absolute_git_url(&cwd, "foo").unwrap().0,
             format!("{cwd_slash}/foo")
         );
         assert_eq!(
-            absolute_git_url(&cwd, r"foo\bar").unwrap(),
+            absolute_git_url(&cwd, r"foo\bar").unwrap().0,
             if cfg!(windows) {
                 format!("{cwd_slash}/foo/bar")
             } else {
@@ -614,40 +623,53 @@ mod tests {
             }
         );
         assert_eq!(
-            absolute_git_url(&cwd.join("bar"), &format!("{cwd_slash}/foo")).unwrap(),
+            absolute_git_url(&cwd.join("bar"), &format!("{cwd_slash}/foo"))
+                .unwrap()
+                .0,
             format!("{cwd_slash}/foo")
         );
 
         // rcp-like
         assert_eq!(
-            absolute_git_url(&cwd, "git@example.org:foo/bar.git").unwrap(),
+            absolute_git_url(&cwd, "git@example.org:foo/bar.git")
+                .unwrap()
+                .0,
             "git@example.org:foo/bar.git"
         );
         // URL
         assert_eq!(
-            absolute_git_url(&cwd, "https://example.org/foo.git").unwrap(),
+            absolute_git_url(&cwd, "https://example.org/foo.git")
+                .unwrap()
+                .0,
             "https://example.org/foo.git"
         );
         // Custom scheme isn't an error
         assert_eq!(
-            absolute_git_url(&cwd, "custom://example.org/foo.git").unwrap(),
+            absolute_git_url(&cwd, "custom://example.org/foo.git")
+                .unwrap()
+                .0,
             "custom://example.org/foo.git"
         );
         // Password shouldn't be redacted (gix::Url::to_string() would do)
         assert_eq!(
-            absolute_git_url(&cwd, "https://user:pass@example.org/").unwrap(),
+            absolute_git_url(&cwd, "https://user:pass@example.org/")
+                .unwrap()
+                .0,
             "https://user:pass@example.org/"
         );
 
         // %-encoded paths: %20 ' ', %25 '%'
         assert_eq!(
-            absolute_git_url(&cwd, "https://example.org/%20%25").unwrap(),
+            absolute_git_url(&cwd, "https://example.org/%20%25")
+                .unwrap()
+                .0,
             "https://example.org/%20%25"
         );
         // No exact match because "/" isn't an absolute path on Windows
         assert!(
             absolute_git_url(&cwd, "file:///%20%25")
                 .unwrap()
+                .0
                 .ends_with("/%20%25")
         );
     }

--- a/cli/tests/test_git_clone.rs
+++ b/cli/tests/test_git_clone.rs
@@ -435,6 +435,103 @@ fn test_git_clone_colocate() -> TestResult {
     Ok(())
 }
 
+// Regression test for https://github.com/jj-vcs/jj/issues/6918
+//
+// `jj git clone --colocate <nonexistent>` with no explicit destination infers a
+// destination equal to the (relative) source. With colocation a valid empty
+// top-level `.git` is created at that path *before* the fetch runs, so the
+// subsequent fetch reads from the empty repo jj just created and silently
+// produces an empty clone instead of erroring. jj should detect the
+// source==destination collision and error out.
+#[test]
+fn test_git_clone_colocate_self_collision() {
+    let test_env = TestEnvironment::default();
+    let root_dir = test_env.work_dir("");
+
+    // No such source repo exists, and no destination is given, so the
+    // destination is inferred to be `nonexistent`, i.e. the same path as the
+    // source. jj should refuse rather than clone an empty repo from the .git it
+    // just created at that path.
+    let output = root_dir.run_jj(["git", "clone", "--colocate", "nonexistent"]);
+    insta::assert_snapshot!(output, @r#"
+    ------- stderr -------
+    Error: Destination directory was inferred from the source and is the same path: "nonexistent"; specify a destination explicitly
+    [EOF]
+    [exit status: 1]
+    "#);
+
+    // No empty repo should have been left behind.
+    assert!(!test_env.env_root().join("nonexistent").exists());
+}
+
+// An explicit destination that reaches the source through a symlink must not
+// defeat the self-collision guard. Here the source and destination are passed
+// as byte-identical absolute paths that include a symlink component (`link` ->
+// `real`), so the physical path differs from the logical one. The guard now
+// normalizes both sides through `absolute_git_url` (which symlink-resolves via
+// gix), so the collision is still detected. The earlier asymmetric comparison
+// (source symlink-resolved, destination only logically normalized) would have
+// let this slip through and silently produced an empty clone.
+#[cfg(unix)]
+#[test]
+fn test_git_clone_colocate_explicit_self_collision_through_symlink() {
+    let test_env = TestEnvironment::default();
+    let root_dir = test_env.work_dir("");
+    root_dir.create_dir("real");
+    std::os::unix::fs::symlink(
+        test_env.env_root().join("real"),
+        test_env.env_root().join("link"),
+    )
+    .unwrap();
+    // Absolute path reaching `real/foo` via the `link` symlink. Passed as BOTH
+    // the source and the (explicit) destination.
+    let via_link = test_env.env_root().join("link").join("foo");
+    let via_link = via_link.to_str().unwrap();
+    let output = root_dir.run_jj(["git", "clone", "--colocate", via_link, via_link]);
+    assert!(
+        output.stderr.raw().contains("is the same as the source"),
+        "explicit symlinked self-collision should be rejected: {}",
+        output.stderr.raw()
+    );
+    assert!(!output.status.success());
+    // No empty repo should have been left behind through the symlink.
+    assert!(!test_env.env_root().join("real").join("foo").exists());
+}
+
+// An explicit destination equal to the source (same path given twice) must be
+// rejected with the explicit-variant message.
+#[test]
+fn test_git_clone_colocate_explicit_self_collision() {
+    let test_env = TestEnvironment::default();
+    let root_dir = test_env.work_dir("");
+
+    let output = root_dir.run_jj(["git", "clone", "--colocate", "nonexistent", "nonexistent"]);
+    insta::assert_snapshot!(output, @r#"
+    ------- stderr -------
+    Error: Destination directory is the same as the source: "nonexistent"
+    [EOF]
+    [exit status: 1]
+    "#);
+
+    // No empty repo should have been left behind.
+    assert!(!test_env.env_root().join("nonexistent").exists());
+}
+
+// The guard must stay silent when the inferred destination differs from the
+// source. `.` clones from the current directory but infers destination `.`
+// which resolves to a different name, so no false collision should fire.
+#[test]
+fn test_git_clone_colocate_no_false_collision() {
+    let test_env = TestEnvironment::default();
+    let root_dir = test_env.work_dir("");
+    let output = root_dir.run_jj(["git", "clone", "--colocate", "."]);
+    assert!(
+        !output.stderr.raw().contains("inferred from the source"),
+        "collision guard should not fire for `.`: {}",
+        output.stderr.raw()
+    );
+}
+
 #[test]
 fn test_git_clone_colocate_via_config() {
     let test_env = TestEnvironment::default();


### PR DESCRIPTION
Fixes #6918.

`jj git clone <source>` without an explicit destination infers it from the source; for a local source that can resolve to the source's own path. With `--colocate`, an empty `.git` is initialized at the destination before the fetch, so jj fetches from the repo it just created and silently produces an empty clone. An explicit destination resolving to the source (including through a symlink) hit the same trap.

The fix canonicalizes both source and destination through `absolute_git_url` and errors when they resolve to the same local (`file:`) path. Per @martinvonz's note on the issue, only the local-path case is handled; `ssh://localhost`-style self-clones remain out of scope.

# Checklist

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does, how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with an eye towards deleting anything that is irrelevant, clarifying anything that is confusing, and adding details that are relevant.
