### PR TITLE
revset: add merge_point function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### New features
 
+* New `merge_point()` revset function which (similar to `fork_point`) finds the
+  point where multiple branches merge.
+
 ### Fixed bugs
 
 ## [0.43.0] - 2026-07-01

--- a/docs/revsets.md
+++ b/docs/revsets.md
@@ -351,6 +351,13 @@ revsets (expressions) as arguments.
   the revset `heads(::x_1 & ::x_2 & ... & ::x_N)`, where `x_{1..N}` are commits
   in `x`. If `x` resolves to a single commit, `fork_point(x)` resolves to `x`.
 
+* `merge_point(x)`: The merge point of all commits in `x`. Similar to the fork
+  point, the merge point is the common descendant(s) of all commits in `x` which
+  do not have any ancestors that are also common descendants of all commits in
+  `x`. It is equivalent to the revset `roots(x_1:: & x_2:: & ... & x_N::)`,
+  where `x_{1..N}` are commits in `x`. If `x` resolves to a single commit,
+  `merge_point(x)` resolves to `x`.
+
 * `bisect(x)`: Finds commits in the input set for which about half of the input
   set are descendants. The current implementation deals somewhat poorly with
   non-linear history.

--- a/lib/src/default_index/revset_engine.rs
+++ b/lib/src/default_index/revset_engine.rs
@@ -1005,6 +1005,47 @@ impl EvaluationContext<'_> {
                 }
                 Ok(Box::new(EagerRevset { positions }))
             }
+            ResolvedExpression::MergePoint {
+                roots,
+                visible_heads,
+            } => {
+                let mut root_position_iter = self.evaluate(roots)?.positions().attach(index);
+                let Some(position) = root_position_iter.next() else {
+                    return Ok(Box::new(EagerRevset::empty()));
+                };
+                let visible_head_positions = self
+                    .evaluate(visible_heads)?
+                    .positions()
+                    .attach(index)
+                    .try_collect()?;
+                let mut candidates = RevWalkBuilder::new(index)
+                    .wanted_heads(visible_head_positions)
+                    .descendants(maplit::hashset![position?])
+                    .collect_vec();
+                candidates.reverse();
+                for position in root_position_iter {
+                    let descendants = RevWalkBuilder::new(index)
+                        .wanted_heads(candidates.clone())
+                        .descendants(maplit::hashset![position?])
+                        .collect_positions_set();
+                    candidates.retain(|pos| descendants.contains(pos));
+                    if candidates.is_empty() {
+                        return Ok(Box::new(EagerRevset::empty()));
+                    }
+                }
+                let candidate_set: HashSet<_> = candidates.iter().copied().collect();
+                candidates.retain(|&pos| {
+                    !index
+                        .commits()
+                        .entry_by_pos(pos)
+                        .parent_positions()
+                        .iter()
+                        .any(|parent| candidate_set.contains(parent))
+                });
+                Ok(Box::new(EagerRevset {
+                    positions: candidates,
+                }))
+            }
             ResolvedExpression::Bisect(candidates) => {
                 let set = self.evaluate(candidates)?;
                 // TODO: Make this more correct in non-linear history

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -312,8 +312,9 @@ pub enum RevsetExpression<St: ExpressionState> {
         filter: Arc<Self>,
     },
     Roots(Arc<Self>),
-    ForkPoint(Arc<Self>),
     Forks,
+    ForkPoint(Arc<Self>),
+    MergePoint(Arc<Self>),
     Bisect(Arc<Self>),
     HasSize {
         candidates: Arc<Self>,
@@ -555,6 +556,11 @@ impl<St: ExpressionState> RevsetExpression<St> {
         Arc::new(Self::ForkPoint(self.clone()))
     }
 
+    /// Merge point (best common descendants) of `self`.
+    pub fn merge_point(self: &Arc<Self>) -> Arc<Self> {
+        Arc::new(Self::MergePoint(self.clone()))
+    }
+
     /// Commits with ~half of the descendants in `self`.
     pub fn bisect(self: &Arc<Self>) -> Arc<Self> {
         Arc::new(Self::Bisect(self.clone()))
@@ -767,6 +773,10 @@ pub enum ResolvedExpression {
         heads: Box<Self>,
     },
     ForkPoint(Box<Self>),
+    MergePoint {
+        roots: Box<Self>,
+        visible_heads: Box<Self>,
+    },
     Bisect(Box<Self>),
     HasSize {
         candidates: Box<Self>,
@@ -990,6 +1000,11 @@ static BUILTIN_FUNCTION_MAP: LazyLock<HashMap<&str, RevsetFunction>> = LazyLock:
         let [expression_arg] = function.expect_exact_arguments()?;
         let expression = lower_expression(diagnostics, expression_arg, context)?;
         Ok(RevsetExpression::fork_point(&expression))
+    });
+    map.insert("merge_point", |diagnostics, function, context| {
+        let [expression_arg] = function.expect_exact_arguments()?;
+        let expression = lower_expression(diagnostics, expression_arg, context)?;
+        Ok(RevsetExpression::merge_point(&expression))
     });
     map.insert("bisect", |diagnostics, function, context| {
         let [expression_arg] = function.expect_exact_arguments()?;
@@ -1575,6 +1590,9 @@ fn try_transform_expression<St: ExpressionState, E>(
             RevsetExpression::ForkPoint(expression) => {
                 transform_rec(expression, pre, post)?.map(RevsetExpression::ForkPoint)
             }
+            RevsetExpression::MergePoint(expression) => {
+                transform_rec(expression, pre, post)?.map(RevsetExpression::MergePoint)
+            }
             RevsetExpression::Bisect(expression) => {
                 transform_rec(expression, pre, post)?.map(RevsetExpression::Bisect)
             }
@@ -1822,6 +1840,10 @@ where
         RevsetExpression::ForkPoint(expression) => {
             let expression = folder.fold_expression(expression)?;
             RevsetExpression::ForkPoint(expression).into()
+        }
+        RevsetExpression::MergePoint(expression) => {
+            let expression = folder.fold_expression(expression)?;
+            RevsetExpression::MergePoint(expression).into()
         }
         RevsetExpression::Bisect(expression) => {
             let expression = folder.fold_expression(expression)?;
@@ -3174,6 +3196,10 @@ impl VisibilityResolutionContext<'_> {
             RevsetExpression::ForkPoint(expression) => {
                 ResolvedExpression::ForkPoint(self.resolve(expression).into())
             }
+            RevsetExpression::MergePoint(expression) => ResolvedExpression::MergePoint {
+                roots: self.resolve(expression).into(),
+                visible_heads: self.resolve_visible_heads_or_referenced().into(),
+            },
             RevsetExpression::Bisect(expression) => {
                 ResolvedExpression::Bisect(self.resolve(expression).into())
             }
@@ -3312,6 +3338,7 @@ impl VisibilityResolutionContext<'_> {
             | RevsetExpression::Roots(_)
             | RevsetExpression::Forks
             | RevsetExpression::ForkPoint(_)
+            | RevsetExpression::MergePoint(_)
             | RevsetExpression::Bisect(_)
             | RevsetExpression::HasSize { .. }
             | RevsetExpression::Latest { .. } => {

--- a/lib/tests/test_revset.rs
+++ b/lib/tests/test_revset.rs
@@ -3279,6 +3279,201 @@ fn test_evaluate_expression_fork_point_merge_with_ancestor() {
 }
 
 #[test]
+fn test_evaluate_expression_merge_point() {
+    let test_repo = TestRepo::init();
+    let repo = &test_repo.repo;
+
+    // 7
+    // |\
+    // | |\
+    // 5 6 |
+    // | | |
+    // 4 | |
+    // |\| |
+    // 1 2 3
+    // | |/
+    // |/
+    // 0
+    let mut tx = repo.start_transaction();
+    let mut_repo = tx.repo_mut();
+    let root_commit = repo.store().root_commit();
+    let commit1 = write_random_commit(mut_repo);
+    let commit2 = write_random_commit(mut_repo);
+    let commit3 = write_random_commit(mut_repo);
+    let commit4 = write_random_commit_with_parents(mut_repo, &[&commit1, &commit2]);
+    let commit5 = write_random_commit_with_parents(mut_repo, &[&commit4]);
+    let commit6 = write_random_commit_with_parents(mut_repo, &[&commit2]);
+    let commit7 = write_random_commit_with_parents(mut_repo, &[&commit5, &commit6, &commit3]);
+
+    assert_eq!(resolve_commit_ids(mut_repo, "merge_point(none())"), vec![]);
+    assert_eq!(
+        resolve_commit_ids(mut_repo, "merge_point(all())"),
+        vec![commit7.id().clone()]
+    );
+    assert_eq!(
+        resolve_commit_ids(mut_repo, "merge_point(root())"),
+        vec![root_commit.id().clone()]
+    );
+    assert_eq!(
+        resolve_commit_ids(mut_repo, &format!("merge_point({})", commit1.id())),
+        vec![commit1.id().clone()]
+    );
+    assert_eq!(
+        resolve_commit_ids(mut_repo, &format!("merge_point({})", commit2.id())),
+        vec![commit2.id().clone()]
+    );
+    assert_eq!(
+        resolve_commit_ids(mut_repo, &format!("merge_point({})", commit3.id())),
+        vec![commit3.id().clone()]
+    );
+    assert_eq!(
+        resolve_commit_ids(mut_repo, &format!("merge_point({})", commit4.id())),
+        vec![commit4.id().clone()]
+    );
+    assert_eq!(
+        resolve_commit_ids(mut_repo, &format!("merge_point({})", commit5.id())),
+        vec![commit5.id().clone()]
+    );
+    assert_eq!(
+        resolve_commit_ids(mut_repo, &format!("merge_point({})", commit6.id())),
+        vec![commit6.id().clone()]
+    );
+    assert_eq!(
+        resolve_commit_ids(
+            mut_repo,
+            &format!("merge_point({} | {})", commit5.id(), commit6.id())
+        ),
+        vec![commit7.id().clone()]
+    );
+    assert_eq!(
+        resolve_commit_ids(
+            mut_repo,
+            &format!("merge_point({} | {})", commit6.id(), commit3.id())
+        ),
+        vec![commit7.id().clone()]
+    );
+    assert_eq!(
+        resolve_commit_ids(
+            mut_repo,
+            &format!(
+                "merge_point({} | {} | {})",
+                commit5.id(),
+                commit6.id(),
+                commit3.id()
+            )
+        ),
+        vec![commit7.id().clone()]
+    );
+    assert_eq!(
+        resolve_commit_ids(
+            mut_repo,
+            &format!("merge_point({} | {})", commit5.id(), commit4.id())
+        ),
+        vec![commit5.id().clone()]
+    );
+    assert_eq!(
+        resolve_commit_ids(
+            mut_repo,
+            &format!("merge_point({} | {})", commit6.id(), commit1.id())
+        ),
+        vec![commit7.id().clone()]
+    );
+    assert_eq!(
+        resolve_commit_ids(
+            mut_repo,
+            &format!("merge_point({} | {})", commit3.id(), commit2.id())
+        ),
+        vec![commit7.id().clone()]
+    );
+    assert_eq!(
+        resolve_commit_ids(
+            mut_repo,
+            &format!("merge_point({} | {})", commit5.id(), commit1.id())
+        ),
+        vec![commit5.id().clone()]
+    );
+    assert_eq!(
+        resolve_commit_ids(
+            mut_repo,
+            &format!("merge_point({} | {})", commit4.id(), commit1.id())
+        ),
+        vec![commit4.id().clone()]
+    );
+    assert_eq!(
+        resolve_commit_ids(
+            mut_repo,
+            &format!("merge_point({} | {})", commit1.id(), commit2.id())
+        ),
+        vec![commit4.id().clone()]
+    );
+}
+
+#[test]
+fn test_evaluate_expression_merge_point_criss_cross() {
+    let test_repo = TestRepo::init();
+    let repo = &test_repo.repo;
+
+    // 3 4
+    // |X|
+    // 1 2
+    // |/
+    // 0
+    let mut tx = repo.start_transaction();
+    let mut_repo = tx.repo_mut();
+    let commit1 = write_random_commit(mut_repo);
+    let commit2 = write_random_commit(mut_repo);
+    let commit3 = write_random_commit_with_parents(mut_repo, &[&commit1, &commit2]);
+    let commit4 = write_random_commit_with_parents(mut_repo, &[&commit1, &commit2]);
+
+    assert_eq!(
+        resolve_commit_ids(
+            mut_repo,
+            &format!("merge_point({} | {})", commit1.id(), commit2.id())
+        ),
+        vec![commit4.id().clone(), commit3.id().clone()]
+    );
+
+    assert_eq!(
+        resolve_commit_ids(
+            mut_repo,
+            &format!("merge_point({} | {})", commit3.id(), commit4.id())
+        ),
+        vec![]
+    );
+}
+
+#[test]
+fn test_evaluate_expression_merge_point_with_descendants() {
+    let test_repo = TestRepo::init();
+    let repo = &test_repo.repo;
+
+    //   6   7
+    //    \ /
+    // 3   4   5
+    //  \ / \ /
+    //   1   2
+    //    \ /
+    //     0
+    let mut tx = repo.start_transaction();
+    let mut_repo = tx.repo_mut();
+    let commit1 = write_random_commit(mut_repo);
+    let commit2 = write_random_commit(mut_repo);
+    let commit4 = write_random_commit_with_parents(mut_repo, &[&commit1, &commit2]);
+    let _commit3 = write_random_commit_with_parents(mut_repo, &[&commit1]);
+    let _commit5 = write_random_commit_with_parents(mut_repo, &[&commit2]);
+    let _commit6 = write_random_commit_with_parents(mut_repo, &[&commit4]);
+    let _commit7 = write_random_commit_with_parents(mut_repo, &[&commit4]);
+
+    assert_eq!(
+        resolve_commit_ids(
+            mut_repo,
+            &format!("merge_point({} | {})", commit1.id(), commit2.id())
+        ),
+        vec![commit4.id().clone()]
+    );
+}
+
+#[test]
 fn test_evaluate_expression_exactly() {
     let test_repo = TestRepo::init();
     let repo = &test_repo.repo;

--- a/lib/tests/test_revset_optimized.rs
+++ b/lib/tests/test_revset_optimized.rs
@@ -132,6 +132,8 @@ fn arb_expression(
                 expr.clone().prop_map(|x| x.roots()),
                 // ForkPoint
                 expr.clone().prop_map(|x| x.fork_point()),
+                // MergePoint
+                expr.clone().prop_map(|x| x.merge_point()),
                 // Latest
                 (expr.clone(), 0..5_usize).prop_map(|(x, n)| x.latest(n)),
                 // AtOperation (or WithinVisibility)


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

Relates to #8643 

This adds the revset function `merge_point(x)` which computes the merge point of all commits in `x`.
Similar to the existing `fork_point(x)` function, which shows you where two branches fork from each other, `merge_point(x)` shows you where two branches merge together.

- `fork_point(x)   :=  heads(::x_1 & ::x_2 & ... & ::x_N)` (since 0.24.0)
- `merge_point(x)  :=  roots(x_1:: & x_2:: & ... & x_N::)` (new)

This is my first contribution to this project, no AI/LLM has been used for this PR

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
