### PR TITLE
git: list all remote push URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   aliases of the reserved `.git` and `.jj` directories.
   [#8924](https://github.com/jj-vcs/jj/issues/8924)
 
+* `jj git remote list` now shows all configured push URLs for a remote instead
+  of only one.
+  [#9651](https://github.com/jj-vcs/jj/issues/9651)
+
 * `jj` now creates a new working-copy revision during snapshotting if the
   working copy was immutable. Previously, the new revision was created
   immediately after the working copy became immutable.

--- a/cli/src/commands/git/remote/list.rs
+++ b/cli/src/commands/git/remote/list.rs
@@ -35,6 +35,7 @@ pub async fn cmd_git_remote_list(
 ) -> Result<(), CommandError> {
     let workspace_command = command.workspace_helper(ui).await?;
     let git_repo = git::get_git_repo(workspace_command.repo().store())?;
+    let config_snapshot = git_repo.config_snapshot();
     for remote_name in git_repo.remote_names() {
         let remote = match git_repo.try_find_remote(&*remote_name) {
             Some(Ok(remote)) => remote,
@@ -47,12 +48,31 @@ pub async fn cmd_git_remote_list(
             None => continue, // ignore empty [remote "<name>"] section
         };
         let fetch_url = get_url(&remote, gix::remote::Direction::Fetch);
-        let push_url = get_url(&remote, gix::remote::Direction::Push);
-        if fetch_url == push_url {
-            writeln!(ui.stdout(), "{remote_name} {fetch_url}")?;
-        } else {
-            writeln!(ui.stdout(), "{remote_name} {fetch_url} (push: {push_url})")?;
+
+        // gix::Remote::url(Direction::Push) returns one push url, but git
+        // remotes can have multiple pushurl values.
+        let push_urls = config_snapshot
+            .strings_filter_by(
+                "remote",
+                Some(&remote_name),
+                "pushurl",
+                gix::config::section::is_trusted,
+            )
+            .unwrap_or_default();
+
+        write!(ui.stdout(), "{remote_name} {fetch_url}")?;
+
+        match push_urls.as_slice() {
+            [] => {}
+            [push_url] if push_url.as_ref() == fetch_url => {}
+            push_urls => {
+                for push_url in push_urls {
+                    write!(ui.stdout(), " (push: {push_url})")?;
+                }
+            }
         }
+
+        writeln!(ui.stdout())?;
     }
     Ok(())
 }

--- a/cli/tests/test_git_remotes.rs
+++ b/cli/tests/test_git_remotes.rs
@@ -1131,3 +1131,39 @@ fn test_git_remote_name_validation() {
     [exit status: 1]
     "#);
 }
+
+#[test]
+fn test_git_list_multiple_push_urls() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    work_dir
+        .run_jj([
+            "git",
+            "remote",
+            "add",
+            "origin",
+            "https://example.com/repo/origin",
+            "--push-url",
+            "ssh://example.com/repo/origin",
+        ])
+        .success();
+    let mut config_file = fs::OpenOptions::new()
+        .append(true)
+        .open(work_dir.root().join(".jj/repo/store/git/config"))
+        .unwrap();
+    // Git allows multiple pushurl values for one remote.
+    writeln!(
+        config_file,
+        "\tpushurl = ssh://example.com/repo/origin-mirror"
+    )
+    .unwrap();
+    drop(config_file);
+
+    let output = work_dir.run_jj(["git", "remote", "list"]);
+    insta::assert_snapshot!(output, @"
+    origin https://example.com/repo/origin (push: ssh://example.com/repo/origin) (push: ssh://example.com/repo/origin-mirror)
+    [EOF]
+    ");
+}


### PR DESCRIPTION
Fetches all `pushurl` associated with remotes and outputs them. Preserves original styling.

The original ticket also describes a nicer way of presenting the listed remotes, however I believe restyling the output should be a separate ticket as it touches multiple tests that are out of scope for this PR.

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
