### PR TITLE
flake: build jujutsu against the consumer's nixpkgs in the overlay

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,9 @@
   }:
     {
       overlays.default = final: prev: {
-        jujutsu = self.packages.${final.stdenv.hostPlatform.system}.jujutsu;
+        jujutsu = final.callPackage ./default.nix {
+          gitRev = self.rev or self.dirtyRev or null;
+        };
       };
     }
     // (flake-utils.lib.eachSystem nixpkgs.lib.systems.flakeExposed (system: let


### PR DESCRIPTION
The overlay returned jj's own `self.packages.$system.jujutsu`, pinned to jj's
nixpkgs, so downstream overrides never propagated.

This commit uses `final.callPackage ./default.nix` so consumers get jj
built against their own package set.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
