### PR TITLE
lock: avoid flocking creation descriptors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   aliases that are simply repeated. For example, with the alias `jj = []`, the
   command `jj jj jj log` will resolve to `jj log` as expected.
 
+* Fixed Unix file locking on Docker for Mac VirtioFS bind mounts. Previously,
+  colocated Git repositories could allow concurrent Git import/export work,
+  which could leave jj commands failing with `Failed to reset Git HEAD state`
+  and `Shared index checksum mismatch`.
+
 ## [0.43.0] - 2026-07-01
 
 ### Release highlights

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -246,6 +246,11 @@ Thanks to the people who made this release happen!
 * Yash Bavadiya (@xevrion)
 * Yuya Nishihara (@yuja)
 
+* Fixed Unix file locking on Docker for Mac VirtioFS bind mounts. Previously,
+  colocated Git repositories could allow concurrent Git import/export work,
+  which could leave jj commands failing with `Failed to reset Git HEAD state`
+  and `Shared index checksum mismatch`.
+
 ## [0.43.0] - 2026-07-01
 
 ### Release highlights

--- a/lib/src/lock/backoff.rs
+++ b/lib/src/lock/backoff.rs
@@ -20,7 +20,6 @@ pub struct BackoffIterator {
 }
 
 impl BackoffIterator {
-    #[cfg_attr(unix, expect(dead_code))]
     pub fn new() -> Self {
         Self {
             next_sleep_secs: 0.001,

--- a/lib/src/lock/unix.rs
+++ b/lib/src/lock/unix.rs
@@ -15,6 +15,9 @@
 #![expect(missing_docs)]
 
 use std::fs::File;
+use std::fs::OpenOptions;
+use std::io;
+use std::path::Path;
 use std::path::PathBuf;
 
 use rustix::fs::FlockOperation;
@@ -48,12 +51,23 @@ impl FileLock {
             FlockOperation::NonBlockingLockExclusive
         };
         loop {
-            // Create lockfile, or open pre-existing one
-            let file = File::create(&path).map_err(|err| FileLockError {
-                message: "Failed to open lock file",
-                path: path.clone(),
-                err,
-            })?;
+            let file = match open_lock_file(&path) {
+                Ok(file) => file,
+                Err(err) if err.kind() == io::ErrorKind::NotFound => {
+                    // Another lock holder may have removed the lock path
+                    // between our create-or-observe step and our reopen step.
+                    // Retry so we do not report a transient deletion as a
+                    // lock acquisition failure.
+                    continue;
+                }
+                Err(err) => {
+                    return Err(FileLockError {
+                        message: "Failed to open lock file",
+                        path: path.clone(),
+                        err,
+                    });
+                }
+            };
             // If the lock was already held, block until it's released, or (in
             // non-blocking mode) report that it's currently unavailable.
             match rustix::fs::flock(&file, operation) {
@@ -99,6 +113,43 @@ impl FileLock {
             return Ok(Some(Self { path, file }));
         }
     }
+}
+
+fn open_lock_file(path: &Path) -> io::Result<File> {
+    match OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create_new(true)
+        .open(path)
+    {
+        Ok(created_file) => {
+            // Docker for Mac's VirtioFS bind mounts have allowed two
+            // exclusive flock holders when the first holder creates a missing
+            // lock file and then flocks the same descriptor. See:
+            // https://github.com/docker/for-mac/issues/7004
+            //
+            // The failure matters when a jj repository lives on a host
+            // directory bind-mounted into a Docker for Mac container. A fresh
+            // short-lived lock path is often missing because FileLock removes
+            // it on drop, so the next process is likely to be the process that
+            // creates the file. Taking flock on that creation descriptor can
+            // fail to exclude a concurrent process on affected VirtioFS mounts.
+            //
+            // Close the creation descriptor explicitly before reopening the
+            // file. The working probe showed that the create-close-open
+            // sequence preserves mutual exclusion on both ordinary directories
+            // and Docker for Mac VirtioFS bind mounts.
+            drop(created_file);
+        }
+        Err(err) if err.kind() == io::ErrorKind::AlreadyExists => {
+            // The lock file already exists, so no creation descriptor was
+            // involved in this process. Opening the existing file directly is
+            // the pattern that works on the affected VirtioFS mounts.
+        }
+        Err(err) => return Err(err),
+    }
+
+    OpenOptions::new().read(true).write(true).open(path)
 }
 
 impl Drop for FileLock {

--- a/lib/src/lock/unix.rs
+++ b/lib/src/lock/unix.rs
@@ -15,12 +15,17 @@
 #![expect(missing_docs)]
 
 use std::fs::File;
+use std::fs::OpenOptions;
+use std::io;
+use std::path::Path;
 use std::path::PathBuf;
+use std::thread;
 
 use rustix::fs::FlockOperation;
 use tracing::instrument;
 
 use super::FileLockError;
+use super::backoff::BackoffIterator;
 
 pub struct FileLock {
     path: PathBuf,
@@ -47,13 +52,33 @@ impl FileLock {
         } else {
             FlockOperation::NonBlockingLockExclusive
         };
+        let mut backoff_iterator = BackoffIterator::new();
         loop {
-            // Create lockfile, or open pre-existing one
-            let file = File::create(&path).map_err(|err| FileLockError {
-                message: "Failed to open lock file",
-                path: path.clone(),
-                err,
-            })?;
+            let file = match open_lock_file(&path) {
+                Ok(file) => file,
+                Err(err) if err.kind() == io::ErrorKind::NotFound => {
+                    // Another lock holder may have removed the lock path
+                    // between our create-or-observe step and our reopen step.
+                    // Retry so we do not report a transient deletion as a
+                    // lock acquisition failure.
+                    let Some(duration) = backoff_iterator.next() else {
+                        return Err(FileLockError {
+                            message: "Failed to open lock file",
+                            path: path.clone(),
+                            err,
+                        });
+                    };
+                    thread::sleep(duration);
+                    continue;
+                }
+                Err(err) => {
+                    return Err(FileLockError {
+                        message: "Failed to open lock file",
+                        path: path.clone(),
+                        err,
+                    });
+                }
+            };
             // If the lock was already held, block until it's released, or (in
             // non-blocking mode) report that it's currently unavailable.
             match rustix::fs::flock(&file, operation) {
@@ -99,6 +124,75 @@ impl FileLock {
             return Ok(Some(Self { path, file }));
         }
     }
+}
+
+fn open_lock_file(path: &Path) -> io::Result<File> {
+    match OpenOptions::new().write(true).create_new(true).open(path) {
+        Ok(created_file) => {
+            // Docker for Mac's `fakeowner` layer over VirtioFS has allowed two
+            // exclusive flock holders when the first holder creates a missing
+            // lock file and then flocks the same descriptor. See:
+            // https://github.com/docker/for-mac/issues/7004
+            //
+            // The failure matters when a jj repository lives on a host
+            // directory bind-mounted into a Docker for Mac container. A fresh
+            // short-lived lock path is often missing because FileLock removes
+            // it on drop, so the next process is likely to be the process that
+            // creates the file. Taking flock on that creation descriptor can
+            // fail to exclude a concurrent process on affected `fakeowner`
+            // mounts.
+            //
+            // On Linux, limit the workaround to filesystem implementations
+            // which may be affected. Other Unix systems use the creation
+            // descriptor directly.
+            if creation_descriptor_may_have_broken_flock(&created_file) {
+                // Close the creation descriptor explicitly before reopening the
+                // file. The working probe showed that the create-close-open
+                // sequence preserves mutual exclusion on affected Docker for Mac
+                // bind mounts.
+                drop(created_file);
+                OpenOptions::new().write(true).open(path)
+            } else {
+                Ok(created_file)
+            }
+        }
+        Err(err) if err.kind() == io::ErrorKind::AlreadyExists => {
+            // The lock file already exists, so no creation descriptor was
+            // involved in this process. Opening the existing file directly is
+            // the pattern that works on the affected `fakeowner` mounts.
+            OpenOptions::new().write(true).open(path)
+        }
+        Err(err) => Err(err),
+    }
+}
+
+/// Checks whether `file` may be affected by Docker Desktop's `fakeowner` bug.
+///
+/// The creation and existing-file open paths can use different inode layers,
+/// allowing both descriptors to acquire an exclusive flock. See
+/// https://github.com/docker/for-mac/issues/7004.
+#[cfg(target_os = "linux")]
+fn creation_descriptor_may_have_broken_flock(file: &File) -> bool {
+    // The undocumented magic value reported by Docker Desktop's out-of-tree
+    // `fakeowner` ownership wrapper, which may be placed above VirtioFS. It is
+    // not a guaranteed interface and is only a best-effort Docker Desktop signal.
+    const DOCKER_DESKTOP_FAKEOWNER_MAGIC: u64 = 0x6a65_6a63;
+
+    match rustix::fs::fstatfs(file) {
+        // The suspected bug is in Docker Desktop's `fakeowner` layer, not the
+        // underlying VirtioFS filesystem. A raw VirtioFS mount does not exhibit
+        // the broken locking behavior described in the linked report above.
+        Ok(stat) => stat.f_type as u64 == DOCKER_DESKTOP_FAKEOWNER_MAGIC,
+        // A false negative could restore the broken locking behavior. Detection
+        // failure is unusual, so retain the safe workaround in that case.
+        Err(_) => true,
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn creation_descriptor_may_have_broken_flock(_file: &File) -> bool {
+    // The known broken behavior is limited to Linux guests in Docker Desktop.
+    false
 }
 
 impl Drop for FileLock {


### PR DESCRIPTION
Let me start by saying I'm not entirely convinced this should be patched in Jujutsu. It feels dirty and expecting every piece of software ever running inside Docker for Mac containers in VirtIO-mounted host directories to work around VirtIO flock issues doesn't seem scalable to me.

On the other hand I can't use Jujutsu reliably in this scenario and I can't see any other solution to this problem, at least not a short-term one.

I figured I'd submit something for discussion. No hard feelings if this is not considered the right thing to do.

I was on the fence regarding the changelog entry, I added one for now but feedback is welcome.

I ran some stress tests and in non-VirtIO directories I found no regressions (old code+new code and new code+new code combinations work fine as far as mutual exclusion is concerned).

In a VirtIO-mounted directories the new implementation ensures mutual exclusion now (my tests revealed no failures in that regard).


Anyway, the initial commit message below:

---


Docker for Mac VirtioFS bind mounts can let two exclusive flock holders coexist when the first process creates a missing lock file and then locks that same descriptor (see the Docker issue).

FileLock intentionally removes the path on drop, so repositories on host directories bind-mounted into Docker for Mac commonly start the next lock acquisition from a missing path. Keep that short-lived behavior, but split the Unix acquisition path into create-new, close, reopen-existing, then flock, which works around the problem.

The failure allowed concurrent Git import/export work in colocated repositories to corrupt split-index state. An example failure from my environment when I ran jj diff --stat in such repository:

    Error: Failed to reset Git HEAD state
    Caused by:
    1: Shared index checksum mismatch
    2: Hash was 8a2f86eb509b8a18a01fb3579708b5c1376cb49a, but should have been 732f524541444d452e6d64000000000000000000

Reference: https://github.com/docker/for-mac/issues/7004

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
