### PR TITLE
cli: resolve default command during alias resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 * Recursive alias definitions are detected more precisely. jj can now expand
   aliases that are simply repeated. For example, with the alias `jj = []`, the
-  command `jj jj jj log` will resolve to `jj log` as expected.
+  command `jj jj jj` will resolve to `jj`. Aliases can also fall back to the
+  default command. For example, with the alias `i = ["--ignore-working-copy"]`,
+  `jj i` will resolve to `jj --ignore-working-copy`.
 
 ## [0.43.0] - 2026-07-01
 

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -3792,14 +3792,12 @@ fn resolve_default_command(
     Ok(string_args)
 }
 
-fn resolve_aliases(
+fn load_aliases<'config>(
     ui: &Ui,
-    config: &StackedConfig,
+    config: &'config StackedConfig,
     app: &Command,
-    mut string_args: Vec<String>,
-) -> Result<Vec<String>, CommandError> {
-    let defined_aliases: HashSet<_> = config.table_keys("aliases").collect();
-    let mut recursion_check_stack: Vec<(&str, Range<usize>)> = Vec::new();
+) -> Result<HashSet<&'config str>, CommandError> {
+    let mut defined_aliases: HashSet<_> = config.table_keys("aliases").collect();
     let mut real_commands = HashSet::new();
     for command in app.get_subcommands() {
         real_commands.insert(command.get_name());
@@ -3807,12 +3805,25 @@ fn resolve_aliases(
             real_commands.insert(alias);
         }
     }
-    for alias in defined_aliases.intersection(&real_commands).sorted() {
+    for alias in defined_aliases
+        .extract_if(|a| real_commands.contains(a))
+        .sorted()
+    {
         writeln!(
             ui.warning_default(),
             "Cannot define an alias that overrides the built-in command '{alias}'"
         )?;
     }
+    Ok(defined_aliases)
+}
+
+fn resolve_aliases(
+    config: &StackedConfig,
+    app: &Command,
+    defined_aliases: &HashSet<&str>,
+    mut string_args: Vec<String>,
+) -> Result<Vec<String>, CommandError> {
+    let mut recursion_check_stack: Vec<(&str, Range<usize>)> = Vec::new();
 
     loop {
         let app_clone = app.clone().allow_external_subcommands(true);
@@ -3821,10 +3832,6 @@ fn resolve_aliases(
             // No more alias commands, or hit unknown option
             return Ok(string_args);
         };
-        if real_commands.contains(command_name) {
-            // cannot alias real commands
-            return Ok(string_args);
-        }
         let alias_name = command_name.to_string();
         let alias_args = submatches
             .get_many::<OsString>("")
@@ -4023,9 +4030,12 @@ pub fn expand_args(
     args_os: impl IntoIterator<Item = OsString>,
     config: &StackedConfig,
 ) -> Result<Vec<String>, CommandError> {
-    let string_args = to_string_args(args_os)?;
-    let string_args = resolve_default_command(ui, config, app, string_args)?;
-    resolve_aliases(ui, config, app, string_args)
+    let mut string_args = to_string_args(args_os)?;
+    let aliases = load_aliases(ui, config, app)?;
+    string_args = resolve_aliases(config, app, &aliases, string_args)?;
+    string_args = resolve_default_command(ui, config, app, string_args)?;
+    string_args = resolve_aliases(config, app, &aliases, string_args)?;
+    Ok(string_args)
 }
 
 fn expand_args_for_completion(
@@ -4034,19 +4044,25 @@ fn expand_args_for_completion(
     args_os: impl IntoIterator<Item = OsString>,
     config: &StackedConfig,
 ) -> Result<Vec<String>, CommandError> {
-    let string_args = to_string_args(args_os)?;
-
-    // If a subcommand has been given, including the potentially incomplete argument
-    // that is being completed, the default command is not resolved and the
-    // completion candidates for the subcommand are prioritized.
-    let mut string_args = resolve_default_command(ui, config, app, string_args)?;
+    let mut string_args = to_string_args(args_os)?;
+    let aliases = load_aliases(ui, config, app)?;
 
     // Resolution of subcommand aliases must not consider the argument that is being
     // completed.
     let cursor_arg = string_args.pop();
-    let mut resolved_args = resolve_aliases(ui, config, app, string_args)?;
-    resolved_args.extend(cursor_arg);
-    Ok(resolved_args)
+    string_args = resolve_aliases(config, app, &aliases, string_args)?;
+    string_args.extend(cursor_arg);
+
+    // If a subcommand has been given, including the potentially incomplete argument
+    // that is being completed, the default command is not resolved and the
+    // completion candidates for the subcommand are prioritized.
+    string_args = resolve_default_command(ui, config, app, string_args)?;
+
+    let cursor_arg = string_args.pop();
+    string_args = resolve_aliases(config, app, &aliases, string_args)?;
+    string_args.extend(cursor_arg);
+
+    Ok(string_args)
 }
 
 fn to_string_args(

--- a/cli/tests/test_alias.rs
+++ b/cli/tests/test_alias.rs
@@ -60,6 +60,7 @@ fn test_alias_calls_empty_command() {
 
     test_env.add_config(
         r#"
+    ui.default-command = []
     aliases.empty = []
     aliases.empty_command_with_opts = ["--no-pager"]
     "#,
@@ -505,5 +506,30 @@ fn test_alias_recursion_check() {
     Error: Recursive alias definition involving `c`
     [EOF]
     [exit status: 1]
+    ");
+}
+
+#[test]
+fn test_alias_falls_back_to_default_command() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+    test_env.add_config(
+        r#"
+        ui.default-command = ["log", "-Tbuiltin_log_oneline"]
+        aliases.jj = []
+        aliases.log-root = ["-r=root()"]
+        "#,
+    );
+    let output = work_dir.run_jj(["jj"]);
+    insta::assert_snapshot!(output, @"
+    @  qpvuntsm test.user 2001-02-03 08:05:07 e8849ae1 (empty) (no description set)
+    ◆  zzzzzzzz root() 00000000
+    [EOF]
+    ");
+    let output = work_dir.run_jj(["log-root"]);
+    insta::assert_snapshot!(output, @"
+    ◆  zzzzzzzz root() 00000000
+    [EOF]
     ");
 }


### PR DESCRIPTION
- [x] I have updated `CHANGELOG.md`
- [n/a] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [n/a] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] No LLM was involved in the creation of this PR in any way.

This PR was inspired by a discussion on lobsters:
https://lobste.rs/s/96kp1m/jj_jj_jj_jj_jj

I find the empty alias solution to be more elegant than using `util exec`, so I wanted it to be equally powerful.