### PR TITLE
File search: can print lines and line numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * `jj run` gained a `--passthrough` flag that connects the subprocess's
   stdout/stderr directly to the terminal instead of capturing output.
 
+* `jj file search` now supports `-n`/`--line-number` to prefix each match with
+  its 1-based line number within the file.
+
 ### Fixed bugs
 
 * Recursive alias definitions are detected more precisely. jj can now expand

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   return `Option<FsPath>` and `FsPath` respectively, instead of `String`. The
   `path` keyword in `jj config list` templates now returns `Option<FsPath>`.
 
+* `jj file search` now prints every matched line prefixed by the file path,
+  instead of only the file paths of files containing a match. Use
+  `--name-only` for the previous behavior.
+  [#9399](https://github.com/jj-vcs/jj/issues/9399)
+
 ### Deprecations
 
 ### New features

--- a/cli/src/commands/file/search.rs
+++ b/cli/src/commands/file/search.rs
@@ -12,10 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::io;
+use std::io::Write as _;
+
 use clap_complete::ArgValueCompleter;
 use jj_lib::conflicts::MaterializedTreeValue;
 use jj_lib::conflicts::materialize_tree_value;
 use jj_lib::repo::Repo as _;
+use jj_lib::str_util::StringMatcher;
 use jj_lib::str_util::StringPattern;
 use tracing::instrument;
 
@@ -25,15 +29,16 @@ use crate::cli_util::print_unmatched_explicit_paths;
 use crate::command_error::CommandError;
 use crate::command_error::cli_error;
 use crate::complete;
+use crate::formatter::Formatter;
 use crate::ui::Ui;
 
 /// Search for content in files
 ///
-/// Lists files containing the specified pattern.
+/// Prints each line that matches the specified pattern, prefixed by the file
+/// path. Use `--name-only` to print only the file paths.
 ///
-/// This is an early version of the command. It only supports glob matching for
-/// now, it doesn't search files concurrently, and it doesn't indicate where in
-/// the file the match was found.
+/// This is an early version of the command. It does not search files
+/// concurrently.
 #[derive(clap::Args, Clone, Debug)]
 pub(crate) struct FileSearchArgs {
     /// The revision to search files in
@@ -53,6 +58,11 @@ pub(crate) struct FileSearchArgs {
     ///     https://docs.jj-vcs.dev/latest/revsets/#string-patterns
     #[arg(long, short, value_name = "PATTERN")]
     pattern: String,
+
+    /// Print only the paths of files that contain a match, not the matched
+    /// lines
+    #[arg(long)]
+    name_only: bool,
 
     /// Only search files matching these prefixes (instead of all files)
     #[arg(value_name = "FILESETS", value_hint = clap::ValueHint::AnyPath)]
@@ -103,19 +113,28 @@ pub(crate) async fn cmd_file_search(
                 let content = materialized_file_value.read_all(&path).await?;
                 // TODO: Make output templated
                 let ui_path = workspace_command.format_file_path(&path);
-                if let Some(_line) = pattern_matcher.match_lines(&content).next() {
-                    // TODO: Optionally also print the line and line number
-                    writeln!(formatter, "{ui_path}")?;
+                if args.name_only {
+                    if pattern_matcher.match_lines(&content).next().is_some() {
+                        writeln!(formatter, "{ui_path}")?;
+                    }
+                } else {
+                    write_matches(formatter.as_mut(), &ui_path, &content, &pattern_matcher)?;
                 }
             }
             MaterializedTreeValue::Symlink { .. } => {}
             MaterializedTreeValue::FileConflict(materialized_file_value) => {
                 let ui_path = workspace_command.format_file_path(&path);
-                for content in materialized_file_value.contents.adds() {
-                    if let Some(_line) = pattern_matcher.match_lines(content).next() {
-                        // TODO: Optionally also print the conflict side, line and line number
+                // TODO: Optionally also print the conflict side
+                let mut adds = materialized_file_value.contents.adds();
+                if args.name_only {
+                    // Multiple blobs per file; print the path if any blob
+                    // matches.
+                    if adds.any(|c| pattern_matcher.match_lines(c).next().is_some()) {
                         writeln!(formatter, "{ui_path}")?;
-                        break;
+                    }
+                } else {
+                    for content in adds {
+                        write_matches(formatter.as_mut(), &ui_path, content, &pattern_matcher)?;
                     }
                 }
             }
@@ -125,5 +144,21 @@ pub(crate) async fn cmd_file_search(
         }
     }
     print_unmatched_explicit_paths(ui, &workspace_command, &fileset_expression, [&tree])?;
+    Ok(())
+}
+
+fn write_matches(
+    formatter: &mut dyn Formatter,
+    ui_path: &str,
+    content: &[u8],
+    matcher: &StringMatcher,
+) -> io::Result<()> {
+    for line in matcher.match_lines(content) {
+        write!(formatter, "{ui_path}:")?;
+        formatter.write_all(line)?;
+        if !line.ends_with(b"\n") {
+            writeln!(formatter)?;
+        }
+    }
     Ok(())
 }

--- a/cli/src/commands/file/search.rs
+++ b/cli/src/commands/file/search.rs
@@ -61,8 +61,12 @@ pub(crate) struct FileSearchArgs {
 
     /// Print only the paths of files that contain a match, not the matched
     /// lines
-    #[arg(long)]
+    #[arg(long, conflicts_with = "line_number")]
     name_only: bool,
+
+    /// Prefix each matched line with its 1-based line number within the file
+    #[arg(long, short = 'n')]
+    line_number: bool,
 
     /// Only search files matching these prefixes (instead of all files)
     #[arg(value_name = "FILESETS", value_hint = clap::ValueHint::AnyPath)]
@@ -118,7 +122,13 @@ pub(crate) async fn cmd_file_search(
                         writeln!(formatter, "{ui_path}")?;
                     }
                 } else {
-                    write_matches(formatter.as_mut(), &ui_path, &content, &pattern_matcher)?;
+                    write_matches(
+                        formatter.as_mut(),
+                        &ui_path,
+                        &content,
+                        &pattern_matcher,
+                        args.line_number,
+                    )?;
                 }
             }
             MaterializedTreeValue::Symlink { .. } => {}
@@ -133,8 +143,16 @@ pub(crate) async fn cmd_file_search(
                         writeln!(formatter, "{ui_path}")?;
                     }
                 } else {
+                    // -n numbers lines within each side independently; there
+                    // is no meaningful unified line numbering across sides.
                     for content in adds {
-                        write_matches(formatter.as_mut(), &ui_path, content, &pattern_matcher)?;
+                        write_matches(
+                            formatter.as_mut(),
+                            &ui_path,
+                            content,
+                            &pattern_matcher,
+                            args.line_number,
+                        )?;
                     }
                 }
             }
@@ -152,9 +170,21 @@ fn write_matches(
     ui_path: &str,
     content: &[u8],
     matcher: &StringMatcher,
+    line_number: bool,
 ) -> io::Result<()> {
-    for line in matcher.match_lines(content) {
-        write!(formatter, "{ui_path}:")?;
+    let matches = content
+        .split_inclusive(|b| *b == b'\n')
+        .enumerate()
+        .filter_map(|(i, line)| {
+            let stripped = line.strip_suffix(b"\n").unwrap_or(line);
+            matcher.is_match_bytes(stripped).then_some((i + 1, line))
+        });
+    for (line_no, line) in matches {
+        if line_number {
+            write!(formatter, "{ui_path}:{line_no}:")?;
+        } else {
+            write!(formatter, "{ui_path}:")?;
+        }
         formatter.write_all(line)?;
         if !line.ends_with(b"\n") {
             writeln!(formatter)?;

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -1256,6 +1256,7 @@ This is an early version of the command. It does not search files concurrently.
 
    [string pattern syntax]: https://docs.jj-vcs.dev/latest/revsets/#string-patterns
 * `--name-only` — Print only the paths of files that contain a match, not the matched lines
+* `-n`, `--line-number` — Prefix each matched line with its 1-based line number within the file
 
 
 

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -1233,9 +1233,9 @@ List files in a revision
 
 Search for content in files
 
-Lists files containing the specified pattern.
+Prints each line that matches the specified pattern, prefixed by the file path. Use `--name-only` to print only the file paths.
 
-This is an early version of the command. It only supports glob matching for now, it doesn't search files concurrently, and it doesn't indicate where in the file the match was found.
+This is an early version of the command. It does not search files concurrently.
 
 **Usage:** `jj file search [OPTIONS] --pattern <PATTERN> [FILESETS]...`
 
@@ -1255,6 +1255,7 @@ This is an early version of the command. It only supports glob matching for now,
    If it is a glob pattern, the whole line must match the pattern, so you may want to pass something like `--pattern 'glob:*foo*'`.
 
    [string pattern syntax]: https://docs.jj-vcs.dev/latest/revsets/#string-patterns
+* `--name-only` — Print only the paths of files that contain a match, not the matched lines
 
 
 

--- a/cli/tests/test_file_search_command.rs
+++ b/cli/tests/test_file_search_command.rs
@@ -113,6 +113,15 @@ fn test_file_search() {
     multi
     [EOF]
     ");
+
+    // -n prefixes each match with its 1-based line number
+    let output = work_dir.run_jj(["file", "search", "-n", "--pattern=hit", "multi"]);
+    insta::assert_snapshot!(output.normalize_backslash(), @"
+    multi:1:hit-one
+    multi:3:hit-two
+    multi:4:hit-three
+    [EOF]
+    ");
 }
 
 #[test]
@@ -176,6 +185,15 @@ fn test_file_search_conflicts() {
     ]);
     insta::assert_snapshot!(output.normalize_backslash(), @"
     file1
+    [EOF]
+    ");
+
+    // -n numbers lines within each conflict side independently, so matches on
+    // different sides can share a line number.
+    let output = work_dir.run_jj(["file", "search", "-n", "--pattern=regex:-(foo|baz)-"]);
+    insta::assert_snapshot!(output.normalize_backslash(), @"
+    file1:1:-foo-
+    file1:1:-baz-
     [EOF]
     ");
 

--- a/cli/tests/test_file_search_command.rs
+++ b/cli/tests/test_file_search_command.rs
@@ -26,8 +26,17 @@ fn test_file_search() {
     work_dir.create_dir("dir");
     work_dir.write_file("dir/file3", "-foobar-");
 
-    // Searches all files in the current revision by default
+    // Searches all files in the current revision by default and prints each
+    // matched line prefixed by the file path
     let output = work_dir.run_jj(["file", "search", "--pattern=glob:*foo*"]);
+    insta::assert_snapshot!(output.normalize_backslash(), @"
+    dir/file3:-foobar-
+    file1:-foo-
+    [EOF]
+    ");
+
+    // --name-only restores path-only output
+    let output = work_dir.run_jj(["file", "search", "--name-only", "--pattern=glob:*foo*"]);
     insta::assert_snapshot!(output.normalize_backslash(), @"
     dir/file3
     file1
@@ -41,14 +50,14 @@ fn test_file_search() {
     // Can search files in another revision
     let output = work_dir.run_jj(["file", "search", "--pattern=glob:*foo*", "-r=@-"]);
     insta::assert_snapshot!(output.normalize_backslash(), @"
-    file1
+    file1:-foo-
     [EOF]
     ");
 
     // Can filter by path
     let output = work_dir.run_jj(["file", "search", "--pattern=glob:*foo*", "dir"]);
     insta::assert_snapshot!(output.normalize_backslash(), @"
-    dir/file3
+    dir/file3:-foobar-
     [EOF]
     ");
 
@@ -63,16 +72,16 @@ fn test_file_search() {
     // The default is regex
     let output = work_dir.run_jj(["file", "search", "--pattern=f.o"]);
     insta::assert_snapshot!(output.normalize_backslash(), @"
-    dir/file3
-    file1
+    dir/file3:-foobar-
+    file1:-foo-
     [EOF]
     ");
 
     // Can specify the kind
     let output = work_dir.run_jj(["file", "search", "--pattern=glob-i:*foo*"]);
     insta::assert_snapshot!(output.normalize_backslash(), @"
-    dir/file3
-    file1
+    dir/file3:-foobar-
+    file1:-foo-
     [EOF]
     ");
 
@@ -88,6 +97,22 @@ fn test_file_search() {
     // Colons can be in the pattern part.
     let output = work_dir.run_jj(["file", "search", "--pattern=regex-i:foo:bar"]);
     insta::assert_snapshot!(output.normalize_backslash(), @"");
+
+    // Prints every matched line, not just the first
+    work_dir.write_file("multi", "hit-one\nmiss\nhit-two\nhit-three\n");
+    let output = work_dir.run_jj(["file", "search", "--pattern=hit", "multi"]);
+    insta::assert_snapshot!(output.normalize_backslash(), @"
+    multi:hit-one
+    multi:hit-two
+    multi:hit-three
+    [EOF]
+    ");
+    // --name-only collapses the same file to a single line
+    let output = work_dir.run_jj(["file", "search", "--name-only", "--pattern=hit", "multi"]);
+    insta::assert_snapshot!(output.normalize_backslash(), @"
+    multi
+    [EOF]
+    ");
 }
 
 #[test]
@@ -115,8 +140,14 @@ fn test_file_search_conflicts() {
     >>>>>>> conflict 1 of 1 ends
     ");
 
-    // Matches positive terms
+    // Matches positive terms (one match per matching add side)
     let output = work_dir.run_jj(["file", "search", "--pattern=glob:*foo*"]);
+    insta::assert_snapshot!(output.normalize_backslash(), @"
+    file1:-foo-
+    [EOF]
+    ");
+    // --name-only collapses per-file even with a conflict
+    let output = work_dir.run_jj(["file", "search", "--name-only", "--pattern=glob:*foo*"]);
     insta::assert_snapshot!(output.normalize_backslash(), @"
     file1
     [EOF]
@@ -124,6 +155,25 @@ fn test_file_search_conflicts() {
     let output = work_dir.run_jj(["file", "search", "--pattern=glob:*bar*"]);
     insta::assert_snapshot!(output.normalize_backslash(), @"");
     let output = work_dir.run_jj(["file", "search", "--pattern=glob:*baz*"]);
+    insta::assert_snapshot!(output.normalize_backslash(), @"
+    file1:-baz-
+    [EOF]
+    ");
+
+    // A pattern that matches on multiple add sides: each matching side emits
+    // one line; with --name-only the path is deduped to a single output.
+    let output = work_dir.run_jj(["file", "search", "--pattern=regex:-(foo|baz)-"]);
+    insta::assert_snapshot!(output.normalize_backslash(), @"
+    file1:-foo-
+    file1:-baz-
+    [EOF]
+    ");
+    let output = work_dir.run_jj([
+        "file",
+        "search",
+        "--name-only",
+        "--pattern=regex:-(foo|baz)-",
+    ]);
     insta::assert_snapshot!(output.normalize_backslash(), @"
     file1
     [EOF]

--- a/docs/git-command-table.yml
+++ b/docs/git-command-table.yml
@@ -176,7 +176,7 @@
   Git command: >
     `git grep foo`
   Jujutsu command: >
-    `grep foo $(jj file list)`
+    `jj file search --pattern=foo`
     or `rg --no-require-git foo`
   Notes:
 


### PR DESCRIPTION
Closes #9399

Two commits:
1. print matched lines, unless `--name-only`
2. print line numbers if `-n`

As specced in #9399 by @martinvonz

## Testing

- Existing snapshots updated to reflect the new `path:line` default output.
- `--name-only` restores path-only output.
- `-n` / `--line-number` prefixes matches with 1-based line numbers.
- `--name-only` combined with `-n` errors out (clap-enforced).
- Multi-match files emit one line per match; `--name-only` collapses to one line per file.
- Conflict files: `--name-only` deduplicates across matching add-sides.
- Conflict files: `-n` numbers lines within each side independently.

## Known issue: Binary files

Because we now emit matched-line contents (not just paths), a search that happens to match bytes in a binary file will dump raw bytes, potentially including terminal control codes, to stdout.

Addressed in the follow-up PR #9742 (mirrors `git grep`: `Binary file <path> matches` by default, `-a`/`--text` and `-I`/`--no-binary` overrides).

## Not in scope

- Templated output (`--template`): the bigger stretch goal on #9399.
- Labelling which conflict side a match came from: existing `TODO` in the code.
- Streaming the file reader: plain-file path currently uses `read_all`, which will inflate process memory on big files. Can be moved to streaming but wanted to keep this PR small.
- Concurrent file reads: existing `TODO` in the code.

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
