### PR TITLE
file-search: emit "Binary file <path> matches" for binary content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,12 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `revsets.log` now defaults to `builtin_log()`, so custom log revsets can
   reuse the built-in default instead of copying its full expression.
 
+* `jj file search` now detects binary files (any null byte in the first
+  8KB) and emits `Binary file <path> matches` instead of dumping raw
+  bytes to stdout. Mirrors `git grep`'s default. Use `-a`/`--text` to
+  force text treatment, or `-I`/`--no-binary` to skip binary files
+  entirely.
+
 ### Fixed bugs
 
 * Recursive alias definitions are detected more precisely. jj can now expand

--- a/cli/src/commands/file/search.rs
+++ b/cli/src/commands/file/search.rs
@@ -68,6 +68,16 @@ pub(crate) struct FileSearchArgs {
     #[arg(long, short = 'n')]
     line_number: bool,
 
+    /// Treat binary files as text, matching and printing raw bytes even if
+    /// they contain null bytes (mirrors `git grep -a`)
+    #[arg(long, short = 'a', conflicts_with = "no_binary")]
+    text: bool,
+
+    /// Skip binary files entirely, even if they contain matches (mirrors
+    /// `git grep -I`)
+    #[arg(long, short = 'I')]
+    no_binary: bool,
+
     /// Only search files matching these prefixes (instead of all files)
     #[arg(value_name = "FILESETS", value_hint = clap::ValueHint::AnyPath)]
     #[arg(add = ArgValueCompleter::new(complete::all_revision_files))]
@@ -115,8 +125,21 @@ pub(crate) async fn cmd_file_search(
             }
             MaterializedTreeValue::File(mut materialized_file_value) => {
                 let content = materialized_file_value.read_all(&path).await?;
-                // TODO: Make output templated
                 let ui_path = workspace_command.format_file_path(&path);
+                if !args.text && is_probably_binary(&content) {
+                    if args.no_binary {
+                        continue;
+                    }
+                    if pattern_matcher.match_lines(&content).next().is_some() {
+                        if args.name_only {
+                            writeln!(formatter, "{ui_path}")?;
+                        } else {
+                            writeln!(formatter, "Binary file {ui_path} matches")?;
+                        }
+                    }
+                    continue;
+                }
+                // TODO: Make output templated
                 if args.name_only {
                     if pattern_matcher.match_lines(&content).next().is_some() {
                         writeln!(formatter, "{ui_path}")?;
@@ -134,6 +157,31 @@ pub(crate) async fn cmd_file_search(
             MaterializedTreeValue::Symlink { .. } => {}
             MaterializedTreeValue::FileConflict(materialized_file_value) => {
                 let ui_path = workspace_command.format_file_path(&path);
+                if !args.text
+                    && materialized_file_value
+                        .contents
+                        .adds()
+                        .any(|c| is_probably_binary(c))
+                {
+                    // At least one side looks binary; treat the whole file as
+                    // binary rather than emitting bytes from the text side(s).
+                    if args.no_binary {
+                        continue;
+                    }
+                    let any_match = materialized_file_value
+                        .contents
+                        .adds()
+                        .any(|c| pattern_matcher.match_lines(c).next().is_some());
+                    if !any_match {
+                        continue;
+                    }
+                    if args.name_only {
+                        writeln!(formatter, "{ui_path}")?;
+                    } else {
+                        writeln!(formatter, "Binary file {ui_path} matches")?;
+                    }
+                    continue;
+                }
                 // TODO: Optionally also print the conflict side
                 let mut adds = materialized_file_value.contents.adds();
                 if args.name_only {
@@ -163,6 +211,14 @@ pub(crate) async fn cmd_file_search(
     }
     print_unmatched_explicit_paths(ui, &workspace_command, &fileset_expression, [&tree])?;
     Ok(())
+}
+
+/// Naive binary detection: any null byte in the first 8KB. Matches the
+/// heuristic used by `git grep`. `jj_lib::eol::is_binary` uses a similar
+/// probe but is `pub(crate)`; unifying the codebase's binary detectors is
+/// left as a follow-up.
+fn is_probably_binary(content: &[u8]) -> bool {
+    content.iter().take(8192).any(|b| *b == 0)
 }
 
 fn write_matches(

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -1256,6 +1256,8 @@ This is an early version of the command. It does not search files concurrently.
    [string pattern syntax]: https://docs.jj-vcs.dev/latest/revsets/#string-patterns
 * `--name-only` — Print only the paths of files that contain a match, not the matched lines
 * `-n`, `--line-number` — Prefix each matched line with its 1-based line number within the file
+* `-a`, `--text` — Treat binary files as text, matching and printing raw bytes even if they contain null bytes (mirrors `git grep -a`)
+* `-I`, `--no-binary` — Skip binary files entirely, even if they contain matches (mirrors `git grep -I`)
 
 
 

--- a/cli/tests/test_file_search_command.rs
+++ b/cli/tests/test_file_search_command.rs
@@ -122,6 +122,46 @@ fn test_file_search() {
     multi:4:hit-three
     [EOF]
     ");
+    // Files that look binary (null byte in the first 8KB) emit
+    // `Binary file <path> matches` instead of raw bytes, mirroring
+    // `git grep`'s default.
+    work_dir.write_file("binfile", b"hit\0hit\n");
+    let output = work_dir.run_jj(["file", "search", "--pattern=hit", "binfile"]);
+    insta::assert_snapshot!(output.normalize_backslash(), @"
+    Binary file binfile matches
+    [EOF]
+    ");
+    // --name-only on a binary match prints just the path.
+    let output = work_dir.run_jj(["file", "search", "--name-only", "--pattern=hit", "binfile"]);
+    insta::assert_snapshot!(output.normalize_backslash(), @"
+    binfile
+    [EOF]
+    ");
+    // No output when the pattern doesn't match, even on a binary file.
+    let output = work_dir.run_jj(["file", "search", "--pattern=nope", "binfile"]);
+    insta::assert_snapshot!(output.normalize_backslash(), @"");
+    // -a/--text forces text treatment; matches emit raw bytes as if the
+    // file were regular text.
+    let output = work_dir.run_jj(["file", "search", "-a", "--pattern=hit", "binfile"]);
+    insta::assert_snapshot!(output.normalize_backslash(), @"
+    binfile:hit\0hit
+    [EOF]
+    ");
+    // -I/--no-binary skips the file entirely.
+    let output = work_dir.run_jj(["file", "search", "-I", "--pattern=hit", "binfile"]);
+    insta::assert_snapshot!(output.normalize_backslash(), @"");
+    // -a and -I are mutually exclusive.
+    let output = work_dir.run_jj(["file", "search", "-a", "-I", "--pattern=hit", "binfile"]);
+    insta::assert_snapshot!(output.normalize_stderr_exit_status(), @r"
+    ------- stderr -------
+    error: the argument '--text' cannot be used with '--no-binary'
+
+    Usage: jj file search --pattern <PATTERN> --text <FILESETS>...
+
+    For more information, try '--help'.
+    [EOF]
+    [exit status: 2]
+    ");
 }
 
 #[test]
@@ -203,5 +243,41 @@ fn test_file_search_conflicts() {
 
     // Doesn't list file if the pattern doesn't match
     let output = work_dir.run_jj(["file", "search", "--pattern=glob:*qux*"]);
+    insta::assert_snapshot!(output.normalize_backslash(), @"");
+}
+
+#[test]
+fn test_file_search_conflicts_binary() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    // Set up a conflict on a binary file: each parent has a different binary
+    // content, both matching `hit`.
+    work_dir.write_file("binfile", b"base\n");
+    work_dir.run_jj(["new"]).success();
+    work_dir.write_file("binfile", b"hit-A\0\n");
+    work_dir.run_jj(["new"]).success();
+    work_dir.write_file("binfile", b"hit-B\0\n");
+    work_dir.run_jj(["rebase", "-r=@", "-B=@-"]).success();
+
+    // Default: any binary add-side is treated as binary; a match collapses to
+    // `Binary file <path> matches`.
+    let output = work_dir.run_jj(["file", "search", "--pattern=hit"]);
+    insta::assert_snapshot!(output.normalize_backslash(), @"
+    Binary file binfile matches
+    [EOF]
+    ");
+    // --name-only on binary conflict prints just the path.
+    let output = work_dir.run_jj(["file", "search", "--name-only", "--pattern=hit"]);
+    insta::assert_snapshot!(output.normalize_backslash(), @"
+    binfile
+    [EOF]
+    ");
+    // -I skips binary conflicts entirely.
+    let output = work_dir.run_jj(["file", "search", "-I", "--pattern=hit"]);
+    insta::assert_snapshot!(output.normalize_backslash(), @"");
+    // No output when no side matches.
+    let output = work_dir.run_jj(["file", "search", "--pattern=nope"]);
     insta::assert_snapshot!(output.normalize_backslash(), @"");
 }


### PR DESCRIPTION
Follows up on #9740 (merged).

## Behavior

Mirrors `git grep`.

A file is considered binary if any of the first 8KB is `\0`.

- **Default**: match on a binary file emits `Binary file <path> matches` (no per-line output). `--name-only` still prints just the path.
- `-a` / `--text`: bypass the check; treat all files as text and emit raw bytes for matches.
- `-I` / `--no-binary`: skip binary files entirely, even if they contain matches.

`-a` and `-I` are mutually exclusive (clap-enforced).

The heuristic is a local inline check for now (`content.iter().take(8192).any(|b| *b == 0)`).
Will follow up with unifying with `jj_lib::eol::is_binary` and `lib/src/diff_presentation/mod.rs:71`.

**Conflicts**: if any add-side of a conflict looks binary, the whole file is treated as binary and follows the same three modes above. Per-side awareness is left as a follow-up alongside the existing conflict-side `TODO` in the code.

## Testing

- Match on binary file emits `Binary file <path> matches`.
- `--name-only` on binary match prints just the path.
- No output when the pattern doesn't match, even on binary.
- `-a` bypasses the check and emits raw bytes.
- `-I` skips binary files entirely.
- `-a` combined with `-I` errors out (clap-enforced).
- Binary conflict (any add-side has a null byte) emits `Binary file <path> matches`.
- `--name-only` on binary conflict prints just the path.
- `-I` on binary conflict skips it entirely.

## Not in scope

- Streaming file reads: the current code `read_all`s the whole file into memory before the 8KB binary probe runs, so `-I` doesn't save any I/O. A streaming reader could probe the first 8KB and short-circuit without reading the rest. Deferred to keep this PR small.
- Unifying `is_binary` across the codebase (`eol`, `diff_presentation`, and now this file).
- `.gitattributes` `binary`/`-text` support. Depends on a wider stack of `.gitattributes` PRs (#7164, #8144, #8266, #8719, #9635) that haven't landed.

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
