### PR TITLE
cli: ignore repeated consecutive executable names (jj jj jj ...)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Breaking changes
 
+* CLI argument parsing ignores all consecutive repetitions of the executable
+  name passed as arguments. For example, `jj jj jj` would previously pass
+  `jj jj` as first two arguments, now they are ignored. This breaks all
+  command aliases matching the name of the executable (aliases are simply
+  ignored/removed from the argument list).
+
 ### Deprecations
 
 ### New features

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -4406,7 +4406,25 @@ impl<'a> CliRunner<'a> {
             return handle_shell_completion(&Ui::null(), &self.app, &config, &cwd);
         }
 
-        let string_args = expand_args(ui, &self.app, env::args_os(), &config)?;
+        // Ignore consecutive repetition of the first argument (executable name).
+        // If executable name is repeated n-times consecutively, skip n-1 args.
+        let os_args = {
+            let argc = env::args_os().count();
+            let first = env::args_os().nth(0).unwrap();
+            let skip = env::args_os().position(|arg| arg != first).unwrap_or(argc) - 1;
+
+            if skip > 0 {
+                writeln!(
+                    ui.warning_default(),
+                    "Ignoring repeated consecutive '{}' passed as arguments.",
+                    first.to_str().unwrap_or("<executable name>")
+                )?;
+            }
+
+            env::args_os().skip(skip)
+        };
+
+        let string_args = expand_args(ui, &self.app, os_args, &config)?;
         let (args, config_layers) = parse_early_args(&self.app, &string_args)?;
         if !config_layers.is_empty() {
             raw_config.as_mut().extend_layers(config_layers);

--- a/cli/tests/runner.rs
+++ b/cli/tests/runner.rs
@@ -66,6 +66,7 @@ mod test_op_integrate_command;
 mod test_op_restore_command;
 mod test_op_revert_command;
 mod test_operations;
+mod test_os_args;
 mod test_parallelize_command;
 mod test_rebase_command;
 mod test_repo_change_report;

--- a/cli/tests/test_os_args.rs
+++ b/cli/tests/test_os_args.rs
@@ -1,0 +1,151 @@
+// Copyright 2026 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::common::TestEnvironment;
+
+#[test]
+fn test_os_args_repeated_consecutive() {
+    let test_env = TestEnvironment::default();
+    let jj_cmd = assert_cmd::cargo::cargo_bin!("jj")
+        .as_os_str()
+        .to_str()
+        .unwrap();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+    // Consecutive repetitions of `jj_cmd` should be coalesced into a single
+    // `jj_cmd`.
+    let output = work_dir.run_jj(&[jj_cmd, jj_cmd, jj_cmd, jj_cmd, "--help"]);
+    // We have to replace the whole line, instead of matching for `jj_cmd` and
+    // replacing it, because this fails on Windows.
+    let normalized_warning =
+        "Warning: Ignoring repeated consecutive '@@JJ_EXECUTABLE_NAME@@' passed as arguments.\n";
+    let output = output
+        .normalize_stdout_with(|s| s.split_inclusive('\n').take(7).collect())
+        .normalize_stderr_with(|s| {
+            s.lines()
+                .map(|l| {
+                    if l.starts_with("Warning: Ignoring repeated consecutive") {
+                        normalized_warning
+                    } else {
+                        l
+                    }
+                })
+                .collect()
+        });
+    insta::assert_snapshot!(output, @"
+    Jujutsu (An experimental VCS)
+
+    To get started, see the tutorial [`jj help -k tutorial`].
+
+    [`jj help -k tutorial`]: https://docs.jj-vcs.dev/latest/tutorial/
+
+    Usage: jj [OPTIONS] <COMMAND>
+    [EOF]
+    ------- stderr -------
+    Warning: Ignoring repeated consecutive '@@JJ_EXECUTABLE_NAME@@' passed as arguments.
+    [EOF]
+    ");
+}
+
+#[test]
+fn test_os_args_repeated_non_consecutive() {
+    let test_env = TestEnvironment::default();
+    let jj_cmd = assert_cmd::cargo::cargo_bin!("jj")
+        .as_os_str()
+        .to_str()
+        .unwrap();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+    // Make sure that default command is not --help.
+    test_env.add_config(r#"ui.default-command = "log""#);
+    // Only *consecutive* repetitions of `jj_cmd` should be coalesced,
+    // everything else passed as arguments.
+    let output = work_dir.run_jj(&[jj_cmd, jj_cmd, jj_cmd, "--help", jj_cmd]);
+    // We have to replace the whole line, instead of matching for `jj_cmd` and
+    // replacing it, because this fails on Windows.
+    let normalized_warning =
+        "Warning: Ignoring repeated consecutive '@@JJ_EXECUTABLE_NAME@@' passed as arguments.\n";
+    let output = output
+        .normalize_stdout_with(|s| s.split_inclusive('\n').take(7).collect())
+        .normalize_stderr_with(|s| {
+            s.lines()
+                .map(|l| {
+                    if l.starts_with("Warning: Ignoring repeated consecutive") {
+                        normalized_warning
+                    } else {
+                        l
+                    }
+                })
+                .collect()
+        });
+    insta::assert_snapshot!(output, @"
+    Jujutsu (An experimental VCS)
+
+    To get started, see the tutorial [`jj help -k tutorial`].
+
+    [`jj help -k tutorial`]: https://docs.jj-vcs.dev/latest/tutorial/
+
+    Usage: jj [OPTIONS] <COMMAND>
+    [EOF]
+    ------- stderr -------
+    Warning: Ignoring repeated consecutive '@@JJ_EXECUTABLE_NAME@@' passed as arguments.
+    [EOF]
+    ");
+}
+
+#[test]
+fn test_os_args_repeated_consecutive_no_cmd() {
+    let test_env = TestEnvironment::default();
+    let jj_cmd = assert_cmd::cargo::cargo_bin!("jj")
+        .as_os_str()
+        .to_str()
+        .unwrap();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+    // Make sure that default command is --help.
+    test_env.add_config(r#"ui.default-command = "--help""#);
+    // When there's only consecutive repeated `jj_cmd` this should be treated
+    // as a single `jj_cmd` and run the default command.
+    let output = work_dir.run_jj(&[jj_cmd, jj_cmd, jj_cmd, jj_cmd]);
+    // We have to replace the whole line, instead of matching for `jj_cmd` and
+    // replacing it, because this fails on Windows.
+    let normalized_warning =
+        "Warning: Ignoring repeated consecutive '@@JJ_EXECUTABLE_NAME@@' passed as arguments.\n";
+    let output = output
+        .normalize_stdout_with(|s| s.split_inclusive('\n').take(7).collect())
+        .normalize_stderr_with(|s| {
+            s.lines()
+                .map(|l| {
+                    if l.starts_with("Warning: Ignoring repeated consecutive") {
+                        normalized_warning
+                    } else {
+                        l
+                    }
+                })
+                .collect()
+        });
+    insta::assert_snapshot!(output, @"
+    Jujutsu (An experimental VCS)
+
+    To get started, see the tutorial [`jj help -k tutorial`].
+
+    [`jj help -k tutorial`]: https://docs.jj-vcs.dev/latest/tutorial/
+
+    Usage: jj [OPTIONS] <COMMAND>
+    [EOF]
+    ------- stderr -------
+    Warning: Ignoring repeated consecutive '@@JJ_EXECUTABLE_NAME@@' passed as arguments.
+    [EOF]
+    ");
+}


### PR DESCRIPTION
The typo of repeating the name of the executable (e.g. `jj jj`) is common and painful enough to  make people alias `jj` to `util exec jj` (see https://caiustheory.com/jj-jj-jj-jj-jj/ and https://lobste.rs/s/96kp1m/jj_jj_jj_jj_jj).

Make this a non-issue by simply ignoring any consecutive executable names repeated at the begining of the argument list. If the exec name is repated n times, simply skip the first n-1 arguments.

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.

No LLM was used for generating any of the code/prose.