### PR TITLE
cli: add test for default command set to alias

### DIFF
--- a/cli/tests/test_alias.rs
+++ b/cli/tests/test_alias.rs
@@ -468,3 +468,15 @@ fn test_aliases_overriding_friendly_errors() {
     [EOF]
     ");
 }
+
+#[test]
+fn test_default_command_is_alias() {
+    let test_env = TestEnvironment::default();
+    test_env.add_config(
+        r#"
+        ui.default-command = ["my-version"]
+        aliases.my-version = ["version"]
+        "#,
+    );
+    test_env.run_jj_in(".", [""; 0]).success();
+}


### PR DESCRIPTION
I wrote a patch that broke this, thankfully [caught by Yuya](https://github.com/jj-vcs/jj/pull/9738#issuecomment-4875724211).

- [n/a] I have updated `CHANGELOG.md`
- [n/a] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [n/a] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [n/a] No LLM was used in the creation of this PR.