### PR TITLE
copies: keep renames detected against multiple merge parents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   aliases that are simply repeated. For example, with the alias `jj = []`, the
   command `jj jj jj log` will resolve to `jj log` as expected.
 
+* `jj diff` and `jj status` no longer omit a rename or copy in a merge commit
+  when the renamed source is present in more than one parent. The identical copy
+  record reported for each parent was mistaken for a conflict and discarded.
+  [#9752](https://github.com/jj-vcs/jj/issues/9752)
+
 ## [0.43.0] - 2026-07-01
 
 ### Release highlights

--- a/cli/tests/test_diff_command.rs
+++ b/cli/tests/test_diff_command.rs
@@ -4089,3 +4089,32 @@ fn test_diff_revisions() {
     [EOF]
     ");
 }
+
+#[test]
+fn test_diff_rename_in_merge_commit() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    // A rename in a merge commit is detected once per parent. When the renamed
+    // source is present in more than one parent, the same copy record is reported
+    // for each, and those duplicates must not cancel each other out and drop the
+    // rename. https://github.com/jj-vcs/jj/issues/9752
+    work_dir.write_file("a.txt", "aaa\n");
+    work_dir.run_jj(["describe", "-m", "base"]).success();
+    work_dir.run_jj(["new", "-m", "first branch"]).success();
+    work_dir
+        .run_jj(["new", "@-", "-m", "second branch"])
+        .success();
+    // Merge both children of "base" (@-+); each holds a.txt, so the rename is
+    // detected against both parents.
+    work_dir.run_jj(["new", "@-+", "-m", "merge"]).success();
+    work_dir.remove_file("a.txt");
+    work_dir.write_file("b.txt", "aaa\n");
+
+    let output = work_dir.run_jj(["diff", "-s"]);
+    insta::assert_snapshot!(output, @"
+    R {a.txt => b.txt}
+    [EOF]
+    ");
+}

--- a/cli/tests/test_diffedit_command.rs
+++ b/cli/tests/test_diffedit_command.rs
@@ -710,7 +710,7 @@ fn test_diffedit_merge() -> TestResult {
     let output = work_dir.run_jj(["diff", "-r", "@-", "-s"]);
     insta::assert_snapshot!(output, @"
     M file1
-    A file3
+    C {file1 => file3}
     [EOF]
     ");
 

--- a/lib/src/copies.rs
+++ b/lib/src/copies.rs
@@ -65,6 +65,18 @@ impl CopyRecords {
     /// conflicts is discarded and treated as not having an origin.
     pub fn add_records(&mut self, copy_records: impl IntoIterator<Item = CopyRecord>) {
         for r in copy_records {
+            // The same copy or rename is reported once per parent when diffing a
+            // merge commit. Identical (source, target) pairs describe the same
+            // operation, so skip the duplicate instead of marking both maps as
+            // conflicting, which would otherwise drop the copy/rename entirely.
+            let is_duplicate = self
+                .targets
+                .get(&r.target)
+                .and_then(|&i| self.records.get(i))
+                .is_some_and(|existing| existing.source == r.source);
+            if is_duplicate {
+                continue;
+            }
             self.sources
                 .entry(r.source.clone())
                 // TODO: handle conflicts instead of ignoring both sides.


### PR DESCRIPTION
Fixes #9752.

`jj diff` (and `jj status`) on a merge commit could silently drop a rename or copy. In the issue's reproduction, a file renamed in a merge whose parents all hold the source shows up as a plain `A b.txt` with no `D a.txt`, instead of `R {a.txt => b.txt}`.

Cause: for a merge commit the diff command detects copies once per parent and feeds each parent's records into `CopyRecords::add_records`. When the same rename exists against more than one parent, the identical `(source, target)` record arrives multiple times. `add_records` interpreted the repeated target as a target with several different sources and set both the source and target map entries to an out of range index, which is how it marks a path as conflicting. After that, `for_target(b.txt)` returns `None` so the target renders as a plain addition, while `has_source(a.txt)` still returns true so the deletion entry is suppressed. The rename is lost from both sides.

Fix: skip a record whose `(source, target)` pair was already recorded, so a duplicate coming from another parent is no longer mistaken for a conflict. A genuine conflict, where one target has two different sources across parents, is still discarded exactly as before. Since the fix is in the shared `add_records`, `jj status` on a merge commit benefits too.

Regression test: `test_diff_rename_in_merge_commit` builds a merge of two branches that both contain the file and then renames it. `jj diff -s` prints `R {a.txt => b.txt}` with the fix and `A b.txt` without it. The full `test_diff_command` suite and the jj-lib copy tests pass, and clippy and fmt are clean.

Thanks @yuja for pointing at the relevant code in the issue thread.

**Update:** the existing `test_diffedit_merge` was asserting this same bug from the other direction. It makes a copy inside a merge commit and expected it to render as a plain `A file3`. With the fix it now shows `C {file1 => file3}`, which is exactly what the same edit produces against a single parent (verified with `jj debug copy-detection`). Full `jj-cli` and `jj-lib` suites pass (0 failures).
