### PR TITLE
diff: add function names to git hunk headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### New features
 
+* Git-format diff hunk headers now include nearby source symbols for many common
+  programming and markup languages.
+
 * New `merge_point()` revset function which (similar to `fork_point`) finds the
   point where multiple branches merge.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### New features
 
+* Git-format diff hunk headers now include nearby source symbols for many common
+  programming and markup languages.
+
 * `jj workspace add` supports `--colocate`/`--no-colocate` flags to control
   whether a Git worktree is created alongside the workspace. The default
   colocates when the current workspace is colocated and the `git.colocate`

--- a/cli/src/diff_util.rs
+++ b/cli/src/diff_util.rs
@@ -94,6 +94,8 @@ use crate::merge_tools::ExternalMergeTool;
 use crate::merge_tools::generate_diff;
 use crate::merge_tools::invoke_external_diff;
 use crate::merge_tools::new_utf8_temp_dir;
+use crate::source_symbol::SourceLanguage;
+use crate::source_symbol::find_source_symbols;
 use crate::templater::TemplateRenderer;
 use crate::text_util;
 use crate::ui::Ui;
@@ -1657,6 +1659,7 @@ impl UnifiedDiffOptions {
 
 fn show_unified_diff_hunks(
     formatter: &mut dyn Formatter,
+    language: Option<SourceLanguage>,
     contents: Diff<&BStr>,
     options: &UnifiedDiffOptions,
 ) -> io::Result<()> {
@@ -1675,8 +1678,23 @@ fn show_unified_diff_hunks(
         }
     }
 
-    for hunk in unified_diff_hunks(contents, options.context, options.line_diff.compare_mode) {
-        writeln!(
+    let hunks = unified_diff_hunks(contents, options.context, options.line_diff.compare_mode);
+    let before_symbols = language.map(|language| {
+        find_source_symbols(
+            language,
+            contents.before,
+            hunks.iter().map(|hunk| &hunk.left_line_range),
+        )
+    });
+    let after_symbols = language.map(|language| {
+        find_source_symbols(
+            language,
+            contents.after,
+            hunks.iter().map(|hunk| &hunk.right_line_range),
+        )
+    });
+    for (hunk_index, hunk) in hunks.into_iter().enumerate() {
+        write!(
             formatter.labeled("hunk_header"),
             "@@ -{},{} +{},{} @@",
             to_line_number(hunk.left_line_range.clone()),
@@ -1684,6 +1702,41 @@ fn show_unified_diff_hunks(
             to_line_number(hunk.right_line_range.clone()),
             hunk.right_line_range.len()
         )?;
+        // Prefer the new side, except for deletion-only hunks. Detect those
+        // from line types because context lines make the new-side range nonempty.
+        let has_added_lines = hunk
+            .lines
+            .iter()
+            .any(|(line_type, _)| *line_type == DiffLineType::Added);
+        let before_symbol = before_symbols
+            .as_ref()
+            .and_then(|symbols| symbols[hunk_index]);
+        let after_symbol = after_symbols
+            .as_ref()
+            .and_then(|symbols| symbols[hunk_index]);
+        let source_symbol = if !has_added_lines {
+            before_symbol.or(after_symbol)
+        } else {
+            after_symbol.or(before_symbol)
+        };
+        if let Some(source_symbol) = source_symbol {
+            // Match Git's byte limit for the source context appended to hunk
+            // headers.
+            const MAX_SOURCE_SYMBOL_LEN: usize = 80;
+            let mut end = source_symbol.len().min(MAX_SOURCE_SYMBOL_LEN);
+            // Don't split valid UTF-8 while enforcing the byte limit. Invalid
+            // source bytes are preserved, just like bytes in the diff body.
+            if let Ok(source_symbol) = str::from_utf8(source_symbol) {
+                while !source_symbol.is_char_boundary(end) {
+                    end -= 1;
+                }
+            }
+            write!(formatter.labeled("hunk_header"), " ")?;
+            formatter
+                .labeled("hunk_header")
+                .write_all(&source_symbol[..end])?;
+        }
+        writeln!(formatter.labeled("hunk_header"))?;
         for (line_type, tokens) in &hunk.lines {
             let (label, sigil) = match line_type {
                 DiffLineType::Context => ("context", " "),
@@ -1735,6 +1788,10 @@ pub async fn show_git_diff(
         let right_prefix = if options.show_path_prefix { "b/" } else { "" };
         let left_path_string = left_path.as_internal_file_string();
         let right_path_string = right_path.as_internal_file_string();
+        let language = right_path
+            .components()
+            .next_back()
+            .and_then(|name| SourceLanguage::from_file_name(name.as_internal_str()));
         let values = values?;
 
         let left_part = git_diff_part(left_path, values.before, &materialize_options).await?;
@@ -1804,6 +1861,7 @@ pub async fn show_git_diff(
             writeln!(formatter.labeled("file_header"), "+++ {right_path}")?;
             show_unified_diff_hunks(
                 formatter,
+                language,
                 Diff::new(&left_part.content.contents, &right_part.content.contents).map(BStr::new),
                 options,
             )?;
@@ -1838,7 +1896,7 @@ fn show_git_diff_texts<T: AsRef<[u8]>>(
             materialize_options,
         )),
     });
-    show_unified_diff_hunks(formatter, contents.as_ref().map(Cow::as_ref), options)
+    show_unified_diff_hunks(formatter, None, contents.as_ref().map(Cow::as_ref), options)
 }
 
 #[instrument(skip_all)]

--- a/cli/src/diff_util.rs
+++ b/cli/src/diff_util.rs
@@ -97,6 +97,8 @@ use crate::merge_tools::ExternalMergeTool;
 use crate::merge_tools::generate_diff;
 use crate::merge_tools::invoke_external_diff;
 use crate::merge_tools::new_utf8_temp_dir;
+use crate::source_symbol::SourceLanguage;
+use crate::source_symbol::SourceSymbolScanner;
 use crate::templater::TemplateRenderer;
 use crate::text_util;
 use crate::ui::Ui;
@@ -1666,6 +1668,7 @@ impl UnifiedDiffOptions {
 
 fn show_unified_diff_hunks(
     formatter: &mut dyn Formatter,
+    language: Option<SourceLanguage>,
     contents: Diff<&BStr>,
     options: &UnifiedDiffOptions,
 ) -> io::Result<()> {
@@ -1684,8 +1687,11 @@ fn show_unified_diff_hunks(
         }
     }
 
+    let before_symbols =
+        language.map(|language| SourceSymbolScanner::new(language, contents.before));
+    let after_symbols = language.map(|language| SourceSymbolScanner::new(language, contents.after));
     for hunk in unified_diff_hunks(contents, options.context, options.line_diff.compare_mode) {
-        writeln!(
+        write!(
             formatter.labeled("hunk_header"),
             "@@ -{},{} +{},{} @@",
             to_line_number(hunk.left_line_range.clone()),
@@ -1693,6 +1699,38 @@ fn show_unified_diff_hunks(
             to_line_number(hunk.right_line_range.clone()),
             hunk.right_line_range.len()
         )?;
+        // Prefer the new side, except for deletion-only hunks. Detect those
+        // from line types because context lines make the new-side range nonempty.
+        let has_added_lines = hunk
+            .lines
+            .iter()
+            .any(|(line_type, _)| *line_type == DiffLineType::Added);
+        let source_symbol = if !has_added_lines {
+            before_symbols
+                .as_ref()
+                .and_then(|scanner| scanner.find(&hunk.left_line_range))
+                .or_else(|| {
+                    after_symbols
+                        .as_ref()
+                        .and_then(|scanner| scanner.find(&hunk.right_line_range))
+                })
+        } else {
+            after_symbols
+                .as_ref()
+                .and_then(|scanner| scanner.find(&hunk.right_line_range))
+                .or_else(|| {
+                    before_symbols
+                        .as_ref()
+                        .and_then(|scanner| scanner.find(&hunk.left_line_range))
+                })
+        };
+        if let Some(source_symbol) = source_symbol {
+            write!(formatter.labeled("hunk_header"), " ")?;
+            formatter
+                .labeled("hunk_header")
+                .write_all(trim_source_symbol(source_symbol))?;
+        }
+        writeln!(formatter.labeled("hunk_header"))?;
         for (line_type, tokens) in &hunk.lines {
             let (label, sigil) = match line_type {
                 DiffLineType::Context => ("context", " "),
@@ -1708,6 +1746,20 @@ fn show_unified_diff_hunks(
         }
     }
     Ok(())
+}
+
+fn trim_source_symbol(source_symbol: &[u8]) -> &[u8] {
+    // Match Git's byte limit for the source context appended to hunk headers.
+    const MAX_SOURCE_SYMBOL_LEN: usize = 80;
+    let mut end = source_symbol.len().min(MAX_SOURCE_SYMBOL_LEN);
+    // Treat a consecutive run of non-ASCII bytes as one unit. If the limit
+    // splits a run, omit the whole run.
+    if source_symbol.get(end).is_some_and(|byte| *byte >= 0x80) {
+        while end > 0 && source_symbol[end - 1] >= 0x80 {
+            end -= 1;
+        }
+    }
+    &source_symbol[..end]
 }
 
 fn show_diff_line_tokens(
@@ -1744,6 +1796,10 @@ pub async fn show_git_diff(
         let right_prefix = if options.show_path_prefix { "b/" } else { "" };
         let left_path_string = left_path.as_internal_file_string();
         let right_path_string = right_path.as_internal_file_string();
+        let language = right_path
+            .components()
+            .next_back()
+            .and_then(|name| SourceLanguage::from_file_name(name.as_internal_str()));
         let values = values?;
 
         let left_part = git_diff_part(left_path, values.before, &materialize_options).await?;
@@ -1813,6 +1869,7 @@ pub async fn show_git_diff(
             writeln!(formatter.labeled("file_header"), "+++ {right_path}")?;
             show_unified_diff_hunks(
                 formatter,
+                language,
                 Diff::new(&left_part.content.contents, &right_part.content.contents).map(BStr::new),
                 options,
             )?;
@@ -1847,7 +1904,7 @@ fn show_git_diff_texts<T: AsRef<[u8]>>(
             materialize_options,
         )),
     });
-    show_unified_diff_hunks(formatter, contents.as_ref().map(Cow::as_ref), options)
+    show_unified_diff_hunks(formatter, None, contents.as_ref().map(Cow::as_ref), options)
 }
 
 #[instrument(skip_all)]

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -49,6 +49,7 @@ pub mod movement_util;
 pub mod operation_templater;
 mod progress;
 pub mod revset_util;
+mod source_symbol;
 pub mod template_builder;
 pub mod template_parser;
 pub mod templater;

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -34,6 +34,7 @@ pub mod movement_util;
 pub mod operation_templater;
 mod progress;
 pub mod revset_util;
+mod source_symbol;
 pub mod template_builder;
 pub mod template_parser;
 pub mod templater;

--- a/cli/src/source_symbol.rs
+++ b/cli/src/source_symbol.rs
@@ -1,0 +1,823 @@
+// Copyright 2026 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::ops::Range;
+use std::sync::LazyLock;
+
+use bstr::BStr;
+use regex::bytes::Regex;
+
+// Built-in source symbol patterns for common languages. This stop-gap only
+// selects patterns from common file names/extensions.
+// TODO: Replace this with gix support once available, including
+// .gitattributes-based driver selection and custom hunk-header regexes.
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum SourceLanguage {
+    BibTeX,
+    CLike,
+    CSharp,
+    Dts,
+    Elixir,
+    Go,
+    Html,
+    Ini,
+    Java,
+    JavaScript,
+    Kotlin,
+    Markdown,
+    Matlab,
+    MatlabOrObjC,
+    ObjC,
+    CLikeOrObjC,
+    Pascal,
+    Perl,
+    Php,
+    Python,
+    R,
+    Ruby,
+    Rust,
+    Scheme,
+    Shell,
+    Tex,
+}
+
+impl SourceLanguage {
+    pub(crate) fn from_file_name(file_name: &str) -> Option<Self> {
+        let extension = file_name.rsplit_once('.').map(|(_, extension)| extension);
+        match extension {
+            Some("bib") => Some(Self::BibTeX),
+            Some("c" | "cc" | "cpp" | "cxx" | "hh" | "hpp" | "hxx") => Some(Self::CLike),
+            Some("h") => Some(Self::CLikeOrObjC),
+            Some("cs") => Some(Self::CSharp),
+            Some("dts" | "dtsi") => Some(Self::Dts),
+            Some("ex" | "exs") => Some(Self::Elixir),
+            Some("go") => Some(Self::Go),
+            Some("htm" | "html" | "xhtml") => Some(Self::Html),
+            Some("cfg" | "conf" | "config" | "ini") => Some(Self::Ini),
+            Some("java") => Some(Self::Java),
+            Some("js" | "jsx" | "mjs" | "cjs" | "ts" | "tsx") => Some(Self::JavaScript),
+            Some("kt" | "kts") => Some(Self::Kotlin),
+            Some("markdown" | "md" | "mdown") => Some(Self::Markdown),
+            // `.m` is shared by MATLAB and Objective-C. Objective-C++ `.mm`
+            // and Objective-C headers can also contain ordinary C-like symbols.
+            Some("m") => Some(Self::MatlabOrObjC),
+            Some("matlab") => Some(Self::Matlab),
+            Some("mm") => Some(Self::CLikeOrObjC),
+            Some("p" | "pas") => Some(Self::Pascal),
+            Some("pl" | "pm" | "pod" | "psgi" | "t") => Some(Self::Perl),
+            Some("php" | "php3" | "php4" | "php5" | "phtml") => Some(Self::Php),
+            Some("py" | "pyw") => Some(Self::Python),
+            Some("r" | "R") => Some(Self::R),
+            Some("rb" | "rake" | "gemspec") => Some(Self::Ruby),
+            Some("rs") => Some(Self::Rust),
+            Some("scm" | "scheme" | "ss" | "lisp" | "lsp") => Some(Self::Scheme),
+            Some("sh" | "bash" | "zsh" | "fish") => Some(Self::Shell),
+            Some("tex" | "ltx" | "latex") => Some(Self::Tex),
+            _ => match file_name {
+                "Gemfile" | "Rakefile" => Some(Self::Ruby),
+                _ => None,
+            },
+        }
+    }
+
+    fn is_source_symbol(self, line: &[u8]) -> bool {
+        static BIBTEX_FUNCTION_RE: LazyLock<Regex> = LazyLock::new(|| {
+            Regex::new(r#"^@[A-Za-z]+[ \t]*\{?[ \t]*[^ \t"@',\\#}{~%]*"#).unwrap()
+        });
+        static C_LIKE_FUNCTION_RE: LazyLock<Regex> = LazyLock::new(|| {
+            Regex::new(
+                r"^(?:[A-Za-z_][\w:<>,~]*|[*&]|\[[^\]]*\]|\s+)+[A-Za-z_~][\w:~]*\s*\([^;{}]*",
+            )
+            .unwrap()
+        });
+        static CSHARP_FUNCTION_RE: LazyLock<Regex> = LazyLock::new(|| {
+            Regex::new(
+                r"^(?:(?:[\w@_.]+(?:<[\w@_, \t<>]+>)?)(?:\s+[\w@_.]+(?:<[\w@_, \t<>]+>)?)+\s*\([^;]*|(?:(?:static|public|internal|private|protected|new|unsafe|sealed|abstract|partial)\s+)*(?:class|enum|interface|struct|record)\s+.*|namespace\s+.*)$",
+            )
+            .unwrap()
+        });
+        static DTS_FUNCTION_RE: LazyLock<Regex> =
+            LazyLock::new(|| Regex::new(r"^(?:/[ \t]*\{|&?[A-Za-z_].*)").unwrap());
+        static ELIXIR_FUNCTION_RE: LazyLock<Regex> = LazyLock::new(|| {
+            Regex::new(r"^(?:def(?:macro|module|impl|protocol|p)?|test)\s+.*").unwrap()
+        });
+        static GO_FUNCTION_RE: LazyLock<Regex> = LazyLock::new(|| {
+            Regex::new(r"^(?:func\s*.*(?:\{\s*)?|type\s+.*(?:struct|interface)\s*(?:\{\s*)?)$")
+                .unwrap()
+        });
+        static HTML_FUNCTION_RE: LazyLock<Regex> =
+            LazyLock::new(|| Regex::new(r"^<[Hh][1-6](?:\s.*)?>.*").unwrap());
+        static INI_FUNCTION_RE: LazyLock<Regex> =
+            LazyLock::new(|| Regex::new(r"^\[[^]]+\]").unwrap());
+        static JAVA_FUNCTION_RE: LazyLock<Regex> = LazyLock::new(|| {
+            Regex::new(
+                r"^(?:(?:[a-z-]+\s+)*(?:class|enum|interface|record)\s+.*|(?:[A-Za-z_<>&][\]?&<>.,A-Za-z_0-9]*\s+)+[A-Za-z_][A-Za-z_0-9]*\s*\([^;]*)$",
+            )
+            .unwrap()
+        });
+        static JAVASCRIPT_FUNCTION_RE: LazyLock<Regex> = LazyLock::new(|| {
+            Regex::new(
+                r"^(?:(?:export|default|async|static|get|set)\s+)*(?:function\b|class\b|[A-Za-z_$][\w$]*\s*\([^)]*\)\s*\{|[A-Za-z_$][\w$]*\s*[:=]\s*(?:async\s*)?(?:function\b|\([^)]*\)\s*=>))",
+            )
+            .unwrap()
+        });
+        static KOTLIN_FUNCTION_RE: LazyLock<Regex> =
+            LazyLock::new(|| Regex::new(r"^(?:[a-z]+\s+)*(?:fun|class|interface)\s+.*").unwrap());
+        static MARKDOWN_FUNCTION_RE: LazyLock<Regex> =
+            LazyLock::new(|| Regex::new(r"^#{1,6}\s+.*").unwrap());
+        static MATLAB_FUNCTION_RE: LazyLock<Regex> = LazyLock::new(|| {
+            Regex::new(r"^(?:(?:classdef|function)\s+.*|(?:%%%?|##)\s+.*)$").unwrap()
+        });
+        static OBJC_FUNCTION_RE: LazyLock<Regex> = LazyLock::new(|| {
+            Regex::new(
+                r"^(?:[-+]\s*\(\s*[A-Za-z_][A-Za-z_0-9* \t]*\)\s*[A-Za-z_].*|(?:[A-Za-z_][A-Za-z_0-9]*\s+)+[A-Za-z_][A-Za-z_0-9]*\s*\([^;]*|@(?:implementation|interface|protocol)\s+.*)$",
+            )
+            .unwrap()
+        });
+        static PASCAL_FUNCTION_RE: LazyLock<Regex> = LazyLock::new(|| {
+            Regex::new(
+                r"^(?:(?:(?:class\s+)?(?:procedure|function)|constructor|destructor|interface|implementation|initialization|finalization)\s*.*|.*=\s*(?:class|record).*)$",
+            )
+            .unwrap()
+        });
+        static PERL_FUNCTION_RE: LazyLock<Regex> = LazyLock::new(|| {
+            Regex::new(
+                r"^(?:package .*|sub [[:alnum:]_':]+[ \t]*(?:\([^)]*\)[ \t]*)?(?::[^;#]*)?(?:\{[ \t]*)?(?:#.*)?|(?:BEGIN|END|INIT|CHECK|UNITCHECK|AUTOLOAD|DESTROY)[ \t]*(?:\{[ \t]*)?(?:#.*)?|=head[0-9] .*)$",
+            )
+            .unwrap()
+        });
+        static PHP_FUNCTION_RE: LazyLock<Regex> = LazyLock::new(|| {
+            Regex::new(
+                r"^(?:(?:(?:public|protected|private|static|abstract|final)\s+)*function.*|(?:(?:(?:final|abstract)\s+)?class|enum|interface|trait).*)$",
+            )
+            .unwrap()
+        });
+        static PYTHON_FUNCTION_RE: LazyLock<Regex> =
+            LazyLock::new(|| Regex::new(r"^(?:async\s+def|def|class)\s+\w+").unwrap());
+        static R_FUNCTION_RE: LazyLock<Regex> = LazyLock::new(|| {
+            Regex::new(r"^[A-Za-z][A-Za-z0-9_.]*\s*(?:<-|=)\s*function.*$").unwrap()
+        });
+        static RUBY_FUNCTION_RE: LazyLock<Regex> =
+            LazyLock::new(|| Regex::new(r"^(?:class|module|def)\s+.*").unwrap());
+        static RUST_FUNCTION_RE: LazyLock<Regex> = LazyLock::new(|| {
+            Regex::new(
+                r#"^(?:(?:pub(?:\([^)]*\))?|const|async|unsafe|extern(?:\s+"[^"]+")?)\s+)*(?:(?:fn|struct|enum|impl|trait|mod|type|union)\b|macro_rules!\s*)"#,
+            )
+            .unwrap()
+        });
+        static SCHEME_FUNCTION_RE: LazyLock<Regex> = LazyLock::new(|| {
+            Regex::new(
+                r"^(?:\((?:(?:define|def(?:struct|syntax|class|method|rules|record|proto|alias)?)[-*/ \t]|(?:library|module|struct|class)[*+ \t]).*|[Dd][Ee][Ff].*)$",
+            )
+            .unwrap()
+        });
+        static SHELL_FUNCTION_RE: LazyLock<Regex> = LazyLock::new(|| {
+            Regex::new(
+                r"^(?:[A-Za-z_][A-Za-z0-9_]*\s*\(\s*\)|function\s+[A-Za-z_][A-Za-z0-9_]*(?:(?:\s*\(\s*\))|\s+)).*$",
+            )
+            .unwrap()
+        });
+        static TEX_FUNCTION_RE: LazyLock<Regex> =
+            LazyLock::new(|| Regex::new(r"^\\(?:(?:sub)*section|chapter|part)\*?\{.*").unwrap());
+
+        match self {
+            Self::BibTeX => BIBTEX_FUNCTION_RE.is_match(line),
+            Self::CLike => {
+                let before_paren = line.split(|byte| *byte == b'(').next().unwrap_or(line);
+                !line.first().is_some_and(u8::is_ascii_whitespace)
+                    && !before_paren.windows(2).any(|window| window == b": ")
+                    && !starts_with_keyword(line, &["do", "for", "if", "switch", "while"])
+                    && C_LIKE_FUNCTION_RE.is_match(line)
+            }
+            Self::CSharp => {
+                !starts_with_keyword(
+                    line,
+                    &[
+                        "do", "while", "for", "foreach", "if", "else", "new", "default", "return",
+                        "switch", "case", "throw", "catch", "using", "lock", "fixed",
+                    ],
+                ) && CSHARP_FUNCTION_RE.is_match(line)
+            }
+            Self::Dts => {
+                !line.contains(&b';') && !line.contains(&b'=') && DTS_FUNCTION_RE.is_match(line)
+            }
+            Self::Elixir => ELIXIR_FUNCTION_RE.is_match(line),
+            Self::Go => GO_FUNCTION_RE.is_match(line),
+            Self::Html => HTML_FUNCTION_RE.is_match(line),
+            Self::Ini => INI_FUNCTION_RE.is_match(line),
+            Self::Java => {
+                !starts_with_keyword(
+                    line,
+                    &[
+                        "catch",
+                        "do",
+                        "for",
+                        "if",
+                        "instanceof",
+                        "new",
+                        "return",
+                        "switch",
+                        "throw",
+                        "while",
+                    ],
+                ) && JAVA_FUNCTION_RE.is_match(line)
+            }
+            Self::JavaScript => {
+                !starts_with_keyword(line, &["catch", "for", "if", "switch", "while", "with"])
+                    && JAVASCRIPT_FUNCTION_RE.is_match(line)
+            }
+            Self::Kotlin => KOTLIN_FUNCTION_RE.is_match(line),
+            Self::Markdown => MARKDOWN_FUNCTION_RE.is_match(line),
+            Self::Matlab => MATLAB_FUNCTION_RE.is_match(line),
+            Self::MatlabOrObjC => {
+                Self::Matlab.is_source_symbol(line) || Self::ObjC.is_source_symbol(line)
+            }
+            Self::ObjC => {
+                !starts_with_keyword(
+                    line,
+                    &["do", "for", "if", "else", "return", "switch", "while"],
+                ) && OBJC_FUNCTION_RE.is_match(line)
+            }
+            Self::CLikeOrObjC => {
+                Self::CLike.is_source_symbol(line) || Self::ObjC.is_source_symbol(trim_line(line))
+            }
+            Self::Pascal => PASCAL_FUNCTION_RE.is_match(line),
+            Self::Perl => PERL_FUNCTION_RE.is_match(line),
+            Self::Php => PHP_FUNCTION_RE.is_match(line),
+            Self::Python => PYTHON_FUNCTION_RE.is_match(line),
+            Self::R => R_FUNCTION_RE.is_match(line),
+            Self::Ruby => RUBY_FUNCTION_RE.is_match(line),
+            Self::Rust => RUST_FUNCTION_RE.is_match(line),
+            Self::Scheme => SCHEME_FUNCTION_RE.is_match(line),
+            Self::Shell => SHELL_FUNCTION_RE.is_match(line),
+            Self::Tex => TEX_FUNCTION_RE.is_match(line),
+        }
+    }
+}
+
+fn starts_with_keyword(line: &[u8], keywords: &[&str]) -> bool {
+    keywords.iter().any(|keyword| {
+        let keyword = keyword.as_bytes();
+        line.starts_with(keyword)
+            && line
+                .get(keyword.len())
+                .is_none_or(|byte| byte.is_ascii_whitespace() || matches!(byte, b'(' | b'{' | b';'))
+    })
+}
+
+fn strip_line_ending(line: &[u8]) -> &[u8] {
+    let line = line.strip_suffix(b"\n").unwrap_or(line);
+    line.strip_suffix(b"\r").unwrap_or(line)
+}
+
+fn trim_line(line: &[u8]) -> &[u8] {
+    strip_line_ending(line).trim_ascii()
+}
+
+fn has_unescaped_closing_single_quote(line: &[u8], start: usize) -> bool {
+    let mut escaped = false;
+    for byte in &line[start + 1..] {
+        if escaped {
+            escaped = false;
+        } else if *byte == b'\\' {
+            escaped = true;
+        } else if *byte == b'\'' {
+            return true;
+        }
+    }
+    false
+}
+
+fn update_c_style_block_comment_state(line: &[u8], in_block_comment: &mut bool) {
+    let mut quote = None;
+    let mut escaped = false;
+    let mut index = 0;
+    while index < line.len() {
+        if *in_block_comment {
+            if line.get(index..index + 2) == Some(b"*/") {
+                *in_block_comment = false;
+                index += 2;
+            } else {
+                index += 1;
+            }
+        } else if let Some(expected_quote) = quote {
+            let byte = line[index];
+            if escaped {
+                escaped = false;
+            } else if byte == b'\\' {
+                escaped = true;
+            } else if byte == expected_quote {
+                quote = None;
+            }
+            index += 1;
+        } else {
+            match line.get(index..index + 2) {
+                Some(b"/*") => {
+                    *in_block_comment = true;
+                    index += 2;
+                }
+                Some(b"//") => break,
+                _ => {
+                    if matches!(line[index], b'"' | b'`')
+                        || (line[index] == b'\'' && has_unescaped_closing_single_quote(line, index))
+                    {
+                        quote = Some(line[index]);
+                    }
+                    index += 1;
+                }
+            }
+        }
+    }
+}
+
+fn is_c_style_comment_line(line: &[u8], in_block_comment: &mut bool) -> bool {
+    let is_comment = *in_block_comment
+        || line.starts_with(b"/*")
+        || line.starts_with(b"//")
+        || line.starts_with(b"*");
+    update_c_style_block_comment_state(line, in_block_comment);
+    is_comment
+}
+
+fn is_comment_line(line: &[u8], language: SourceLanguage, in_block_comment: &mut bool) -> bool {
+    match language {
+        SourceLanguage::CLike
+        | SourceLanguage::CLikeOrObjC
+        | SourceLanguage::CSharp
+        | SourceLanguage::Go
+        | SourceLanguage::Java
+        | SourceLanguage::JavaScript
+        | SourceLanguage::Kotlin
+        | SourceLanguage::ObjC
+        | SourceLanguage::Php
+        | SourceLanguage::Rust => is_c_style_comment_line(line, in_block_comment),
+        SourceLanguage::MatlabOrObjC => is_c_style_comment_line(line, in_block_comment),
+        SourceLanguage::Elixir
+        | SourceLanguage::Perl
+        | SourceLanguage::Python
+        | SourceLanguage::R
+        | SourceLanguage::Ruby
+        | SourceLanguage::Shell => line.starts_with(b"#"),
+        SourceLanguage::Tex => line.starts_with(b"%"),
+        SourceLanguage::BibTeX
+        | SourceLanguage::Dts
+        | SourceLanguage::Html
+        | SourceLanguage::Ini
+        | SourceLanguage::Markdown
+        | SourceLanguage::Matlab
+        | SourceLanguage::Pascal
+        | SourceLanguage::Scheme => false,
+    }
+}
+
+fn source_symbols(
+    content: &BStr,
+    language: SourceLanguage,
+) -> impl Iterator<Item = (usize, &[u8])> {
+    let mut in_block_comment = false;
+    content
+        .split_inclusive(|byte| *byte == b'\n')
+        .enumerate()
+        .filter_map(move |(line_number, line)| {
+            let line = strip_line_ending(line);
+            let trimmed_line = trim_line(line);
+            let line_to_match = match language {
+                // C function definitions/prototypes are top-level. Keep leading
+                // whitespace so indented calls/control flow inside a function don't
+                // become source symbols.
+                SourceLanguage::CLike | SourceLanguage::CLikeOrObjC => line,
+                _ => trimmed_line,
+            };
+            (!is_comment_line(trimmed_line, language, &mut in_block_comment)
+                && language.is_source_symbol(line_to_match))
+            .then_some((line_number, trimmed_line))
+        })
+}
+
+/// Finds source symbols near sorted, non-overlapping line ranges in one version
+/// of a file.
+///
+/// The content is scanned once and only one result per range is retained. For
+/// each range, the closest preceding symbol (including the range's first line)
+/// is selected. If there is no preceding symbol, the first symbol in the range
+/// is selected, which is useful for newly-added sections.
+pub(crate) fn find_source_symbols<'a, 'range>(
+    language: SourceLanguage,
+    content: &'a BStr,
+    line_ranges: impl IntoIterator<Item = &'range Range<usize>>,
+) -> Vec<Option<&'a [u8]>> {
+    let mut symbols = source_symbols(content, language).peekable();
+    let mut preceding_symbol = None;
+    let mut previous_range_end = None;
+
+    line_ranges
+        .into_iter()
+        .map(|line_range| {
+            debug_assert!(
+                previous_range_end.is_none_or(|end| end <= line_range.start),
+                "line ranges must be sorted and non-overlapping"
+            );
+            previous_range_end = Some(line_range.end);
+
+            while symbols.peek().is_some_and(|(line, _)| {
+                if line_range.is_empty() {
+                    *line < line_range.start
+                } else {
+                    *line <= line_range.start
+                }
+            }) {
+                let (_, symbol) = symbols.next().unwrap();
+                preceding_symbol = Some(symbol);
+            }
+            if preceding_symbol.is_some() {
+                return preceding_symbol;
+            }
+
+            let first_in_range = symbols
+                .peek()
+                .filter(|(line, _)| *line < line_range.end)
+                .copied();
+            if first_in_range.is_some() {
+                let (_, symbol) = symbols.next().unwrap();
+                preceding_symbol = Some(symbol);
+            }
+            first_in_range.map(|(_, symbol)| symbol)
+        })
+        .collect()
+}
+
+#[cfg(test)]
+fn collect_source_symbols(content: &BStr, language: SourceLanguage) -> Vec<(usize, &[u8])> {
+    source_symbols(content, language).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_source_symbol_patterns() {
+        let samples: &[(SourceLanguage, &[&str])] = &[
+            (
+                SourceLanguage::BibTeX,
+                &[
+                    "@article{example,",
+                    "@string { name = value }",
+                    "plain text",
+                ],
+            ),
+            (
+                SourceLanguage::CLike,
+                &[
+                    "static int example(int value)",
+                    "void *pointer(void)",
+                    "    call(value)",
+                    "if (condition)",
+                    "label: call()",
+                ],
+            ),
+            (
+                SourceLanguage::CSharp,
+                &[
+                    "public class Example",
+                    "namespace Example.Core",
+                    "public async Task<int> Run(int value)",
+                    "if (condition)",
+                ],
+            ),
+            (
+                SourceLanguage::Dts,
+                &["/ {", "device_node {", "property = <1>;"],
+            ),
+            (
+                SourceLanguage::Elixir,
+                &["defmodule Example do", "defp run(value) do", "if ready do"],
+            ),
+            (
+                SourceLanguage::Go,
+                &[
+                    "func Example(value int) int {",
+                    "type Example struct {",
+                    "var example = func() {}",
+                ],
+            ),
+            (
+                SourceLanguage::Html,
+                &[
+                    "<h2 class=\"title\">Example</h2>",
+                    "<H1>Title</H1>",
+                    "<p>text</p>",
+                ],
+            ),
+            (
+                SourceLanguage::Ini,
+                &["[section]", "[section.subsection] value", "key = value"],
+            ),
+            (
+                SourceLanguage::Java,
+                &[
+                    "public class Example",
+                    "public static String run(int value)",
+                    "if (condition)",
+                ],
+            ),
+            (
+                SourceLanguage::JavaScript,
+                &[
+                    "export async function example() {",
+                    "class Example {",
+                    "handler = async (event) => {",
+                    "if (condition) {",
+                ],
+            ),
+            (
+                SourceLanguage::Kotlin,
+                &[
+                    "public fun example(value: Int)",
+                    "data class Example",
+                    "if (condition)",
+                ],
+            ),
+            (
+                SourceLanguage::Markdown,
+                &["# Title", "###### Detail", "plain text", "#missing-space"],
+            ),
+            (
+                SourceLanguage::Matlab,
+                &[
+                    "function y = example(x)",
+                    "classdef Example",
+                    "%% Section",
+                    "y = x + 1;",
+                ],
+            ),
+            (
+                SourceLanguage::ObjC,
+                &[
+                    "- (void)example:(id)value",
+                    "@interface Example : NSObject",
+                    "if (condition)",
+                ],
+            ),
+            (
+                SourceLanguage::Pascal,
+                &[
+                    "function Example(Value: Integer): Integer;",
+                    "TExample = class(TObject)",
+                    "var Value: Integer;",
+                ],
+            ),
+            (
+                SourceLanguage::Perl,
+                &[
+                    "package Example;",
+                    "sub example : prototype($) {",
+                    "BEGIN {",
+                    "=head1 Documentation",
+                    "my $value = 1;",
+                ],
+            ),
+            (
+                SourceLanguage::Php,
+                &[
+                    "public static function example($value) {",
+                    "final class Example {",
+                    "if ($condition) {",
+                ],
+            ),
+            (
+                SourceLanguage::Python,
+                &[
+                    "async def example(value):",
+                    "class Example:",
+                    "if condition:",
+                ],
+            ),
+            (
+                SourceLanguage::R,
+                &[
+                    "example <- function(value) {",
+                    "example.name = function(value) {",
+                    "if (condition) {",
+                ],
+            ),
+            (
+                SourceLanguage::Ruby,
+                &["module Example", "def example(value)", "if condition"],
+            ),
+            (
+                SourceLanguage::Rust,
+                &[
+                    "pub(crate) async fn example(value: i32) -> i32 {",
+                    "impl<T> Example<T> {",
+                    "macro_rules! example {",
+                    "if condition {",
+                ],
+            ),
+            (
+                SourceLanguage::Scheme,
+                &[
+                    "(define (example value)",
+                    "(module example scheme",
+                    "(display value)",
+                    "display value",
+                ],
+            ),
+            (
+                SourceLanguage::Shell,
+                &["example() {", "function example {", "if condition; then"],
+            ),
+            (
+                SourceLanguage::Tex,
+                &[
+                    "\\section{Example}",
+                    "\\subsubsection*{Detail}",
+                    "plain text",
+                ],
+            ),
+        ];
+
+        let results = samples
+            .iter()
+            .flat_map(|(language, lines)| {
+                lines.iter().map(move |line| {
+                    format!(
+                        "{language:?}: {:?} = {}",
+                        BStr::new(line),
+                        language.is_source_symbol(line.as_bytes())
+                    )
+                })
+            })
+            .collect::<Vec<_>>();
+        insta::assert_debug_snapshot!(results, @r#######"
+        [
+            "BibTeX: \"@article{example,\" = true",
+            "BibTeX: \"@string { name = value }\" = true",
+            "BibTeX: \"plain text\" = false",
+            "CLike: \"static int example(int value)\" = true",
+            "CLike: \"void *pointer(void)\" = true",
+            "CLike: \"    call(value)\" = false",
+            "CLike: \"if (condition)\" = false",
+            "CLike: \"label: call()\" = false",
+            "CSharp: \"public class Example\" = true",
+            "CSharp: \"namespace Example.Core\" = true",
+            "CSharp: \"public async Task<int> Run(int value)\" = true",
+            "CSharp: \"if (condition)\" = false",
+            "Dts: \"/ {\" = true",
+            "Dts: \"device_node {\" = true",
+            "Dts: \"property = <1>;\" = false",
+            "Elixir: \"defmodule Example do\" = true",
+            "Elixir: \"defp run(value) do\" = true",
+            "Elixir: \"if ready do\" = false",
+            "Go: \"func Example(value int) int {\" = true",
+            "Go: \"type Example struct {\" = true",
+            "Go: \"var example = func() {}\" = false",
+            "Html: \"<h2 class=\\\"title\\\">Example</h2>\" = true",
+            "Html: \"<H1>Title</H1>\" = true",
+            "Html: \"<p>text</p>\" = false",
+            "Ini: \"[section]\" = true",
+            "Ini: \"[section.subsection] value\" = true",
+            "Ini: \"key = value\" = false",
+            "Java: \"public class Example\" = true",
+            "Java: \"public static String run(int value)\" = true",
+            "Java: \"if (condition)\" = false",
+            "JavaScript: \"export async function example() {\" = true",
+            "JavaScript: \"class Example {\" = true",
+            "JavaScript: \"handler = async (event) => {\" = true",
+            "JavaScript: \"if (condition) {\" = false",
+            "Kotlin: \"public fun example(value: Int)\" = true",
+            "Kotlin: \"data class Example\" = true",
+            "Kotlin: \"if (condition)\" = false",
+            "Markdown: \"# Title\" = true",
+            "Markdown: \"###### Detail\" = true",
+            "Markdown: \"plain text\" = false",
+            "Markdown: \"#missing-space\" = false",
+            "Matlab: \"function y = example(x)\" = true",
+            "Matlab: \"classdef Example\" = true",
+            "Matlab: \"%% Section\" = true",
+            "Matlab: \"y = x + 1;\" = false",
+            "ObjC: \"- (void)example:(id)value\" = true",
+            "ObjC: \"@interface Example : NSObject\" = true",
+            "ObjC: \"if (condition)\" = false",
+            "Pascal: \"function Example(Value: Integer): Integer;\" = true",
+            "Pascal: \"TExample = class(TObject)\" = true",
+            "Pascal: \"var Value: Integer;\" = false",
+            "Perl: \"package Example;\" = true",
+            "Perl: \"sub example : prototype($) {\" = true",
+            "Perl: \"BEGIN {\" = true",
+            "Perl: \"=head1 Documentation\" = true",
+            "Perl: \"my $value = 1;\" = false",
+            "Php: \"public static function example($value) {\" = true",
+            "Php: \"final class Example {\" = true",
+            "Php: \"if ($condition) {\" = false",
+            "Python: \"async def example(value):\" = true",
+            "Python: \"class Example:\" = true",
+            "Python: \"if condition:\" = false",
+            "R: \"example <- function(value) {\" = true",
+            "R: \"example.name = function(value) {\" = true",
+            "R: \"if (condition) {\" = false",
+            "Ruby: \"module Example\" = true",
+            "Ruby: \"def example(value)\" = true",
+            "Ruby: \"if condition\" = false",
+            "Rust: \"pub(crate) async fn example(value: i32) -> i32 {\" = true",
+            "Rust: \"impl<T> Example<T> {\" = true",
+            "Rust: \"macro_rules! example {\" = true",
+            "Rust: \"if condition {\" = false",
+            "Scheme: \"(define (example value)\" = true",
+            "Scheme: \"(module example scheme\" = true",
+            "Scheme: \"(display value)\" = false",
+            "Scheme: \"display value\" = false",
+            "Shell: \"example() {\" = true",
+            "Shell: \"function example {\" = true",
+            "Shell: \"if condition; then\" = false",
+            "Tex: \"\\\\section{Example}\" = true",
+            "Tex: \"\\\\subsubsection*{Detail}\" = true",
+            "Tex: \"plain text\" = false",
+        ]
+        "#######);
+    }
+
+    #[test]
+    fn test_collect_source_symbols_ignores_c_comments_and_indentation() {
+        let content = BStr::new(
+            b"void outer(void)\n/*\n * misleading(comment)\n */\n    call(value);\nint value = 0; /* starts mid-line\nint also_misleading(comment)\n*/\nconst char *text = \"/* not a comment */\";\nextern int actual(int value);\n",
+        );
+        let symbols = collect_source_symbols(content, SourceLanguage::CLike)
+            .into_iter()
+            .map(|(line, symbol)| (line, BStr::new(symbol)))
+            .collect::<Vec<_>>();
+        insta::assert_debug_snapshot!(symbols, @r#"
+        [
+            (
+                0,
+                "void outer(void)",
+            ),
+            (
+                9,
+                "extern int actual(int value);",
+            ),
+        ]
+        "#);
+    }
+
+    #[test]
+    fn test_find_source_symbols_uses_first_symbol_in_range() {
+        let content = BStr::new(b"preamble\n\nfn first() {\n}\n\nfn second() {\n}\n");
+        let line_range = 1..7;
+
+        assert_eq!(
+            find_source_symbols(
+                SourceLanguage::Rust,
+                content,
+                std::slice::from_ref(&line_range),
+            ),
+            vec![Some(&b"fn first() {"[..])]
+        );
+    }
+
+    #[test]
+    fn test_collect_source_symbols_tracks_comments_after_rust_lifetimes() {
+        let symbols = collect_source_symbols(
+            BStr::new(b"fn outer<'a>() { /*\nfn misleading() {}\n*/\n    changed();\n}\n"),
+            SourceLanguage::Rust,
+        );
+
+        assert_eq!(symbols, vec![(0, &b"fn outer<'a>() { /*"[..])]);
+    }
+
+    #[test]
+    fn test_find_source_symbols_handles_ambiguous_objc_extension() {
+        let objc_content =
+            BStr::new(b"@implementation Example\n- (void)method {\n    value++;\n}\n@end\n");
+        let objc_range = 2..3;
+        assert_eq!(
+            find_source_symbols(
+                SourceLanguage::MatlabOrObjC,
+                objc_content,
+                std::slice::from_ref(&objc_range),
+            ),
+            vec![Some(&b"- (void)method {"[..])]
+        );
+
+        let matlab_content = BStr::new(b"%% Section\nfunction y = example(x)\ny = x + 1;\nend\n");
+        let matlab_ranges = [0..1, 2..3];
+        assert_eq!(
+            find_source_symbols(SourceLanguage::MatlabOrObjC, matlab_content, &matlab_ranges),
+            vec![
+                Some(&b"%% Section"[..]),
+                Some(&b"function y = example(x)"[..])
+            ]
+        );
+    }
+}

--- a/cli/src/source_symbol.rs
+++ b/cli/src/source_symbol.rs
@@ -1,0 +1,754 @@
+// Copyright 2026 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::ops::Range;
+use std::sync::LazyLock;
+
+use bstr::BStr;
+use bstr::ByteSlice as _;
+use regex::bytes::Regex;
+
+// Built-in source symbol patterns for common languages. This stop-gap only
+// selects patterns from common file names/extensions.
+// TODO: Replace this with gix support once available, including
+// .gitattributes-based driver selection and custom hunk-header regexes.
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum SourceLanguage {
+    BibTeX,
+    CLike,
+    CSharp,
+    Dts,
+    Elixir,
+    Go,
+    Html,
+    Ini,
+    Java,
+    JavaScript,
+    Kotlin,
+    Markdown,
+    Matlab,
+    MatlabOrObjC,
+    ObjC,
+    CLikeOrObjC,
+    Pascal,
+    Perl,
+    Php,
+    Python,
+    R,
+    Ruby,
+    Rust,
+    Scheme,
+    Shell,
+    Tex,
+}
+
+impl SourceLanguage {
+    pub(crate) fn from_file_name(file_name: &str) -> Option<Self> {
+        let extension = file_name.rsplit_once('.').map(|(_, extension)| extension);
+        match extension {
+            Some("bib") => Some(Self::BibTeX),
+            Some("c" | "cc" | "cpp" | "cxx" | "hh" | "hpp" | "hxx") => Some(Self::CLike),
+            Some("h") => Some(Self::CLikeOrObjC),
+            Some("cs") => Some(Self::CSharp),
+            Some("dts" | "dtsi") => Some(Self::Dts),
+            Some("ex" | "exs") => Some(Self::Elixir),
+            Some("go") => Some(Self::Go),
+            Some("htm" | "html" | "xhtml") => Some(Self::Html),
+            Some("cfg" | "conf" | "config" | "ini") => Some(Self::Ini),
+            Some("java") => Some(Self::Java),
+            Some("js" | "jsx" | "mjs" | "cjs" | "ts" | "tsx") => Some(Self::JavaScript),
+            Some("kt" | "kts") => Some(Self::Kotlin),
+            Some("markdown" | "md" | "mdown") => Some(Self::Markdown),
+            // `.m` is shared by MATLAB and Objective-C. Objective-C++ `.mm`
+            // and Objective-C headers can also contain ordinary C-like symbols.
+            Some("m") => Some(Self::MatlabOrObjC),
+            Some("matlab") => Some(Self::Matlab),
+            Some("mm") => Some(Self::CLikeOrObjC),
+            Some("p" | "pas") => Some(Self::Pascal),
+            Some("pl" | "pm" | "pod" | "psgi" | "t") => Some(Self::Perl),
+            Some("php" | "php3" | "php4" | "php5" | "phtml") => Some(Self::Php),
+            Some("py" | "pyw") => Some(Self::Python),
+            Some("r" | "R") => Some(Self::R),
+            Some("rb" | "rake" | "gemspec") => Some(Self::Ruby),
+            Some("rs") => Some(Self::Rust),
+            Some("scm" | "scheme" | "ss" | "lisp" | "lsp") => Some(Self::Scheme),
+            Some("sh" | "bash" | "zsh" | "fish") => Some(Self::Shell),
+            Some("tex" | "ltx" | "latex") => Some(Self::Tex),
+            _ => match file_name {
+                "Gemfile" | "Rakefile" => Some(Self::Ruby),
+                _ => None,
+            },
+        }
+    }
+
+    fn is_source_symbol(self, line: &[u8]) -> bool {
+        static BIBTEX_FUNCTION_RE: LazyLock<Regex> = LazyLock::new(|| {
+            Regex::new(r#"^@[A-Za-z]+[ \t]*\{?[ \t]*[^ \t"@',\\#}{~%]*"#).unwrap()
+        });
+        static C_LIKE_FUNCTION_RE: LazyLock<Regex> = LazyLock::new(|| {
+            Regex::new(
+                r"^(?:[A-Za-z_][\w:<>,~]*|[*&]|\[[^\]]*\]|\s+)+[A-Za-z_~][\w:~]*\s*\([^;{}]*",
+            )
+            .unwrap()
+        });
+        static CSHARP_FUNCTION_RE: LazyLock<Regex> = LazyLock::new(|| {
+            Regex::new(
+                r"^(?:(?:[\w@_.]+(?:<[\w@_, \t<>]+>)?)(?:\s+[\w@_.]+(?:<[\w@_, \t<>]+>)?)+\s*\([^;]*|(?:(?:static|public|internal|private|protected|new|unsafe|sealed|abstract|partial)\s+)*(?:class|enum|interface|struct|record)\s+.*|namespace\s+.*)$",
+            )
+            .unwrap()
+        });
+        static DTS_FUNCTION_RE: LazyLock<Regex> =
+            LazyLock::new(|| Regex::new(r"^(?:/[ \t]*\{|&?[A-Za-z_].*)").unwrap());
+        static ELIXIR_FUNCTION_RE: LazyLock<Regex> = LazyLock::new(|| {
+            Regex::new(r"^(?:def(?:macro|module|impl|protocol|p)?|test)\s+.*").unwrap()
+        });
+        static GO_FUNCTION_RE: LazyLock<Regex> = LazyLock::new(|| {
+            Regex::new(r"^(?:func\s*.*(?:\{\s*)?|type\s+.*(?:struct|interface)\s*(?:\{\s*)?)$")
+                .unwrap()
+        });
+        static HTML_FUNCTION_RE: LazyLock<Regex> =
+            LazyLock::new(|| Regex::new(r"^<[Hh][1-6](?:\s.*)?>.*").unwrap());
+        static INI_FUNCTION_RE: LazyLock<Regex> =
+            LazyLock::new(|| Regex::new(r"^\[[^]]+\]").unwrap());
+        static JAVA_FUNCTION_RE: LazyLock<Regex> = LazyLock::new(|| {
+            Regex::new(
+                r"^(?:(?:[a-z-]+\s+)*(?:class|enum|interface|record)\s+.*|(?:[A-Za-z_<>&][\]?&<>.,A-Za-z_0-9]*\s+)+[A-Za-z_][A-Za-z_0-9]*\s*\([^;]*)$",
+            )
+            .unwrap()
+        });
+        static JAVASCRIPT_FUNCTION_RE: LazyLock<Regex> = LazyLock::new(|| {
+            Regex::new(
+                r"^(?:(?:export|default|async|static|get|set)\s+)*(?:function\b|class\b|[A-Za-z_$][\w$]*\s*\([^)]*\)\s*\{|[A-Za-z_$][\w$]*\s*[:=]\s*(?:async\s*)?(?:function\b|\([^)]*\)\s*=>))",
+            )
+            .unwrap()
+        });
+        static KOTLIN_FUNCTION_RE: LazyLock<Regex> =
+            LazyLock::new(|| Regex::new(r"^(?:[a-z]+\s+)*(?:fun|class|interface)\s+.*").unwrap());
+        static MARKDOWN_FUNCTION_RE: LazyLock<Regex> =
+            LazyLock::new(|| Regex::new(r"^#{1,6}\s+.*").unwrap());
+        static MATLAB_FUNCTION_RE: LazyLock<Regex> = LazyLock::new(|| {
+            Regex::new(r"^(?:(?:classdef|function)\s+.*|(?:%%%?|##)\s+.*)$").unwrap()
+        });
+        static OBJC_FUNCTION_RE: LazyLock<Regex> = LazyLock::new(|| {
+            Regex::new(
+                r"^(?:[-+]\s*\(\s*[A-Za-z_][A-Za-z_0-9* \t]*\)\s*[A-Za-z_].*|(?:[A-Za-z_][A-Za-z_0-9]*\s+)+[A-Za-z_][A-Za-z_0-9]*\s*\([^;]*|@(?:implementation|interface|protocol)\s+.*)$",
+            )
+            .unwrap()
+        });
+        static PASCAL_FUNCTION_RE: LazyLock<Regex> = LazyLock::new(|| {
+            Regex::new(
+                r"^(?:(?:(?:class\s+)?(?:procedure|function)|constructor|destructor|interface|implementation|initialization|finalization)\s*.*|.*=\s*(?:class|record).*)$",
+            )
+            .unwrap()
+        });
+        static PERL_FUNCTION_RE: LazyLock<Regex> = LazyLock::new(|| {
+            Regex::new(
+                r"^(?:package .*|sub [[:alnum:]_':]+[ \t]*(?:\([^)]*\)[ \t]*)?(?::[^;#]*)?(?:\{[ \t]*)?(?:#.*)?|(?:BEGIN|END|INIT|CHECK|UNITCHECK|AUTOLOAD|DESTROY)[ \t]*(?:\{[ \t]*)?(?:#.*)?|=head[0-9] .*)$",
+            )
+            .unwrap()
+        });
+        static PHP_FUNCTION_RE: LazyLock<Regex> = LazyLock::new(|| {
+            Regex::new(
+                r"^(?:(?:(?:public|protected|private|static|abstract|final)\s+)*function.*|(?:(?:(?:final|abstract)\s+)?class|enum|interface|trait).*)$",
+            )
+            .unwrap()
+        });
+        static PYTHON_FUNCTION_RE: LazyLock<Regex> =
+            LazyLock::new(|| Regex::new(r"^(?:async\s+def|def|class)\s+\w+").unwrap());
+        static R_FUNCTION_RE: LazyLock<Regex> = LazyLock::new(|| {
+            Regex::new(r"^[A-Za-z][A-Za-z0-9_.]*\s*(?:<-|=)\s*function.*$").unwrap()
+        });
+        static RUBY_FUNCTION_RE: LazyLock<Regex> =
+            LazyLock::new(|| Regex::new(r"^(?:class|module|def)\s+.*").unwrap());
+        static RUST_FUNCTION_RE: LazyLock<Regex> = LazyLock::new(|| {
+            Regex::new(
+                r#"^(?:(?:pub(?:\([^)]*\))?|const|async|unsafe|extern(?:\s+"[^"]+")?)\s+)*(?:(?:fn|struct|enum|impl|trait|mod|type|union)\b|macro_rules!\s*)"#,
+            )
+            .unwrap()
+        });
+        static SCHEME_FUNCTION_RE: LazyLock<Regex> = LazyLock::new(|| {
+            Regex::new(
+                r"^(?:\((?:(?:define|def(?:struct|syntax|class|method|rules|record|proto|alias)?)[-*/ \t]|(?:library|module|struct|class)[*+ \t]).*|[Dd][Ee][Ff].*)$",
+            )
+            .unwrap()
+        });
+        static SHELL_FUNCTION_RE: LazyLock<Regex> = LazyLock::new(|| {
+            Regex::new(
+                r"^(?:[A-Za-z_][A-Za-z0-9_]*\s*\(\s*\)|function\s+[A-Za-z_][A-Za-z0-9_]*(?:(?:\s*\(\s*\))|\s+)).*$",
+            )
+            .unwrap()
+        });
+        static TEX_FUNCTION_RE: LazyLock<Regex> =
+            LazyLock::new(|| Regex::new(r"^\\(?:(?:sub)*section|chapter|part)\*?\{.*").unwrap());
+
+        match self {
+            Self::BibTeX => BIBTEX_FUNCTION_RE.is_match(line),
+            Self::CLike => {
+                let before_paren = line.split(|byte| *byte == b'(').next().unwrap_or(line);
+                !line.first().is_some_and(u8::is_ascii_whitespace)
+                    && !before_paren.contains_str(": ")
+                    && !starts_with_keyword(line, &["do", "for", "if", "switch", "while"])
+                    && C_LIKE_FUNCTION_RE.is_match(line)
+            }
+            Self::CSharp => {
+                !starts_with_keyword(
+                    line,
+                    &[
+                        "do", "while", "for", "foreach", "if", "else", "new", "default", "return",
+                        "switch", "case", "throw", "catch", "using", "lock", "fixed",
+                    ],
+                ) && CSHARP_FUNCTION_RE.is_match(line)
+            }
+            Self::Dts => {
+                !line.contains(&b';') && !line.contains(&b'=') && DTS_FUNCTION_RE.is_match(line)
+            }
+            Self::Elixir => ELIXIR_FUNCTION_RE.is_match(line),
+            Self::Go => GO_FUNCTION_RE.is_match(line),
+            Self::Html => HTML_FUNCTION_RE.is_match(line),
+            Self::Ini => INI_FUNCTION_RE.is_match(line),
+            Self::Java => {
+                !starts_with_keyword(
+                    line,
+                    &[
+                        "catch",
+                        "do",
+                        "for",
+                        "if",
+                        "instanceof",
+                        "new",
+                        "return",
+                        "switch",
+                        "throw",
+                        "while",
+                    ],
+                ) && JAVA_FUNCTION_RE.is_match(line)
+            }
+            Self::JavaScript => {
+                !starts_with_keyword(line, &["catch", "for", "if", "switch", "while", "with"])
+                    && JAVASCRIPT_FUNCTION_RE.is_match(line)
+            }
+            Self::Kotlin => KOTLIN_FUNCTION_RE.is_match(line),
+            Self::Markdown => MARKDOWN_FUNCTION_RE.is_match(line),
+            Self::Matlab => MATLAB_FUNCTION_RE.is_match(line),
+            Self::MatlabOrObjC => {
+                Self::Matlab.is_source_symbol(line) || Self::ObjC.is_source_symbol(line)
+            }
+            Self::ObjC => {
+                !starts_with_keyword(
+                    line,
+                    &["do", "for", "if", "else", "return", "switch", "while"],
+                ) && OBJC_FUNCTION_RE.is_match(line)
+            }
+            Self::CLikeOrObjC => {
+                Self::CLike.is_source_symbol(line) || Self::ObjC.is_source_symbol(trim_line(line))
+            }
+            Self::Pascal => PASCAL_FUNCTION_RE.is_match(line),
+            Self::Perl => PERL_FUNCTION_RE.is_match(line),
+            Self::Php => PHP_FUNCTION_RE.is_match(line),
+            Self::Python => PYTHON_FUNCTION_RE.is_match(line),
+            Self::R => R_FUNCTION_RE.is_match(line),
+            Self::Ruby => RUBY_FUNCTION_RE.is_match(line),
+            Self::Rust => RUST_FUNCTION_RE.is_match(line),
+            Self::Scheme => SCHEME_FUNCTION_RE.is_match(line),
+            Self::Shell => SHELL_FUNCTION_RE.is_match(line),
+            Self::Tex => TEX_FUNCTION_RE.is_match(line),
+        }
+    }
+}
+
+fn starts_with_keyword(line: &[u8], keywords: &[&str]) -> bool {
+    keywords.iter().any(|keyword| {
+        line.strip_prefix(keyword.as_bytes()).is_some_and(|rest| {
+            rest.first()
+                .is_none_or(|byte| byte.is_ascii_whitespace() || matches!(byte, b'(' | b'{' | b';'))
+        })
+    })
+}
+
+fn strip_line_ending(line: &[u8]) -> &[u8] {
+    let line = line.strip_suffix(b"\n").unwrap_or(line);
+    line.strip_suffix(b"\r").unwrap_or(line)
+}
+
+fn trim_line(line: &[u8]) -> &[u8] {
+    strip_line_ending(line).trim_ascii()
+}
+
+fn is_c_style_comment_line(line: &[u8]) -> bool {
+    // A leading `*` can also belong to a pointer-returning function declaration.
+    line.starts_with(b"/*") || line.starts_with(b"//")
+}
+
+fn is_comment_line(line: &[u8], language: SourceLanguage) -> bool {
+    match language {
+        SourceLanguage::CLike
+        | SourceLanguage::CLikeOrObjC
+        | SourceLanguage::CSharp
+        | SourceLanguage::Go
+        | SourceLanguage::Java
+        | SourceLanguage::JavaScript
+        | SourceLanguage::Kotlin
+        | SourceLanguage::ObjC
+        | SourceLanguage::Php
+        | SourceLanguage::Rust => is_c_style_comment_line(line),
+        SourceLanguage::MatlabOrObjC => is_c_style_comment_line(line),
+        SourceLanguage::Elixir
+        | SourceLanguage::Perl
+        | SourceLanguage::Python
+        | SourceLanguage::R
+        | SourceLanguage::Ruby
+        | SourceLanguage::Shell => line.starts_with(b"#"),
+        SourceLanguage::Tex => line.starts_with(b"%"),
+        SourceLanguage::BibTeX
+        | SourceLanguage::Dts
+        | SourceLanguage::Html
+        | SourceLanguage::Ini
+        | SourceLanguage::Markdown
+        | SourceLanguage::Matlab
+        | SourceLanguage::Pascal
+        | SourceLanguage::Scheme => false,
+    }
+}
+
+fn source_symbols(
+    content: &BStr,
+    language: SourceLanguage,
+) -> impl Iterator<Item = (usize, &[u8])> {
+    content
+        .split_inclusive(|byte| *byte == b'\n')
+        .enumerate()
+        .filter_map(move |(line_number, line)| {
+            let line = strip_line_ending(line);
+            let trimmed_line = trim_line(line);
+            let line_to_match = match language {
+                // Keep leading whitespace so the C-like matcher excludes indented
+                // calls/control flow inside a function. This heuristic intentionally
+                // also excludes indented C++ class methods and namespace members.
+                SourceLanguage::CLike | SourceLanguage::CLikeOrObjC => line,
+                _ => trimmed_line,
+            };
+            (!is_comment_line(trimmed_line, language) && language.is_source_symbol(line_to_match))
+                .then_some((line_number, trimmed_line))
+        })
+}
+
+/// Finds source symbols near line ranges in one version of a file.
+///
+/// A scanner operates on a single file content so it can also be used for
+/// diffs with more than two sides.
+pub(crate) struct SourceSymbolScanner<'a> {
+    symbols: Vec<(usize, &'a [u8])>,
+}
+
+impl<'a> SourceSymbolScanner<'a> {
+    pub(crate) fn new(language: SourceLanguage, content: &'a BStr) -> Self {
+        Self {
+            symbols: source_symbols(content, language).collect(),
+        }
+    }
+
+    /// Finds a symbol on the first line of a nonempty range, or the closest
+    /// symbol strictly before the range.
+    ///
+    /// If there is no preceding symbol, the first symbol in the changed range
+    /// is returned. This is useful for newly-added sections.
+    pub(crate) fn find(&self, line_range: &Range<usize>) -> Option<&'a [u8]> {
+        let preceding_end = self
+            .symbols
+            .partition_point(|(line, _)| *line < line_range.start);
+        let first_in_range = self
+            .symbols
+            .get(preceding_end)
+            .filter(|(line, _)| *line < line_range.end);
+        if let Some((line, symbol)) = first_in_range
+            && *line == line_range.start
+        {
+            return Some(symbol);
+        }
+
+        self.symbols[..preceding_end]
+            .last()
+            .or(first_in_range)
+            .map(|(_, symbol)| *symbol)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn collect_source_symbols(content: &BStr, language: SourceLanguage) -> Vec<(usize, &[u8])> {
+        source_symbols(content, language).collect()
+    }
+
+    #[test]
+    fn test_source_symbol_patterns() {
+        let samples: &[(SourceLanguage, &[&str])] = &[
+            (
+                SourceLanguage::BibTeX,
+                &[
+                    "@article{example,",
+                    "@string { name = value }",
+                    "plain text",
+                ],
+            ),
+            (
+                SourceLanguage::CLike,
+                &[
+                    "static int example(int value)",
+                    "void *pointer(void)",
+                    "    call(value)",
+                    "if (condition)",
+                    "label: call()",
+                ],
+            ),
+            (
+                SourceLanguage::CSharp,
+                &[
+                    "public class Example",
+                    "namespace Example.Core",
+                    "public async Task<int> Run(int value)",
+                    "if (condition)",
+                ],
+            ),
+            (
+                SourceLanguage::Dts,
+                &["/ {", "device_node {", "property = <1>;"],
+            ),
+            (
+                SourceLanguage::Elixir,
+                &["defmodule Example do", "defp run(value) do", "if ready do"],
+            ),
+            (
+                SourceLanguage::Go,
+                &[
+                    "func Example(value int) int {",
+                    "type Example struct {",
+                    "var example = func() {}",
+                ],
+            ),
+            (
+                SourceLanguage::Html,
+                &[
+                    "<h2 class=\"title\">Example</h2>",
+                    "<H1>Title</H1>",
+                    "<p>text</p>",
+                ],
+            ),
+            (
+                SourceLanguage::Ini,
+                &["[section]", "[section.subsection] value", "key = value"],
+            ),
+            (
+                SourceLanguage::Java,
+                &[
+                    "public class Example",
+                    "public static String run(int value)",
+                    "if (condition)",
+                ],
+            ),
+            (
+                SourceLanguage::JavaScript,
+                &[
+                    "export async function example() {",
+                    "class Example {",
+                    "handler = async (event) => {",
+                    "if (condition) {",
+                ],
+            ),
+            (
+                SourceLanguage::Kotlin,
+                &[
+                    "public fun example(value: Int)",
+                    "data class Example",
+                    "if (condition)",
+                ],
+            ),
+            (
+                SourceLanguage::Markdown,
+                &["# Title", "###### Detail", "plain text", "#missing-space"],
+            ),
+            (
+                SourceLanguage::Matlab,
+                &[
+                    "function y = example(x)",
+                    "classdef Example",
+                    "%% Section",
+                    "y = x + 1;",
+                ],
+            ),
+            (
+                SourceLanguage::ObjC,
+                &[
+                    "- (void)example:(id)value",
+                    "@interface Example : NSObject",
+                    "if (condition)",
+                ],
+            ),
+            (
+                SourceLanguage::Pascal,
+                &[
+                    "function Example(Value: Integer): Integer;",
+                    "TExample = class(TObject)",
+                    "var Value: Integer;",
+                ],
+            ),
+            (
+                SourceLanguage::Perl,
+                &[
+                    "package Example;",
+                    "sub example : prototype($) {",
+                    "BEGIN {",
+                    "=head1 Documentation",
+                    "my $value = 1;",
+                ],
+            ),
+            (
+                SourceLanguage::Php,
+                &[
+                    "public static function example($value) {",
+                    "final class Example {",
+                    "if ($condition) {",
+                ],
+            ),
+            (
+                SourceLanguage::Python,
+                &[
+                    "async def example(value):",
+                    "class Example:",
+                    "if condition:",
+                ],
+            ),
+            (
+                SourceLanguage::R,
+                &[
+                    "example <- function(value) {",
+                    "example.name = function(value) {",
+                    "if (condition) {",
+                ],
+            ),
+            (
+                SourceLanguage::Ruby,
+                &["module Example", "def example(value)", "if condition"],
+            ),
+            (
+                SourceLanguage::Rust,
+                &[
+                    "pub(crate) async fn example(value: i32) -> i32 {",
+                    "impl<T> Example<T> {",
+                    "macro_rules! example {",
+                    "if condition {",
+                ],
+            ),
+            (
+                SourceLanguage::Scheme,
+                &[
+                    "(define (example value)",
+                    "(module example scheme",
+                    "(display value)",
+                    "display value",
+                ],
+            ),
+            (
+                SourceLanguage::Shell,
+                &["example() {", "function example {", "if condition; then"],
+            ),
+            (
+                SourceLanguage::Tex,
+                &[
+                    "\\section{Example}",
+                    "\\subsubsection*{Detail}",
+                    "plain text",
+                ],
+            ),
+        ];
+
+        let results = samples
+            .iter()
+            .flat_map(|(language, lines)| {
+                lines.iter().map(move |line| {
+                    format!(
+                        "{language:?}: {:?} = {}",
+                        BStr::new(line),
+                        language.is_source_symbol(line.as_bytes())
+                    )
+                })
+            })
+            .collect::<Vec<_>>();
+        insta::assert_debug_snapshot!(results, @r#######"
+        [
+            "BibTeX: \"@article{example,\" = true",
+            "BibTeX: \"@string { name = value }\" = true",
+            "BibTeX: \"plain text\" = false",
+            "CLike: \"static int example(int value)\" = true",
+            "CLike: \"void *pointer(void)\" = true",
+            "CLike: \"    call(value)\" = false",
+            "CLike: \"if (condition)\" = false",
+            "CLike: \"label: call()\" = false",
+            "CSharp: \"public class Example\" = true",
+            "CSharp: \"namespace Example.Core\" = true",
+            "CSharp: \"public async Task<int> Run(int value)\" = true",
+            "CSharp: \"if (condition)\" = false",
+            "Dts: \"/ {\" = true",
+            "Dts: \"device_node {\" = true",
+            "Dts: \"property = <1>;\" = false",
+            "Elixir: \"defmodule Example do\" = true",
+            "Elixir: \"defp run(value) do\" = true",
+            "Elixir: \"if ready do\" = false",
+            "Go: \"func Example(value int) int {\" = true",
+            "Go: \"type Example struct {\" = true",
+            "Go: \"var example = func() {}\" = false",
+            "Html: \"<h2 class=\\\"title\\\">Example</h2>\" = true",
+            "Html: \"<H1>Title</H1>\" = true",
+            "Html: \"<p>text</p>\" = false",
+            "Ini: \"[section]\" = true",
+            "Ini: \"[section.subsection] value\" = true",
+            "Ini: \"key = value\" = false",
+            "Java: \"public class Example\" = true",
+            "Java: \"public static String run(int value)\" = true",
+            "Java: \"if (condition)\" = false",
+            "JavaScript: \"export async function example() {\" = true",
+            "JavaScript: \"class Example {\" = true",
+            "JavaScript: \"handler = async (event) => {\" = true",
+            "JavaScript: \"if (condition) {\" = false",
+            "Kotlin: \"public fun example(value: Int)\" = true",
+            "Kotlin: \"data class Example\" = true",
+            "Kotlin: \"if (condition)\" = false",
+            "Markdown: \"# Title\" = true",
+            "Markdown: \"###### Detail\" = true",
+            "Markdown: \"plain text\" = false",
+            "Markdown: \"#missing-space\" = false",
+            "Matlab: \"function y = example(x)\" = true",
+            "Matlab: \"classdef Example\" = true",
+            "Matlab: \"%% Section\" = true",
+            "Matlab: \"y = x + 1;\" = false",
+            "ObjC: \"- (void)example:(id)value\" = true",
+            "ObjC: \"@interface Example : NSObject\" = true",
+            "ObjC: \"if (condition)\" = false",
+            "Pascal: \"function Example(Value: Integer): Integer;\" = true",
+            "Pascal: \"TExample = class(TObject)\" = true",
+            "Pascal: \"var Value: Integer;\" = false",
+            "Perl: \"package Example;\" = true",
+            "Perl: \"sub example : prototype($) {\" = true",
+            "Perl: \"BEGIN {\" = true",
+            "Perl: \"=head1 Documentation\" = true",
+            "Perl: \"my $value = 1;\" = false",
+            "Php: \"public static function example($value) {\" = true",
+            "Php: \"final class Example {\" = true",
+            "Php: \"if ($condition) {\" = false",
+            "Python: \"async def example(value):\" = true",
+            "Python: \"class Example:\" = true",
+            "Python: \"if condition:\" = false",
+            "R: \"example <- function(value) {\" = true",
+            "R: \"example.name = function(value) {\" = true",
+            "R: \"if (condition) {\" = false",
+            "Ruby: \"module Example\" = true",
+            "Ruby: \"def example(value)\" = true",
+            "Ruby: \"if condition\" = false",
+            "Rust: \"pub(crate) async fn example(value: i32) -> i32 {\" = true",
+            "Rust: \"impl<T> Example<T> {\" = true",
+            "Rust: \"macro_rules! example {\" = true",
+            "Rust: \"if condition {\" = false",
+            "Scheme: \"(define (example value)\" = true",
+            "Scheme: \"(module example scheme\" = true",
+            "Scheme: \"(display value)\" = false",
+            "Scheme: \"display value\" = false",
+            "Shell: \"example() {\" = true",
+            "Shell: \"function example {\" = true",
+            "Shell: \"if condition; then\" = false",
+            "Tex: \"\\\\section{Example}\" = true",
+            "Tex: \"\\\\subsubsection*{Detail}\" = true",
+            "Tex: \"plain text\" = false",
+        ]
+        "#######);
+    }
+
+    #[test]
+    fn test_collect_source_symbols_ignores_c_comments_and_indentation() {
+        let content = BStr::new(
+            b"void outer(void)\n/*\n * misleading(comment)\n */\n    call(value);\nextern int actual(int value);\n",
+        );
+        let symbols = collect_source_symbols(content, SourceLanguage::CLike)
+            .into_iter()
+            .map(|(line, symbol)| (line, BStr::new(symbol)))
+            .collect::<Vec<_>>();
+        insta::assert_debug_snapshot!(symbols, @r#"
+        [
+            (
+                0,
+                "void outer(void)",
+            ),
+            (
+                5,
+                "extern int actual(int value);",
+            ),
+        ]
+        "#);
+    }
+
+    #[test]
+    fn test_source_symbol_scanner_finds_pointer_returning_c_function() {
+        let content = BStr::new(b"int\n*foo(void) {\n    return 0;\n}\n");
+        for language in [SourceLanguage::CLike, SourceLanguage::CLikeOrObjC] {
+            let scanner = SourceSymbolScanner::new(language, content);
+            assert_eq!(scanner.find(&(2..3)), Some(&b"*foo(void) {"[..]));
+        }
+    }
+
+    #[test]
+    fn test_source_symbol_scanner_uses_first_symbol_in_range() {
+        let scanner = SourceSymbolScanner::new(
+            SourceLanguage::Rust,
+            BStr::new(b"preamble\n\nfn first() {\n}\n\nfn second() {\n}\n"),
+        );
+
+        assert_eq!(scanner.find(&(1..7)), Some(&b"fn first() {"[..]));
+        assert_eq!(scanner.find(&(1..2)), None);
+    }
+
+    #[test]
+    fn test_source_symbol_scanner_range_start() {
+        let scanner = SourceSymbolScanner::new(
+            SourceLanguage::Rust,
+            BStr::new(b"fn first() {\n}\n\nfn second() {\n}\n"),
+        );
+
+        // An exact match takes precedence over the preceding symbol.
+        assert_eq!(scanner.find(&(3..4)), Some(&b"fn second() {"[..]));
+        // Empty ranges exclude the symbol at their start.
+        assert_eq!(scanner.find(&(3..3)), Some(&b"fn first() {"[..]));
+        assert_eq!(scanner.find(&(0..0)), None);
+        // A preceding symbol takes precedence over a later symbol in the range.
+        assert_eq!(scanner.find(&(2..5)), Some(&b"fn first() {"[..]));
+    }
+
+    #[test]
+    fn test_source_symbol_scanner_handles_ambiguous_objc_extension() {
+        let objc_scanner = SourceSymbolScanner::new(
+            SourceLanguage::MatlabOrObjC,
+            BStr::new(b"@implementation Example\n- (void)method {\n    value++;\n}\n@end\n"),
+        );
+        assert_eq!(objc_scanner.find(&(2..3)), Some(&b"- (void)method {"[..]));
+
+        let matlab_scanner = SourceSymbolScanner::new(
+            SourceLanguage::MatlabOrObjC,
+            BStr::new(b"%% Section\nfunction y = example(x)\ny = x + 1;\nend\n"),
+        );
+        assert_eq!(matlab_scanner.find(&(0..1)), Some(&b"%% Section"[..]));
+        assert_eq!(
+            matlab_scanner.find(&(2..3)),
+            Some(&b"function y = example(x)"[..])
+        );
+    }
+}

--- a/cli/tests/test_diff_command.rs
+++ b/cli/tests/test_diff_command.rs
@@ -29,6 +29,157 @@ fn strip_ansi_escape_codes(output: String) -> String {
 }
 
 #[test]
+fn test_diff_git_hunk_header_section() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    work_dir.write_file(
+        "src/lib.rs",
+        indoc! {"
+            fn unchanged() {
+                let value = 1;
+            }
+
+            pub async fn changed(value: i32) -> i32 {
+                value + 1
+            }
+        "},
+    );
+    work_dir.run_jj(["new"]).success();
+    work_dir.write_file(
+        "src/lib.rs",
+        indoc! {"
+            fn unchanged() {
+                let value = 1;
+            }
+
+            pub async fn changed(value: i32) -> i32 {
+                value + 2
+            }
+        "},
+    );
+
+    let output = work_dir.run_jj(["diff", "--git", "--context=0"]);
+    insta::assert_snapshot!(output, @"
+    diff --git a/src/lib.rs b/src/lib.rs
+    index a29875152a..dc32bb3132 100644
+    --- a/src/lib.rs
+    +++ b/src/lib.rs
+    @@ -6,1 +6,1 @@ pub async fn changed(value: i32) -> i32 {
+    -    value + 1
+    +    value + 2
+    [EOF]
+    ");
+}
+
+#[test]
+fn test_diff_git_hunk_header_added_section_uses_first_and_is_truncated() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    work_dir.write_file("example.rs", "preamble\n");
+    work_dir.run_jj(["new"]).success();
+
+    let first_header = format!("fn first_{}() {{", "x".repeat(100));
+    work_dir.write_file(
+        "example.rs",
+        format!("preamble\n\n{first_header}\n}}\nfn second() {{\n}}\n"),
+    );
+
+    let output = work_dir.run_jj(["diff", "--git", "--context=0"]);
+    insta::assert_snapshot!(output, @"
+    diff --git a/example.rs b/example.rs
+    index 17a33febd0..381a95e747 100644
+    --- a/example.rs
+    +++ b/example.rs
+    @@ -1,0 +2,5 @@ fn first_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+    +
+    +fn first_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx() {
+    +}
+    +fn second() {
+    +}
+    [EOF]
+    ");
+}
+
+#[test]
+fn test_diff_git_hunk_header_truncates_multibyte_symbol_by_bytes() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    let header = format!("fn example() {{ // {}", "€".repeat(100));
+    work_dir.write_file("example.rs", format!("{header}\n    1\n}}\n"));
+    work_dir.run_jj(["new"]).success();
+    work_dir.write_file("example.rs", format!("{header}\n    2\n}}\n"));
+
+    let output = work_dir.run_jj(["diff", "--git", "--context=0"]);
+    let hunk_header = output
+        .stdout
+        .raw()
+        .lines()
+        .find(|line| line.starts_with("@@"))
+        .unwrap();
+    let source_symbol = hunk_header.rsplit_once("@@ ").unwrap().1;
+    assert_eq!(
+        source_symbol,
+        format!("fn example() {{ // {}", "€".repeat(20))
+    );
+    assert_eq!(source_symbol.len(), 78);
+}
+
+#[test]
+fn test_diff_git_hunk_header_deletion_uses_deleted_section() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    work_dir.write_file(
+        "src/lib.rs",
+        indoc! {"
+            fn deleted() {
+                let value = 1;
+            }
+
+            fn later() {}
+        "},
+    );
+    work_dir.run_jj(["new"]).success();
+    work_dir.write_file("src/lib.rs", "fn later() {}\n");
+
+    let output = work_dir.run_jj(["diff", "--git"]);
+    insta::assert_snapshot!(output, @"
+    diff --git a/src/lib.rs b/src/lib.rs
+    index 1c67155809..43e292937e 100644
+    --- a/src/lib.rs
+    +++ b/src/lib.rs
+    @@ -1,5 +1,1 @@ fn deleted() {
+    -fn deleted() {
+    -    let value = 1;
+    -}
+    -
+     fn later() {}
+    [EOF]
+    ");
+
+    let output = work_dir.run_jj(["diff", "--git", "--context=0"]);
+    insta::assert_snapshot!(output, @"
+    diff --git a/src/lib.rs b/src/lib.rs
+    index 1c67155809..43e292937e 100644
+    --- a/src/lib.rs
+    +++ b/src/lib.rs
+    @@ -1,4 +0,0 @@ fn deleted() {
+    -fn deleted() {
+    -    let value = 1;
+    -}
+    -
+    [EOF]
+    ");
+}
+
+#[test]
 fn test_diff_basic() {
     let test_env = TestEnvironment::default();
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();

--- a/cli/tests/test_diff_command.rs
+++ b/cli/tests/test_diff_command.rs
@@ -29,6 +29,157 @@ fn strip_ansi_escape_codes(output: String) -> String {
 }
 
 #[test]
+fn test_diff_git_hunk_header_section() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    work_dir.write_file(
+        "src/lib.rs",
+        indoc! {"
+            fn unchanged() {
+                let value = 1;
+            }
+
+            pub async fn changed(value: i32) -> i32 {
+                value + 1
+            }
+        "},
+    );
+    work_dir.run_jj(["new"]).success();
+    work_dir.write_file(
+        "src/lib.rs",
+        indoc! {"
+            fn unchanged() {
+                let value = 1;
+            }
+
+            pub async fn changed(value: i32) -> i32 {
+                value + 2
+            }
+        "},
+    );
+
+    let output = work_dir.run_jj(["diff", "--git", "--context=0"]);
+    insta::assert_snapshot!(output, @"
+    diff --git a/src/lib.rs b/src/lib.rs
+    index a29875152a..dc32bb3132 100644
+    --- a/src/lib.rs
+    +++ b/src/lib.rs
+    @@ -6,1 +6,1 @@ pub async fn changed(value: i32) -> i32 {
+    -    value + 1
+    +    value + 2
+    [EOF]
+    ");
+}
+
+#[test]
+fn test_diff_git_hunk_header_added_section_uses_first_and_is_truncated() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    work_dir.write_file("example.rs", "preamble\n");
+    work_dir.run_jj(["new"]).success();
+
+    let first_header = format!("fn first_{}() {{", "x".repeat(100));
+    work_dir.write_file(
+        "example.rs",
+        format!("preamble\n\n{first_header}\n}}\nfn second() {{\n}}\n"),
+    );
+
+    let output = work_dir.run_jj(["diff", "--git", "--context=0"]);
+    insta::assert_snapshot!(output, @"
+    diff --git a/example.rs b/example.rs
+    index 17a33febd0..381a95e747 100644
+    --- a/example.rs
+    +++ b/example.rs
+    @@ -1,0 +2,5 @@ fn first_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+    +
+    +fn first_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx() {
+    +}
+    +fn second() {
+    +}
+    [EOF]
+    ");
+}
+
+#[test]
+fn test_diff_git_hunk_header_truncates_multibyte_symbol_by_bytes() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    let header = format!("fn example() {{ // {}", "€ ".repeat(100));
+    work_dir.write_file("example.rs", format!("{header}\n    1\n}}\n"));
+    work_dir.run_jj(["new"]).success();
+    work_dir.write_file("example.rs", format!("{header}\n    2\n}}\n"));
+
+    let output = work_dir.run_jj(["diff", "--git", "--context=0"]);
+    let hunk_header = output
+        .stdout
+        .raw()
+        .lines()
+        .find(|line| line.starts_with("@@"))
+        .unwrap();
+    let source_symbol = hunk_header.rsplit_once("@@ ").unwrap().1;
+    assert_eq!(
+        source_symbol,
+        format!("fn example() {{ // {}", "€ ".repeat(15))
+    );
+    assert_eq!(source_symbol.len(), 78);
+}
+
+#[test]
+fn test_diff_git_hunk_header_deletion_uses_deleted_section() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    work_dir.write_file(
+        "src/lib.rs",
+        indoc! {"
+            fn deleted() {
+                let value = 1;
+            }
+
+            fn later() {}
+        "},
+    );
+    work_dir.run_jj(["new"]).success();
+    work_dir.write_file("src/lib.rs", "fn later() {}\n");
+
+    let output = work_dir.run_jj(["diff", "--git"]);
+    insta::assert_snapshot!(output, @"
+    diff --git a/src/lib.rs b/src/lib.rs
+    index 1c67155809..43e292937e 100644
+    --- a/src/lib.rs
+    +++ b/src/lib.rs
+    @@ -1,5 +1,1 @@ fn deleted() {
+    -fn deleted() {
+    -    let value = 1;
+    -}
+    -
+     fn later() {}
+    [EOF]
+    ");
+
+    let output = work_dir.run_jj(["diff", "--git", "--context=0"]);
+    insta::assert_snapshot!(output, @"
+    diff --git a/src/lib.rs b/src/lib.rs
+    index 1c67155809..43e292937e 100644
+    --- a/src/lib.rs
+    +++ b/src/lib.rs
+    @@ -1,4 +0,0 @@ fn deleted() {
+    -fn deleted() {
+    -    let value = 1;
+    -}
+    -
+    [EOF]
+    ");
+}
+
+#[test]
 fn test_diff_basic() {
     let test_env = TestEnvironment::default();
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();


### PR DESCRIPTION
Feel free to close this if we want to wait for the full .gitattributes driver implementation.

Teach --git unified diffs to append a best-effort function or section name after the @@ range header, matching the convention used by Git.

This adds built-in hunk-header drivers selected from common file names/extensions. It intentionally does not try to implement attribute-driven hunk-header selection yet: .gitattributes driver selection and custom xfuncname regexes should eventually come from gix and replace this stop-gap implementation.

The scanner looks for the closest recognizable section header before each hunk, falls back to the hunk body for newly-added sections, and skips comments to avoid using prose as a header. C-like matching keeps leading whitespace so indented statements and calls inside functions are not mistaken for top-level declarations.

Add regression coverage for Rust, Perl, C comment false positives, and indented C statements.

Fixes: #4797

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
