### PR TITLE
run: Add --ignore-errors option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * `jj git push` gained a `--allow-conflicts` flag to allow pushing commits
   containing conflicts.
 
+* `jj run` gained a `--ignore-errors` flag to continue running against the
+  remaining revisions even if the command exits with a nonzero exit code.
+
 ### Fixed bugs
 
 * Recursive alias definitions are detected more precisely. jj can now expand

--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -650,6 +650,17 @@ pub struct RunArgs {
     /// `--ignore-immutable`.
     #[arg(long, conflicts_with = "restore_descendants")]
     ignore_changes: bool,
+
+    /// Continue with remaining revisions when a command's exit code indicates
+    /// failure
+    ///
+    /// Any changes made by a failed command will not be saved, but changes from
+    /// successful commands are still applied atomically at the end.
+    ///
+    /// The exit code from any failed command will not impact the exit code of
+    /// `jj run` itself.
+    #[arg(long)]
+    ignore_errors: bool,
 }
 
 /// Precedence: `--jobs`, `run.jobs` config, 1.
@@ -809,7 +820,7 @@ pub async fn cmd_run(
                             let mut err = ui.stderr();
                             err.write_all(&res.stderr)?;
                         }
-                        if !status.success() {
+                        if !status.success() && !args.ignore_errors {
                             let commit = store.get_commit_async(&res.old_id).await?;
                             let mut error: CommandError =
                                 RunError::CommandFailure(spec.to_string(), status).into();

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -3028,6 +3028,11 @@ $ jj run -j 4 -- pre-commit run .github/pre-commit.yaml
    Each revision is checked out and the command is executed, but changes made to the working copy are discarded. Useful for read-only checks (tests, linters).
 
    This option permits running on immutable commits without passing `--ignore-immutable`.
+* `--ignore-errors` — Continue with remaining revisions when a command's exit code indicates failure
+
+   Any changes made by a failed command will not be saved, but changes from successful commands are still applied atomically at the end.
+
+   The exit code from any failed command will not impact the exit code of `jj run` itself.
 
 
 

--- a/cli/tests/test_run_command.rs
+++ b/cli/tests/test_run_command.rs
@@ -451,6 +451,101 @@ fn test_run_failure_rewrites_nothing() {
 }
 
 #[test]
+fn test_run_ignore_errors_rewrites_successes() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+    create_commit_with_files(&work_dir, "a", &[], &[("a.txt", "a")]);
+    create_commit_with_files(&work_dir, "b", &["a"], &[("b.txt", "b")]);
+
+    // Fail on A; succeed on B. A should be untouched, B should be rewritten.
+    let jj_args: &[&str] = if cfg!(windows) {
+        &[
+            "run",
+            "--ignore-errors",
+            "-r",
+            "..b",
+            "--",
+            "cmd",
+            "/c",
+            "type nul >ran.txt & (if not exist b.txt exit 1)",
+        ]
+    } else {
+        &[
+            "run",
+            "--ignore-errors",
+            "-r",
+            "..b",
+            "--",
+            "sh",
+            "-c",
+            "touch ran.txt; if [ ! -f b.txt ]; then exit 1; fi",
+        ]
+    };
+    let output = work_dir.run_jj(jj_args);
+    assert_snapshot!(
+        output.success(), @r"
+    ------- stderr -------
+    Rewrote 1 commits.
+    Working copy  (@) now at: zsuskuln f3c3b6ac b | b
+    Parent commit (@-)      : rlvkpnrz 2385de9f a | a
+    Added 1 files, modified 0 files, removed 0 files
+    [EOF]
+    "
+    );
+    insta::assert_snapshot!(
+        work_dir.run_jj(&["file", "list", "-r=a"]),
+        @r"
+    a.txt
+    [EOF]
+    "
+    );
+    insta::assert_snapshot!(
+        work_dir.run_jj(&["file", "list", "-r=b"]),
+        @r"
+    a.txt
+    b.txt
+    ran.txt
+    [EOF]
+    "
+    );
+}
+
+#[test]
+fn test_run_ignore_errors_all_fail() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let fake_formatter = assert_cmd::cargo::cargo_bin("fake-formatter");
+    assert!(fake_formatter.is_file());
+    let fake_formatter_path = fake_formatter.to_string_lossy().into_owned();
+    let work_dir = test_env.work_dir("repo");
+    work_dir.write_file("A.txt", "A");
+    work_dir.run_jj(&["commit", "-m", "A"]).success();
+
+    let log_before = get_log_output(&work_dir);
+
+    let output = work_dir.run_jj(&[
+        "run",
+        "--ignore-errors",
+        "-r",
+        "@-",
+        "--",
+        &fake_formatter_path,
+        "--fail",
+    ]);
+    assert_snapshot!(
+        output.success(), @r"
+    ------- stderr -------
+    Nothing changed.
+    [EOF]
+    "
+    );
+
+    // Log is unchanged: no commits were rewritten.
+    assert_eq!(get_log_output(&work_dir), log_before);
+}
+
+#[test]
 fn test_run_recovers_after_failure() {
     let test_env = TestEnvironment::default();
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();


### PR DESCRIPTION
This command instructs `jj run` to continue even if a command exits with a nonzero status code.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [X] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [X] I have added/updated tests to cover my changes
- [X] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [X] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
