### PR TITLE
run: preserve conflicts instead of panicking on conflicted commits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   record reported for each parent was mistaken for a conflict and discarded.
   [#9752](https://github.com/jj-vcs/jj/issues/9752)
 
+* `jj run` no longer panics when its revset includes a conflicted commit. The
+  conflict is now preserved in the rewritten commit.
+  [#9747](https://github.com/jj-vcs/jj/issues/9747)
+
 ## [0.43.0] - 2026-07-01
 
 ### Release highlights

--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -54,8 +54,6 @@ use jj_lib::merge::Merge;
 use jj_lib::merged_tree::MergedTree;
 use jj_lib::object_id::ObjectId as _;
 use jj_lib::repo::Repo as _;
-use jj_lib::repo_path::RepoPathBuf;
-use jj_lib::tree::Tree;
 use jj_lib::working_copy::SnapshotOptions;
 use tokio::runtime::Builder;
 use tokio::sync::Semaphore;
@@ -360,8 +358,9 @@ struct RunJob {
     /// The original tree of the commit before the command ran.
     old_tree: MergedTree,
     /// The new tree generated from the commit. `None` when the command wasn't
-    /// run (i.e. the commit was skipped).
-    new_tree: Option<Tree>,
+    /// run (i.e. the commit was skipped). May be a conflicted tree when the
+    /// command left conflicts in the working copy.
+    new_tree: Option<MergedTree>,
     /// Was the tree even modified.
     dirty: bool,
     /// Bytes the subprocess wrote to its stdout, captured in full.
@@ -541,10 +540,10 @@ async fn rewrite_commit(
     workspace.persist()?;
 
     let new_tree = if output.status.success() {
-        let rewritten_id = workspace.tree_state.current_tree().tree_ids();
-        let new_id = rewritten_id.as_resolved().unwrap();
-
-        Some(commit.store().get_tree(RepoPathBuf::root(), new_id).await?)
+        // Keep the snapshot as-is. The command may have left (or introduced) a
+        // conflict, and jj stores conflicts in the tree, so preserve the whole
+        // `MergedTree` rather than assuming it resolved to a single tree.
+        Some(workspace.tree_state.current_tree().clone())
 
         // TODO: Serialize the new tree into /output/{id-tree} for a cache
         // lookup TODO: supersede with a custom workspace implementation
@@ -864,10 +863,7 @@ pub async fn cmd_run(
                         count += 1;
                         // Use the command result on top of the commit's
                         // original tree, ignoring rewrites of its ancestors.
-                        builder
-                            .set_tree(MergedTree::resolved(store.clone(), new_tree.id().clone()))
-                            .write()
-                            .await?;
+                        builder.set_tree(new_tree.clone()).write().await?;
                     }
                     (Some((old_tree, new_tree)), false) => {
                         let builder = rewriter.rebase().await?;
@@ -877,10 +873,7 @@ pub async fn cmd_run(
                         // ancestor rewrites via the normal rebase merge.
                         let rebased_tree = builder.tree();
                         let merged = MergedTree::merge(Merge::from_vec(vec![
-                            (
-                                MergedTree::resolved(store.clone(), new_tree.id().clone()),
-                                "command result".to_owned(),
-                            ),
+                            (new_tree.clone(), "command result".to_owned()),
                             (old_tree.clone(), "original commit".to_owned()),
                             (rebased_tree, "rebased".to_owned()),
                         ]))

--- a/cli/tests/test_run_command.rs
+++ b/cli/tests/test_run_command.rs
@@ -1761,3 +1761,75 @@ fn test_run_passthrough_rejects_multi_job() {
     [EOF]
     ");
 }
+
+#[test]
+fn test_run_on_conflicted_commit() {
+    // Regression test for https://github.com/jj-vcs/jj/issues/9747: `jj run`
+    // panicked when its revset contained a conflicted commit. The post-command
+    // snapshot of such a commit is a conflicted (unresolved) tree, and the code
+    // assumed the result always resolved to a single tree.
+    let mut test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let fake_formatter = assert_cmd::cargo::cargo_bin("fake-formatter");
+    assert!(fake_formatter.is_file());
+    let fake_formatter_path = fake_formatter.to_string_lossy().into_owned();
+    test_env.add_paths_to_normalize(fake_formatter.clone(), "$FAKE_FORMATTER_PATH");
+    let work_dir = test_env.work_dir("repo");
+
+    // Build a merge whose two sides change `file` differently, so the merge
+    // commit `conflict` (and the working copy on it) conflicts in `file`.
+    create_commit_with_files(&work_dir, "base", &[], &[("file", "base\n")]);
+    create_commit_with_files(&work_dir, "a", &["base"], &[("file", "a\n")]);
+    create_commit_with_files(&work_dir, "b", &["base"], &[("file", "b\n")]);
+    create_commit_with_files(&work_dir, "conflict", &["a", "b"], &[]);
+    insta::assert_snapshot!(work_dir.run_jj(&["resolve", "--list"]).success().stdout, @r"
+    file    2-sided conflict
+    [EOF]
+    ");
+
+    // `jj run` over the conflicted commit used to panic. `--tee` writes a file in
+    // its working copy so the commit is actually rewritten, proving the conflict
+    // survives the rewrite instead of crashing.
+    let output = work_dir.run_jj(&[
+        "run",
+        "-r",
+        "conflict",
+        "--",
+        &fake_formatter_path,
+        "--stdout",
+        "x",
+        "--tee",
+        "touched.txt",
+    ]);
+    insta::assert_snapshot!(output, @r"
+    x[EOF]
+    ------- stderr -------
+    Rewrote 1 commits.
+    Working copy  (@) now at: vruxwmqv 74643194 conflict | (conflict) conflict
+    Parent commit (@-)      : zsuskuln 45537d53 a | a
+    Parent commit (@-)      : royxmykx 89d1b299 b | b
+    Added 1 files, modified 0 files, removed 0 files
+    Warning: There are unresolved conflicts at these paths:
+    file    2-sided conflict
+    New conflicts appeared in 1 commits:
+      vruxwmqv 74643194 conflict | (conflict) conflict
+    Hint: To resolve the conflicts, start by creating a commit on top of
+    the conflicted commit:
+      jj new vruxwmqv
+    Then use `jj resolve`, or edit the conflict markers in the file directly.
+    Once the conflicts are resolved, you can inspect the result with `jj diff`.
+    Then run `jj squash` to move the resolution into the conflicted commit.
+    [EOF]
+    ");
+
+    // The rewritten commit still conflicts in `file` and gained touched.txt.
+    insta::assert_snapshot!(work_dir.run_jj(&["resolve", "--list", "-r", "conflict"]).success().stdout, @r"
+    file    2-sided conflict
+    [EOF]
+    ");
+    insta::assert_snapshot!(work_dir.run_jj(&["file", "list", "-r", "conflict"]).success().stdout, @r"
+    file
+    touched.txt
+    [EOF]
+    ");
+}


### PR DESCRIPTION
## Problem

`jj run` panics when its revset includes a conflicted commit. Repro from #9747:

```
mkdir jj-run-bug && cd jj-run-bug && jj git init
echo foo >file && jj new -r zzzz && echo bar >file && jj new zzzz+
jj run -r 'mutable()' -- bash -c 'echo $JJ_CHANGE_ID'
```

It aborts with:

```
thread 'tokio-rt-worker' panicked at cli/src/commands/run.rs:526:49:
called `Option::unwrap()` on a `None` value
```

## Root cause

After running the command in a per-commit working copy, `rewrite_commit` snapshots
the result and did:

```rust
let rewritten_id = workspace.tree_state.current_tree().tree_ids();
let new_id = rewritten_id.as_resolved().unwrap();
```

`as_resolved()` returns `None` when the tree is conflicted. Checking out a conflicted
commit materializes the conflict, and if the command leaves it in place the snapshot is
again a conflicted tree, so the unwrap panics. This affects any conflicted commit in the
revset.

## Fix

`RunJob.new_tree` now carries the whole `MergedTree` from the snapshot (it was
`Option<Tree>`), which represents a conflict natively. The two rewrite sites already held
a `MergedTree` for `old_tree`, so they use `new_tree` directly instead of rebuilding a
resolved tree. The change is a net simplification, and the conflict is preserved in the
rewritten commit, consistent with how jj stores conflicts elsewhere.

## Test

`test_run_on_conflicted_commit` builds a merge that conflicts in `file`, runs `jj run`
over it with a command that also writes a new file, and asserts the commit is rewritten
with the conflict preserved and the new file added. It panics on the old code (confirmed
by reverting the one line change) and passes with the fix.

Fixes #9747