### PR TITLE
docs: Fix link to style guide in contributing.md

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -183,7 +183,7 @@ for an overview, especially if you are familiar with C++.
 
 ## Style guide
 
-See [here](style_guide.md).
+See [here](/docs/style_guide.md).
 
 ## Setting up a development environment
 


### PR DESCRIPTION
It is now absolute, so works both when viewed on the repository index page (i.e. the Contributing tab) and when navigating to docs/contributing.md directly.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] ~~I have updated `CHANGELOG.md`~~ (This is a documentation typo, so I don't think it warrants a changelog entry)
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`) :upside_down_face: 
- [ ] ~~I have updated the config schema (`cli/src/config-schema.json`)~~ - _N/A_
- [ ] ~~I have added/updated tests to cover my changes~~ - _N/A_
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] ~~For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.~~ _No LLMs involved here_
