### PR TITLE
cli: clean up gix temporaries on SIGINT/SIGTERM/SIGHUP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   aliases that are simply repeated. For example, with the alias `jj = []`, the
   command `jj jj jj log` will resolve to `jj log` as expected.
 
+* Git temporary files are now cleaned up more reliably in the presence of
+  signals (e.g. `Ctrl-C`). This should reduce the rate of "Could not acquire
+  lock for index file" errors. (#7530)
+
 ## [0.43.0] - 2026-07-01
 
 ### Release highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,6 +271,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "borrow-or-share"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -718,6 +727,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
+dependencies = [
+ "dispatch2",
+ "nix 0.31.3",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -890,6 +910,18 @@ dependencies = [
  "option-ext",
  "redox_users",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.13.0",
+ "block2",
+ "libc",
+ "objc2",
 ]
 
 [[package]]
@@ -2511,6 +2543,7 @@ dependencies = [
  "clap_mangen",
  "criterion",
  "crossterm",
+ "ctrlc",
  "datatest-stable",
  "dunce",
  "erased-serde",
@@ -3126,6 +3159,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
 name = "objc2-core-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3133,6 +3175,12 @@ checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.13.0",
 ]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "objc2-system-configuration"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ clap_mangen = "0.3.0"
 clru = "0.6.3"
 criterion = "0.8.2"
 crossterm = { version = "0.29", default-features = false, features = ["windows"] }
+ctrlc = { version = "3.5.2", features = ["termination"] }
 datatest-stable = "0.3.3"
 digest = "0.10.7"
 dunce = "1.0.5"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -73,6 +73,7 @@ clap_complete_nushell = { workspace = true }
 clap_mangen = { workspace = true }
 criterion = { workspace = true, optional = true }
 crossterm = { workspace = true }
+ctrlc = { workspace = true }
 dunce = { workspace = true }
 erased-serde = { workspace = true }
 etcetera = { workspace = true }

--- a/cli/src/cleanup_guard.rs
+++ b/cli/src/cleanup_guard.rs
@@ -1,6 +1,5 @@
-use std::io;
+use std::panic::AssertUnwindSafe;
 use std::sync::Mutex;
-use std::sync::Once;
 
 use slab::Slab;
 use tracing::instrument;
@@ -10,24 +9,39 @@ static LIVE_GUARDS: Mutex<GuardTable> = Mutex::new(Slab::new());
 
 type GuardTable = Slab<Box<dyn FnOnce() + Send>>;
 
-/// Prepare to run [`CleanupGuard`]s on `SIGINT`/`SIGTERM`
+/// Prepare to run [`CleanupGuard`]s on `SIGINT`/`SIGTERM`/`SIGHUP`
 pub fn init() {
-    // Safety: `` ensures at most one call
-    static CALLED: Once = Once::new();
-    CALLED.call_once(|| {
-        if let Err(e) = unsafe { platform::init() } {
-            eprintln!("couldn't register signal handler: {e}");
+    if let Err(e) = ctrlc::set_handler(|| {
+        // We must hold the lock for the remainder of the process's lifetime to avoid a
+        // race where a guard is created after we unlock but before we exit.
+        let guards = &mut *LIVE_GUARDS.lock().unwrap();
+        if let Err(e) = std::panic::catch_unwind(AssertUnwindSafe(|| {
+            for guard in guards.drain() {
+                guard();
+            }
+        })) {
+            match e.downcast::<String>() {
+                Ok(s) => eprintln!("ctrlc handler panicked: {s}"),
+                Err(_) => eprintln!("ctrlc handler panicked"),
+            }
         }
-    });
+
+        #[cfg(feature = "git")]
+        gix::tempfile::registry::cleanup_tempfiles();
+
+        std::process::exit(1);
+    }) {
+        eprintln!("couldn't register signal handler: {e}");
+    }
 }
 
-/// A drop guard that also runs on `SIGINT`/`SIGTERM`
+/// A drop guard that also runs on `SIGINT`/`SIGTERM`/`SIGHUP`
 pub struct CleanupGuard {
     slot: usize,
 }
 
 impl CleanupGuard {
-    /// Invoke `f` when dropped or killed by `SIGINT`/`SIGTERM`
+    /// Invoke `f` when dropped or killed by `SIGINT`/`SIGTERM`/`SIGHUP`
     pub fn new<F: FnOnce() + Send + 'static>(f: F) -> Self {
         let guards = &mut *LIVE_GUARDS.lock().unwrap();
         Self {
@@ -42,89 +56,5 @@ impl Drop for CleanupGuard {
         let guards = &mut *LIVE_GUARDS.lock().unwrap();
         let f = guards.remove(self.slot);
         f();
-    }
-}
-
-#[cfg(unix)]
-mod platform {
-    use std::os::unix::io::IntoRawFd as _;
-    use std::os::unix::io::RawFd;
-    use std::os::unix::net::UnixDatagram;
-    use std::panic::AssertUnwindSafe;
-    use std::sync::atomic::AtomicBool;
-    use std::sync::atomic::Ordering;
-    use std::thread;
-
-    use libc::SIGINT;
-    use libc::SIGTERM;
-    use libc::c_int;
-
-    use super::*;
-
-    /// Safety: Must be called at most once
-    pub unsafe fn init() -> io::Result<()> {
-        unsafe {
-            let (send, recv) = UnixDatagram::pair()?;
-
-            // Spawn a background thread that waits for the signal handler to write a signal
-            // into it
-            thread::spawn(move || {
-                let mut buf = [0];
-                let signal = match recv.recv(&mut buf) {
-                    Ok(1) => c_int::from(buf[0]),
-                    _ => unreachable!(),
-                };
-                // We must hold the lock for the remainder of the process's lifetime to avoid a
-                // race where a guard is created between `on_signal` and `raise`.
-                let guards = &mut *LIVE_GUARDS.lock().unwrap();
-                if let Err(e) = std::panic::catch_unwind(AssertUnwindSafe(|| on_signal(guards))) {
-                    match e.downcast::<String>() {
-                        Ok(s) => eprintln!("signal handler panicked: {s}"),
-                        Err(_) => eprintln!("signal handler panicked"),
-                    }
-                }
-                libc::signal(signal, libc::SIG_DFL);
-                libc::raise(signal);
-            });
-
-            SIGNAL_SEND = send.into_raw_fd();
-            libc::signal(SIGINT, handler as *const () as libc::sighandler_t);
-            libc::signal(SIGTERM, handler as *const () as libc::sighandler_t);
-            Ok(())
-        }
-    }
-
-    // Invoked on a background thread. Process exits after this returns.
-    fn on_signal(guards: &mut GuardTable) {
-        for guard in guards.drain() {
-            guard();
-        }
-    }
-
-    unsafe extern "C" fn handler(signal: c_int) {
-        unsafe {
-            // Treat the second signal as instantly fatal.
-            static SIGNALED: AtomicBool = AtomicBool::new(false);
-            if SIGNALED.swap(true, Ordering::Relaxed) {
-                libc::signal(signal, libc::SIG_DFL);
-                libc::raise(signal);
-            }
-
-            let buf = [signal as u8];
-            libc::write(SIGNAL_SEND, buf.as_ptr().cast(), buf.len());
-        }
-    }
-
-    static mut SIGNAL_SEND: RawFd = 0;
-}
-
-#[cfg(not(unix))]
-mod platform {
-    use super::*;
-
-    /// Safety: this function is safe to call, but is marked as unsafe to have
-    /// the same signature as other `init` functions in other platforms.
-    pub unsafe fn init() -> io::Result<()> {
-        Ok(())
     }
 }


### PR DESCRIPTION
This performs a series of minor improvements to the existing signal handling logic in `cleanup_guard.rs`:

1. Switch to using the `ctrlc` crate instead of manual signal syscalls. This crate has explicit Windows support, and provides a basic safe API for registering signal handlers. This is done by starting a background thread which is woken by termination signals.

2. If the git feature is enabled, instruct `gix` to cleanup any temporary files before exiting. This was done over instructing `gix` to install its own signal handlers to maintain control over exit behaviour.

# Notes

- This is similar in intention to #9507, but aims to be a more contained change. I expect eventually it might be nice to hook up `jj-lib` internals to be cancelled using a global cancellation token so that a single `Ctrl-C` could do graceful shutdown, but that seems like a substantial project requiring a lot of new hooks which would be difficult to review.

- ~~This patch adds a new copy of `signal-hook` into the tree, as `crossterm` uses `0.3.x`. This is OK, as the low-level registry is in the `signal-hook-registry` crate, which is intentionally shared across versions of the `signal-hook` crate (per the documentation: https://docs.rs/signal-hook-registry/latest/signal_hook_registry/)~~

- The `tokio` crate also has async signal handling features, including Windows support (https://docs.rs/tokio/latest/tokio/signal/index.html). I didn't use it as a tokio runtime is not started for most sub-commands.

- This subtly changes exit behaviour when jj is killed by a signal. On Linux, the program will now always exit with status 130 when killed with `SIGINT`, `SIGTERM` or `SIGHUP`, rather than exiting due to a signal. 

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
