### PR TITLE
remotes: suppress spurious trunk() warning

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -2227,19 +2227,6 @@ to the current parents may contain changes from multiple commits.
         description: impl Into<String>,
         _git_import_export_lock: &GitImportExportLock,
     ) -> Result<(), CommandError> {
-        if let Err(err) =
-            revset_util::try_resolve_trunk_alias(tx.repo(), &self.env.revset_parse_context())
-        {
-            writeln!(
-                ui.warning_default(),
-                "Failed to resolve `revset-aliases.trunk()`: {err}"
-            )?;
-            writeln!(
-                ui.hint_default(),
-                "Use `jj config edit --repo` to adjust the `trunk()` alias."
-            )?;
-        }
-
         let old_repo = tx.base_repo().clone();
 
         let maybe_old_wc_commit = old_repo

--- a/cli/src/commands/git/remote/remove.rs
+++ b/cli/src/commands/git/remote/remove.rs
@@ -38,12 +38,12 @@ pub async fn cmd_git_remote_remove(
     let mut workspace_command = command.workspace_helper(ui).await?;
     let mut tx = workspace_command.start_transaction();
     git::remove_remote(tx.repo_mut(), &args.remote)?;
+    remove_remote_from_repo_config(ui, command.raw_config(), &args.remote)?;
     if tx.repo().has_changes() {
         tx.finish(ui, format!("remove git remote {}", args.remote.as_symbol()))
             .await?;
     } else {
         // Do not print "Nothing changed." for the remote named "git".
     }
-    remove_remote_from_repo_config(ui, command.raw_config(), &args.remote)?;
     Ok(())
 }

--- a/cli/src/commands/git/remote/rename.rs
+++ b/cli/src/commands/git/remote/rename.rs
@@ -41,6 +41,7 @@ pub async fn cmd_git_remote_rename(
     let mut workspace_command = command.workspace_helper(ui).await?;
     let mut tx = workspace_command.start_transaction();
     git::rename_remote(tx.repo_mut(), &args.old, &args.new)?;
+    rename_remote_in_repo_config(ui, command.raw_config(), &args.old, &args.new)?;
     if tx.repo().has_changes() {
         tx.finish(
             ui,
@@ -54,6 +55,5 @@ pub async fn cmd_git_remote_rename(
     } else {
         // Do not print "Nothing changed."
     }
-    rename_remote_in_repo_config(ui, command.raw_config(), &args.old, &args.new)?;
     Ok(())
 }

--- a/cli/src/commands/util/exec.rs
+++ b/cli/src/commands/util/exec.rs
@@ -92,7 +92,7 @@ pub async fn cmd_util_exec(
 
     let status = cmd.status().map_err(|err| {
         user_error_with_message(
-            format!("Failed to execute external command '{}'", &args.command),
+            format!("Failed to execute external command '{}'", args.command),
             err,
         )
     })?;

--- a/cli/tests/test_git_clone.rs
+++ b/cli/tests/test_git_clone.rs
@@ -976,8 +976,6 @@ fn test_git_clone_trunk_deleted() {
     ------- stderr -------
     Forgot 1 local bookmarks.
     Forgot 1 remote bookmarks.
-    Warning: Failed to resolve `revset-aliases.trunk()`: Revision `main@origin` doesn't exist
-    Hint: Use `jj config edit --repo` to adjust the `trunk()` alias.
     [EOF]
     ");
 

--- a/cli/tests/test_git_remotes.rs
+++ b/cli/tests/test_git_remotes.rs
@@ -653,6 +653,36 @@ fn test_git_remote_rename() {
 }
 
 #[test]
+fn test_git_remote_rename_updates_trunk() {
+    // Verify trunk() resolves correctly after renaming the remote it references.
+    let test_env = TestEnvironment::default();
+
+    let remote_repo = git::init(test_env.env_root().join("remote"));
+    git::add_commit(&remote_repo, "refs/heads/main", "file", b"", "init", &[]);
+    git::set_symbolic_reference(&remote_repo, "HEAD", "refs/heads/main");
+    test_env
+        .run_jj_in(".", ["git", "clone", "--branch=main", "remote", "local"])
+        .success();
+    let local_dir = test_env.work_dir("local");
+
+    let output = local_dir.run_jj(["git", "remote", "rename", "origin", "upstream"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    Updating the revset alias `trunk()` to `main@upstream`.
+    [EOF]
+    ");
+
+    // trunk() should resolve to the correct commit after the rename
+    let output = local_dir.run_jj(["log", "-r", "trunk()", "-T", "description"]);
+    insta::assert_snapshot!(output, @"
+    ◆  init
+    │
+    ~
+    [EOF]
+    ");
+}
+
+#[test]
 fn test_git_remote_with_preset_config() {
     let test_env = TestEnvironment::default();
     // Add user-level config which shouldn't be renamed
@@ -714,12 +744,9 @@ fn test_git_remote_with_preset_config() {
     "#);
 
     // Preset repo-level config should be updated automatically
-    // TODO: suppress warning about unresolvable trunk()
     let output = local_dir.run_jj(["git", "remote", "rename", "origin", "foo"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Warning: Failed to resolve `revset-aliases.trunk()`: Revision `main@origin` doesn't exist
-    Hint: Use `jj config edit --repo` to adjust the `trunk()` alias.
     Updating the revset alias `trunk()` to `main@foo`.
     [EOF]
     ");
@@ -742,8 +769,6 @@ fn test_git_remote_with_preset_config() {
     let output = local_dir.run_jj(["git", "remote", "remove", "foo"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Warning: Failed to resolve `revset-aliases.trunk()`: Revision `main@foo` doesn't exist
-    Hint: Use `jj config edit --repo` to adjust the `trunk()` alias.
     Resetting the revset alias `trunk()` to default value.
     [EOF]
     ");


### PR DESCRIPTION
When renaming or removing a remote that the trunk() alias references, finish_transaction() would warn about the broken alias because the in-memory revset alias still pointed to the old remote name. The config file was only updated afterwards.

Fix this by updating the in-memory trunk() alias before finishing the transaction. Added update_revset_alias() on WorkspaceCommandTransaction for this purpose. The config file is still updated persistently afterwards by rename_remote_in_repo_config() / remove_remote_from_repo_config().

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [~] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [~] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
