### PR TITLE
annotate: use memchr to speed up line counting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2592,6 +2592,7 @@ dependencies = [
  "itertools 0.15.0",
  "jj-lib-proc-macros",
  "maplit",
+ "memchr",
  "nix 0.31.3",
  "num_cpus",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ itertools = "0.15.0"
 jsonschema = { version = "0.46.5", default-features = false }
 libc = { version = "0.2.186" }
 maplit = "1.0.2"
+memchr = "2.8.2"
 # no_thp due to perf issues with kernel page compaction, see #9708
 mimalloc = { version = "0.1.52", features = ["no_thp"] }
 nix = "0.31.3"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -49,6 +49,7 @@ interim = { workspace = true }
 itertools = { workspace = true }
 jj-lib-proc-macros = { workspace = true }
 maplit = { workspace = true }
+memchr = { workspace = true }
 once_cell = { workspace = true }
 pest = { workspace = true }
 pest_derive = { workspace = true }

--- a/lib/src/annotate.rs
+++ b/lib/src/annotate.rs
@@ -423,7 +423,7 @@ fn copy_same_lines_with(
     for hunk in diff.hunks() {
         match hunk.kind {
             DiffHunkKind::Matching => {
-                let count = hunk.contents[0].split_inclusive(|b| *b == b'\n').count();
+                let count = count_lines(hunk.contents[0]);
                 copy(current_line_counter, parent_line_counter, count);
                 current_line_counter += count;
                 parent_line_counter += count;
@@ -431,11 +431,20 @@ fn copy_same_lines_with(
             DiffHunkKind::Different => {
                 let current_output = hunk.contents[0];
                 let parent_output = hunk.contents[1];
-                current_line_counter += current_output.split_inclusive(|b| *b == b'\n').count();
-                parent_line_counter += parent_output.split_inclusive(|b| *b == b'\n').count();
+                current_line_counter += count_lines(current_output);
+                parent_line_counter += count_lines(parent_output);
             }
         }
     }
+}
+
+/// Counts the number of lines in `text`, where the last line may not end with
+/// a newline character. Equivalent to `text.split_inclusive(|b| *b ==
+/// b'\n').count()`, but faster.
+fn count_lines(text: &[u8]) -> usize {
+    let newlines = memchr::memchr_iter(b'\n', text).count();
+    let end_is_not_newline = text.last().is_some_and(|b| *b != b'\n');
+    newlines + usize::from(end_is_not_newline)
 }
 
 async fn get_file_contents(
@@ -564,5 +573,17 @@ mod tests {
                 (Ok(&commit_id3), 4..7),
             ]
         );
+    }
+
+    #[test]
+    fn test_count_lines() {
+        assert_eq!(count_lines(b""), 0);
+        assert_eq!(count_lines(b"\n"), 1);
+        assert_eq!(count_lines(b"foo"), 1);
+        assert_eq!(count_lines(b"foo\n"), 1);
+        assert_eq!(count_lines(b"foo\nbar"), 2);
+        assert_eq!(count_lines(b"foo\nbar\n"), 2);
+        assert_eq!(count_lines(b"foo\n\nbar\n"), 3);
+        assert_eq!(count_lines(b"foo\n\nbar\n\n"), 4);
     }
 }


### PR DESCRIPTION
'jj file annotate' is often much slower than 'git blame', which can make it frustrating to use (cc #4878). This change speeds up 'jj file annotate' significantly by using memchr. When testing on a file in my local rust-lang/rust checkout with a long history, I found a speedup of about 35%.

Before:

    ❯ hyperfine "~/code/jj/target/release/jj --no-pager file annotate src/librustdoc/clean/mod.rs"
    Benchmark 1: ~/code/jj/target/release/jj --no-pager file annotate src/librustdoc/clean/mod.rs
      Time (mean ± σ):     18.174 s ±  0.348 s    [User: 18.171 s, System: 0.207 s]
      Range (min … max):   17.545 s … 18.836 s    10 runs

After:

    ❯ hyperfine "~/code/jj/target/release/jj --no-pager file annotate src/librustdoc/clean/mod.rs"
    Benchmark 1: ~/code/jj/target/release/jj --no-pager file annotate src/librustdoc/clean/mod.rs
      Time (mean ± σ):     13.472 s ±  0.141 s    [User: 13.471 s, System: 0.206 s]
      Range (min … max):   13.291 s … 13.714 s    10 runs

LLM disclaimer: I used an LLM to investigate this performance problem and find a fix, but I manually checked and tweaked the code and ran the above performance evaluation.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
