### PR TITLE
git init: use shlex::try_quote for remote name bookmark hints

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -4600,6 +4600,12 @@ fn warn_if_args_mismatch(
     Ok(())
 }
 
+pub fn shell_quote(s: &str) -> Cow<'_, str> {
+    // shlex::try_quote fails if `s` has a nul byte, which
+    // shouldn't usually happen. Fall back to unquoted on error.
+    shlex::try_quote(s).unwrap_or(s.into())
+}
+
 #[cfg(test)]
 mod tests {
     use clap::CommandFactory as _;

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -3122,12 +3122,7 @@ pub fn print_large_file_hint(
 ) -> io::Result<()> {
     let (command, extra) = large_files
         .map(|files| {
-            // shlex::try_quote fails if the string contains a nul byte, which
-            // shouldn't happen for file paths. Fall back to unquoted on error.
-            let files_list = files
-                .iter()
-                .map(|s| shlex::try_quote(s).unwrap_or(s.into()))
-                .join(" ");
+            let files_list = files.iter().map(|s| shell_quote(s)).join(" ");
             let command = format!("file track {files_list}");
             let extra = format!(
                 r"

--- a/cli/src/commands/git/init.rs
+++ b/cli/src/commands/git/init.rs
@@ -33,6 +33,7 @@ use jj_lib::workspace::Workspace;
 use super::RepoPresets;
 use super::write_repo_presets;
 use crate::cli_util::CommandHelper;
+use crate::cli_util::shell_quote;
 use crate::cli_util::start_repo_transaction;
 use crate::command_error::CommandError;
 use crate::command_error::cli_error;
@@ -359,8 +360,8 @@ fn print_trackable_remote_bookmarks(ui: &Ui, view: &View) -> io::Result<()> {
             writeln!(
                 formatter.labeled("hint"),
                 "  jj bookmark track {name} --remote={remote}",
-                name = symbol.name.as_symbol(),
-                remote = symbol.remote.as_symbol()
+                name = shell_quote(&symbol.name.as_symbol().to_string()),
+                remote = shell_quote(&symbol.remote.as_symbol().to_string()),
             )?;
         }
     }


### PR DESCRIPTION
Found this issue when using `jj` with Radicle since it sets up remotes with names in the form of `alias@rid` which then lead to the `Failed to parse name pattern: Invalid string expression` error when using the generated `jj bookmark track main --remote="alias@rid"` hint.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
