### PR TITLE
cli: hint at recovered changes after `workspace update-stale`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * New `merge_point()` revset function which (similar to `fork_point`) finds the
   point where multiple branches merge.
 
+* When `jj workspace update-stale` resets a working copy with un-snapshotted
+  changes, it now provides a hint on how to recover them.
+  [#7229](https://github.com/jj-vcs/jj/issues/7229)
+
 ### Fixed bugs
 
 * Recursive alias definitions are detected more precisely. jj can now expand

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -596,6 +596,7 @@ impl CommandHelper {
                 // operation, then merge the divergent operations. The wc_commit_id of the
                 // merged repo wouldn't change because the old one wins, but it's probably
                 // fine if we picked the new wc_commit_id.
+                let pre_snapshot_commit_id = workspace_command.get_wc_commit_id().cloned();
                 let stale_stats = workspace_command
                     .snapshot_working_copy(ui)
                     .await
@@ -604,6 +605,9 @@ impl CommandHelper {
                 let wc_commit_id = workspace_command.get_wc_commit_id().unwrap();
                 let repo = workspace_command.repo().clone();
                 let stale_wc_commit = repo.store().get_commit_async(wc_commit_id).await?;
+                // The snapshot above amends the working-copy commit only if the stale working
+                // copy had un-snapshotted changes.
+                let recovered_local_changes = pre_snapshot_commit_id.as_ref() != Some(wc_commit_id);
 
                 let mut workspace_command = self.workspace_helper_no_snapshot(ui).await?;
 
@@ -645,6 +649,20 @@ impl CommandHelper {
                             "Updated working copy to fresh commit {}",
                             short_commit_hash(desired_wc_commit.id())
                         )?;
+                        // The checkout above overwrote the working copy on disk, so files appear
+                        // to change or disappear even though nothing was lost: the un-snapshotted
+                        // changes were preserved in `stale_wc_commit`. Point the user at that
+                        // commit so the update doesn't look like data loss.
+                        if recovered_local_changes {
+                            let stale_commit = short_commit_hash(stale_wc_commit.id());
+                            writedoc!(
+                                ui.hint_default(),
+                                "
+                                Working-copy changes were saved in commit {stale_commit}.
+                                Restore them with `jj restore --from {stale_commit}`.
+                                ",
+                            )?;
+                        }
                     }
                 }
 

--- a/cli/tests/test_workspaces.rs
+++ b/cli/tests/test_workspaces.rs
@@ -766,6 +766,8 @@ fn test_workspaces_conflicting_edits() {
     Parent commit (@-)      : qpvuntsm b853f7c8 (no description set)
     Added 0 files, modified 1 files, removed 0 files
     Updated working copy to fresh commit 90f3d42e0bff
+    Hint: Working-copy changes were saved in commit 5f9e41510c33.
+    Restore them with `jj restore --from 5f9e41510c33`.
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&secondary_dir),
@@ -998,6 +1000,8 @@ fn test_workspaces_updated_by_other_with_changes_in_working_copy_automatic() {
     Parent commit (@-)      : qpvuntsm b853f7c8 (no description set)
     Added 0 files, modified 1 files, removed 0 files
     Updated working copy to fresh commit 90f3d42e0bff
+    Hint: Working-copy changes were saved in commit 8e2b91d60d5d.
+    Restore them with `jj restore --from 8e2b91d60d5d`.
     Working copy  (@) now at: pmmvwywv/0 c38323e3 (divergent) (empty) modified
     Parent commit (@-)      : qpvuntsm b853f7c8 (no description set)
     [EOF]
@@ -1325,6 +1329,55 @@ fn test_workspaces_update_stale_snapshot() {
     ◆  000000000000
     [EOF]
     ");
+}
+
+/// `jj workspace update-stale` overwrites the working copy on disk, but should
+/// tell the user which commit their un-snapshotted changes were saved in, and
+/// that commit should recover them via `jj restore`.
+#[test]
+fn test_workspaces_update_stale_recovers_changes() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "main"]).success();
+    let main_dir = test_env.work_dir("main");
+    let secondary_dir = test_env.work_dir("secondary");
+
+    main_dir.write_file("file", "contents\n");
+    main_dir.run_jj(["new"]).success();
+    main_dir
+        .run_jj(["workspace", "add", "../secondary"])
+        .success();
+
+    // Make an un-snapshotted change in the secondary working copy, then rewrite
+    // that workspace's working-copy commit from the main workspace so the
+    // secondary working copy becomes stale.
+    secondary_dir.write_file("file", "precious changes\n");
+    main_dir.write_file("file", "changed in main\n");
+    main_dir.run_jj(["squash"]).success();
+
+    // Recovering the stale working copy overwrites the file on disk, but the
+    // hint points at the commit that preserved the un-snapshotted change.
+    let output = secondary_dir.run_jj(["workspace", "update-stale"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    Concurrent modification detected, resolving automatically.
+    Rebased 1 descendant commits onto commits rewritten by other operation.
+    Working copy  (@) now at: pmmvwywv/2 9986aa24 (divergent) (empty) (no description set)
+    Parent commit (@-)      : qpvuntsm dcf7f611 (no description set)
+    Added 0 files, modified 1 files, removed 0 files
+    Updated working copy to fresh commit 9986aa24e594
+    Hint: Working-copy changes were saved in commit 9ae6e8703803.
+    Restore them with `jj restore --from 9ae6e8703803`.
+    [EOF]
+    ");
+
+    // The un-snapshotted change is no longer on disk...
+    insta::assert_snapshot!(secondary_dir.read_file("file"), @"changed in main");
+
+    // ...but restoring from the hinted commit brings it back.
+    secondary_dir
+        .run_jj(["restore", "--from", "9ae6e8703803"])
+        .success();
+    insta::assert_snapshot!(secondary_dir.read_file("file"), @"precious changes\n");
 }
 
 /// Test that "workspace update-stale" works in colocated repos.


### PR DESCRIPTION
## Problem

When `jj workspace update-stale` resets a stale working copy, it first snapshots any un-snapshotted on-disk changes into a commit, then checks out the fresh commit — overwriting those changes on disk. The only output names the *fresh* commit, so the update looks like data loss even though the changes were preserved and are recoverable:

```
$ jj workspace update-stale
...
Updated working copy to fresh commit 90f3d42e0bff
```

This has confused several users (e.g. #7229, and reports on Discord). `jj undo` doesn't help here either, because update-stale ends on a reconcile/merge operation (`Error: Cannot undo a merge operation`), so the command's own output is the only reasonable place to surface the recovery path.

## Change

When the pre-update snapshot actually preserved un-snapshotted changes, print a hint naming the commit they were saved in and the `jj restore` to get them back:

```
Updated working copy to fresh commit 90f3d42e0bff
Hint: Working-copy changes were saved in commit 5f9e41510c33.
Restore them with `jj restore --from 5f9e41510c33`.
```

- Only fires when the pre-update snapshot amended the working-copy commit (i.e. there were un-snapshotted changes that got overwritten) — no output in the clean case.
- The lost-operation recovery path already prints a labeled `RECOVERY COMMIT FROM ...` explanation; this gives the far more common normal path the same legibility.

## Tests

- New `test_workspaces_update_stale_recovers_changes`: makes a workspace stale with an un-snapshotted edit, runs `jj workspace update-stale`, asserts the hint, then runs the exact `jj restore --from <hinted commit>` and asserts the edit is recovered — a full round-trip.
- Updated the two existing snapshots that hit this path (explicit `update-stale`, and the auto-update-stale case). The clean-stale and "attempted recovery, but not stale" tests are unchanged, pinning the gating.
- Full `jj-cli` suite passes; `cargo fmt` clean.

Addresses the confusion reported in #7229.
