### PR TITLE
cli: warn that a forgotten current workspace becomes a shadow checkout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   aliases are available for `jj workspace list`, and `WorkspaceRef.root()` now
   returns an optional `FsPath` value.
 
+* `jj workspace forget` now hints, when you forget the workspace you're currently
+  in, that its working copy is left on disk as an unregistered checkout — and that
+  a later workspace reusing the same name (e.g. `jj workspace add <path>` deriving
+  the name from the path) would silently shadow it.
+
 ### Fixed bugs
 
 * Recursive alias definitions are detected more precisely. jj can now expand

--- a/cli/src/commands/workspace/forget.rs
+++ b/cli/src/commands/workspace/forget.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use clap_complete::ArgValueCandidates;
+use indoc::writedoc;
 use itertools::Itertools as _;
 use jj_lib::ref_name::WorkspaceNameBuf;
 use jj_lib::workspace_store::SimpleWorkspaceStore;
@@ -44,8 +45,10 @@ pub async fn cmd_workspace_forget(
 ) -> Result<(), CommandError> {
     let mut workspace_command = command.workspace_helper(ui).await?;
 
+    let current_workspace = workspace_command.workspace_name().to_owned();
+
     let wss = if args.workspaces.is_empty() {
-        vec![workspace_command.workspace_name().to_owned()]
+        vec![current_workspace.clone()]
     } else {
         args.workspaces.clone()
     };
@@ -93,6 +96,27 @@ pub async fn cmd_workspace_forget(
         )
     };
 
+    let forgot_current = forget_ws.iter().any(|ws| **ws == current_workspace);
+
     tx.finish(ui, description).await?;
+
+    // Forgetting the workspace you're standing in leaves its working copy on
+    // disk as an unregistered checkout. If a new workspace later reuses this
+    // name (e.g. `jj workspace add <path>` derives the name from the path's
+    // basename), this directory will silently shadow it and jj commands run
+    // here can create divergent commits.
+    if forgot_current {
+        let name = current_workspace.as_symbol();
+        writedoc!(
+            ui.hint_default(),
+            "
+            The working copy for '{name}' is left on disk but is no longer a registered
+            workspace. Creating another workspace with the same name will make this
+            directory shadow it; give future workspaces a distinct name with
+            `jj workspace add --name`.
+            ",
+        )?;
+    }
+
     Ok(())
 }

--- a/cli/tests/test_workspaces.rs
+++ b/cli/tests/test_workspaces.rs
@@ -1466,6 +1466,10 @@ fn test_workspaces_forget() {
     ------- stderr -------
     Warning: The current workspace 'default' no longer exists after this operation. The working copy was left untouched.
     Hint: Restore to an operation that contains the workspace (e.g. `jj undo` or `jj redo`).
+    Hint: The working copy for 'default' is left on disk but is no longer a registered
+    workspace. Creating another workspace with the same name will make this
+    directory shadow it; give future workspaces a distinct name with
+    `jj workspace add --name`.
     [EOF]
     ");
 
@@ -1535,6 +1539,38 @@ fn test_workspaces_forget() {
     insta::assert_snapshot!(output, @"");
 }
 
+/// Forgetting the current workspace warns that its leftover checkout could be
+/// shadowed by a same-named workspace; forgetting another one does not.
+#[test]
+fn test_workspaces_forget_warns_about_shadow() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "main"]).success();
+    let main_dir = test_env.work_dir("main");
+
+    main_dir
+        .run_jj(["workspace", "add", "../secondary"])
+        .success();
+
+    // Forgetting a workspace other than the current one leaves the current working
+    // copy untouched, so there is no shadowing warning.
+    let output = main_dir.run_jj(["workspace", "forget", "secondary"]);
+    insta::assert_snapshot!(output, @"");
+
+    // Forgetting the current workspace leaves its working copy on disk as an
+    // unregistered checkout, so warn that a same-named workspace would shadow it.
+    let output = main_dir.run_jj(["workspace", "forget"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    Warning: The current workspace 'default' no longer exists after this operation. The working copy was left untouched.
+    Hint: Restore to an operation that contains the workspace (e.g. `jj undo` or `jj redo`).
+    Hint: The working copy for 'default' is left on disk but is no longer a registered
+    workspace. Creating another workspace with the same name will make this
+    directory shadow it; give future workspaces a distinct name with
+    `jj workspace add --name`.
+    [EOF]
+    ");
+}
+
 /// Test forgetting workspace created before workspace store
 #[test]
 fn test_workspaces_forget_from_before_workspace_store() {
@@ -1549,6 +1585,10 @@ fn test_workspaces_forget_from_before_workspace_store() {
     ------- stderr -------
     Warning: The current workspace 'default' no longer exists after this operation. The working copy was left untouched.
     Hint: Restore to an operation that contains the workspace (e.g. `jj undo` or `jj redo`).
+    Hint: The working copy for 'default' is left on disk but is no longer a registered
+    workspace. Creating another workspace with the same name will make this
+    directory shadow it; give future workspaces a distinct name with
+    `jj workspace add --name`.
     [EOF]
     ");
 


### PR DESCRIPTION
## Problem

`jj workspace forget` leaves the working copy on disk (by design). When you forget the workspace you're currently in — commonly the repo root, when setting up a "bare-ish" repo where all real work happens in nested workspaces — that directory becomes an *unregistered* checkout. Nothing warns you that it's now a latent footgun:

- `jj workspace add <path>` derives the new workspace's name from the path's basename, so `jj workspace add work/default` recreates a workspace named `default`. If the old `default` checkout is still on disk (e.g. the repo root), the two now share one logical workspace name.
- From then on, jj commands run in the shadow directory snapshot *its* tree as that workspace, which can produce divergent commits and strand edits made in the "real" workspace — all with no error.

This is the setup behind the confusion in #5271 (and a recent Discord thread on peer-workspace / bare-repo layouts). The maintainers there agreed a warning would help; this adds the piece that's cleanly detectable today.

## Change

When `jj workspace forget` forgets the workspace you're currently in, print a hint:

```
Hint: The working copy for 'default' is left on disk but is no longer a registered workspace. Creating another workspace with the same name will make this directory shadow it; give future workspaces a distinct name with `jj workspace add --name`, or delete this directory.
```

- Fires **only** when the forgotten set includes the current workspace — the immediate, dangerous case. Forgetting other workspaces stays silent.
- It's an additional hint after the existing "current workspace no longer exists … `jj undo`" warning; the shared warning message is untouched, so `op restore`/`undo`/`redo` output is unchanged.

## Scope

This intentionally does **not** try to detect the more general "you forgot the workspace that holds the git store" case (#5271's original example), because the repo view tracks workspaces by name → commit only, with no on-disk path — so jj can't identify the store-holding workspace after the fact. The forget-current case is what's cleanly detectable and covers the common shadow-checkout footgun. A fuller solution would need workspace path tracking.

## Tests

- Updated the two existing forget-of-current snapshots (`test_workspaces_forget`, `test_workspaces_forget_from_before_workspace_store`) to include the hint.
- The three forget-of-other tests stay unchanged, pinning that the hint does not fire for non-current workspaces.
- Full `jj-cli` suite passes; nightly `cargo fmt` clean.

Discussed in #5271.
