### PR TITLE
op diff: treat diff of a merge operation as empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   aliases that are simply repeated. For example, with the alias `jj = []`, the
   command `jj jj jj log` will resolve to `jj log` as expected.
 
+* `jj op diff` of a merge operation (e.g. "reconcile divergent operations")
+  now shows an empty diff, consistent with `jj op log --op-diff` and
+  `jj op show`. It previously re-executed the merge, which could show
+  spurious changed commits or fail with "Predecessors cycle detected".
+  [#8925](https://github.com/jj-vcs/jj/issues/8925)
+
 ## [0.43.0] - 2026-07-01
 
 ### Release highlights

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -223,6 +223,12 @@ Thanks to the people who made this release happen!
 * Yash Bavadiya (@xevrion)
 * Yuya Nishihara (@yuja)
 
+* `jj op diff` of a merge operation (e.g. "reconcile divergent operations")
+  now shows an empty diff, consistent with `jj op log --op-diff` and
+  `jj op show`. It previously re-executed the merge, which could show
+  spurious changed commits or fail with "Predecessors cycle detected".
+  [#8925](https://github.com/jj-vcs/jj/issues/8925)
+
 ## [0.43.0] - 2026-07-01
 
 ### Release highlights

--- a/cli/src/commands/operation/diff.rs
+++ b/cli/src/commands/operation/diff.rs
@@ -31,6 +31,7 @@ use jj_lib::matchers::EverythingMatcher;
 use jj_lib::op_store::RefTarget;
 use jj_lib::op_store::RemoteRef;
 use jj_lib::op_store::RemoteRefState;
+use jj_lib::operation::Operation;
 use jj_lib::refs::diff_named_commit_ids;
 use jj_lib::refs::diff_named_ref_targets;
 use jj_lib::refs::diff_named_remote_refs;
@@ -126,6 +127,25 @@ pub async fn cmd_op_diff(
     }
     let graph_style = GraphStyle::from_settings(settings)?;
     let with_content_format = LogContentFormat::new(ui, settings)?;
+    let diff_formats = diff_formats_for_log(settings, &args.diff_format, args.patch)?;
+    let op_diff_changes_expr =
+        parse_op_diff_changes_in(ui, settings, workspace_env, args.show_changes_in.as_deref())?;
+
+    // The diff of a merge operation is treated as empty, matching the output
+    // of `op log --op-diff` and `op show` for multi-parent operations
+    // (#4465). The parent operations aren't merged here because that would
+    // re-execute the rebasing of descendants, which would produce commits
+    // different from the ones recorded by the merge operation and write an
+    // unpublished operation to the store.
+    if from_ops.len() > 1 {
+        let op_summary_template = workspace_command
+            .operation_summary_template()
+            .labeled(["op_diff"]);
+        ui.request_pager();
+        let mut formatter = ui.stdout_formatter();
+        write_op_diff_header(&mut *formatter, &op_summary_template, &from_ops, &to_op)?;
+        return Ok(());
+    }
 
     let workspace_name = None;
     let transaction_description = None;
@@ -150,11 +170,16 @@ pub async fn cmd_op_diff(
     let merged_repo = tx.repo();
 
     let diff_renderer = {
-        let formats = diff_formats_for_log(settings, &args.diff_format, args.patch)?;
         let path_converter = workspace_env.path_converter();
         let conflict_marker_style = workspace_env.conflict_marker_style();
-        (!formats.is_empty())
-            .then(|| DiffRenderer::new(merged_repo, path_converter, conflict_marker_style, formats))
+        (!diff_formats.is_empty()).then(|| {
+            DiffRenderer::new(
+                merged_repo,
+                path_converter,
+                conflict_marker_style,
+                diff_formats,
+            )
+        })
     };
     let id_prefix_context = workspace_env.new_id_prefix_context();
     let commit_summary_template = {
@@ -165,23 +190,12 @@ pub async fn cmd_op_diff(
             .labeled(["op_diff", "commit"])
     };
 
-    let op_diff_changes_expr =
-        parse_op_diff_changes_in(ui, settings, workspace_env, args.show_changes_in.as_deref())?;
-
     let op_summary_template = workspace_command
         .operation_summary_template()
         .labeled(["op_diff"]);
     ui.request_pager();
     let mut formatter = ui.stdout_formatter();
-    for op in &from_ops {
-        write!(formatter, "From operation: ")?;
-        op_summary_template.format(op, &mut *formatter)?;
-        writeln!(formatter)?;
-    }
-    //                "From operation: "
-    write!(formatter, "  To operation: ")?;
-    op_summary_template.format(&to_op, &mut *formatter)?;
-    writeln!(formatter)?;
+    write_op_diff_header(&mut *formatter, &op_summary_template, &from_ops, &to_op)?;
 
     show_op_diff(
         ui,
@@ -197,6 +211,24 @@ pub async fn cmd_op_diff(
         op_diff_changes_expr,
     )
     .await
+}
+
+fn write_op_diff_header(
+    formatter: &mut dyn Formatter,
+    op_summary_template: &TemplateRenderer<Operation>,
+    from_ops: &[Operation],
+    to_op: &Operation,
+) -> Result<(), CommandError> {
+    for op in from_ops {
+        write!(formatter, "From operation: ")?;
+        op_summary_template.format(op, formatter)?;
+        writeln!(formatter)?;
+    }
+    //                "From operation: "
+    write!(formatter, "  To operation: ")?;
+    op_summary_template.format(to_op, formatter)?;
+    writeln!(formatter)?;
+    Ok(())
 }
 
 /// Parses the revset expression used to filter revisions in operation diffs.

--- a/cli/src/commands/operation/diff.rs
+++ b/cli/src/commands/operation/diff.rs
@@ -31,6 +31,7 @@ use jj_lib::matchers::EverythingMatcher;
 use jj_lib::op_store::RefTarget;
 use jj_lib::op_store::RemoteRef;
 use jj_lib::op_store::RemoteRefState;
+use jj_lib::operation::Operation;
 use jj_lib::refs::diff_named_commit_ids;
 use jj_lib::refs::diff_named_ref_targets;
 use jj_lib::refs::diff_named_remote_refs;
@@ -125,6 +126,25 @@ pub async fn cmd_op_diff(
     }
     let graph_style = GraphStyle::from_settings(settings)?;
     let with_content_format = LogContentFormat::new(ui, settings)?;
+    let diff_formats = diff_formats_for_log(settings, &args.diff_format, args.patch)?;
+    let op_diff_changes_expr =
+        parse_op_diff_changes_in(ui, settings, workspace_env, args.show_changes_in.as_deref())?;
+
+    // The diff of a merge operation is treated as empty, matching the output
+    // of `op log --op-diff` and `op show` for multi-parent operations
+    // (#4465). The parent operations aren't merged here because that would
+    // re-execute the rebasing of descendants, which would produce commits
+    // different from the ones recorded by the merge operation and write an
+    // unpublished operation to the store.
+    if from_ops.len() > 1 {
+        let op_summary_template = workspace_command
+            .operation_summary_template()
+            .labeled(["op_diff"]);
+        ui.request_pager();
+        let mut formatter = ui.stdout_formatter();
+        write_op_diff_header(&mut *formatter, &op_summary_template, &from_ops, &to_op)?;
+        return Ok(());
+    }
 
     let merged_from_op = repo_loader.merge_operations(from_ops.clone(), None).await?;
     let from_repo = repo_loader.load_at(&merged_from_op).await?;
@@ -138,11 +158,16 @@ pub async fn cmd_op_diff(
     let merged_repo = tx.repo();
 
     let diff_renderer = {
-        let formats = diff_formats_for_log(settings, &args.diff_format, args.patch)?;
         let path_converter = workspace_env.path_converter();
         let conflict_marker_style = workspace_env.conflict_marker_style();
-        (!formats.is_empty())
-            .then(|| DiffRenderer::new(merged_repo, path_converter, conflict_marker_style, formats))
+        (!diff_formats.is_empty()).then(|| {
+            DiffRenderer::new(
+                merged_repo,
+                path_converter,
+                conflict_marker_style,
+                diff_formats,
+            )
+        })
     };
     let id_prefix_context = workspace_env.new_id_prefix_context();
     let commit_summary_template = {
@@ -153,23 +178,12 @@ pub async fn cmd_op_diff(
             .labeled(["op_diff", "commit"])
     };
 
-    let op_diff_changes_expr =
-        parse_op_diff_changes_in(ui, settings, workspace_env, args.show_changes_in.as_deref())?;
-
     let op_summary_template = workspace_command
         .operation_summary_template()
         .labeled(["op_diff"]);
     ui.request_pager();
     let mut formatter = ui.stdout_formatter();
-    for op in &from_ops {
-        write!(formatter, "From operation: ")?;
-        op_summary_template.format(op, &mut *formatter)?;
-        writeln!(formatter)?;
-    }
-    //                "From operation: "
-    write!(formatter, "  To operation: ")?;
-    op_summary_template.format(&to_op, &mut *formatter)?;
-    writeln!(formatter)?;
+    write_op_diff_header(&mut *formatter, &op_summary_template, &from_ops, &to_op)?;
 
     show_op_diff(
         ui,
@@ -185,6 +199,24 @@ pub async fn cmd_op_diff(
         op_diff_changes_expr,
     )
     .await
+}
+
+fn write_op_diff_header(
+    formatter: &mut dyn Formatter,
+    op_summary_template: &TemplateRenderer<Operation>,
+    from_ops: &[Operation],
+    to_op: &Operation,
+) -> Result<(), CommandError> {
+    for op in from_ops {
+        write!(formatter, "From operation: ")?;
+        op_summary_template.format(op, formatter)?;
+        writeln!(formatter)?;
+    }
+    //                "From operation: "
+    write!(formatter, "  To operation: ")?;
+    op_summary_template.format(to_op, formatter)?;
+    writeln!(formatter)?;
+    Ok(())
 }
 
 /// Parses the revset expression used to filter revisions in operation diffs.

--- a/cli/tests/test_operations.rs
+++ b/cli/tests/test_operations.rs
@@ -2239,17 +2239,28 @@ fn test_op_diff_at_merge_op_with_rebased_commits() {
     [EOF]
     ");
 
-    // FIXME: the diff should be empty
+    // The diff of a merge operation is treated as empty.
     let output = work_dir.run_jj(["op", "diff"]);
     insta::assert_snapshot!(output, @"
     From operation: aebc639c7fdb (2001-02-03 08:05:09) describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     From operation: f36a8c8cba9e (2001-02-03 08:05:10) describe commit ab92d1a87bebb4300165a16a753c5403bd7bc578
       To operation: 8f0e2ab3b7cc (2001-02-03 08:05:11) reconcile divergent operations
-
-    Changed commits:
-    ○  + rlvkpnrz/1 8f35f6a6 (divergent) (empty) 2b
-       - rlvkpnrz/0 4545eaf5 (hidden) (empty) 2b
     [EOF]
+    ");
+
+    // Argument validation still applies even though the diff is empty.
+    let output = work_dir.run_jj(["op", "diff", "--show-changes-in", "(bad"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    Error: Invalid `--show-changes-in` expression: (bad
+    Caused by:  --> 1:5
+      |
+    1 | (bad
+      |     ^---
+      |
+      = expected `@`, `:`, `-`, `+`, `::`, `..`, `|`, `&`, or `~`
+    [EOF]
+    [exit status: 1]
     ");
 
     let output = work_dir.run_jj(["op", "show"]);

--- a/cli/tests/test_operations.rs
+++ b/cli/tests/test_operations.rs
@@ -2237,17 +2237,28 @@ fn test_op_diff_at_merge_op_with_rebased_commits() {
     [EOF]
     ");
 
-    // FIXME: the diff should be empty
+    // The diff of a merge operation is treated as empty.
     let output = work_dir.run_jj(["op", "diff"]);
     insta::assert_snapshot!(output, @"
     From operation: e20b9b9f8704 (2001-02-03 08:05:09) describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     From operation: 71ec13d562f6 (2001-02-03 08:05:10) describe commit ab92d1a87bebb4300165a16a753c5403bd7bc578
       To operation: 110aea121037 (2001-02-03 08:05:11) reconcile divergent operations
-
-    Changed commits:
-    ○  + rlvkpnrz/1 8f35f6a6 (divergent) (empty) 2b
-       - rlvkpnrz/0 4545eaf5 (hidden) (empty) 2b
     [EOF]
+    ");
+
+    // Argument validation still applies even though the diff is empty.
+    let output = work_dir.run_jj(["op", "diff", "--show-changes-in", "(bad"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    Error: Invalid `--show-changes-in` expression: (bad
+    Caused by:  --> 1:5
+      |
+    1 | (bad
+      |     ^---
+      |
+      = expected `@`, `:`, `-`, `+`, `::`, `..`, `|`, `&`, or `~`
+    [EOF]
+    [exit status: 1]
     ");
 
     let output = work_dir.run_jj(["op", "show"]);


### PR DESCRIPTION
`jj op diff` on a reconcile operation built its from-side by re-running
the merge of the parent operations, including `rebase_descendants()`.
The re-run mints commits timestamped "now", so their ids never match
the ones the reconcile actually recorded. Besides the spurious diff in
#8925, the same mechanism makes `op diff` fail with "Internal error:
Predecessors cycle detected" when run within the same second as the
reconciliation (the re-minted id collides with the recorded one), and
it writes an unpublished operation to the store on every invocation.

This treats the diff of a merge operation as empty, matching the
output of `op log --op-diff` and `op show` for multi-parent
operations, and resolves the FIXME in
`test_op_diff_at_merge_op_with_rebased_commits`.

Note that `op show` and `op log --op-diff` still run the merge before
skipping the display, so they still write an unpublished operation on
each invocation over a merge operation. Happy to align them with this
approach in a follow-up if that's wanted.

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
