### PR TITLE
run: add --passthrough flag to pass through the terminal to the subprocess

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
    order is guaranteed: each revision begins execution only after the previous
    one has started, even with `--jobs` higher than 1.
 
+* `jj run` gained a `--passthrough` flag that connects the subprocess's
+  stdout/stderr directly to the terminal instead of capturing output.
+
 ### Fixed bugs
 
 * Recursive alias definitions are detected more precisely. jj can now expand

--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -25,6 +25,7 @@ use std::num::NonZeroUsize;
 use std::path::Path;
 use std::path::PathBuf;
 use std::process::ExitStatus;
+use std::process::Output;
 use std::process::Stdio;
 use std::sync::Arc;
 use std::time::Duration;
@@ -376,6 +377,7 @@ struct RunJob {
 }
 
 // TODO: make this more revset/commit stream friendly.
+#[allow(clippy::too_many_arguments)]
 async fn run_inner(
     tx: &WorkspaceCommandTransaction<'_>,
     sender: Sender<RunJob>,
@@ -384,6 +386,7 @@ async fn run_inner(
     pool: Arc<WorkspacePool>,
     commits: Arc<Vec<Commit>>,
     jobs: usize,
+    passthrough: bool,
 ) -> Result<(), RunError> {
     let base_ignores = tx.base_workspace_helper().base_ignores().unwrap().clone();
     let semaphore = Arc::new(Semaphore::new(jobs));
@@ -403,7 +406,7 @@ async fn run_inner(
             async move {
                 let _permit = permit;
                 // TODO: handle/propagate error here
-                rewrite_commit(base_ignores, pool, commit, spec).await
+                rewrite_commit(base_ignores, pool, commit, spec, passthrough).await
             },
             handle,
         );
@@ -433,6 +436,7 @@ async fn rewrite_commit(
     pool: Arc<WorkspacePool>,
     commit: Commit,
     spec: Arc<CommandSpec>,
+    passthrough: bool,
 ) -> Result<RunJob, RunError> {
     let mut workspace = pool.acquire(&commit, base_ignores.clone()).await?;
     let working_copy_dir = workspace.working_copy_dir.clone();
@@ -477,22 +481,34 @@ async fn rewrite_commit(
     // ...
     // ```
     tracing::debug!("trying to run command '{}' on commit {}", spec, commit.id());
-    // Pipe and buffer the subprocess's stdout/stderr so we can emit them
-    // atomically to the parent's stdout/stderr after the process exits. Writing
-    // concurrently from multiple jobs would interleave output.
-    let command = tokio::process::Command::new(&spec.program)
+
+    let mut command = tokio::process::Command::new(&spec.program);
+    command
         .args(&spec.args)
         .current_dir(&exec_dir)
         .env("JJ_WORKSPACE_ROOT", &working_copy_dir)
         .env("JJ_CHANGE_ID", commit.change_id().reverse_hex())
         .env("JJ_COMMIT_ID", commit.id().hex())
         .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .kill_on_drop(true) // No zombies allowed.
-        .spawn()?;
-
-    let output = command.wait_with_output().await?;
+        .kill_on_drop(true);
+    let output = if passthrough {
+        // Connect stdout/stderr directly to the terminal so TTY-aware
+        // programs work as expected. Capture is not possible; we wait
+        // for the process to exit and return empty stdout/stderr.
+        command.stdout(Stdio::inherit()).stderr(Stdio::inherit());
+        let status = command.status().await?;
+        Output {
+            status,
+            stdout: Vec::new(),
+            stderr: Vec::new(),
+        }
+    } else {
+        // Pipe and buffer the subprocess's stdout/stderr so we can emit them
+        // atomically to the parent's stdout/stderr after the process exits.
+        // Writing concurrently from multiple jobs would interleave output.
+        command.stdout(Stdio::piped()).stderr(Stdio::piped());
+        command.spawn()?.wait_with_output().await?
+    };
 
     let options = pool.snapshot_options(base_ignores);
     tracing::debug!("trying to snapshot the new tree");
@@ -612,6 +628,16 @@ pub struct RunArgs {
     /// Preserve the content (not the diff) when rebasing descendants
     #[arg(long)]
     restore_descendants: bool,
+
+    /// Pass through stdout and stderr directly to the terminal
+    ///
+    /// The command's stdout and stderr are connected directly to the
+    /// terminal (instead of being captured), so programs that behave
+    /// differently on a TTY (e.g. colored output, progress bars) work
+    /// as expected. Stdin is not inherited. Only one job is allowed
+    /// since parallel jobs would interleave their output.
+    #[arg(long)]
+    passthrough: bool,
 }
 
 /// Precedence: `--jobs`, `run.jobs` config, 1.
@@ -676,6 +702,13 @@ pub async fn cmd_run(
 
     let jobs = resolve_jobs(&workspace_command, args.jobs)?;
 
+    if args.passthrough && jobs.get() > 1 {
+        return Err(CommandError::new(
+            CommandErrorKind::Cli,
+            "cannot use --passthrough with more than one job".to_string(),
+        ));
+    }
+
     tracing::debug!(?jobs, "starting `jj run`");
 
     // Run each command from the subdirectory the user invoked `jj run` from,
@@ -734,6 +767,7 @@ pub async fn cmd_run(
                 pool.clone(),
                 Arc::new(resolved_commits.clone()),
                 jobs.get(),
+                args.passthrough,
             )
             .await
             .map_err(CommandError::from)

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -2997,6 +2997,9 @@ $ jj run -j 4 -- pre-commit run .github/pre-commit.yaml
 
    By default `jj run` reuses working copies between invocations so build artifacts are preserved. With `--clean`, every commit starts from a freshly checked-out tree.
 * `--restore-descendants` — Preserve the content (not the diff) when rebasing descendants
+* `--passthrough` — Pass through stdout and stderr directly to the terminal
+
+   The command's stdout and stderr are connected directly to the terminal (instead of being captured), so programs that behave differently on a TTY (e.g. colored output, progress bars) work as expected. Stdin is not inherited. Only one job is allowed since parallel jobs would interleave their output.
 
 
 

--- a/cli/tests/test_run_command.rs
+++ b/cli/tests/test_run_command.rs
@@ -1388,3 +1388,107 @@ fn test_run_order() {
     [EOF]
     ");
 }
+
+#[test]
+fn test_run_passthrough() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+    work_dir.write_file("A.txt", "A");
+    work_dir.run_jj(&["commit", "-m", "A"]).success();
+    work_dir.write_file("b.txt", "b");
+    work_dir.run_jj(&["commit", "-m", "B"]).success();
+
+    insta::assert_snapshot!(
+        work_dir.run_jj(&["log", "-T", r#"change_id ++ " " ++ description ++ "\n""#, "-r", "..@"]),
+        @r"
+    @  kkmpptxzrspxrzommnulwmwkkqwworpl
+    ○  rlvkpnrzqnoowoytxnquwvuryrwnrmlp B
+    │
+    ○  qpvuntsmwlqtpsluzzsnyyzlmlwvmlnu A
+    │
+    ~
+    [EOF]
+    "
+    );
+
+    // --passthrough passes the child's stdout/stderr directly through. The output
+    // appears in `jj run`'s own stdout/stderr (captured by the test harness).
+    let jj_args: &[&str] = if cfg!(windows) {
+        &[
+            "run",
+            "--passthrough",
+            "-r",
+            "..@",
+            "--",
+            "cmd",
+            "/c",
+            "echo hello from passthrough",
+        ]
+    } else {
+        &[
+            "run",
+            "--passthrough",
+            "-r",
+            "..@",
+            "--",
+            "echo",
+            "hello from passthrough",
+        ]
+    };
+    let output = work_dir.run_jj(jj_args).success();
+    insta::assert_snapshot!(output.stdout, @"hello from passthrough
+hello from passthrough
+hello from passthrough
+[EOF]
+");
+}
+
+#[test]
+fn test_run_passthrough_failure_rewrites_nothing() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+    work_dir.write_file("A.txt", "A");
+    work_dir.run_jj(&["commit", "-m", "A"]).success();
+    work_dir.write_file("b.txt", "b");
+    work_dir.run_jj(&["commit", "-m", "B"]).success();
+    let log_before = get_log_output(&work_dir);
+    insta::assert_snapshot!(log_before, @r"
+    @  kkmpptxzrspxrzommnulwmwkkqwworpl
+    ○  rlvkpnrzqnoowoytxnquwvuryrwnrmlpB
+    │
+    ○  qpvuntsmwlqtpsluzzsnyyzlmlwvmlnuA
+    │
+    ◆  zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz
+    [EOF]
+    ");
+
+    // A failing command run with --passthrough should not rewrite any commits.
+    let output = work_dir.run_jj(&["run", "--passthrough", "-r", "..@", "--", "false"]);
+    assert!(!output.status.success(), "expected `jj run` to fail");
+    assert_eq!(get_log_output(&work_dir), log_before);
+}
+
+#[test]
+fn test_run_passthrough_rejects_multi_job() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    let output = work_dir.run_jj(&[
+        "run",
+        "--passthrough",
+        "--jobs",
+        "2",
+        "-r",
+        "@",
+        "--",
+        "true",
+    ]);
+    assert!(!output.status.success());
+    insta::assert_snapshot!(output.stderr, @r"
+    Error: cannot use --passthrough with more than one job
+    [EOF]
+    ");
+}


### PR DESCRIPTION
When --passthrough is set, the command's stdout and stderr are connected directly to the terminal instead of being captured, so TTY-aware programs (colored output, progress bars) work as expected. Stdin is not inherited. Only one job is allowed since parallel jobs would interleave their output on the terminal.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
