### PR TITLE
run: show colored commit summary in error message

### DIFF
--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -77,8 +77,8 @@ use crate::ui::Ui;
 enum RunError {
     #[error("failed to checkout the commit {}", .0)]
     FailedCheckout(CommitId),
-    #[error("the command '{}' failed with {} for commit {}", .0,.1, .2)]
-    CommandFailure(String, ExitStatus, CommitId),
+    #[error("the command '{}' failed with {}", .0, .1)]
+    CommandFailure(String, ExitStatus),
     #[error(transparent)]
     IoError(#[from] io::Error),
     #[error("failed to create path {}: {}", .0.to_string_lossy(), .1)]
@@ -758,12 +758,14 @@ pub async fn cmd_run(
                             err.write_all(&res.stderr)?;
                         }
                         if !status.success() {
-                            return Err(RunError::CommandFailure(
-                                spec.to_string(),
-                                status,
-                                res.old_id,
-                            )
-                            .into());
+                            let commit = store.get_commit_async(&res.old_id).await?;
+                            let mut error: CommandError =
+                                RunError::CommandFailure(spec.to_string(), status).into();
+                            error.add_formatted_hint_with(|formatter| {
+                                write!(formatter, "Failed revision: ")?;
+                                tx.write_commit_summary(formatter, &commit)
+                            });
+                            return Err(error);
                         }
                     }
                     if res.dirty

--- a/cli/tests/test_run_command.rs
+++ b/cli/tests/test_run_command.rs
@@ -1290,14 +1290,15 @@ fn test_run_failure_shows_output() {
             ("exit code", "exit status"), // Windows
         ],
     }, {
-        insta::assert_snapshot!(&output.normalize_stderr_with(|stderr| stderr.replace(&fake_formatter_path.clone(), "fake-formatter")), @r"
+        insta::assert_snapshot!(&output.normalize_stderr_with(|stderr| stderr.replace(&fake_formatter_path.clone(), "fake-formatter")), @"
         hello stdout
         [EOF]
         ------- stderr -------
         hello stderr
         Error: the command 'fake-formatter --stdout hello stdout
          --stderr hello stderr
-         --fail' failed with exit status: 1 for commit 26d8ff9bba4faa4da6735ced959c57280e49afa7
+         --fail' failed with exit status: 1
+        Hint: Failed revision: qpvuntsm 26d8ff9b A
         [EOF]
         [exit status: 1]
         ");


### PR DESCRIPTION
When a command fails, the error now includes the commit's change ID, commit ID, and description with proper template coloring via a formatted hint, instead of the raw commit hash.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
