### PR TITLE
run: start jobs in commit ascending index-position order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * New `builtin_workspace_list` and `builtin_workspace_list_with_root` template
   aliases are available for `jj workspace list`.
 
+ * `jj run` now processes revisions from oldest to newest by default. The start
+   order is guaranteed: each revision begins execution only after the previous
+   one has started, even with `--jobs` higher than 1.
+
 ### Fixed bugs
 
 * Recursive alias definitions are detected more precisely. jj can now expand

--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -57,7 +57,6 @@ use jj_lib::repo_path::RepoPathBuf;
 use jj_lib::tree::Tree;
 use jj_lib::working_copy::SnapshotOptions;
 use tokio::runtime::Builder;
-use tokio::sync::OwnedSemaphorePermit;
 use tokio::sync::Semaphore;
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::Sender;
@@ -390,15 +389,19 @@ async fn run_inner(
     let semaphore = Arc::new(Semaphore::new(jobs));
     let mut command_futures: JoinSet<Result<RunJob, RunError>> = JoinSet::new();
     for commit in commits.iter() {
-        let permit_future = semaphore.clone().acquire_owned();
+        // Acquire the permit before spawning so tasks start in commit order.
+        let permit = semaphore
+            .clone()
+            .acquire_owned()
+            .await
+            .expect("semaphore not closed");
         let base_ignores = base_ignores.clone();
         let pool = pool.clone();
         let commit = commit.clone();
         let spec = spec.clone();
         command_futures.spawn_on(
             async move {
-                let _permit: OwnedSemaphorePermit =
-                    permit_future.await.expect("semaphore not closed");
+                let _permit = permit;
                 // TODO: handle/propagate error here
                 rewrite_commit(base_ignores, pool, commit, spec).await
             },

--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -654,7 +654,7 @@ pub async fn cmd_run(
     fs::create_dir_all(&base_path)?;
 
     let mut workspace_command = command.workspace_helper(ui).await?;
-    let resolved_commits: Vec<_> = if args.revisions.is_empty() {
+    let mut resolved_commits: Vec<_> = if args.revisions.is_empty() {
         let revs = workspace_command.settings().get_string("revsets.run")?;
         workspace_command
             .parse_revset(ui, &RevisionArg::from(revs))?
@@ -668,6 +668,7 @@ pub async fn cmd_run(
             .try_collect()
             .await?
     };
+    resolved_commits.reverse();
 
     workspace_command
         .check_rewritable(resolved_commits.iter().ids())

--- a/cli/tests/test_run_command.rs
+++ b/cli/tests/test_run_command.rs
@@ -1381,10 +1381,10 @@ fn test_run_order() {
         &["run", "-r=..@", "--", "sh", "-c", "echo $JJ_CHANGE_ID"]
     };
     assert_snapshot!(work_dir.run_jj(jj_args).success().stdout,@"
-    zsuskulnrvyrovkzqrwmxqlsskqntxvp
-    kkmpptxzrspxrzommnulwmwkkqwworpl
-    rlvkpnrzqnoowoytxnquwvuryrwnrmlp
     qpvuntsmwlqtpsluzzsnyyzlmlwvmlnu
+    rlvkpnrzqnoowoytxnquwvuryrwnrmlp
+    kkmpptxzrspxrzommnulwmwkkqwworpl
+    zsuskulnrvyrovkzqrwmxqlsskqntxvp
     [EOF]
     ");
 }

--- a/cli/tests/test_run_command.rs
+++ b/cli/tests/test_run_command.rs
@@ -1362,3 +1362,29 @@ fn get_log_output(work_dir: &TestWorkDir) -> String {
         .stdout
         .to_string()
 }
+
+#[test]
+fn test_run_order() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+    work_dir.write_file("file.txt", "a");
+    work_dir.run_jj(&["commit", "-m", "A"]).success();
+    work_dir.write_file("file.txt", "b");
+    work_dir.run_jj(&["commit", "-m", "B"]).success();
+    work_dir.write_file("file.txt", "c");
+    work_dir.run_jj(&["commit", "-m", "C"]).success();
+
+    let jj_args: &[&str] = if cfg!(windows) {
+        &["run", "-r=..@", "--", "cmd", "/c", "echo %JJ_CHANGE_ID%"]
+    } else {
+        &["run", "-r=..@", "--", "sh", "-c", "echo $JJ_CHANGE_ID"]
+    };
+    assert_snapshot!(work_dir.run_jj(jj_args).success().stdout,@"
+    zsuskulnrvyrovkzqrwmxqlsskqntxvp
+    kkmpptxzrspxrzommnulwmwkkqwworpl
+    rlvkpnrzqnoowoytxnquwvuryrwnrmlp
+    qpvuntsmwlqtpsluzzsnyyzlmlwvmlnu
+    [EOF]
+    ");
+}


### PR DESCRIPTION
    Processes commits in ascending index-position order instead of the
    descending order. Useful for workflows like running tests
    across all revisions and fixing failures from the oldest revision
    first, so that each fix propagates forward through the stack.

    The --reverse is available to process in descending order.
# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
