### PR TITLE
Remove trailing periods in some log messages

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -1981,7 +1981,7 @@ to the current parents may contain changes from multiple commits.
             let exact = upper_bound == Some(lower_bound);
             let or_more = if exact { "" } else { " or more" };
             error.add_hint(format!(
-                "This operation would rewrite {lower_bound}{or_more} immutable commits."
+                "This operation would rewrite {lower_bound}{or_more} immutable commits"
             ));
 
             error
@@ -2409,7 +2409,7 @@ to the current parents may contain changes from multiple commits.
                 .sum();
             writeln!(
                 fmt,
-                "Existing conflicts were resolved or abandoned from {num_resolved} commits."
+                "Existing conflicts were resolved or abandoned from {num_resolved} commits"
             )?;
         }
         if !new_conflicts_by_change_id.is_empty() {

--- a/cli/src/commands/absorb.rs
+++ b/cli/src/commands/absorb.rs
@@ -121,7 +121,7 @@ pub(crate) async fn cmd_absorb(
         if stats.num_rebased > 0 {
             writeln!(
                 formatter,
-                "Rebased {} descendant commits.",
+                "Rebased {} descendant commits",
                 stats.num_rebased
             )?;
         }

--- a/cli/src/commands/debug/index_changed_paths.rs
+++ b/cli/src/commands/debug/index_changed_paths.rs
@@ -59,7 +59,7 @@ pub async fn cmd_debug_index_changed_paths(
     let stats = index.stats();
     writeln!(
         ui.status(),
-        "Finished indexing {:?} commits.",
+        "Finished indexing {:?} commits",
         stats.changed_path_commits_range.unwrap()
     )?;
     Ok(())

--- a/cli/src/commands/debug/reindex.rs
+++ b/cli/src/commands/debug/reindex.rs
@@ -46,7 +46,7 @@ pub async fn cmd_debug_reindex(
             .map_err(internal_error)?;
         writeln!(
             ui.status(),
-            "Finished indexing {} commits.",
+            "Finished indexing {} commits",
             default_index.num_commits()
         )?;
     } else {

--- a/cli/src/commands/simplify_parents.rs
+++ b/cli/src/commands/simplify_parents.rs
@@ -106,7 +106,7 @@ pub(crate) async fn cmd_simplify_parents(
     {
         writeln!(
             formatter,
-            "Removed {edges} edges from {simplified_commits} out of {num_orig_commits} commits.",
+            "Removed {edges} edges from {simplified_commits} out of {num_orig_commits} commits",
         )?;
         if reparented_descendants > 0 {
             writeln!(

--- a/cli/src/git_util.rs
+++ b/cli/src/git_util.rs
@@ -262,7 +262,7 @@ fn print_imported_changes(
     if !stats.rewritten_commit_ids.is_empty() {
         writeln!(
             formatter,
-            "Updated {} rewritten commits.",
+            "Updated {} rewritten commits",
             stats.rewritten_commit_ids.len()
         )?;
     }
@@ -311,7 +311,7 @@ pub fn print_git_import_stats_summary(ui: &Ui, stats: &GitImportStats) -> Result
         if !stats.rewritten_commit_ids.is_empty() {
             writeln!(
                 formatter,
-                "Updated {} rewritten commits.",
+                "Updated {} rewritten commits",
                 stats.rewritten_commit_ids.len()
             )?;
         }

--- a/cli/tests/test_absorb_command.rs
+++ b/cli/tests/test_absorb_command.rs
@@ -56,11 +56,11 @@ fn test_absorb_simple() {
     // Modify middle line in hunk
     work_dir.write_file("file1", "1X\n1A\n1b\n2a\n2b\n2Z\n");
     let output = work_dir.run_jj(["absorb"]);
-    insta::assert_snapshot!(output, @"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Absorbed changes into 1 revisions:
       kkmpptxz 5810eb0f 1
-    Rebased 1 descendant commits.
+    Rebased 1 descendant commits
     Working copy  (@) now at: vruxwmqv 48c7d8fa (empty) (no description set)
     Parent commit (@-)      : zsuskuln 8edd60a2 2
     [EOF]
@@ -173,11 +173,11 @@ fn test_absorb_replace_single_line_hunk() {
     work_dir.run_jj(["new"]).success();
     work_dir.write_file("file1", "2a\n1A\n2b\n");
     let output = work_dir.run_jj(["absorb"]);
-    insta::assert_snapshot!(output, @"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Absorbed changes into 1 revisions:
       qpvuntsm 125fba68 (conflict) 1
-    Rebased 1 descendant commits.
+    Rebased 1 descendant commits
     Working copy  (@) now at: mzvwutvl deeb043a (empty) (no description set)
     Parent commit (@-)      : kkmpptxz 732472fb 2
     New conflicts appeared in 1 commits:
@@ -260,12 +260,12 @@ fn test_absorb_merge() {
     // Modify first and last lines, absorb from merge
     work_dir.write_file("file1", "1A\n1b\n0a\n2a\n2B\n");
     let output = work_dir.run_jj(["absorb"]);
-    insta::assert_snapshot!(output, @"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Absorbed changes into 2 revisions:
       zsuskuln a6fde7ea 2
       kkmpptxz 00ecc958 1
-    Rebased 1 descendant commits.
+    Rebased 1 descendant commits
     Working copy  (@) now at: mzvwutvl 30499858 (empty) 3
     Parent commit (@-)      : kkmpptxz 00ecc958 1
     Parent commit (@-)      : zsuskuln a6fde7ea 2
@@ -360,12 +360,12 @@ fn test_absorb_discardable_merge_with_descendant() {
     work_dir.write_file("file2", "3a\n");
     // Then absorb the merge commit
     let output = work_dir.run_jj(["absorb", "--from=@-"]);
-    insta::assert_snapshot!(output, @"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Absorbed changes into 2 revisions:
       zsuskuln a6cd8e87 2
       kkmpptxz 98b7d214 1
-    Rebased 1 descendant commits.
+    Rebased 1 descendant commits
     Working copy  (@) now at: royxmykx df946e9b 3
     Parent commit (@-)      : kkmpptxz 98b7d214 1
     Parent commit (@-)      : zsuskuln a6cd8e87 2
@@ -495,11 +495,11 @@ fn test_absorb_deleted_file() {
     // Since the destinations are chosen based on content diffs, file3 cannot be
     // absorbed.
     let output = work_dir.run_jj(["absorb"]);
-    insta::assert_snapshot!(output, @"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Absorbed changes into 1 revisions:
       qpvuntsm 38af7fd3 1
-    Rebased 1 descendant commits.
+    Rebased 1 descendant commits
     Working copy  (@) now at: kkmpptxz efd883f6 (no description set)
     Parent commit (@-)      : qpvuntsm 38af7fd3 1
     Remaining changes:
@@ -550,12 +550,12 @@ fn test_absorb_deleted_file_with_multiple_hunks() {
     work_dir.remove_file("file1");
     work_dir.remove_file("file2");
     let output = work_dir.run_jj(["absorb"]);
-    insta::assert_snapshot!(output, @"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Absorbed changes into 2 revisions:
       kkmpptxz 3e1b2472 (conflict) 2
       qpvuntsm c49bcdd3 (conflict) 1
-    Rebased 1 descendant commits.
+    Rebased 1 descendant commits
     Working copy  (@) now at: zsuskuln 9376eb56 (no description set)
     Parent commit (@-)      : kkmpptxz 3e1b2472 (conflict) 2
     New conflicts appeared in 2 commits:
@@ -667,11 +667,11 @@ fn test_absorb_file_mode() {
 
     // Mode change shouldn't be absorbed
     let output = work_dir.run_jj(["absorb"]);
-    insta::assert_snapshot!(output, @"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Absorbed changes into 1 revisions:
       qpvuntsm 2a0c7f1d 1
-    Rebased 1 descendant commits.
+    Rebased 1 descendant commits
     Working copy  (@) now at: zsuskuln 8ca9761d (no description set)
     Parent commit (@-)      : qpvuntsm 2a0c7f1d 1
     Remaining changes:
@@ -713,11 +713,11 @@ fn test_absorb_from_into() {
     work_dir.run_jj(["new"]).success();
     work_dir.write_file("file1", "1a\nX\n2a\n1b\nY\n1c\n2b\nZ\n");
     let output = work_dir.run_jj(["absorb", "--into=@-"]);
-    insta::assert_snapshot!(output, @"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Absorbed changes into 1 revisions:
       kkmpptxz cae507ef 2
-    Rebased 1 descendant commits.
+    Rebased 1 descendant commits
     Working copy  (@) now at: zsuskuln f02fd9ea (no description set)
     Parent commit (@-)      : kkmpptxz cae507ef 2
     Remaining changes:
@@ -758,11 +758,11 @@ fn test_absorb_from_into() {
     // Absorb all lines from the working-copy parent. An empty commit won't be
     // discarded because "absorb" isn't a command to squash commit descriptions.
     let output = work_dir.run_jj(["absorb", "--from=@-"]);
-    insta::assert_snapshot!(output, @"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Absorbed changes into 1 revisions:
       rlvkpnrz ddaed33d 1
-    Rebased 2 descendant commits.
+    Rebased 2 descendant commits
     Working copy  (@) now at: zsuskuln 3652e5e5 (no description set)
     Parent commit (@-)      : kkmpptxz 7f4339e7 (empty) 2
     [EOF]
@@ -828,11 +828,11 @@ fn test_absorb_paths() {
     ");
 
     let output = work_dir.run_jj(["absorb", "file1"]);
-    insta::assert_snapshot!(output, @"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Absorbed changes into 1 revisions:
       qpvuntsm ca07fabe 1
-    Rebased 1 descendant commits.
+    Rebased 1 descendant commits
     Working copy  (@) now at: kkmpptxz 4d80ada8 (no description set)
     Parent commit (@-)      : qpvuntsm ca07fabe 1
     Remaining changes:
@@ -889,11 +889,11 @@ fn test_absorb_immutable() {
 
     // Immutable revisions are excluded by default
     let output = work_dir.run_jj(["absorb"]);
-    insta::assert_snapshot!(output, @"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Absorbed changes into 1 revisions:
       kkmpptxz e68cc3e2 2
-    Rebased 1 descendant commits.
+    Rebased 1 descendant commits
     Working copy  (@) now at: mzvwutvl 88443af7 (no description set)
     Parent commit (@-)      : kkmpptxz e68cc3e2 2
     Remaining changes:
@@ -911,7 +911,7 @@ fn test_absorb_immutable() {
     Hint: For more information, see:
           - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
           - `jj help -k config`, "Set of immutable commits"
-    Hint: This operation would rewrite 1 immutable commits.
+    Hint: This operation would rewrite 1 immutable commits
     [EOF]
     [exit status: 1]
     "#);

--- a/cli/tests/test_debug_command.rs
+++ b/cli/tests/test_debug_command.rs
@@ -172,9 +172,9 @@ fn test_debug_index() {
 
     // Enable changed-path index, index one commit
     let output = work_dir.run_jj(["debug", "index-changed-paths", "-n1"]);
-    assert_snapshot!(output, @"
+    assert_snapshot!(output, @r"
     ------- stderr -------
-    Finished indexing 1..2 commits.
+    Finished indexing 1..2 commits
     [EOF]
     ");
     let output = work_dir.run_jj(["debug", "index"]);
@@ -229,9 +229,9 @@ fn test_debug_reindex() {
     [EOF]
     ");
     let output = work_dir.run_jj(["debug", "reindex"]);
-    insta::assert_snapshot!(output, @"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Finished indexing 4 commits.
+    Finished indexing 4 commits
     [EOF]
     ");
     let output = work_dir.run_jj(["debug", "index"]);

--- a/cli/tests/test_diffedit_command.rs
+++ b/cli/tests/test_diffedit_command.rs
@@ -478,7 +478,7 @@ fn test_diffedit_external_tool_conflict_marker_style() -> TestResult {
         .join("\0"),
     )?;
     let output = work_dir.run_jj(["diffedit"]);
-    insta::assert_snapshot!(output, @"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Working copy  (@) now at: mzvwutvl a2e4617e (conflict) (empty) (no description set)
     Parent commit (@-)      : rlvkpnrz 74e448a1 side-a
@@ -486,7 +486,7 @@ fn test_diffedit_external_tool_conflict_marker_style() -> TestResult {
     Added 0 files, modified 1 files, removed 0 files
     Warning: There are unresolved conflicts at these paths:
     file    2-sided conflict
-    Existing conflicts were resolved or abandoned from 1 commits.
+    Existing conflicts were resolved or abandoned from 1 commits
     [EOF]
     ");
     // Conflicts should render using "snapshot" format in diff editor

--- a/cli/tests/test_fix_command.rs
+++ b/cli/tests/test_fix_command.rs
@@ -904,7 +904,7 @@ fn test_fix_immutable_commit() {
     Hint: For more information, see:
           - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
           - `jj help -k config`, "Set of immutable commits"
-    Hint: This operation would rewrite 1 immutable commits.
+    Hint: This operation would rewrite 1 immutable commits
     [EOF]
     [exit status: 1]
     "#);

--- a/cli/tests/test_gerrit_upload.rs
+++ b/cli/tests/test_gerrit_upload.rs
@@ -171,7 +171,7 @@ fn test_gerrit_upload_default_revision_already_in_trunk() {
     local_dir.run_jj(["describe", "-m="]).success();
 
     let output = local_dir.run_jj(["gerrit", "upload", "--dry-run"]);
-    insta::assert_snapshot!(output, @"
+    insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     No revision provided and @ has no description. Defaulting to @-
     Error: Commit 57df4838fd85 is immutable
@@ -179,11 +179,11 @@ fn test_gerrit_upload_default_revision_already_in_trunk() {
     Hint: Immutable commits are used to protect shared history.
     Hint: For more information, see:
           - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
-          - `jj help -k config`, \"Set of immutable commits\"
-    Hint: This operation would rewrite 1 immutable commits.
+          - `jj help -k config`, "Set of immutable commits"
+    Hint: This operation would rewrite 1 immutable commits
     [EOF]
     [exit status: 1]
-    ");
+    "#);
 }
 
 #[test]

--- a/cli/tests/test_git_colocated.rs
+++ b/cli/tests/test_git_colocated.rs
@@ -735,13 +735,13 @@ fn test_git_colocated_fetch_deleted_or_moved_bookmark() -> TestResult {
         .run_jj(["describe", "C_to_move", "-m", "moved C"])
         .success();
     let output = clone_dir.run_jj(["git", "fetch"]);
-    insta::assert_snapshot!(output, @"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
     bookmark: B_to_delete@origin [deleted] untracked
     bookmark: C_to_move@origin   [updated] tracked
     Abandoned 1 commits that are no longer reachable:
       zsuskuln b2ea51c0 B_to_delete@git | (empty) B_to_delete
-    Updated 1 rewritten commits.
+    Updated 1 rewritten commits
     [EOF]
     ");
     // "original C" and "B_to_delete" are abandoned, as the corresponding bookmarks

--- a/cli/tests/test_git_fetch.rs
+++ b/cli/tests/test_git_fetch.rs
@@ -1014,13 +1014,13 @@ fn test_git_fetch_all() {
     [EOF]
     ");
     let output = target_dir.run_jj(["git", "fetch"]);
-    insta::assert_snapshot!(output, @"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
     bookmark: a1@origin     [updated] tracked
     bookmark: a2@origin     [updated] tracked
     bookmark: b@origin      [updated] tracked
     bookmark: trunk2@origin [new] tracked
-    Updated 2 rewritten commits.
+    Updated 2 rewritten commits
     [EOF]
     ");
     insta::assert_snapshot!(get_bookmark_output(&target_dir), @"
@@ -1204,11 +1204,11 @@ fn test_git_fetch_some_of_many_bookmarks() {
     [EOF]
     "#);
     let output = target_dir.run_jj(["git", "fetch", "--branch=~(a2 | trunk*)"]);
-    insta::assert_snapshot!(output, @"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
     bookmark: a1@origin [updated] tracked
     bookmark: b@origin  [updated] tracked
-    Updated 1 rewritten commits.
+    Updated 1 rewritten commits
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&target_dir), @r#"
@@ -1243,10 +1243,10 @@ fn test_git_fetch_some_of_many_bookmarks() {
     // Now, let's fetch a2 and double-check that fetching a1 and b again doesn't do
     // anything.
     let output = target_dir.run_jj(["git", "fetch", "--branch", "b", "--branch", "a*"]);
-    insta::assert_snapshot!(output, @"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
     bookmark: a2@origin [updated] tracked
-    Updated 1 rewritten commits.
+    Updated 1 rewritten commits
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&target_dir), @r#"
@@ -2091,10 +2091,10 @@ fn test_git_fetch_remotely_rewritten() {
 
     // Fetch the rewritten revisions
     let output = local_dir.run_jj(["git", "fetch"]);
-    insta::assert_snapshot!(output, @"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
     bookmark: book@origin [updated] untracked
-    Updated 2 rewritten commits.
+    Updated 2 rewritten commits
     Rebased 1 descendant commits
     Working copy  (@) now at: royxmykx 0818b176 (empty) (no description set)
     Parent commit (@-)      : kkmpptxz 3ee37bc8 book@origin | (empty) bookmarked
@@ -2129,10 +2129,10 @@ fn test_git_fetch_remotely_rewritten() {
     // Undo the previous fetch and try again, which unhides abandoned revisions
     local_dir.run_jj(["op", "restore", &setup_op_id]).success();
     let output = local_dir.run_jj(["git", "fetch"]);
-    insta::assert_snapshot!(output, @"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
     bookmark: book@origin [updated] untracked
-    Updated 2 rewritten commits.
+    Updated 2 rewritten commits
     Rebased 1 descendant commits
     Working copy  (@) now at: royxmykx 3eb3f040 (empty) (no description set)
     Parent commit (@-)      : kkmpptxz 3ee37bc8 book@origin | (empty) bookmarked
@@ -2275,10 +2275,10 @@ fn test_git_fetch_remotely_rewritten_descendants() {
 
     // Fetch one of the rewritten branches
     let output = local_dir.run_jj(["git", "fetch", "--branch=book1"]);
-    insta::assert_snapshot!(output, @"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
     bookmark: book1@origin [updated] untracked
-    Updated 2 rewritten commits.
+    Updated 2 rewritten commits
     Rebased 1 descendant commits
     Working copy  (@) now at: vruxwmqv a1d01244 (empty) local
     Parent commit (@-)      : qpvuntsm/0 a843bfad (divergent) (empty) modified
@@ -2301,12 +2301,12 @@ fn test_git_fetch_remotely_rewritten_descendants() {
 
     // Fetch the other branch
     let output = local_dir.run_jj(["git", "fetch"]);
-    insta::assert_snapshot!(output, @"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
     bookmark: book2@origin [updated] untracked
     Abandoned 1 commits that are no longer reachable:
       qpvuntsm/1 97604bbe (divergent) (empty) original
-    Updated 1 rewritten commits.
+    Updated 1 rewritten commits
     [EOF]
     ");
 

--- a/cli/tests/test_immutable_commits.rs
+++ b/cli/tests/test_immutable_commits.rs
@@ -51,7 +51,7 @@ fn test_rewrite_immutable_generic() {
     Hint: For more information, see:
           - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
           - `jj help -k config`, "Set of immutable commits"
-    Hint: This operation would rewrite 1 immutable commits.
+    Hint: This operation would rewrite 1 immutable commits
     [EOF]
     [exit status: 1]
     "#);
@@ -65,7 +65,7 @@ fn test_rewrite_immutable_generic() {
     Hint: For more information, see:
           - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
           - `jj help -k config`, "Set of immutable commits"
-    Hint: This operation would rewrite 2 immutable commits.
+    Hint: This operation would rewrite 2 immutable commits
     [EOF]
     [exit status: 1]
     "#);
@@ -351,7 +351,7 @@ fn test_rewrite_immutable_commands() {
     Hint: For more information, see:
           - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
           - `jj help -k config`, "Set of immutable commits"
-    Hint: This operation would rewrite 1 immutable commits.
+    Hint: This operation would rewrite 1 immutable commits
     [EOF]
     [exit status: 1]
     "#);
@@ -365,7 +365,7 @@ fn test_rewrite_immutable_commands() {
     Hint: For more information, see:
           - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
           - `jj help -k config`, "Set of immutable commits"
-    Hint: This operation would rewrite 2 immutable commits.
+    Hint: This operation would rewrite 2 immutable commits
     [EOF]
     [exit status: 1]
     "#);
@@ -379,7 +379,7 @@ fn test_rewrite_immutable_commands() {
     Hint: For more information, see:
           - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
           - `jj help -k config`, "Set of immutable commits"
-    Hint: This operation would rewrite 1 immutable commits.
+    Hint: This operation would rewrite 1 immutable commits
     [EOF]
     [exit status: 1]
     "#);
@@ -393,7 +393,7 @@ fn test_rewrite_immutable_commands() {
     Hint: For more information, see:
           - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
           - `jj help -k config`, "Set of immutable commits"
-    Hint: This operation would rewrite 1 immutable commits.
+    Hint: This operation would rewrite 1 immutable commits
     [EOF]
     [exit status: 1]
     "#);
@@ -407,7 +407,7 @@ fn test_rewrite_immutable_commands() {
     Hint: For more information, see:
           - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
           - `jj help -k config`, "Set of immutable commits"
-    Hint: This operation would rewrite 1 immutable commits.
+    Hint: This operation would rewrite 1 immutable commits
     [EOF]
     [exit status: 1]
     "#);
@@ -421,7 +421,7 @@ fn test_rewrite_immutable_commands() {
     Hint: For more information, see:
           - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
           - `jj help -k config`, "Set of immutable commits"
-    Hint: This operation would rewrite 1 immutable commits.
+    Hint: This operation would rewrite 1 immutable commits
     [EOF]
     [exit status: 1]
     "#);
@@ -435,7 +435,7 @@ fn test_rewrite_immutable_commands() {
     Hint: For more information, see:
           - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
           - `jj help -k config`, "Set of immutable commits"
-    Hint: This operation would rewrite 1 immutable commits.
+    Hint: This operation would rewrite 1 immutable commits
     [EOF]
     [exit status: 1]
     "#);
@@ -449,7 +449,7 @@ fn test_rewrite_immutable_commands() {
     Hint: For more information, see:
           - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
           - `jj help -k config`, "Set of immutable commits"
-    Hint: This operation would rewrite 1 immutable commits.
+    Hint: This operation would rewrite 1 immutable commits
     [EOF]
     [exit status: 1]
     "#);
@@ -463,7 +463,7 @@ fn test_rewrite_immutable_commands() {
     Hint: For more information, see:
           - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
           - `jj help -k config`, "Set of immutable commits"
-    Hint: This operation would rewrite 1 immutable commits.
+    Hint: This operation would rewrite 1 immutable commits
     [EOF]
     [exit status: 1]
     "#);
@@ -477,7 +477,7 @@ fn test_rewrite_immutable_commands() {
     Hint: For more information, see:
           - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
           - `jj help -k config`, "Set of immutable commits"
-    Hint: This operation would rewrite 1 immutable commits.
+    Hint: This operation would rewrite 1 immutable commits
     [EOF]
     [exit status: 1]
     "#);
@@ -491,7 +491,7 @@ fn test_rewrite_immutable_commands() {
     Hint: For more information, see:
           - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
           - `jj help -k config`, "Set of immutable commits"
-    Hint: This operation would rewrite 1 immutable commits.
+    Hint: This operation would rewrite 1 immutable commits
     [EOF]
     [exit status: 1]
     "#);
@@ -505,7 +505,7 @@ fn test_rewrite_immutable_commands() {
     Hint: For more information, see:
           - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
           - `jj help -k config`, "Set of immutable commits"
-    Hint: This operation would rewrite 1 immutable commits.
+    Hint: This operation would rewrite 1 immutable commits
     [EOF]
     [exit status: 1]
     "#);
@@ -519,7 +519,7 @@ fn test_rewrite_immutable_commands() {
     Hint: For more information, see:
           - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
           - `jj help -k config`, "Set of immutable commits"
-    Hint: This operation would rewrite 2 immutable commits.
+    Hint: This operation would rewrite 2 immutable commits
     [EOF]
     [exit status: 1]
     "#);
@@ -533,7 +533,7 @@ fn test_rewrite_immutable_commands() {
     Hint: For more information, see:
           - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
           - `jj help -k config`, "Set of immutable commits"
-    Hint: This operation would rewrite 1 immutable commits.
+    Hint: This operation would rewrite 1 immutable commits
     [EOF]
     [exit status: 1]
     "#);
@@ -547,7 +547,7 @@ fn test_rewrite_immutable_commands() {
     Hint: For more information, see:
           - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
           - `jj help -k config`, "Set of immutable commits"
-    Hint: This operation would rewrite 1 immutable commits.
+    Hint: This operation would rewrite 1 immutable commits
     [EOF]
     [exit status: 1]
     "#);
@@ -561,7 +561,7 @@ fn test_rewrite_immutable_commands() {
     Hint: For more information, see:
           - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
           - `jj help -k config`, "Set of immutable commits"
-    Hint: This operation would rewrite 1 immutable commits.
+    Hint: This operation would rewrite 1 immutable commits
     [EOF]
     [exit status: 1]
     "#);
@@ -575,7 +575,7 @@ fn test_rewrite_immutable_commands() {
     Hint: For more information, see:
           - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
           - `jj help -k config`, "Set of immutable commits"
-    Hint: This operation would rewrite 1 immutable commits.
+    Hint: This operation would rewrite 1 immutable commits
     [EOF]
     [exit status: 1]
     "#);
@@ -589,7 +589,7 @@ fn test_rewrite_immutable_commands() {
     Hint: For more information, see:
           - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
           - `jj help -k config`, "Set of immutable commits"
-    Hint: This operation would rewrite 1 immutable commits.
+    Hint: This operation would rewrite 1 immutable commits
     [EOF]
     [exit status: 1]
     "#);
@@ -603,7 +603,7 @@ fn test_rewrite_immutable_commands() {
     Hint: For more information, see:
           - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
           - `jj help -k config`, "Set of immutable commits"
-    Hint: This operation would rewrite 1 immutable commits.
+    Hint: This operation would rewrite 1 immutable commits
     [EOF]
     [exit status: 1]
     "#);
@@ -617,7 +617,7 @@ fn test_rewrite_immutable_commands() {
     Hint: For more information, see:
           - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
           - `jj help -k config`, "Set of immutable commits"
-    Hint: This operation would rewrite 4 immutable commits.
+    Hint: This operation would rewrite 4 immutable commits
     [EOF]
     [exit status: 1]
     "#);
@@ -631,7 +631,7 @@ fn test_rewrite_immutable_commands() {
     Hint: For more information, see:
           - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
           - `jj help -k config`, "Set of immutable commits"
-    Hint: This operation would rewrite 1 immutable commits.
+    Hint: This operation would rewrite 1 immutable commits
     [EOF]
     [exit status: 1]
     "#);
@@ -645,7 +645,7 @@ fn test_rewrite_immutable_commands() {
     Hint: For more information, see:
           - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
           - `jj help -k config`, "Set of immutable commits"
-    Hint: This operation would rewrite 1 immutable commits.
+    Hint: This operation would rewrite 1 immutable commits
     [EOF]
     [exit status: 1]
     "#);
@@ -659,7 +659,7 @@ fn test_rewrite_immutable_commands() {
     Hint: For more information, see:
           - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
           - `jj help -k config`, "Set of immutable commits"
-    Hint: This operation would rewrite 1 immutable commits.
+    Hint: This operation would rewrite 1 immutable commits
     [EOF]
     [exit status: 1]
     "#);
@@ -673,7 +673,7 @@ fn test_rewrite_immutable_commands() {
     Hint: For more information, see:
           - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
           - `jj help -k config`, "Set of immutable commits"
-    Hint: This operation would rewrite 1 immutable commits.
+    Hint: This operation would rewrite 1 immutable commits
     [EOF]
     [exit status: 1]
     "#);
@@ -687,7 +687,7 @@ fn test_rewrite_immutable_commands() {
     Hint: For more information, see:
           - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
           - `jj help -k config`, "Set of immutable commits"
-    Hint: This operation would rewrite 1 immutable commits.
+    Hint: This operation would rewrite 1 immutable commits
     [EOF]
     [exit status: 1]
     "#);
@@ -701,7 +701,7 @@ fn test_rewrite_immutable_commands() {
     Hint: For more information, see:
           - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
           - `jj help -k config`, "Set of immutable commits"
-    Hint: This operation would rewrite 1 immutable commits.
+    Hint: This operation would rewrite 1 immutable commits
     [EOF]
     [exit status: 1]
     "#);

--- a/cli/tests/test_parallelize_command.rs
+++ b/cli/tests/test_parallelize_command.rs
@@ -747,7 +747,7 @@ fn test_parallelize_no_immutable_non_base_commits() {
     Hint: For more information, see:
           - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
           - `jj help -k config`, "Set of immutable commits"
-    Hint: This operation would rewrite 1 immutable commits.
+    Hint: This operation would rewrite 1 immutable commits
     [EOF]
     [exit status: 1]
     "#);

--- a/cli/tests/test_repo_change_report.rs
+++ b/cli/tests/test_repo_change_report.rs
@@ -49,13 +49,13 @@ fn test_report_conflicts() {
     ");
 
     let output = work_dir.run_jj(["rebase", "-d=subject(A)"]);
-    insta::assert_snapshot!(output, @"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Rebased 3 commits to destination
     Working copy  (@) now at: zsuskuln bad741db (empty) (no description set)
     Parent commit (@-)      : kkmpptxz cec3d034 C
     Added 0 files, modified 1 files, removed 0 files
-    Existing conflicts were resolved or abandoned from 2 commits.
+    Existing conflicts were resolved or abandoned from 2 commits
     [EOF]
     ");
 
@@ -96,11 +96,11 @@ fn test_report_conflicts() {
     ");
     work_dir.write_file("file", "resolved\n");
     let output = work_dir.run_jj(["squash"]);
-    insta::assert_snapshot!(output, @"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Working copy  (@) now at: yostqsxw 350a6e50 (empty) (no description set)
     Parent commit (@-)      : rlvkpnrz 1aa1004b B
-    Existing conflicts were resolved or abandoned from 1 commits.
+    Existing conflicts were resolved or abandoned from 1 commits
     [EOF]
     ");
 }
@@ -146,13 +146,13 @@ fn test_report_conflicts_with_divergent_commits() {
     ");
 
     let output = work_dir.run_jj(["rebase", "-d=subject(A)"]);
-    insta::assert_snapshot!(output, @"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Rebased 3 commits to destination
     Working copy  (@) now at: zsuskuln/1 27ef05d9 (divergent) C2
     Parent commit (@-)      : kkmpptxz 9039ed49 B
     Added 0 files, modified 1 files, removed 0 files
-    Existing conflicts were resolved or abandoned from 3 commits.
+    Existing conflicts were resolved or abandoned from 3 commits
     [EOF]
     ");
 
@@ -193,21 +193,21 @@ fn test_report_conflicts_with_divergent_commits() {
     ");
 
     let output = work_dir.run_jj(["rebase", "-s=subject(C2)", "-d=subject(B)"]);
-    insta::assert_snapshot!(output, @"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Rebased 1 commits to destination
     Working copy  (@) now at: zsuskuln/0 3fcf2fd2 (divergent) C2
     Parent commit (@-)      : kkmpptxz 9039ed49 B
     Added 0 files, modified 1 files, removed 0 files
-    Existing conflicts were resolved or abandoned from 1 commits.
+    Existing conflicts were resolved or abandoned from 1 commits
     [EOF]
     ");
 
     let output = work_dir.run_jj(["rebase", "-s=subject(C3)", "-d=subject(B)"]);
-    insta::assert_snapshot!(output, @"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Rebased 1 commits to destination
-    Existing conflicts were resolved or abandoned from 1 commits.
+    Existing conflicts were resolved or abandoned from 1 commits
     [EOF]
     ");
 }

--- a/cli/tests/test_resolve_command.rs
+++ b/cli/tests/test_resolve_command.rs
@@ -1464,13 +1464,13 @@ fn test_resolve_change_delete_executable() -> TestResult {
 
     // Take modified content, the executable bit should be kept as "x"
     let output = work_dir.run_jj(["resolve", "file5", "--tool=:theirs"]);
-    insta::assert_snapshot!(output, @"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Working copy  (@) now at: kmkuslsw 7337267a conflict | conflict
     Parent commit (@-)      : mzvwutvl e2d3924b a | a
     Parent commit (@-)      : vruxwmqv 888b6cc3 b | b
     Added 0 files, modified 1 files, removed 0 files
-    Existing conflicts were resolved or abandoned from 1 commits.
+    Existing conflicts were resolved or abandoned from 1 commits
     [EOF]
     ");
 

--- a/cli/tests/test_simplify_parents_command.rs
+++ b/cli/tests/test_simplify_parents_command.rs
@@ -144,9 +144,9 @@ fn test_simplify_parents_redundant_parent(args: &[&str]) {
     }
     let output = work_dir.run_jj(args);
     insta::allow_duplicates! {
-        insta::assert_snapshot!(output, @"
+        insta::assert_snapshot!(output, @r"
         ------- stderr -------
-        Removed 1 edges from 1 out of 3 commits.
+        Removed 1 edges from 1 out of 3 commits
         Working copy  (@) now at: royxmykx 265f0407 c | c
         Parent commit (@-)      : zsuskuln 123b4d91 b | b
         [EOF]
@@ -196,9 +196,9 @@ fn test_simplify_parents_multiple_redundant_parents() {
 
     // Test with `-r`.
     let output = work_dir.run_jj(["simplify-parents", "-r", "c", "-r", "f"]);
-    insta::assert_snapshot!(output, @"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Removed 2 edges from 2 out of 2 commits.
+    Removed 2 edges from 2 out of 2 commits
     Rebased 2 descendant commits
     Working copy  (@) now at: kmkuslsw 5ad764e9 f | f
     Parent commit (@-)      : znkkpsqq 9102487c e | e
@@ -220,9 +220,9 @@ fn test_simplify_parents_multiple_redundant_parents() {
     // Test with `-s`.
     work_dir.run_jj(["op", "restore", &setup_opid]).success();
     let output = work_dir.run_jj(["simplify-parents", "-s", "c"]);
-    insta::assert_snapshot!(output, @"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Removed 2 edges from 2 out of 4 commits.
+    Removed 2 edges from 2 out of 4 commits
     Rebased 2 descendant commits
     Working copy  (@) now at: kmkuslsw 2b2c1c63 f | f
     Parent commit (@-)      : znkkpsqq 9142e3bb e | e
@@ -272,9 +272,9 @@ fn test_simplify_parents_no_args() {
     let setup_opid = work_dir.current_operation_id();
 
     let output = work_dir.run_jj(["simplify-parents"]);
-    insta::assert_snapshot!(output, @"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Removed 2 edges from 2 out of 6 commits.
+    Removed 2 edges from 2 out of 6 commits
     Rebased 2 descendant commits
     Working copy  (@) now at: kmkuslsw 5ad764e9 f | f
     Parent commit (@-)      : znkkpsqq 9102487c e | e
@@ -297,9 +297,9 @@ fn test_simplify_parents_no_args() {
     work_dir.run_jj(["op", "restore", &setup_opid]).success();
     test_env.add_config(r#"revsets.simplify-parents = "d::""#);
     let output = work_dir.run_jj(["simplify-parents"]);
-    insta::assert_snapshot!(output, @"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Removed 1 edges from 1 out of 3 commits.
+    Removed 1 edges from 1 out of 3 commits
     Working copy  (@) now at: kmkuslsw 1180d0f5 f | f
     Parent commit (@-)      : znkkpsqq 009aef72 e | e
     [EOF]


### PR DESCRIPTION
Noticed this when I did a `jj git fetch` and got:

```
Updated 10 rewritten commits.
Rebased 1 descendant commits
```

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
