### PR TITLE
templater: make RepoPath::absolute() and config path return PathBuf instead of String

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 * `jj git push --all` now pushes all tags in addition to bookmarks.
 
+* The `WorkspaceRef.root()` and `RepoPath.absolute()` template functions now
+  return `Option<FsPath>` and `FsPath` respectively, instead of `String`.
+
 ### Deprecations
 
 ### New features
@@ -33,8 +36,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   point where multiple branches merge.
 
 * New `builtin_workspace_list` and `builtin_workspace_list_with_root` template
-  aliases are available for `jj workspace list`, and `WorkspaceRef.root()` now
-  returns an optional `FsPath` value.
+  aliases are available for `jj workspace list`.
 
 ### Fixed bugs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * `jj git push --all` now pushes all tags in addition to bookmarks.
 
 * The `WorkspaceRef.root()` and `RepoPath.absolute()` template functions now
-  return `Option<FsPath>` and `FsPath` respectively, instead of `String`.
+  return `Option<FsPath>` and `FsPath` respectively, instead of `String`. The
+  `path` keyword in `jj config list` templates now returns `Option<FsPath>`.
 
 ### Deprecations
 

--- a/cli/src/commands/config/list.rs
+++ b/cli/src/commands/config/list.rs
@@ -59,7 +59,7 @@ pub struct ConfigListArgs {
     /// * `value: ConfigValue`: Value to be formatted in TOML syntax.
     /// * `overridden: Boolean`: True if the value is shadowed by other.
     /// * `source: String`: Source of the value.
-    /// * `path: String`: Path to the config file.
+    /// * `path: Option<FsPath>`: Path to the config file.
     ///
     /// Can be overridden by the `templates.config_list` setting. To
     /// see a detailed config list, use the `builtin_config_list_detailed`
@@ -146,13 +146,7 @@ fn config_template_language(settings: &UserSettings, current_dir: &Path) -> Conf
         Ok(out_property.into_dyn_wrapped())
     });
     language.add_keyword("path", |self_property| {
-        let out_property = self_property.map(|annotated| {
-            // TODO: maybe add FilePath(PathBuf) template type?
-            annotated
-                .path
-                .as_ref()
-                .map_or_else(String::new, |path| path.to_string_lossy().into_owned())
-        });
+        let out_property = self_property.map(|annotated| annotated.path);
         Ok(out_property.into_dyn_wrapped())
     });
     language.add_keyword("overridden", |self_property| {

--- a/cli/src/commit_templater.rs
+++ b/cli/src/commit_templater.rs
@@ -2072,11 +2072,7 @@ fn builtin_repo_path_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, R
             // `RepoPathUiConverter` because absolute paths only make sense for
             // filesystem paths. Other cases should fail here.
             let out_property = self_property.and_then(move |path| match path_converter {
-                RepoPathUiConverter::Fs { cwd: _, base } => path
-                    .to_fs_path(base)?
-                    .into_os_string()
-                    .into_string()
-                    .map_err(|_| TemplatePropertyError("Invalid UTF-8 sequence in path".into())),
+                RepoPathUiConverter::Fs { cwd: _, base } => Ok(path.to_fs_path(base)?),
             });
             Ok(out_property.into_dyn_wrapped())
         },

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -835,7 +835,7 @@ List variables set in config files, along with their values
    * `value: ConfigValue`: Value to be formatted in TOML syntax.
    * `overridden: Boolean`: True if the value is shadowed by other.
    * `source: String`: Source of the value.
-   * `path: String`: Path to the config file.
+   * `path: Option<FsPath>`: Path to the config file.
 
    Can be overridden by the `templates.config_list` setting. To
    see a detailed config list, use the `builtin_config_list_detailed`

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -551,8 +551,7 @@ _Conversion: `Boolean`: no, `Serialize`: yes, `Template`: yes_
 A slash-separated path relative to the repository root. The following methods
 are defined.
 
-* `.absolute() -> String`: Format as absolute path using platform-native
-  separator.
+* `.absolute() -> FsPath`: Absolute filesystem path.
 * `.display() -> String`: Format path for display. The formatted path uses
   platform-native separator, and is relative to the current working directory.
 * `.parent() -> Option<RepoPath>`: Parent directory path.


### PR DESCRIPTION
# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [ ] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
