### PR TITLE
doc: Diff editors should only modify right directory

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -1150,8 +1150,10 @@ edit-args = ["--newtab", "$left", "$right"]
 
 `jj` makes the following substitutions:
 
-- `$left` and `$right` are replaced with the paths to the left and right
-  directories to diff respectively.
+- `$left` is a directory containing the original contents before any changes.
+
+- `$right` is the directory containing the changed contents.
+  Edits are read back from here, so this is where tools should make changes.
 
 - If no `edit-args` are specified, `["$left", "$right"]` are set by default.
 


### PR DESCRIPTION
I was looking through the config documentation today, and I could not tell which directory a diff tool was supposed to make edits to.

This small change clarifies that.

# Checklist

If applicable:

- (N/A) I have updated `CHANGELOG.md`
- (N/A) I have updated the documentation (`README.md`, `docs/`, `demos/`)
- (N/A) I have updated the config schema (`cli/src/config-schema.json`)
- (N/A) I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
