### PR TITLE
cli: cap the "Did you mean" hint at 5 names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   [#9711](https://github.com/jj-vcs/jj/issues/9711)
   [#8884](https://github.com/jj-vcs/jj/issues/8884)
 
+* The "Did you mean" hint for a mistyped bookmark, revision, or function no
+  longer lists every similar name. It now shows the 5 most similar ones,
+  followed by e.g. `or 20 others`.
+  [#8017](https://github.com/jj-vcs/jj/issues/8017)
+
 ## [0.44.0] - 2026-08-05
 
 ### Release highlights

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   conflicted file is snapshotted from the working copy.
   [#9868](https://github.com/jj-vcs/jj/issues/9868)
 
+* The "Did you mean" hint for a mistyped bookmark, revision, or function no
+  longer lists every similar name. It now shows the 5 most similar ones,
+  followed by e.g. `or 20 others`.
+  [#8017](https://github.com/jj-vcs/jj/issues/8017)
+
 ## [0.44.0] - 2026-08-05
 
 ### Release highlights

--- a/cli/src/command_error.rs
+++ b/cli/src/command_error.rs
@@ -29,6 +29,7 @@ use jj_lib::config::ConfigGetError;
 use jj_lib::config::ConfigLoadError;
 use jj_lib::config::ConfigMigrateError;
 use jj_lib::dsl_util::Diagnostics;
+use jj_lib::dsl_util::take_most_similar;
 use jj_lib::evolution::WalkPredecessorsError;
 use jj_lib::fileset::FilePatternParseError;
 use jj_lib::fileset::FilesetParseError;
@@ -223,12 +224,23 @@ pub fn internal_error_with_message(
     CommandError::with_message(CommandErrorKind::Internal, message, source)
 }
 
-fn format_similarity_hint<S: AsRef<str>>(candidates: &[S]) -> Option<String> {
+/// Number of similar names to list before summarizing the rest.
+const MAX_SIMILAR_NAMES: usize = 5;
+
+fn format_similarity_hint<S: AsRef<str>>(
+    name: &str,
+    candidates: &[S],
+    max: Option<usize>,
+) -> Option<String> {
     match candidates {
         [] => None,
         names => {
-            let quoted_names = names.iter().map(|s| format!("`{}`", s.as_ref())).join(", ");
-            Some(format!("Did you mean {quoted_names}?"))
+            let similar_names = take_most_similar(name, names, max.unwrap_or(names.len()));
+            let quoted_names = similar_names.iter().map(|s| format!("`{s}`")).join(", ");
+            match names.len() - similar_names.len() {
+                0 => Some(format!("Did you mean {quoted_names}?")),
+                n => Some(format!("Did you mean {quoted_names}, or {n} others?")),
+            }
         }
     }
 }
@@ -831,10 +843,9 @@ fn fileset_parse_error_hint(err: &FilesetParseError) -> Option<String> {
             "See https://docs.jj-vcs.dev/latest/filesets/ or use `jj help -k filesets` for \
              filesets syntax and how to match file paths.",
         )),
-        FilesetParseErrorKind::NoSuchFunction {
-            name: _,
-            candidates,
-        } => format_similarity_hint(candidates),
+        FilesetParseErrorKind::NoSuchFunction { name, candidates } => {
+            format_similarity_hint(name, candidates, Some(MAX_SIMILAR_NAMES))
+        }
         FilesetParseErrorKind::InvalidArguments { .. } => find_source_parse_error_hint(&err),
         FilesetParseErrorKind::RedefinedFunctionParameter => None,
         FilesetParseErrorKind::Expression(_) => find_source_parse_error_hint(&err),
@@ -884,10 +895,9 @@ pub(crate) fn revset_parse_error_hint(err: &RevsetParseError) -> Option<String> 
             similar_op,
             description,
         } => Some(format!("Did you mean `{similar_op}` for {description}?")),
-        RevsetParseErrorKind::NoSuchFunction {
-            name: _,
-            candidates,
-        } => format_similarity_hint(candidates),
+        RevsetParseErrorKind::NoSuchFunction { name, candidates } => {
+            format_similarity_hint(name, candidates, Some(MAX_SIMILAR_NAMES))
+        }
         RevsetParseErrorKind::InvalidFunctionArguments { .. }
         | RevsetParseErrorKind::Expression(_) => find_source_parse_error_hint(bottom_err),
         _ => None,
@@ -902,10 +912,11 @@ fn revset_resolution_error_hints(err: &RevsetResolutionError) -> Vec<String> {
         )
     };
     match err {
-        RevsetResolutionError::NoSuchRevision {
-            name: _,
-            candidates,
-        } => format_similarity_hint(candidates).into_iter().collect(),
+        RevsetResolutionError::NoSuchRevision { name, candidates } => {
+            format_similarity_hint(name, candidates, Some(MAX_SIMILAR_NAMES))
+                .into_iter()
+                .collect()
+        }
         RevsetResolutionError::DivergentChangeId {
             symbol,
             visible_targets,
@@ -965,11 +976,18 @@ fn template_parse_error_hint(err: &TemplateParseError) -> Option<String> {
     // Only for the bottom error, which is usually the root cause
     let bottom_err = iter::successors(Some(err), |e| e.origin()).last().unwrap();
     match bottom_err.kind() {
-        TemplateParseErrorKind::NoSuchKeyword { candidates, .. }
-        | TemplateParseErrorKind::NoSuchFunction { candidates, .. }
-        | TemplateParseErrorKind::NoSuchMethod { candidates, .. } => {
-            format_similarity_hint(candidates)
+        // Keyword hints aren't capped. `-Tbuiltin` uses this to list every
+        // builtin_* alias, and template-aliases share the list, so a large
+        // alias set isn't truncated here either. (#9811)
+        TemplateParseErrorKind::NoSuchKeyword {
+            name, candidates, ..
+        } => format_similarity_hint(name, candidates, None),
+        TemplateParseErrorKind::NoSuchFunction {
+            name, candidates, ..
         }
+        | TemplateParseErrorKind::NoSuchMethod {
+            name, candidates, ..
+        } => format_similarity_hint(name, candidates, Some(MAX_SIMILAR_NAMES)),
         TemplateParseErrorKind::InvalidArguments { .. } | TemplateParseErrorKind::Expression(_) => {
             find_source_parse_error_hint(bottom_err)
         }

--- a/cli/src/command_error.rs
+++ b/cli/src/command_error.rs
@@ -30,6 +30,7 @@ use jj_lib::config::ConfigLoadError;
 use jj_lib::config::ConfigMigrateError;
 use jj_lib::converge::ConvergeError;
 use jj_lib::dsl_util::Diagnostics;
+use jj_lib::dsl_util::take_most_similar;
 use jj_lib::evolution::WalkPredecessorsError;
 use jj_lib::fileset::FilePatternParseError;
 use jj_lib::fileset::FilesetParseError;
@@ -224,12 +225,23 @@ pub fn internal_error_with_message(
     CommandError::with_message(CommandErrorKind::Internal, message, source)
 }
 
-fn format_similarity_hint<S: AsRef<str>>(candidates: &[S]) -> Option<String> {
+/// Number of similar names to list before summarizing the rest.
+const MAX_SIMILAR_NAMES: usize = 5;
+
+fn format_similarity_hint<S: AsRef<str>>(
+    name: &str,
+    candidates: &[S],
+    max: Option<usize>,
+) -> Option<String> {
     match candidates {
         [] => None,
         names => {
-            let quoted_names = names.iter().map(|s| format!("`{}`", s.as_ref())).join(", ");
-            Some(format!("Did you mean {quoted_names}?"))
+            let similar_names = take_most_similar(name, names, max.unwrap_or(names.len()));
+            let quoted_names = similar_names.iter().map(|s| format!("`{s}`")).join(", ");
+            match names.len() - similar_names.len() {
+                0 => Some(format!("Did you mean {quoted_names}?")),
+                n => Some(format!("Did you mean {quoted_names}, or {n} others?")),
+            }
         }
     }
 }
@@ -851,10 +863,9 @@ fn fileset_parse_error_hint(err: &FilesetParseError) -> Option<String> {
             "See https://docs.jj-vcs.dev/latest/filesets/ or use `jj help -k filesets` for \
              filesets syntax and how to match file paths.",
         )),
-        FilesetParseErrorKind::NoSuchFunction {
-            name: _,
-            candidates,
-        } => format_similarity_hint(candidates),
+        FilesetParseErrorKind::NoSuchFunction { name, candidates } => {
+            format_similarity_hint(name, candidates, Some(MAX_SIMILAR_NAMES))
+        }
         FilesetParseErrorKind::InvalidArguments { .. } => find_source_parse_error_hint(&err),
         FilesetParseErrorKind::RedefinedFunctionParameter => None,
         FilesetParseErrorKind::Expression(_) => find_source_parse_error_hint(&err),
@@ -904,10 +915,9 @@ pub(crate) fn revset_parse_error_hint(err: &RevsetParseError) -> Option<String> 
             similar_op,
             description,
         } => Some(format!("Did you mean `{similar_op}` for {description}?")),
-        RevsetParseErrorKind::NoSuchFunction {
-            name: _,
-            candidates,
-        } => format_similarity_hint(candidates),
+        RevsetParseErrorKind::NoSuchFunction { name, candidates } => {
+            format_similarity_hint(name, candidates, Some(MAX_SIMILAR_NAMES))
+        }
         RevsetParseErrorKind::InvalidFunctionArguments { .. }
         | RevsetParseErrorKind::Expression(_) => find_source_parse_error_hint(bottom_err),
         _ => None,
@@ -922,10 +932,11 @@ fn revset_resolution_error_hints(err: &RevsetResolutionError) -> Vec<String> {
         )
     };
     match err {
-        RevsetResolutionError::NoSuchRevision {
-            name: _,
-            candidates,
-        } => format_similarity_hint(candidates).into_iter().collect(),
+        RevsetResolutionError::NoSuchRevision { name, candidates } => {
+            format_similarity_hint(name, candidates, Some(MAX_SIMILAR_NAMES))
+                .into_iter()
+                .collect()
+        }
         RevsetResolutionError::DivergentChangeId {
             symbol,
             visible_targets,
@@ -987,11 +998,18 @@ fn template_parse_error_hint(err: &TemplateParseError) -> Option<String> {
     // Only for the bottom error, which is usually the root cause
     let bottom_err = iter::successors(Some(err), |e| e.origin()).last().unwrap();
     match bottom_err.kind() {
-        TemplateParseErrorKind::NoSuchKeyword { candidates, .. }
-        | TemplateParseErrorKind::NoSuchFunction { candidates, .. }
-        | TemplateParseErrorKind::NoSuchMethod { candidates, .. } => {
-            format_similarity_hint(candidates)
+        // Keyword hints aren't capped. `-Tbuiltin` uses this to list every
+        // builtin_* alias, and template-aliases share the list, so a large
+        // alias set isn't truncated here either. (#9811)
+        TemplateParseErrorKind::NoSuchKeyword {
+            name, candidates, ..
+        } => format_similarity_hint(name, candidates, None),
+        TemplateParseErrorKind::NoSuchFunction {
+            name, candidates, ..
         }
+        | TemplateParseErrorKind::NoSuchMethod {
+            name, candidates, ..
+        } => format_similarity_hint(name, candidates, Some(MAX_SIMILAR_NAMES)),
         TemplateParseErrorKind::InvalidArguments { .. } | TemplateParseErrorKind::Expression(_) => {
             find_source_parse_error_hint(bottom_err)
         }

--- a/cli/tests/test_revset_output.rs
+++ b/cli/tests/test_revset_output.rs
@@ -447,6 +447,56 @@ fn test_function_name_hint() {
 }
 
 #[test]
+fn test_symbol_name_hint() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+    let evaluate = |expr| work_dir.run_jj(["log", "-r", expr]);
+
+    for i in 1..=6 {
+        work_dir
+            .run_jj(["bookmark", "create", "-r@", &format!("feature-{i}")])
+            .success();
+    }
+
+    insta::assert_snapshot!(evaluate("feature-9"), @"
+    ------- stderr -------
+    Error: Revision `feature-9` doesn't exist
+    Hint: Did you mean `feature-1`, `feature-2`, `feature-3`, `feature-4`, `feature-5`, or 1 others?
+    [EOF]
+    [exit status: 1]
+    ");
+
+    work_dir
+        .run_jj(["bookmark", "create", "-r@", "feature-7"])
+        .success();
+
+    insta::assert_snapshot!(evaluate("feature-9"), @"
+    ------- stderr -------
+    Error: Revision `feature-9` doesn't exist
+    Hint: Did you mean `feature-1`, `feature-2`, `feature-3`, `feature-4`, `feature-5`, or 2 others?
+    [EOF]
+    [exit status: 1]
+    ");
+
+    // 'feature-9' sorts last alphabetically, but it's the most similar name,
+    // so it's still listed.
+    for i in 8..=12 {
+        work_dir
+            .run_jj(["bookmark", "create", "-r@", &format!("feature-{i}")])
+            .success();
+    }
+
+    insta::assert_snapshot!(evaluate("feature-9x"), @"
+    ------- stderr -------
+    Error: Revision `feature-9x` doesn't exist
+    Hint: Did you mean `feature-1`, `feature-2`, `feature-3`, `feature-4`, `feature-9`, or 7 others?
+    [EOF]
+    [exit status: 1]
+    ");
+}
+
+#[test]
 fn test_bad_symbol_or_argument_should_not_be_optimized_out() {
     let test_env = TestEnvironment::default();
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();

--- a/lib/src/dsl_util.rs
+++ b/lib/src/dsl_util.rs
@@ -979,9 +979,58 @@ where
         .collect()
 }
 
+/// Picks at most `max` names most similar to `name`, preserving the order of
+/// the `candidates` list.
+pub fn take_most_similar<'a, S: AsRef<str>>(
+    name: &str,
+    candidates: &'a [S],
+    max: usize,
+) -> Vec<&'a str> {
+    if candidates.len() <= max {
+        return candidates.iter().map(|cand| cand.as_ref()).collect();
+    }
+    let mut scored = candidates
+        .iter()
+        .map(|cand| cand.as_ref())
+        .enumerate()
+        .map(|(index, cand)| (index, cand, strsim::jaro(name, cand)))
+        .collect_vec();
+    // Ties are broken by the input order, so the picked names don't depend on
+    // the sort algorithm.
+    scored.sort_unstable_by(|(index1, _, score1), (index2, _, score2)| {
+        score2.total_cmp(score1).then(index1.cmp(index2))
+    });
+    scored.truncate(max);
+    scored.sort_unstable_by_key(|&(index, _, _)| index);
+    scored.into_iter().map(|(_, cand, _)| cand).collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_take_most_similar() {
+        // Sorted by name, as collect_similar() returns them.
+        let candidates = [
+            "feature-1",
+            "feature-10",
+            "feature-11",
+            "feature-2",
+            "feature-9",
+        ];
+        assert_eq!(take_most_similar("feature-9x", &candidates, 5), candidates);
+        // "feature-9" sorts last, but it's the most similar name.
+        assert_eq!(
+            take_most_similar("feature-9x", &candidates, 3),
+            ["feature-1", "feature-2", "feature-9"]
+        );
+        // Equally similar names are picked in the input order.
+        assert_eq!(
+            take_most_similar("feature-9x", &candidates, 2),
+            ["feature-1", "feature-9"]
+        );
+    }
 
     #[test]
     fn test_expect_arguments() {


### PR DESCRIPTION
The "Did you mean" hint listed every similar name, so with a lot of remote bookmarks it came out as a single line of several hundred characters. It now lists the 5 most similar names and counts the rest. Template keyword hints stay uncapped so `-Tbuiltin` still lists all the builtin aliases.

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
