### PR TITLE
git: replace imported ref update tuples with a struct

### DIFF
--- a/cli/src/git_util.rs
+++ b/cli/src/git_util.rs
@@ -32,6 +32,7 @@ use jj_lib::git;
 use jj_lib::git::FailedRefExportReason;
 use jj_lib::git::GitExportStats;
 use jj_lib::git::GitImportOptions;
+use jj_lib::git::GitImportRefUpdate;
 use jj_lib::git::GitImportStats;
 use jj_lib::git::GitProgress;
 use jj_lib::git::GitPushStats;
@@ -39,9 +40,6 @@ use jj_lib::git::GitRefKind;
 use jj_lib::git::GitSettings;
 use jj_lib::git::GitSidebandLineTerminator;
 use jj_lib::git::GitSubprocessCallback;
-use jj_lib::op_store::RefTarget;
-use jj_lib::op_store::RemoteRef;
-use jj_lib::ref_name::RemoteRefSymbol;
 use jj_lib::repo::ReadonlyRepo;
 use jj_lib::repo::Repo;
 use jj_lib::settings::RemoteSettingsMap;
@@ -238,9 +236,7 @@ fn print_imported_changes(
     ] {
         let refs_stats = changes
             .iter()
-            .map(|(symbol, (remote_ref, ref_target))| {
-                RefStatus::new(kind, symbol.as_ref(), remote_ref, ref_target, tx.repo())
-            })
+            .map(|update| RefStatus::new(kind, update, tx.repo()))
             .collect_vec();
         let Some(max_width) = refs_stats.iter().map(|x| x.symbol.width()).max() else {
             continue;
@@ -412,16 +408,14 @@ struct RefStatus {
 }
 
 impl RefStatus {
-    fn new(
-        ref_kind: GitRefKind,
-        symbol: RemoteRefSymbol<'_>,
-        remote_ref: &RemoteRef,
-        ref_target: &RefTarget,
-        repo: &dyn Repo,
-    ) -> Self {
+    fn new(ref_kind: GitRefKind, update: &GitImportRefUpdate, repo: &dyn Repo) -> Self {
         let tracking_status = match ref_kind {
             GitRefKind::Bookmark => {
-                if repo.view().get_remote_bookmark(symbol).is_tracked() {
+                if repo
+                    .view()
+                    .get_remote_bookmark(update.symbol.as_ref())
+                    .is_tracked()
+                {
                     TrackingStatus::Tracked
                 } else {
                     TrackingStatus::Untracked
@@ -430,14 +424,17 @@ impl RefStatus {
             GitRefKind::Tag => TrackingStatus::NotApplicable,
         };
 
-        let import_status = match (remote_ref.target.is_absent(), ref_target.is_absent()) {
+        let import_status = match (
+            update.old_remote_ref.target.is_absent(),
+            update.new_target.is_absent(),
+        ) {
             (true, false) => ImportStatus::New,
             (false, true) => ImportStatus::Deleted,
             _ => ImportStatus::Updated,
         };
 
         Self {
-            symbol: symbol.to_string(),
+            symbol: update.symbol.to_string(),
             tracking_status,
             import_status,
             ref_kind,

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -524,6 +524,27 @@ pub struct GitImportOptions {
     pub remote_auto_track_bookmarks: HashMap<RemoteNameBuf, StringMatcher>,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GitImportRefUpdate {
+    pub symbol: RemoteRefSymbolBuf,
+    pub old_remote_ref: RemoteRef,
+    pub new_target: RefTarget,
+}
+
+impl GitImportRefUpdate {
+    pub fn new(
+        symbol: RemoteRefSymbolBuf,
+        old_remote_ref: RemoteRef,
+        new_target: RefTarget,
+    ) -> Self {
+        Self {
+            symbol,
+            old_remote_ref,
+            new_target,
+        }
+    }
+}
+
 /// Describes changes made by `import_refs()` or `fetch()`.
 #[derive(Clone, Debug, Eq, PartialEq, Default)]
 pub struct GitImportStats {
@@ -531,12 +552,12 @@ pub struct GitImportStats {
     pub abandoned_commits: Vec<Commit>,
     /// Commits that have been rewritten to the new commits.
     pub rewritten_commit_ids: HashSet<CommitId>,
-    /// Remote bookmark `(symbol, (old_remote_ref, new_target))`s to be merged
-    /// in to the local bookmarks, sorted by `symbol`.
-    pub changed_remote_bookmarks: Vec<(RemoteRefSymbolBuf, (RemoteRef, RefTarget))>,
-    /// Remote tag `(symbol, (old_remote_ref, new_target))`s to be merged in to
-    /// the local tags, sorted by `symbol`.
-    pub changed_remote_tags: Vec<(RemoteRefSymbolBuf, (RemoteRef, RefTarget))>,
+    /// Remote bookmark updates to be merged in to the local bookmarks, sorted
+    /// by `symbol`.
+    pub changed_remote_bookmarks: Vec<GitImportRefUpdate>,
+    /// Remote tag updates to be merged in to the local tags, sorted by
+    /// `symbol`.
+    pub changed_remote_tags: Vec<GitImportRefUpdate>,
     /// Git ref names that couldn't be imported, sorted by name.
     ///
     /// This list doesn't include refs that are supposed to be ignored, such as
@@ -549,12 +570,12 @@ struct RefsToImport {
     /// Git ref `(full_name, new_target)`s to be copied to the view, sorted by
     /// `full_name`.
     changed_git_refs: Vec<(GitRefNameBuf, RefTarget)>,
-    /// Remote bookmark `(symbol, (old_remote_ref, new_target))`s to be merged
-    /// in to the local bookmarks, sorted by `symbol`.
-    changed_remote_bookmarks: Vec<(RemoteRefSymbolBuf, (RemoteRef, RefTarget))>,
-    /// Remote tag `(symbol, (old_remote_ref, new_target))`s to be merged in to
-    /// the local tags, sorted by `symbol`.
-    changed_remote_tags: Vec<(RemoteRefSymbolBuf, (RemoteRef, RefTarget))>,
+    /// Remote bookmark updates to be merged in to the local bookmarks, sorted
+    /// by `symbol`.
+    changed_remote_bookmarks: Vec<GitImportRefUpdate>,
+    /// Remote tag updates to be merged in to the local tags, sorted by
+    /// `symbol`.
+    changed_remote_tags: Vec<GitImportRefUpdate>,
     /// Git ref names that couldn't be imported, sorted by name.
     failed_ref_names: Vec<BString>,
 }
@@ -615,9 +636,9 @@ async fn import_refs_inner(
     let (old_referenced_heads, new_referenced_heads) = {
         let mut old_heads = Vec::new();
         let mut new_heads = Vec::new();
-        for (_, (old_remote_ref, new_target)) in iter_changed_refs() {
-            old_heads.extend(old_remote_ref.target.added_ids().cloned());
-            new_heads.extend(new_target.added_ids().cloned());
+        for update in iter_changed_refs() {
+            old_heads.extend(update.old_remote_ref.target.added_ids().cloned());
+            new_heads.extend(update.new_target.added_ids().cloned());
         }
         (old_heads, new_heads)
     };
@@ -656,9 +677,9 @@ async fn import_refs_inner(
     };
     // Uses iter_changed_refs() instead of new_referenced_heads to report error
     // with ref name.
-    for (symbol, (_, new_target)) in iter_changed_refs() {
-        for id in new_target.added_ids() {
-            let commit = get_commit(id, symbol).await?;
+    for update in iter_changed_refs() {
+        for id in update.new_target.added_ids() {
+            let commit = get_commit(id, &update.symbol).await?;
             head_commits.push(commit);
         }
     }
@@ -671,13 +692,13 @@ async fn import_refs_inner(
     for (full_name, new_target) in changed_git_refs {
         mut_repo.set_git_ref_target(&full_name, new_target);
     }
-    for (symbol, (old_remote_ref, new_target)) in &changed_remote_bookmarks {
-        let symbol = symbol.as_ref();
-        let base_target = old_remote_ref.tracked_target();
+    for update in &changed_remote_bookmarks {
+        let symbol = update.symbol.as_ref();
+        let base_target = update.old_remote_ref.tracked_target();
         let new_remote_ref = RemoteRef {
-            target: new_target.clone(),
-            state: if old_remote_ref != RemoteRef::absent_ref() {
-                old_remote_ref.state
+            target: update.new_target.clone(),
+            state: if &update.old_remote_ref != RemoteRef::absent_ref() {
+                update.old_remote_ref.state
             } else {
                 default_remote_ref_state_for(GitRefKind::Bookmark, symbol, options)
             },
@@ -689,13 +710,13 @@ async fn import_refs_inner(
         // It shouldn't diverge even if we had inconsistent view.
         mut_repo.set_remote_bookmark(symbol, new_remote_ref);
     }
-    for (symbol, (old_remote_ref, new_target)) in &changed_remote_tags {
-        let symbol = symbol.as_ref();
-        let base_target = old_remote_ref.tracked_target();
+    for update in &changed_remote_tags {
+        let symbol = update.symbol.as_ref();
+        let base_target = update.old_remote_ref.tracked_target();
         let new_remote_ref = RemoteRef {
-            target: new_target.clone(),
-            state: if old_remote_ref != RemoteRef::absent_ref() {
-                old_remote_ref.state
+            target: update.new_target.clone(),
+            state: if &update.old_remote_ref != RemoteRef::absent_ref() {
+                update.old_remote_ref.state
             } else {
                 default_remote_ref_state_for(GitRefKind::Tag, symbol, options)
             },
@@ -950,19 +971,28 @@ fn diff_refs_to_import(
     }
     for (RemoteRefKey(symbol), old) in known_remote_bookmarks {
         if old.is_present() {
-            changed_remote_bookmarks.push((symbol.to_owned(), (old.clone(), RefTarget::absent())));
+            changed_remote_bookmarks.push(GitImportRefUpdate::new(
+                symbol.to_owned(),
+                old.clone(),
+                RefTarget::absent(),
+            ));
         }
     }
     for (RemoteRefKey(symbol), old) in known_remote_tags {
         if old.is_present() {
-            changed_remote_tags.push((symbol.to_owned(), (old.clone(), RefTarget::absent())));
+            changed_remote_tags.push(GitImportRefUpdate::new(
+                symbol.to_owned(),
+                old.clone(),
+                RefTarget::absent(),
+            ));
         }
     }
 
     // Stabilize merge order and output.
     changed_git_refs.sort_unstable_by(|(name1, _), (name2, _)| name1.cmp(name2));
-    changed_remote_bookmarks.sort_unstable_by(|(sym1, _), (sym2, _)| sym1.cmp(sym2));
-    changed_remote_tags.sort_unstable_by(|(sym1, _), (sym2, _)| sym1.cmp(sym2));
+    changed_remote_bookmarks
+        .sort_unstable_by(|update1, update2| update1.symbol.cmp(&update2.symbol));
+    changed_remote_tags.sort_unstable_by(|update1, update2| update1.symbol.cmp(&update2.symbol));
     failed_ref_names.sort_unstable();
     Ok(RefsToImport {
         changed_git_refs,
@@ -977,7 +1007,7 @@ fn collect_changed_refs_to_import(
     known_git_refs: &mut HashMap<&GitRefName, &RefTarget>,
     known_remote_refs: &mut HashMap<RemoteRefKey<'_>, &RemoteRef>,
     changed_git_refs: &mut Vec<(GitRefNameBuf, RefTarget)>,
-    changed_remote_refs: &mut Vec<(RemoteRefSymbolBuf, (RemoteRef, RefTarget))>,
+    changed_remote_refs: &mut Vec<GitImportRefUpdate>,
     failed_ref_names: &mut Vec<BString>,
     git_ref_filter: impl Fn(GitRefKind, RemoteRefSymbol<'_>) -> bool,
 ) -> Result<(), GitImportError> {
@@ -1018,7 +1048,11 @@ fn collect_changed_refs_to_import(
             .remove(&symbol)
             .unwrap_or_else(|| RemoteRef::absent_ref());
         if new_target != old_remote_ref.target {
-            changed_remote_refs.push((symbol.to_owned(), (old_remote_ref.clone(), new_target)));
+            changed_remote_refs.push(GitImportRefUpdate::new(
+                symbol.to_owned(),
+                old_remote_ref.clone(),
+                new_target,
+            ));
         }
     }
     Ok(())
@@ -1029,7 +1063,7 @@ fn collect_changed_refs_to_import(
 fn collect_changed_remote_tags_to_import(
     actual_git_refs: gix::reference::iter::Iter,
     known_remote_refs: &mut HashMap<RemoteRefKey<'_>, &RemoteRef>,
-    changed_remote_refs: &mut Vec<(RemoteRefSymbolBuf, (RemoteRef, RefTarget))>,
+    changed_remote_refs: &mut Vec<GitImportRefUpdate>,
     failed_ref_names: &mut Vec<BString>,
     git_ref_filter: impl Fn(GitRefKind, RemoteRefSymbol<'_>) -> bool,
 ) -> Result<(), GitImportError> {
@@ -1061,7 +1095,11 @@ fn collect_changed_remote_tags_to_import(
         let new_target = RefTarget::normal(CommitId::from_bytes(oid.as_bytes()));
         known_remote_refs.remove(&symbol);
         if new_target != old_remote_ref.target {
-            changed_remote_refs.push((symbol.to_owned(), (old_remote_ref.clone(), new_target)));
+            changed_remote_refs.push(GitImportRefUpdate::new(
+                symbol.to_owned(),
+                old_remote_ref.clone(),
+                new_target,
+            ));
         }
     }
     Ok(())

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -1299,7 +1299,10 @@ fn test_import_refs_reimport_remote_tags_deleted() -> TestResult {
     tx.repo_mut().rebase_descendants().block_on()?;
     let repo = tx.commit("test").block_on()?;
     assert_eq!(stats.changed_remote_tags.len(), 1);
-    assert_eq!(stats.changed_remote_tags[0].0, remote_symbol("tag1", "git"));
+    assert_eq!(
+        stats.changed_remote_tags[0].symbol,
+        remote_symbol("tag1", "git")
+    );
 
     // Deleted local and @git tags should be imported.
     assert!(repo.view().get_local_tag("tag1".as_ref()).is_absent());
@@ -4551,7 +4554,7 @@ fn test_fetch_multiple_branches() -> TestResult {
         stats
             .changed_remote_bookmarks
             .iter()
-            .map(|(symbol, _)| symbol)
+            .map(|update| &update.symbol)
             .collect_vec(),
         [remote_symbol("main", "origin")]
     );
@@ -4649,11 +4652,11 @@ fn test_fetch_with_tag_changes() -> TestResult {
     let repo = tx.commit("test").block_on()?;
     assert_eq!(stats.changed_remote_tags.len(), 2);
     assert_eq!(
-        stats.changed_remote_tags[0].0,
+        stats.changed_remote_tags[0].symbol,
         remote_symbol("tag1", "origin")
     );
     assert_eq!(
-        stats.changed_remote_tags[1].0,
+        stats.changed_remote_tags[1].symbol,
         remote_symbol("tag2", "origin")
     );
 
@@ -4712,7 +4715,7 @@ fn test_fetch_with_explicit_tag_patterns() -> TestResult {
     let repo = tx.commit("test").block_on()?;
     assert_eq!(stats.changed_remote_tags.len(), 1);
     assert_eq!(
-        stats.changed_remote_tags[0].0,
+        stats.changed_remote_tags[0].symbol,
         remote_symbol("tag2", "origin")
     );
 
@@ -4734,7 +4737,7 @@ fn test_fetch_with_explicit_tag_patterns() -> TestResult {
     let repo = tx.commit("test").block_on()?;
     assert_eq!(stats.changed_remote_tags.len(), 1);
     assert_eq!(
-        stats.changed_remote_tags[0].0,
+        stats.changed_remote_tags[0].symbol,
         remote_symbol("tag1", "origin")
     );
 


### PR DESCRIPTION
This is the first change in a series implementing the `git sync` subcommand.


# Checklist

If applicable:


- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
