### PR TITLE
store: Use NonZeroUsize instead of usize for COMMIT_CACHE_CAPACITY

### DIFF
--- a/lib/src/signing.rs
+++ b/lib/src/signing.rs
@@ -209,7 +209,7 @@ impl Signer {
         Self {
             main_backend,
             backends: other_backends,
-            cache: Mutex::new(CLruCache::new(COMMIT_CACHE_CAPACITY.try_into().unwrap())),
+            cache: Mutex::new(CLruCache::new(COMMIT_CACHE_CAPACITY)),
         }
     }
 

--- a/lib/src/store.rs
+++ b/lib/src/store.rs
@@ -16,6 +16,7 @@
 
 use std::fmt::Debug;
 use std::fmt::Formatter;
+use std::num::NonZeroUsize;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::Mutex;
@@ -48,7 +49,7 @@ use crate::tree_merge::MergeOptions;
 
 // There are more tree objects than commits, and trees are often shared across
 // commits.
-pub(crate) const COMMIT_CACHE_CAPACITY: usize = 100;
+pub(crate) const COMMIT_CACHE_CAPACITY: NonZeroUsize = NonZeroUsize::new(100).unwrap();
 const TREE_CACHE_CAPACITY: usize = 1000;
 
 /// Wraps the low-level backend and makes it return more convenient types. Also
@@ -78,7 +79,7 @@ impl Store {
         Arc::new(Self {
             backend,
             signer,
-            commit_cache: Mutex::new(CLruCache::new(COMMIT_CACHE_CAPACITY.try_into().unwrap())),
+            commit_cache: Mutex::new(CLruCache::new(COMMIT_CACHE_CAPACITY)),
             tree_cache: Mutex::new(CLruCache::new(TREE_CACHE_CAPACITY.try_into().unwrap())),
             merge_options,
         })


### PR DESCRIPTION
This moves the unwrap from runtime to compile time. Credit to @ssbr for spotting this.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
