### PR TITLE
store: Use NonZeroUsize instead of usize for TREE_CACHE_CAPACITY

### DIFF
--- a/lib/src/store.rs
+++ b/lib/src/store.rs
@@ -50,7 +50,7 @@ use crate::tree_merge::MergeOptions;
 // There are more tree objects than commits, and trees are often shared across
 // commits.
 pub(crate) const COMMIT_CACHE_CAPACITY: NonZeroUsize = NonZeroUsize::new(100).unwrap();
-const TREE_CACHE_CAPACITY: usize = 1000;
+const TREE_CACHE_CAPACITY: NonZeroUsize = NonZeroUsize::new(1000).unwrap();
 
 /// Wraps the low-level backend and makes it return more convenient types. Also
 /// adds caching.
@@ -80,7 +80,7 @@ impl Store {
             backend,
             signer,
             commit_cache: Mutex::new(CLruCache::new(COMMIT_CACHE_CAPACITY)),
-            tree_cache: Mutex::new(CLruCache::new(TREE_CACHE_CAPACITY.try_into().unwrap())),
+            tree_cache: Mutex::new(CLruCache::new(TREE_CACHE_CAPACITY)),
             merge_options,
         })
     }


### PR DESCRIPTION
I did this for COMMIT_CACHE_CAPACITY in the following commit, but overlooked this one. https://github.com/jj-vcs/jj/commit/b83dc5d680c0f259e7389fc7fb18a2c6b5d452bf

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
