### PR TITLE
cli: show workspace roots in workspace list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,8 +41,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * New `merge_point()` revset function which (similar to `fork_point`) finds the
   point where multiple branches merge.
 
-* New `builtin_workspace_list` and `builtin_workspace_list_with_root` template
-  aliases are available for `jj workspace list`.
+* `jj workspace list` now shows workspace roots by default. The output can be
+  customized with `templates.workspace_list` or `-T`, and `WorkspaceRef.root()`
+  returns an optional `FsPath` value.
+  [#9713](https://github.com/jj-vcs/jj/pull/9713),
+  [#9826](https://github.com/jj-vcs/jj/pull/9826)
 
 * `jj run` now processes revisions from oldest to newest by default. The start
   order is guaranteed: each revision begins execution only after the previous

--- a/cli/src/commands/workspace/list.rs
+++ b/cli/src/commands/workspace/list.rs
@@ -35,9 +35,6 @@ pub struct WorkspaceListArgs {
     /// The default template can be set by the `templates.workspace_list`
     /// setting.
     ///
-    /// Use `-T builtin_workspace_list_with_root` to include workspace root
-    /// paths.
-    ///
     /// [`WorkspaceRef` type]:
     ///     https://docs.jj-vcs.dev/latest/templates/#workspaceref-type
     ///

--- a/cli/src/config/templates.toml
+++ b/cli/src/config/templates.toml
@@ -299,15 +299,6 @@ builtin_workspace_list = '''
 concat(
   name,
   ": ",
-  format_commit_summary_with_refs(target, format_commit_ref_names(target.bookmarks())),
-  "\n",
-)
-'''
-
-builtin_workspace_list_with_root = '''
-concat(
-  name,
-  ": ",
   separate(
     " ",
     if(root, root.relative()),

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -3769,8 +3769,6 @@ List workspaces
 
    The default template can be set by the `templates.workspace_list` setting.
 
-   Use `-T builtin_workspace_list_with_root` to include workspace root paths.
-
    [`WorkspaceRef` type]: https://docs.jj-vcs.dev/latest/templates/#workspaceref-type
 
    [`jj help -k templates`]: https://docs.jj-vcs.dev/latest/templates/

--- a/cli/tests/test_completion.rs
+++ b/cli/tests/test_completion.rs
@@ -1582,7 +1582,6 @@ fn test_template_alias() {
     builtin_op_log_oneline
     builtin_op_log_redacted
     builtin_workspace_list
-    builtin_workspace_list_with_root
     commit_summary_separator
     default_commit_description
     description_placeholder

--- a/cli/tests/test_evolog_command.rs
+++ b/cli/tests/test_evolog_command.rs
@@ -609,7 +609,6 @@ fn test_evolog_with_no_template() {
     - builtin_op_log_oneline
     - builtin_op_log_redacted
     - builtin_workspace_list
-    - builtin_workspace_list_with_root
     - commit_summary_separator
     - default_commit_description
     - description_placeholder

--- a/cli/tests/test_log_command.rs
+++ b/cli/tests/test_log_command.rs
@@ -65,7 +65,6 @@ fn test_log_with_no_template() {
     - builtin_op_log_oneline
     - builtin_op_log_redacted
     - builtin_workspace_list
-    - builtin_workspace_list_with_root
     - commit_summary_separator
     - default_commit_description
     - description_placeholder

--- a/cli/tests/test_operations.rs
+++ b/cli/tests/test_operations.rs
@@ -211,7 +211,6 @@ fn test_op_log_with_no_template() {
     - builtin_op_log_oneline
     - builtin_op_log_redacted
     - builtin_workspace_list
-    - builtin_workspace_list_with_root
     - commit_summary_separator
     - default_commit_description
     - description_placeholder

--- a/cli/tests/test_show_command.rs
+++ b/cli/tests/test_show_command.rs
@@ -367,7 +367,6 @@ fn test_show_with_no_template() {
     - builtin_op_log_oneline
     - builtin_op_log_redacted
     - builtin_workspace_list
-    - builtin_workspace_list_with_root
     - commit_summary_separator
     - default_commit_description
     - description_placeholder

--- a/cli/tests/test_templater.rs
+++ b/cli/tests/test_templater.rs
@@ -145,7 +145,7 @@ fn test_templater_parse_error() {
       | ^-----^
       |
       = Keyword `builtin` doesn't exist
-    Hint: Did you mean `builtin_config_list`, `builtin_config_list_detailed`, `builtin_draft_commit_description`, `builtin_draft_commit_description_with_diff`, `builtin_evolog_compact`, `builtin_log_comfortable`, `builtin_log_compact`, `builtin_log_compact_full_description`, `builtin_log_detailed`, `builtin_log_node`, `builtin_log_node_ascii`, `builtin_log_oneline`, `builtin_log_redacted`, `builtin_op_log_comfortable`, `builtin_op_log_compact`, `builtin_op_log_node`, `builtin_op_log_node_ascii`, `builtin_op_log_oneline`, `builtin_op_log_redacted`, `builtin_workspace_list`, `builtin_workspace_list_with_root`?
+    Hint: Did you mean `builtin_config_list`, `builtin_config_list_detailed`, `builtin_draft_commit_description`, `builtin_draft_commit_description_with_diff`, `builtin_evolog_compact`, `builtin_log_comfortable`, `builtin_log_compact`, `builtin_log_compact_full_description`, `builtin_log_detailed`, `builtin_log_node`, `builtin_log_node_ascii`, `builtin_log_oneline`, `builtin_log_redacted`, `builtin_op_log_comfortable`, `builtin_op_log_compact`, `builtin_op_log_node`, `builtin_op_log_node_ascii`, `builtin_op_log_oneline`, `builtin_op_log_redacted`, `builtin_workspace_list`?
     [EOF]
     [exit status: 1]
     ");

--- a/cli/tests/test_workspaces.rs
+++ b/cli/tests/test_workspaces.rs
@@ -58,8 +58,8 @@ fn test_workspaces_add_second_and_third_workspace() {
     main_dir.run_jj(["commit", "-m", "initial"]).success();
 
     let output = main_dir.run_jj(["workspace", "list"]);
-    insta::assert_snapshot!(output, @"
-    default: rlvkpnrz 504e3d8c (empty) (no description set)
+    insta::assert_snapshot!(output.normalize_backslash(), @"
+    default: . rlvkpnrz 504e3d8c (empty) (no description set)
     [EOF]
     ");
 
@@ -94,9 +94,9 @@ fn test_workspaces_add_second_and_third_workspace() {
 
     // Both workspaces show up when we list them
     let output = main_dir.run_jj(["workspace", "list"]);
-    insta::assert_snapshot!(output, @"
-    default: rlvkpnrz 504e3d8c (empty) (no description set)
-    second: rzvqmyuk bcc858e1 (empty) (no description set)
+    insta::assert_snapshot!(output.normalize_backslash(), @"
+    default: . rlvkpnrz 504e3d8c (empty) (no description set)
+    second: ../secondary rzvqmyuk bcc858e1 (empty) (no description set)
     [EOF]
     ");
 
@@ -262,7 +262,7 @@ fn test_workspaces_add_second_workspace_on_merge() {
 
     let output = main_dir.run_jj(["workspace", "list"]);
     insta::assert_snapshot!(output, @"
-    default: zsuskuln 46ed31b6 (empty) merge
+    default: . zsuskuln 46ed31b6 (empty) merge
     [EOF]
     ");
 
@@ -414,7 +414,7 @@ fn test_workspaces_add_workspace_at_revision() {
 
     let output = main_dir.run_jj(["workspace", "list"]);
     insta::assert_snapshot!(output, @"
-    default: kkmpptxz 5ac9178d (empty) (no description set)
+    default: . kkmpptxz 5ac9178d (empty) (no description set)
     [EOF]
     ");
 
@@ -537,8 +537,8 @@ fn test_workspaces_add_workspace_from_subdir() {
     main_dir.run_jj(["commit", "-m", "initial"]).success();
 
     let output = main_dir.run_jj(["workspace", "list"]);
-    insta::assert_snapshot!(output, @"
-    default: rlvkpnrz 0ba0ff35 (empty) (no description set)
+    insta::assert_snapshot!(output.normalize_backslash(), @"
+    default: . rlvkpnrz 0ba0ff35 (empty) (no description set)
     [EOF]
     ");
 
@@ -555,9 +555,9 @@ fn test_workspaces_add_workspace_from_subdir() {
 
     // Both workspaces show up when we list them
     let output = secondary_dir.run_jj(["workspace", "list"]);
-    insta::assert_snapshot!(output, @"
-    default: rlvkpnrz 0ba0ff35 (empty) (no description set)
-    secondary: rzvqmyuk dea1be10 (empty) (no description set)
+    insta::assert_snapshot!(output.normalize_backslash(), @"
+    default: ../main rlvkpnrz 0ba0ff35 (empty) (no description set)
+    secondary: . rzvqmyuk dea1be10 (empty) (no description set)
     [EOF]
     ");
 }
@@ -586,8 +586,8 @@ fn test_workspaces_add_workspace_in_current_workspace() {
     // Workspace created despite warning
     let output = main_dir.run_jj(["workspace", "list"]);
     insta::assert_snapshot!(output, @"
-    default: rlvkpnrz 504e3d8c (empty) (no description set)
-    secondary: pmmvwywv 058f604d (empty) (no description set)
+    default: . rlvkpnrz 504e3d8c (empty) (no description set)
+    secondary: secondary pmmvwywv 058f604d (empty) (no description set)
     [EOF]
     ");
 
@@ -605,9 +605,9 @@ fn test_workspaces_add_workspace_in_current_workspace() {
     // Both workspaces created
     let output = main_dir.run_jj(["workspace", "list"]);
     insta::assert_snapshot!(output, @"
-    default: rlvkpnrz 504e3d8c (empty) (no description set)
-    secondary: pmmvwywv 058f604d (empty) (no description set)
-    third: zxsnswpr 1c1effec (empty) (no description set)
+    default: . rlvkpnrz 504e3d8c (empty) (no description set)
+    secondary: secondary pmmvwywv 058f604d (empty) (no description set)
+    third: third zxsnswpr 1c1effec (empty) (no description set)
     [EOF]
     ");
 
@@ -639,9 +639,9 @@ fn test_workspace_add_override_path_in_store() {
 
     // Both workspaces show up when we list them
     let output = main_dir.run_jj(["workspace", "list"]);
-    insta::assert_snapshot!(output, @"
-    default: rlvkpnrz 504e3d8c (empty) (no description set)
-    second: pmmvwywv 058f604d (empty) (no description set)
+    insta::assert_snapshot!(output.normalize_backslash(), @"
+    default: . rlvkpnrz 504e3d8c (empty) (no description set)
+    second: ../secondary pmmvwywv 058f604d (empty) (no description set)
     [EOF]
     ");
 
@@ -655,8 +655,8 @@ fn test_workspace_add_override_path_in_store() {
 
     // Only default workspace show up when we list them
     let output = main_dir.run_jj(["workspace", "list"]);
-    insta::assert_snapshot!(output, @"
-    default: rlvkpnrz 504e3d8c (empty) (no description set)
+    insta::assert_snapshot!(output.normalize_backslash(), @"
+    default: . rlvkpnrz 504e3d8c (empty) (no description set)
     [EOF]
     ");
 
@@ -673,9 +673,9 @@ fn test_workspace_add_override_path_in_store() {
 
     // Both workspaces show up when we list them
     let output = main_dir.run_jj(["workspace", "list"]);
-    insta::assert_snapshot!(output, @"
-    default: rlvkpnrz 504e3d8c (empty) (no description set)
-    second: spxsnpux 96ef6c50 (empty) (no description set)
+    insta::assert_snapshot!(output.normalize_backslash(), @"
+    default: . rlvkpnrz 504e3d8c (empty) (no description set)
+    second: ../tertiary spxsnpux 96ef6c50 (empty) (no description set)
     [EOF]
     ");
 
@@ -1471,8 +1471,8 @@ fn test_workspaces_forget() {
 
     // When listing workspaces, only the secondary workspace shows up
     let output = main_dir.run_jj(["workspace", "list"]);
-    insta::assert_snapshot!(output, @"
-    secondary: pmmvwywv 31da1455 (empty) (no description set)
+    insta::assert_snapshot!(output.normalize_backslash(), @"
+    secondary: ../secondary pmmvwywv 31da1455 (empty) (no description set)
     [EOF]
     ");
 
@@ -1586,10 +1586,10 @@ fn test_workspaces_forget_multi_transaction() {
 
     // there should be three workspaces
     let output = main_dir.run_jj(["workspace", "list"]);
-    insta::assert_snapshot!(output, @"
-    default: rlvkpnrz f6bf8819 (empty) (no description set)
-    second: pmmvwywv 31da1455 (empty) (no description set)
-    third: rzvqmyuk bf5b5b4d (empty) (no description set)
+    insta::assert_snapshot!(output.normalize_backslash(), @"
+    default: . rlvkpnrz f6bf8819 (empty) (no description set)
+    second: ../second pmmvwywv 31da1455 (empty) (no description set)
+    third: ../third rzvqmyuk bf5b5b4d (empty) (no description set)
     [EOF]
     ");
 
@@ -1598,8 +1598,8 @@ fn test_workspaces_forget_multi_transaction() {
         .run_jj(["workspace", "forget", "second", "third", "fourth"])
         .success();
     let output = main_dir.run_jj(["workspace", "list"]);
-    insta::assert_snapshot!(output, @"
-    default: rlvkpnrz f6bf8819 (empty) (no description set)
+    insta::assert_snapshot!(output.normalize_backslash(), @"
+    default: . rlvkpnrz f6bf8819 (empty) (no description set)
     [EOF]
     ");
 
@@ -1617,8 +1617,8 @@ fn test_workspaces_forget_multi_transaction() {
 
     // finally, there should be three workspaces at the end
     let output = main_dir.run_jj(["workspace", "list"]);
-    insta::assert_snapshot!(output, @"
-    default: rlvkpnrz f6bf8819 (empty) (no description set)
+    insta::assert_snapshot!(output.normalize_backslash(), @"
+    default: . rlvkpnrz f6bf8819 (empty) (no description set)
     second: pmmvwywv 31da1455 (empty) (no description set)
     third: rzvqmyuk bf5b5b4d (empty) (no description set)
     [EOF]
@@ -1643,11 +1643,11 @@ fn test_workspaces_forget_abandon_commits() {
 
     // there should be four workspaces, three of which are at the same empty commit
     let output = main_dir.run_jj(["workspace", "list"]);
-    insta::assert_snapshot!(output, @"
-    default: qpvuntsm 006bd113 (no description set)
-    fourth: uuqppmxq 94f41578 (empty) (no description set)
-    second: uuqppmxq 94f41578 (empty) (no description set)
-    third: uuqppmxq 94f41578 (empty) (no description set)
+    insta::assert_snapshot!(output.normalize_backslash(), @"
+    default: . qpvuntsm 006bd113 (no description set)
+    fourth: ../fourth uuqppmxq 94f41578 (empty) (no description set)
+    second: ../second uuqppmxq 94f41578 (empty) (no description set)
+    third: ../third uuqppmxq 94f41578 (empty) (no description set)
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&main_dir), @"
@@ -1772,18 +1772,6 @@ fn test_list_workspaces_template_root() {
     second: ../secondary
     [EOF]
     ");
-
-    let output = main_dir.run_jj([
-        "workspace",
-        "list",
-        "-T",
-        "builtin_workspace_list_with_root",
-    ]);
-    insta::assert_snapshot!(output.normalize_backslash(), @"
-    default: . qpvuntsm e8849ae1 (empty) (no description set)
-    second: ../secondary uuqppmxq 94f41578 (empty) (no description set)
-    [EOF]
-    ");
 }
 
 #[test]
@@ -1813,12 +1801,7 @@ fn test_list_workspaces_template_root_unavailable() {
     [EOF]
     ");
 
-    let output = main_dir.run_jj([
-        "workspace",
-        "list",
-        "-T",
-        "builtin_workspace_list_with_root",
-    ]);
+    let output = main_dir.run_jj(["workspace", "list"]);
     insta::assert_snapshot!(output, @"
     default: . qpvuntsm e8849ae1 (empty) (no description set)
     second: uuqppmxq 94f41578 (empty) (no description set)
@@ -1893,9 +1876,9 @@ fn test_workspaces_relative_path() -> TestResult {
     ");
 
     let output = main_dir.run_jj(["workspace", "list"]);
-    insta::assert_snapshot!(output, @"
-    default: qpvuntsm e8849ae1 (empty) (no description set)
-    secondary: uuqppmxq 94f41578 (empty) (no description set)
+    insta::assert_snapshot!(output.normalize_backslash(), @"
+    default: . qpvuntsm e8849ae1 (empty) (no description set)
+    secondary: ../secondary uuqppmxq 94f41578 (empty) (no description set)
     [EOF]
     ");
 
@@ -2038,9 +2021,9 @@ fn test_workspaces_rename_workspace() {
 
     // Both workspaces show up when we list them
     let output = main_dir.run_jj(["workspace", "list"]);
-    insta::assert_snapshot!(output, @"
-    default: qpvuntsm e8849ae1 (empty) (no description set)
-    second: uuqppmxq 94f41578 (empty) (no description set)
+    insta::assert_snapshot!(output.normalize_backslash(), @"
+    default: . qpvuntsm e8849ae1 (empty) (no description set)
+    second: ../secondary uuqppmxq 94f41578 (empty) (no description set)
     [EOF]
     ");
 
@@ -2048,9 +2031,9 @@ fn test_workspaces_rename_workspace() {
     insta::assert_snapshot!(output, @"");
 
     let output = main_dir.run_jj(["workspace", "list"]);
-    insta::assert_snapshot!(output, @"
-    default: qpvuntsm e8849ae1 (empty) (no description set)
-    third: uuqppmxq 94f41578 (empty) (no description set)
+    insta::assert_snapshot!(output.normalize_backslash(), @"
+    default: . qpvuntsm e8849ae1 (empty) (no description set)
+    third: ../secondary uuqppmxq 94f41578 (empty) (no description set)
     [EOF]
     ");
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -627,24 +627,6 @@ you can add this to your config:
 config_list = "builtin_config_list_detailed"
 ```
 
-If you want `jj workspace list` to show each workspace root, you can use the
-shipped root-path template:
-
-```sh
-jj workspace list -T builtin_workspace_list_with_root
-```
-
-Workspaces whose roots are not recorded or cannot be resolved are shown without
-the root path. Workspace roots are not recorded for workspaces created before jj
-0.38.0.
-
-Or make it your default:
-
-```toml
-[templates]
-workspace_list = "builtin_workspace_list_with_root"
-```
-
 ## Log
 
 ### Default revisions

--- a/docs/working-copy.md
+++ b/docs/working-copy.md
@@ -84,8 +84,7 @@ while you continue developing in another, for example. If needed,
 `jj workspace root --name <workspace>` prints the root path of the specified
 workspace (defaults to the current one).
 
-Use `jj workspace list -T builtin_workspace_list_with_root` to show every
-workspace together with its available root path.
+`jj workspace list` shows every workspace together with its available root path.
 
 When you're done using a workspace, use `jj workspace forget` to make the repo
 forget about it. The files can be deleted from disk separately (either before or


### PR DESCRIPTION
Follow-up to #9713. This makes the root-bearing workspace list output the default and removes the now-redundant `builtin_workspace_list_with_root` alias.

Fixes #7114.

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it is organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
