### PR TITLE
git: import fetched refs on the latest operation to avoid divergence from concurrent ops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed bugs
 
+* `jj git fetch` and `jj git import` no longer create divergent changes when
+  another process concurrently commits an operation. The Git ref import now runs
+  on the latest operation under the Git import/export lock.
+
 * Recursive alias definitions are detected more precisely. jj can now expand
   aliases that are simply repeated. For example, with the alias `jj = []`, the
   command `jj jj jj` will resolve to `jj`. Aliases can also fall back to the

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -2263,7 +2263,24 @@ to the current parents may contain changes from multiple commits.
             helper: self,
             tx,
             id_prefix_context,
+            git_import_export_lock: None,
         }
+    }
+
+    /// Starts a transaction that holds the Git import/export lock, so a
+    /// concurrent snapshot can't import or export Git refs while the
+    /// transaction is open. The lock is released when the transaction is
+    /// finished or dropped.
+    ///
+    /// Don't trigger anything that takes the same lock while the transaction
+    /// is open.
+    pub fn start_locked_git_import_export_transaction(
+        &mut self,
+    ) -> Result<WorkspaceCommandTransaction<'_>, CommandError> {
+        let lock = self.lock_git_import_export()?;
+        let mut tx = self.start_transaction();
+        tx.git_import_export_lock = Some(lock);
+        Ok(tx)
     }
 
     async fn finish_transaction(
@@ -2676,6 +2693,10 @@ pub struct WorkspaceCommandTransaction<'a> {
     tx: Transaction,
     /// Cache of index built against the current MutableRepo state.
     id_prefix_context: OnceCell<IdPrefixContext>,
+    /// Lock taken by
+    /// [`WorkspaceCommandHelper::start_locked_git_import_export_transaction`],
+    /// reused when the transaction is finished.
+    git_import_export_lock: Option<GitImportExportLock>,
 }
 
 impl WorkspaceCommandTransaction<'_> {
@@ -2757,7 +2778,12 @@ impl WorkspaceCommandTransaction<'_> {
     }
 
     pub async fn finish(self, ui: &Ui, description: impl Into<String>) -> Result<(), CommandError> {
-        let Self { helper, mut tx, .. } = self;
+        let Self {
+            helper,
+            mut tx,
+            git_import_export_lock,
+            ..
+        } = self;
         if !tx.repo().has_changes() {
             writeln!(ui.status(), "Nothing changed.")?;
             return Ok(());
@@ -2766,9 +2792,11 @@ impl WorkspaceCommandTransaction<'_> {
         if num_rebased > 0 {
             writeln!(ui.status(), "Rebased {num_rebased} descendant commits.")?;
         }
-        // Acquire git import/export lock before finishing the transaction to ensure
-        // Git HEAD export happens atomically with the transaction commit.
-        let git_import_export_lock = helper.lock_git_import_export()?;
+        // Reuse the Git import/export lock held since the transaction was started,
+        // or acquire one now, so Git HEAD export happens atomically with the
+        // transaction commit.
+        let git_import_export_lock =
+            git_import_export_lock.map_or_else(|| helper.lock_git_import_export(), Ok)?;
         helper
             .finish_transaction(ui, tx, description, &git_import_export_lock)
             .await

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -2267,17 +2267,25 @@ to the current parents may contain changes from multiple commits.
         }
     }
 
-    /// Starts a transaction that holds the Git import/export lock, so a
-    /// concurrent snapshot can't import or export Git refs while the
-    /// transaction is open. The lock is released when the transaction is
-    /// finished or dropped.
+    /// Starts a transaction that holds the Git import/export lock and runs on
+    /// the latest operation, so a concurrent snapshot can't import or export
+    /// Git refs while the transaction is open, and the import can't repeat
+    /// a rewrite that a concurrent operation already committed, which would
+    /// create divergent changes. The lock is released when the transaction
+    /// is finished or dropped.
     ///
     /// Don't trigger anything that takes the same lock while the transaction
     /// is open.
-    pub fn start_locked_git_import_export_transaction(
+    pub async fn start_locked_git_import_export_transaction(
         &mut self,
+        ui: &Ui,
     ) -> Result<WorkspaceCommandTransaction<'_>, CommandError> {
         let lock = self.lock_git_import_export()?;
+        // Under --at-op the command must run on the operation the user named,
+        // even if the heads have moved on.
+        if self.env.command.should_commit_transaction() && self.env.command.is_at_head_operation() {
+            self.reload_repo_at_head(ui).await?;
+        }
         let mut tx = self.start_transaction();
         tx.git_import_export_lock = Some(lock);
         Ok(tx)

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -1209,6 +1209,26 @@ impl WorkspaceCommandHelper {
         }
     }
 
+    /// Reloads the repo at the current operation head if it has advanced since
+    /// this command loaded it, e.g. because another process committed an
+    /// operation.
+    async fn reload_repo_at_head(&mut self, ui: &Ui) -> Result<(), CommandError> {
+        assert!(self.env.command.is_at_head_operation());
+        let repo = self.repo();
+        let op_heads_store = repo.loader().op_heads_store();
+        let op_heads = op_heads_store.get_op_heads().await?;
+        if std::slice::from_ref(repo.op_id()) == op_heads {
+            return Ok(());
+        }
+        let op = self
+            .env
+            .command
+            .resolve_operation(ui, repo.loader(), self.workspace_name())?;
+        let current_repo = repo.loader().load_at(&op).await?;
+        self.user_repo = ReadonlyUserRepo::new(current_repo);
+        Ok(())
+    }
+
     /// Acquires a lock for git import/export operations if the workspace is
     /// colocated with Git. Returns a token that can be passed to functions
     /// that need to import from or export to Git. For non-colocated repos,
@@ -1247,25 +1267,9 @@ impl WorkspaceCommandHelper {
         // Reload at current head to avoid creating divergent operations if another
         // process committed an operation while we were waiting for the lock.
         if self.working_copy_shared_with_git {
-            let repo = self.repo().clone();
-            let op_heads_store = repo.loader().op_heads_store();
-            let op_heads = op_heads_store
-                .get_op_heads()
+            self.reload_repo_at_head(ui)
                 .await
                 .map_err(snapshot_command_error)?;
-            if std::slice::from_ref(repo.op_id()) != op_heads {
-                let op = self
-                    .env
-                    .command
-                    .resolve_operation(ui, repo.loader(), self.workspace_name())
-                    .map_err(snapshot_command_error)?;
-                let current_repo = repo
-                    .loader()
-                    .load_at(&op)
-                    .await
-                    .map_err(snapshot_command_error)?;
-                self.user_repo = ReadonlyUserRepo::new(current_repo);
-            }
         }
 
         #[cfg(feature = "git")]

--- a/cli/src/commands/git/fetch.rs
+++ b/cli/src/commands/git/fetch.rs
@@ -167,7 +167,9 @@ pub async fn cmd_git_fetch(
 
     // Hold the Git import/export lock across the network fetch, so the fetched
     // refs get imported by this command, not by a concurrent snapshot.
-    let mut tx = workspace_command.start_locked_git_import_export_transaction()?;
+    let mut tx = workspace_command
+        .start_locked_git_import_export_transaction(ui)
+        .await?;
     let remote_settings = tx.settings().remote_settings()?;
 
     let is_specific = args.branches.is_some() || args.tags.is_some();

--- a/cli/src/commands/git/fetch.rs
+++ b/cli/src/commands/git/fetch.rs
@@ -165,7 +165,9 @@ pub async fn cmd_git_fetch(
         return Err(user_error("No git remotes to fetch from"));
     }
 
-    let mut tx = workspace_command.start_transaction();
+    // Hold the Git import/export lock across the network fetch, so the fetched
+    // refs get imported by this command, not by a concurrent snapshot.
+    let mut tx = workspace_command.start_locked_git_import_export_transaction()?;
     let remote_settings = tx.settings().remote_settings()?;
 
     let is_specific = args.branches.is_some() || args.tags.is_some();

--- a/cli/src/commands/git/import.rs
+++ b/cli/src/commands/git/import.rs
@@ -45,7 +45,9 @@ pub async fn cmd_git_import(
     let git_settings = GitSettings::from_settings(workspace_command.settings())?;
     let remote_settings = workspace_command.settings().remote_settings()?;
     let import_options = load_git_import_options(ui, &git_settings, &remote_settings)?;
-    let mut tx = workspace_command.start_locked_git_import_export_transaction()?;
+    let mut tx = workspace_command
+        .start_locked_git_import_export_transaction(ui)
+        .await?;
     // In non-colocated workspace, Git HEAD will never be moved internally by jj.
     // That's why cmd_git_export() doesn't export the HEAD ref.
     git::import_head(tx.repo_mut()).await?;

--- a/cli/src/commands/git/import.rs
+++ b/cli/src/commands/git/import.rs
@@ -45,7 +45,7 @@ pub async fn cmd_git_import(
     let git_settings = GitSettings::from_settings(workspace_command.settings())?;
     let remote_settings = workspace_command.settings().remote_settings()?;
     let import_options = load_git_import_options(ui, &git_settings, &remote_settings)?;
-    let mut tx = workspace_command.start_transaction();
+    let mut tx = workspace_command.start_locked_git_import_export_transaction()?;
     // In non-colocated workspace, Git HEAD will never be moved internally by jj.
     // That's why cmd_git_export() doesn't export the HEAD ref.
     git::import_head(tx.repo_mut()).await?;

--- a/cli/tests/test_git_fetch.rs
+++ b/cli/tests/test_git_fetch.rs
@@ -2655,7 +2655,6 @@ fn test_git_fetch_auto_track_bookmarks() {
 ///
 /// Modeled on `test_concurrent_operations::test_git_head_race_condition`.
 #[test]
-#[should_panic(expected = "must not be divergent")]
 fn test_git_fetch_race_condition() {
     let test_env = TestEnvironment::default();
 

--- a/cli/tests/test_git_fetch.rs
+++ b/cli/tests/test_git_fetch.rs
@@ -2645,3 +2645,169 @@ fn test_git_fetch_auto_track_bookmarks() {
     [EOF]
     ");
 }
+
+/// Concurrent `jj git fetch` processes importing a remotely-rewritten bookmark
+/// must not turn a local commit stacked on it into a divergent change. A
+/// background thread keeps rewriting the bookmark while several fetchers race
+/// to import it; each import rebases the local commit. When two imports start
+/// from the same operation, their rebases get different commit ids and the
+/// change becomes divergent.
+///
+/// Modeled on `test_concurrent_operations::test_git_head_race_condition`.
+#[test]
+#[should_panic(expected = "must not be divergent")]
+fn test_git_fetch_race_condition() {
+    let test_env = TestEnvironment::default();
+
+    // Colocated remote with a bookmark `feat`.
+    test_env
+        .run_jj_in(".", ["git", "init", "--colocate", "remote"])
+        .success();
+    let remote_dir = test_env.work_dir("remote");
+    remote_dir.run_jj(["describe", "-m", "v0"]).success();
+    remote_dir
+        .run_jj(["bookmark", "create", "-r@", "feat"])
+        .success();
+
+    // Clone colocated and stack a local commit on top of `feat`.
+    test_env
+        .run_jj_in(".", ["git", "clone", "--colocate", "remote", "local"])
+        .success();
+    let local_dir = test_env.work_dir("local");
+    local_dir
+        .run_jj(["new", "feat@origin", "-m", "local work"])
+        .success();
+    // The bottom commit stacked on `feat` is the one every import rebases;
+    // capture its change id now, while it's still unambiguous.
+    let local_change_id = local_dir
+        .run_jj(["log", "--no-graph", "-r", "@", "-T", "change_id"])
+        .success()
+        .stdout
+        .into_raw();
+    let local_change_id = local_change_id.trim().to_owned();
+    // Stack a few more commits so each import rebases a taller subtree, which
+    // widens the window for two concurrent imports to collide.
+    for i in 0..4 {
+        local_dir
+            .run_jj(["new", "-m", &format!("local work {i}")])
+            .success();
+    }
+
+    // Rewrite the bookmark once before the fetchers start, so they have a
+    // rewrite to import even if the writer thread below is slow to get going.
+    remote_dir
+        .run_jj(["describe", "-r", "feat", "-m", "v1"])
+        .success();
+
+    // Spawned processes need fresh timestamps/seed so each concurrent rebase
+    // produces a distinct commit id.
+    let base_cmd = test_env.new_jj_cmd();
+    let jj_bin = base_cmd.get_program().to_owned();
+    let base_env: Vec<_> = base_cmd
+        .get_envs()
+        .filter_map(|(k, v)| v.map(|v| (k.to_owned(), v.to_owned())))
+        .filter(|(k, _)| k != "JJ_TIMESTAMP" && k != "JJ_OP_TIMESTAMP" && k != "JJ_RANDOMNESS_SEED")
+        .collect();
+
+    let remote_path = remote_dir.root().to_owned();
+    let local_path = local_dir.root().to_owned();
+    let duration = std::time::Duration::from_secs(5);
+    let start = std::time::Instant::now();
+    // Every spawned command must succeed; the counts only guard against a
+    // vacuous pass if a loop never got to run a command at all.
+    let rewrite_count = std::sync::atomic::AtomicUsize::new(0);
+    let fetch_count = std::sync::atomic::AtomicUsize::new(0);
+    let failures = std::sync::Mutex::new(Vec::new());
+    let succeeded = |command: &str, output: std::process::Output| {
+        if output.status.success() {
+            return true;
+        }
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        failures
+            .lock()
+            .unwrap()
+            .push(format!("`{command}` failed: {}", stderr.trim()));
+        false
+    };
+
+    std::thread::scope(|s| {
+        // Keep rewriting the remote bookmark so each fetch has a rewrite to
+        // import.
+        s.spawn(|| {
+            let mut n = 2;
+            while start.elapsed() < duration {
+                let mut cmd = std::process::Command::new(&jj_bin);
+                cmd.current_dir(&remote_path);
+                cmd.args(["describe", "-r", "feat", "-m", &format!("v{n}")]);
+                for (key, value) in &base_env {
+                    cmd.env(key, value);
+                }
+                let output = cmd.output().expect("failed to spawn jj describe");
+                if succeeded("jj describe", output) {
+                    rewrite_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                }
+                n += 1;
+            }
+        });
+        // Several fetchers race to import the rewrite.
+        for _ in 0..4 {
+            s.spawn(|| {
+                while start.elapsed() < duration {
+                    let mut cmd = std::process::Command::new(&jj_bin);
+                    cmd.current_dir(&local_path);
+                    cmd.args(["git", "fetch"]);
+                    for (key, value) in &base_env {
+                        cmd.env(key, value);
+                    }
+                    let output = cmd.output().expect("failed to spawn jj git fetch");
+                    if succeeded("jj git fetch", output) {
+                        fetch_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    }
+                }
+            });
+        }
+    });
+
+    // Exactly one visible commit must share the local commit's change id.
+    // --ignore-working-copy: don't run another Git import cycle, which can hit
+    // unrelated races in the Git state the concurrent fetches left behind.
+    let revset = format!("change_id({local_change_id})");
+    let output = local_dir
+        .run_jj([
+            "log",
+            "--ignore-working-copy",
+            "--no-graph",
+            "-r",
+            revset.as_str(),
+            "-T",
+            r#"commit_id.short() ++ "\n""#,
+        ])
+        .success();
+    let copies = output
+        .stdout
+        .raw()
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .count();
+    assert_eq!(
+        copies, 1,
+        "the local commit must not be divergent after concurrent fetches; got {copies} copies"
+    );
+
+    // Divergence is asserted first because it's the symptom this test is about;
+    // unserialized imports also make the concurrent fetches fail to update
+    // `refs/remotes/origin/feat`, which these assertions catch.
+    let failures = failures.into_inner().unwrap();
+    assert!(
+        failures.is_empty(),
+        "concurrent commands failed: {failures:#?}"
+    );
+    assert!(
+        rewrite_count.load(std::sync::atomic::Ordering::Relaxed) > 0,
+        "expected the remote bookmark to be rewritten at least once"
+    );
+    assert!(
+        fetch_count.load(std::sync::atomic::Ordering::Relaxed) > 0,
+        "expected `jj git fetch` to run at least once"
+    );
+}


### PR DESCRIPTION
`jj git fetch` and `jj git import` could turn a change divergent (or leave a bookmark conflicted) when another jj process committed an operation concurrently - most often a working-copy snapshot (e.g. Watchman trigger or an IDE integration snapshotting in the background like VisualJJ), or a second `jj git fetch` running in parallel.

Fixes #7349 and #9594.

[Discussion on Discord](https://discord.com/channels/968932220549103686/1527314390158676091/1528022518940827659)

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
