### PR TITLE
cli: create new mutable working-copy commit proactively at tx.finish()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Fixed Git HEAD mismatch after the working copy became immutable.
   [#9827](https://github.com/jj-vcs/jj/issues/9827)
 
+* `jj` now creates a new working-copy revision as soon as the one of the current
+  workspace becomes immutable, as well as during snapshotting. This brings the
+  behavior closer to `jj` 0.42 and earlier.
+
 ## [0.43.0] - 2026-07-01
 
 ### Release highlights

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -2282,6 +2282,33 @@ to the current parents may contain changes from multiple commits.
             .get_wc_commit_id(self.workspace_name())
             .map(|commit_id| tx.repo().store().get_commit(commit_id))
             .transpose()?;
+        // Create a new mutable working-copy commit to reduce unintended states.
+        // This isn't strictly required for correctness, so symbol resolution
+        // failures can be ignored. snapshot_working_copy() ensures that the
+        // working-copy commit is mutable.
+        let maybe_new_wc_commit = if let Some(wc_commit) = &maybe_new_wc_commit
+            && let Ok(immutable_expr) = self.env.resolve_immutable_expression(tx.repo())
+            && !immutable_expr
+                .intersection(&RevsetExpression::commit(wc_commit.id().clone()))
+                .evaluate(tx.repo())?
+                .is_empty()?
+        {
+            let new_wc_commit = tx
+                .repo_mut()
+                .new_commit(vec![wc_commit.id().clone()], wc_commit.tree())
+                .write()
+                .await?;
+            tx.repo_mut()
+                .set_wc_commit(self.workspace_name().to_owned(), new_wc_commit.id().clone())?;
+            writeln!(
+                ui.warning_default(),
+                "The working-copy commit became immutable; a new commit has been created on top \
+                 of it.",
+            )?;
+            Some(new_wc_commit)
+        } else {
+            maybe_new_wc_commit
+        };
 
         #[cfg(feature = "git")]
         if self.working_copy_shared_with_git && self.env.command.should_commit_transaction() {

--- a/cli/tests/test_bookmark_command.rs
+++ b/cli/tests/test_bookmark_command.rs
@@ -1082,6 +1082,9 @@ fn test_bookmark_rename_colocated() {
     ------- stderr -------
     Warning: Tracking of remote bookmark bpushed@origin was dropped.
     Hint: Use `jj bookmark track` to re-track if needed.
+    Warning: The working-copy commit became immutable; a new commit has been created on top of it.
+    Working copy  (@) now at: znkkpsqq cf8db4ba (empty) (no description set)
+    Parent commit (@-)      : royxmykx b6e46c10 bpushed@origin | (empty) commit-1
     [EOF]
     ");
     let output = work_dir.run_jj(["bookmark", "list", "--all", "bpushed"]);

--- a/cli/tests/test_git_private_commits.rs
+++ b/cli/tests/test_git_private_commits.rs
@@ -205,6 +205,9 @@ fn test_git_private_commits_can_be_overridden() {
     ------- stderr -------
     Changes to push to origin:
       bookmark: main [move forward from 95cc152cd086 to 7f665ca27d4e]
+    Warning: The working-copy commit became immutable; a new commit has been created on top of it.
+    Working copy  (@) now at: znkkpsqq 8227d51b (empty) (no description set)
+    Parent commit (@-)      : yqosqzyt 7f665ca2 main | (empty) private 1
     [EOF]
     ");
 }
@@ -227,6 +230,9 @@ fn test_git_private_commits_are_not_checked_if_immutable() {
     ------- stderr -------
     Changes to push to origin:
       bookmark: main [move forward from 95cc152cd086 to 7f665ca27d4e]
+    Warning: The working-copy commit became immutable; a new commit has been created on top of it.
+    Working copy  (@) now at: yostqsxw 17947f20 (empty) (no description set)
+    Parent commit (@-)      : yqosqzyt 7f665ca2 main | (empty) private 1
     [EOF]
     ");
 }
@@ -316,6 +322,9 @@ fn test_git_private_commits_already_on_the_remote_do_not_block_push() {
     Changes to push to origin:
       bookmark: bookmark1 [add to 95cc152cd086]
       bookmark: main [move forward from 95cc152cd086 to 03bc2bf271e0]
+    Warning: The working-copy commit became immutable; a new commit has been created on top of it.
+    Working copy  (@) now at: kpqxywon 5308110d (empty) (no description set)
+    Parent commit (@-)      : yostqsxw 03bc2bf2 main | (empty) public 3
     [EOF]
     ");
 

--- a/cli/tests/test_immutable_commits.rs
+++ b/cli/tests/test_immutable_commits.rs
@@ -143,7 +143,6 @@ fn test_new_wc_commit_when_wc_immutable() {
     work_dir
         .run_jj(["bookmark", "create", "-r@", "main"])
         .success();
-    test_env.add_config(r#"revset-aliases."immutable_heads()" = "main""#);
     work_dir.run_jj(["new", "-m=a"]).success();
     let output = work_dir.run_jj(["bookmark", "set", "main", "-r@"]);
     insta::assert_snapshot!(output, @"
@@ -151,6 +150,8 @@ fn test_new_wc_commit_when_wc_immutable() {
     Moved 1 bookmarks to kkmpptxz e1cb4cf3 main | (empty) a
     [EOF]
     ");
+    // Make the working copy immutable after the fact
+    test_env.add_config(r#"revset-aliases."immutable_heads()" = "main""#);
     work_dir.write_file("file", "a");
     let output = work_dir.run_jj(["log", "-r.."]);
     insta::assert_snapshot!(output, @"
@@ -177,18 +178,23 @@ fn test_immutable_heads_set_to_working_copy() {
         .run_jj(["bookmark", "create", "-r@", "main"])
         .success();
     test_env.add_config(r#"revset-aliases."immutable_heads()" = "@""#);
+    // New working-copy commit is created to mitigate weird UX
     let output = work_dir.run_jj(["new", "-m=a"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: kkmpptxz e1cb4cf3 (empty) a
-    Parent commit (@-)      : qpvuntsm e8849ae1 main | (empty) (no description set)
+    Warning: The working-copy commit became immutable; a new commit has been created on top of it.
+    Working copy  (@) now at: pmmvwywv 08e27304 (empty) (no description set)
+    Parent commit (@-)      : kkmpptxz e1cb4cf3 (empty) a
     [EOF]
     ");
+    // New working-copy commit is created again because @ is still immutable
     work_dir.write_file("file", "a");
     let output = work_dir.run_jj(["log", "-r.."]);
     insta::assert_snapshot!(output, @"
-    @  zsuskuln test.user@example.com 2001-02-03 08:05:10 aa4d78a2
+    @  zsuskuln test.user@example.com 2001-02-03 08:05:10 2e9c5f50
     │  (no description set)
+    ◆  pmmvwywv test.user@example.com 2001-02-03 08:05:09 08e27304
+    │  (empty) (no description set)
     ◆  kkmpptxz test.user@example.com 2001-02-03 08:05:09 e1cb4cf3
     │  (empty) a
     ◆  qpvuntsm test.user@example.com 2001-02-03 08:05:07 main e8849ae1
@@ -197,6 +203,15 @@ fn test_immutable_heads_set_to_working_copy() {
     [EOF]
     ------- stderr -------
     Warning: The working-copy commit is immutable; a new commit has been created on top of it.
+    [EOF]
+    ");
+    // New working-copy commit shouldn't be created repeatedly with no changes
+    let output = work_dir.run_jj(["status"]);
+    insta::assert_snapshot!(output, @"
+    Working copy changes:
+    A file
+    Working copy  (@) : zsuskuln 2e9c5f50 (no description set)
+    Parent commit (@-): pmmvwywv 08e27304 (empty) (no description set)
     [EOF]
     ");
 }
@@ -217,16 +232,20 @@ fn test_new_wc_commit_when_wc_immutable_multi_workspace() {
     let workspace1_dir = test_env.work_dir("workspace1");
     workspace1_dir.run_jj(["edit", "default@"]).success();
 
+    // New working-copy commit is created early for the current workspace
     let output = work_dir.run_jj(["bookmark", "set", "main", "-r@"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Moved 1 bookmarks to kkmpptxz e1cb4cf3 main | (empty) a
+    Warning: The working-copy commit became immutable; a new commit has been created on top of it.
+    Working copy  (@) now at: royxmykx cec19492 (empty) (no description set)
+    Parent commit (@-)      : kkmpptxz e1cb4cf3 main | (empty) a
     [EOF]
     ");
     work_dir.write_file("file", "a");
     let output = work_dir.run_jj(["log", "-r.."]);
     insta::assert_snapshot!(output, @"
-    @  yqosqzyt test.user@example.com 2001-02-03 08:05:13 default@ 3386b5c7
+    @  royxmykx test.user@example.com 2001-02-03 08:05:13 default@ acbba76f
     │  (no description set)
     ◆  kkmpptxz test.user@example.com 2001-02-03 08:05:09 main workspace1@ e1cb4cf3
     │  (empty) a
@@ -234,17 +253,15 @@ fn test_new_wc_commit_when_wc_immutable_multi_workspace() {
     │  (empty) (no description set)
     ~
     [EOF]
-    ------- stderr -------
-    Warning: The working-copy commit is immutable; a new commit has been created on top of it.
-    [EOF]
     ");
 
+    // New working-copy commit is created for the other workspaces as needed
     workspace1_dir.write_file("file", "a");
     let output = workspace1_dir.run_jj(["log", "-r.."]);
     insta::assert_snapshot!(output, @"
     @  vruxwmqv test.user@example.com 2001-02-03 08:05:14 workspace1@ bbc55980
     │  (no description set)
-    │ ○  yqosqzyt test.user@example.com 2001-02-03 08:05:13 default@ 3386b5c7
+    │ ○  royxmykx test.user@example.com 2001-02-03 08:05:13 default@ acbba76f
     ├─╯  (no description set)
     ◆  kkmpptxz test.user@example.com 2001-02-03 08:05:09 main e1cb4cf3
     │  (empty) a

--- a/cli/tests/test_tag_command.rs
+++ b/cli/tests/test_tag_command.rs
@@ -57,10 +57,14 @@ fn test_tag_set_delete() {
     Warning: Target revision is empty.
     Created 1 tags pointing to rlvkpnrz bbc74930 (empty) (no description set)
     Moved 1 tags to rlvkpnrz bbc74930 (empty) (no description set)
+    Warning: The working-copy commit became immutable; a new commit has been created on top of it.
+    Working copy  (@) now at: yqosqzyt 13cbd515 (empty) (no description set)
+    Parent commit (@-)      : rlvkpnrz bbc74930 (empty) (no description set)
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  bbc749308d7f baz foo
+    @  13cbd51558a6
+    ◆  bbc749308d7f baz foo
     ◆  b876c5f49546 bar
     ◆  000000000000
     [EOF]
@@ -73,7 +77,8 @@ fn test_tag_set_delete() {
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  bbc749308d7f baz
+    @  13cbd51558a6
+    ◆  bbc749308d7f baz
     ◆  b876c5f49546 bar
     ◆  000000000000
     [EOF]
@@ -83,11 +88,16 @@ fn test_tag_set_delete() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Warning: Target revision is empty.
-    Nothing changed.
+    Moved 1 tags to yqosqzyt 13cbd515 (empty) (no description set)
+    Warning: The working-copy commit became immutable; a new commit has been created on top of it.
+    Working copy  (@) now at: kpqxywon cca3d7af (empty) (no description set)
+    Parent commit (@-)      : yqosqzyt 13cbd515 (empty) (no description set)
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  bbc749308d7f baz
+    @  cca3d7af9d98
+    ◆  13cbd51558a6 baz
+    ◆  bbc749308d7f
     ◆  b876c5f49546 bar
     ◆  000000000000
     [EOF]
@@ -100,7 +110,9 @@ fn test_tag_set_delete() {
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  bbc749308d7f
+    @  cca3d7af9d98
+    ○  13cbd51558a6
+    ○  bbc749308d7f
     ○  b876c5f49546
     ◆  000000000000
     [EOF]
@@ -273,7 +285,7 @@ fn test_tag_list() {
     [38;5;5mconflicted_tag[39m [38;5;1m(conflicted)[39m:
       - [1m[38;5;5mrl[0m[38;5;8mvkpnrz[39m [1m[38;5;4m8[0m[38;5;8m93e67dc[39m [38;5;2m(empty)[39m commit1
       + [1m[38;5;5mzs[0m[38;5;8muskuln[39m [1m[38;5;4m7[0m[38;5;8m6abdd20[39m [38;5;2m(empty)[39m commit2
-      + [1m[38;5;13mr[38;5;8moyxmykx[39m [38;5;12m1[38;5;8m3c4e819[39m [38;5;10m(empty)[39m commit3[0m
+      + [1m[38;5;5mr[0m[38;5;8moyxmykx[39m [1m[38;5;4m1[0m[38;5;8m3c4e819[39m [38;5;2m(empty)[39m commit3
     [38;5;5mtest_tag[39m: [1m[38;5;5mrl[0m[38;5;8mvkpnrz[39m [1m[38;5;4m8[0m[38;5;8m93e67dc[39m [38;5;2m(empty)[39m commit1
     [38;5;5mtest_tag2[39m: [1m[38;5;5mzs[0m[38;5;8muskuln[39m [1m[38;5;4m7[0m[38;5;8m6abdd20[39m [38;5;2m(empty)[39m commit2
     [EOF]


### PR DESCRIPTION
# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [ ] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
