### PR TITLE
docs: cross-link same-change rule and merge.same-change config

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -2022,7 +2022,9 @@ hunk-level = "line"
 
 `jj` by default resolves conflicts if all sides made the same change. This
 matches what Git and Mercurial do (in the 3-way case at least), but not what
-Darcs does. It also means that repeated 3-way merging of multiple trees may give
+Darcs does. See the technical docs on the
+[same-change rule](technical/conflicts.md#same-change-rule) for background and
+trade-offs. It also means that repeated 3-way merging of multiple trees may give
 different results depending on the order of merging. To turn it off, set
 `same-change = "keep"`.
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -2059,7 +2059,9 @@ hunk-level = "line"
 
 `jj` by default resolves conflicts if all sides made the same change. This
 matches what Git and Mercurial do (in the 3-way case at least), but not what
-Darcs does. It also means that repeated 3-way merging of multiple trees may give
+Darcs does. See the technical docs on the
+[same-change rule](technical/conflicts.md#same-change-rule) for background and
+trade-offs. It also means that repeated 3-way merging of multiple trees may give
 different results depending on the order of merging. To turn it off, set
 `same-change = "keep"`.
 

--- a/docs/technical/conflicts.md
+++ b/docs/technical/conflicts.md
@@ -73,6 +73,11 @@ has the same changes (or a subset thereof) and then rebasing it back will lose
 changes (for a real-life example see [bug #6369]). We do it because it is more
 user-friendly in the vast majority of cases.
 
+You can configure this with the
+[`merge.same-change`](../config.md#resolution-of-same-change-conflicts)
+setting (`accept` by default, or `keep` to leave same-change conflicts
+unresolved).
+
 [bug #6369]: https://github.com/jj-vcs/jj/issues/6369
 [merge-rs]: https://github.com/jj-vcs/jj/blob/main/lib/src/merge.rs
 [resolve]: https://github.com/jj-vcs/jj/blob/53272510bf879086d83bb5eea1406f75ba31f138/lib/src/merge.rs#L85-L99


### PR DESCRIPTION
## Summary

Cross-link the technical *Same-change rule* docs and the `merge.same-change` config section so they reference each other.

## Motivation

Closes #8583. Both pages describe the same behavior; without links it was easy to find one and miss the other (background vs knobs).

## Verification

- Checked relative paths resolve under `docs/` layout (`technical/conflicts.md` ↔ `config.md`)
- Confirmed no open PR already addressing #8583
- Docs-only; no code change

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim:** sera · **Claim-TTL:** 24h
