### PR TITLE
cli: templater: prevent panic on overly-large id.short/shortest length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   conflict is now preserved in the rewritten commit.
   [#9747](https://github.com/jj-vcs/jj/issues/9747)
 
+* Fixed a panic when passing overly-large length parameters to ID templater
+  functions (`commit_id.short()`, `commit_id.shortest()`, etc.).
+  [#9833](https://github.com/jj-vcs/jj/issues/9833)
 ## [0.43.0] - 2026-07-01
 
 ### Release highlights

--- a/cli/src/commit_templater.rs
+++ b/cli/src/commit_templater.rs
@@ -2166,8 +2166,11 @@ where
                     )
                 })
                 .transpose()?;
-            let out_property = (self_property, len_property)
-                .map(|(id, len)| format!("{id:.len$}", len = len.unwrap_or(12)));
+            let out_property = (self_property, len_property).map(|(id, len)| {
+                let mut id_str = id.to_string();
+                id_str.truncate(len.unwrap_or(12));
+                id_str
+            });
             Ok(out_property.into_dyn_wrapped())
         },
     );
@@ -2205,7 +2208,8 @@ where
             // `len` and the length of the shortest unique prefix.
             let out_property = (self_property, len_property).and_then(move |(id, len)| {
                 let prefix_len = id.shortest_prefix_len(repo, &index)?;
-                let mut hex = format!("{id:.len$}", len = max(prefix_len, len.unwrap_or(0)));
+                let mut hex = id.to_string();
+                hex.truncate(max(prefix_len, len.unwrap_or(0)));
                 let rest = hex.split_off(prefix_len);
                 Ok(ShortestIdPrefix { prefix: hex, rest })
             });
@@ -3248,6 +3252,8 @@ mod tests {
         insta::assert_snapshot!(
             env.render_ok("self.short(100)", &id), @"08a70ab33d7143b7130ed8594d8216ef688623c0");
         insta::assert_snapshot!(
+            env.render_ok("self.short(65536)", &id), @"08a70ab33d7143b7130ed8594d8216ef688623c0");
+        insta::assert_snapshot!(
             env.render_ok("self.short(-100)", &id),
             @"<Error: out of range integral type conversion attempted>");
 
@@ -3256,6 +3262,8 @@ mod tests {
         insta::assert_snapshot!(env.render_ok("self.shortest(-0)", &id), @"08");
         insta::assert_snapshot!(
             env.render_ok("self.shortest(100)", &id), @"08a70ab33d7143b7130ed8594d8216ef688623c0");
+        insta::assert_snapshot!(
+            env.render_ok("self.shortest(65536)", &id), @"08a70ab33d7143b7130ed8594d8216ef688623c0");
         insta::assert_snapshot!(
             env.render_ok("self.shortest(-100)", &id),
             @"<Error: out of range integral type conversion attempted>");
@@ -3281,6 +3289,8 @@ mod tests {
         insta::assert_snapshot!(
             env.render_ok("self.short(100)", &id), @"kkmpptxzrspxrzommnulwmwkkqwworpl");
         insta::assert_snapshot!(
+            env.render_ok("self.short(65536)", &id), @"kkmpptxzrspxrzommnulwmwkkqwworpl");
+        insta::assert_snapshot!(
             env.render_ok("self.short(-100)", &id),
             @"<Error: out of range integral type conversion attempted>");
 
@@ -3289,6 +3299,8 @@ mod tests {
         insta::assert_snapshot!(env.render_ok("self.shortest(-0)", &id), @"k");
         insta::assert_snapshot!(
             env.render_ok("self.shortest(100)", &id), @"kkmpptxzrspxrzommnulwmwkkqwworpl");
+        insta::assert_snapshot!(
+            env.render_ok("self.shortest(65536)", &id), @"kkmpptxzrspxrzommnulwmwkkqwworpl");
         insta::assert_snapshot!(
             env.render_ok("self.shortest(-100)", &id),
             @"<Error: out of range integral type conversion attempted>");


### PR DESCRIPTION
Evaluating template functions like `commit_id.short(len)`, `commit_id.shortest(len)`,
`change_id.short(len)`, or `change_id.shortest(len)` with large length parameters
(>= 65536) panics with "Formatting argument out of range". This is caused by Rust's
`std::fmt` dynamic width/precision specifiers capping formatting arguments at `u16::MAX`.

Replace dynamic `format!("{id:.len$}", ...)` specifiers in `short()` and `shortest()`
methods with direct string slicing clamped to the ID string length:
`&id_str[..requested_len.min(id_str.len())]`.

Fixes #9833

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
