### PR TITLE
cli: report fetched remotes for no-op fetches

### DIFF
--- a/cli/src/commands/git/fetch.rs
+++ b/cli/src/commands/git/fetch.rs
@@ -245,14 +245,19 @@ pub async fn cmd_git_fetch(
         warn_if_branches_not_found(ui, &tx, bookmark_expr, &matching_remotes)?;
     }
     // TODO: warn_if_tags_not_found()
-    tx.finish(
-        ui,
-        format!(
-            "fetch from git remote(s) {}",
-            matching_remotes.iter().map(|n| n.as_symbol()).join(",")
-        ),
-    )
-    .await?;
+    let remote_names = matching_remotes
+        .iter()
+        .map(|name| name.as_symbol())
+        .join(", ");
+    if tx.repo().has_changes() {
+        let description = format!("fetch from git remote(s) {remote_names}");
+        tx.finish(ui, description).await?;
+    } else {
+        writeln!(
+            ui.status(),
+            "Fetched from git remote(s) {remote_names}: nothing changed."
+        )?;
+    }
     Ok(())
 }
 

--- a/cli/tests/test_bookmark_command.rs
+++ b/cli/tests/test_bookmark_command.rs
@@ -1501,7 +1501,7 @@ fn test_bookmark_forget_fetched_bookmark() {
     let output = work_dir.run_jj(["git", "fetch", "--remote=origin"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Nothing changed.
+    Fetched from git remote(s) origin: nothing changed.
     [EOF]
     ");
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @"

--- a/cli/tests/test_git_clone.rs
+++ b/cli/tests/test_git_clone.rs
@@ -78,7 +78,7 @@ fn test_git_clone() {
     let output = clone_dir.run_jj(["git", "fetch"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Nothing changed.
+    Fetched from git remote(s) origin: nothing changed.
     [EOF]
     ");
 
@@ -344,7 +344,7 @@ fn test_git_clone_colocate() -> TestResult {
     let output = clone_dir.run_jj(["git", "fetch"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Nothing changed.
+    Fetched from git remote(s) origin: nothing changed.
     [EOF]
     ");
 
@@ -1291,7 +1291,7 @@ fn test_git_clone_branch_or_tag() {
     let output = repo_dir.run_jj(["git", "fetch"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Nothing changed.
+    Fetched from git remote(s) origin: nothing changed.
     [EOF]
     ");
 
@@ -1324,7 +1324,7 @@ fn test_git_clone_branch_or_tag() {
     let output = repo_dir.run_jj(["git", "fetch"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Nothing changed.
+    Fetched from git remote(s) origin: nothing changed.
     [EOF]
     ");
 
@@ -1376,7 +1376,7 @@ fn test_git_clone_branch_or_tag() {
     let output = repo_dir.run_jj(["git", "fetch"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Nothing changed.
+    Fetched from git remote(s) origin: nothing changed.
     [EOF]
     ");
 

--- a/cli/tests/test_git_fetch.rs
+++ b/cli/tests/test_git_fetch.rs
@@ -301,7 +301,7 @@ fn test_git_fetch_default_bookmarks_and_tags() {
     let output = work_dir.run_jj(["git", "fetch", "--all-remotes", "--tag=~*"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Nothing changed.
+    Fetched from git remote(s) rem1, rem2: nothing changed.
     [EOF]
     ");
 }
@@ -385,7 +385,7 @@ fn test_git_fetch_with_ignored_refspecs() {
     Warning: Ignored refspec `refs/heads/bar` from `origin`: fetch-only refspecs are not supported
     Warning: Ignored refspec `+refs/heads/bar*:refs/tags/bar*` from `origin`: only refs/remotes/ is supported for fetch destinations
     Warning: Ignored refspec `+refs/heads/foo*:refs/remotes/origin/baz*` from `origin`: renaming is not supported
-    Nothing changed.
+    Fetched from git remote(s) origin: nothing changed.
     [EOF]
     ");
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @"
@@ -804,7 +804,7 @@ fn test_git_fetch_tags_by_name() -> TestResult {
     let output = work_dir.run_jj(["git", "fetch", "--tag=~*"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Nothing changed.
+    Fetched from git remote(s) origin: nothing changed.
     [EOF]
     ");
 
@@ -1154,7 +1154,7 @@ fn test_git_fetch_some_of_many_bookmarks() {
     let output = target_dir.run_jj(["git", "fetch", "--branch", "a1"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Nothing changed.
+    Fetched from git remote(s) origin: nothing changed.
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&target_dir), @r#"
@@ -1297,7 +1297,7 @@ fn test_git_fetch_bookmarks_some_missing() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Warning: No matching branches found on any specified/configured remote: noexist
-    Nothing changed.
+    Fetched from git remote(s) origin: nothing changed.
     [EOF]
     ");
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @"");
@@ -1309,7 +1309,7 @@ fn test_git_fetch_bookmarks_some_missing() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Warning: No matching branches found on any specified/configured remote: noexist1, noexist2
-    Nothing changed.
+    Fetched from git remote(s) origin: nothing changed.
     [EOF]
     ");
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @"");
@@ -1359,7 +1359,7 @@ fn test_git_fetch_bookmarks_some_missing() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Warning: No matching branches found on any specified/configured remote: notexist
-    Nothing changed.
+    Fetched from git remote(s) rem1: nothing changed.
     [EOF]
     ");
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @"
@@ -1397,7 +1397,7 @@ fn test_git_fetch_bookmarks_missing_with_subprocess_localized_message() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Warning: No matching branches found on any specified/configured remote: unknown
-    Nothing changed.
+    Fetched from git remote(s) origin: nothing changed.
     [EOF]
     ");
 }
@@ -1713,7 +1713,7 @@ fn test_git_fetch_rename_fetch() {
     let output = work_dir.run_jj(["git", "fetch", "--remote", "upstream"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Nothing changed.
+    Fetched from git remote(s) upstream: nothing changed.
     [EOF]
     ");
 }
@@ -1780,7 +1780,7 @@ fn test_git_fetch_removed_bookmark() {
     let output = target_dir.run_jj(["git", "fetch", "--branch", "a1"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Nothing changed.
+    Fetched from git remote(s) origin: nothing changed.
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&target_dir), @r#"
@@ -2494,7 +2494,7 @@ fn test_git_fetch_tracked_no_tracked_bookmarks() {
     let output = work_dir.run_jj(["git", "fetch", "--tracked"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Nothing changed.
+    Fetched from git remote(s) origin: nothing changed.
     [EOF]
     ");
 }


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

`jj git fetch` now names the selected remotes when a successful fetch imports no changes. This makes remote selection visible in repositories with multiple remotes and fork-style `origin`/`upstream` layouts.

Fixes #8573

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
