### PR TITLE
revset: propagate error from is_empty(), replace .try_next().is_some()

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -2072,15 +2072,12 @@ to the current parents may contain changes from multiple commits.
                 .env
                 .resolve_immutable_expression(tx.repo())
                 .map_err(snapshot_command_error)?;
-            let wc_immutable = immutable_expr
+            let wc_immutable = !immutable_expr
                 .intersection(&RevsetExpression::commit(wc_commit.id().clone()))
                 .evaluate(tx.repo())
                 .map_err(snapshot_command_error)?
-                .stream()
-                .try_next()
-                .await
-                .map_err(snapshot_command_error)?
-                .is_some();
+                .is_empty()
+                .map_err(snapshot_command_error)?;
             let mut_repo = tx.repo_mut();
             let new_wc_commit;
             if wc_immutable {

--- a/cli/src/commands/log.rs
+++ b/cli/src/commands/log.rs
@@ -382,7 +382,7 @@ pub(crate) async fn cmd_log(
                  this is often not useful because all non-empty commits touch '.'. If you meant \
                  to show the working copy commit, pass -r '@' instead."
             )?;
-        } else if revset.is_empty()
+        } else if revset.is_empty()?
             && workspace_command
                 .parse_revset(ui, &RevisionArg::from(only_path.to_owned()))
                 .is_ok()

--- a/lib/src/default_index/revset_engine.rs
+++ b/lib/src/default_index/revset_engine.rs
@@ -188,8 +188,8 @@ impl<I: AsCompositeIndex + Clone> Revset for RevsetImpl<I> {
         futures::stream::iter(self.iter_graph_impl(skip_transitive_edges)).boxed_local()
     }
 
-    fn is_empty(&self) -> bool {
-        self.positions().next().is_none()
+    fn is_empty(&self) -> Result<bool, RevsetEvaluationError> {
+        Ok(self.positions().next().transpose()?.is_none())
     }
 
     fn count_estimate(&self) -> Result<(usize, Option<usize>), RevsetEvaluationError> {

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -3407,8 +3407,8 @@ pub trait Revset: fmt::Debug {
     where
         Self: 'a;
 
-    /// Returns true if iterator will emit no commit nor error.
-    fn is_empty(&self) -> bool;
+    /// Returns true if iterator will emit no commit.
+    fn is_empty(&self) -> Result<bool, RevsetEvaluationError>;
 
     /// Inclusive lower bound and, optionally, inclusive upper bound of how many
     /// commits are in the revset. The implementation can use its discretion as


### PR DESCRIPTION
# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [ ] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
