### PR TITLE
repo: Fix TODO about making `enforce_view_invariants()` return an erro…

### DIFF
--- a/lib/src/operation.rs
+++ b/lib/src/operation.rs
@@ -116,7 +116,9 @@ impl Operation {
 
     pub async fn view(&self) -> OpStoreResult<View> {
         let data = self.op_store.read_view(&self.data.view_id).await?;
-        Ok(View::new(data))
+        // head ids read from the backend should always be normalized.
+        let head_normalized = true;
+        Ok(View::new(data, head_normalized))
     }
 
     pub fn metadata(&self) -> &OperationMetadata {

--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -34,7 +34,6 @@ use once_cell::sync::OnceCell;
 use thiserror::Error;
 use tracing::instrument;
 
-use self::dirty_cell::DirtyCell;
 use crate::backend::Backend;
 use crate::backend::BackendError;
 use crate::backend::BackendInitError;
@@ -994,7 +993,7 @@ impl Rewrite {
 pub struct MutableRepo {
     base_repo: Arc<ReadonlyRepo>,
     index: Box<dyn MutableIndex>,
-    view: DirtyCell<View>,
+    view: View,
     /// Mapping from new commit to its predecessors.
     ///
     /// This is similar to (the reverse of) `parent_mapping`, but
@@ -1013,12 +1012,11 @@ pub struct MutableRepo {
 
 impl MutableRepo {
     pub fn new(base_repo: Arc<ReadonlyRepo>, index: &dyn ReadonlyIndex, view: &View) -> Self {
-        let mut_view = view.clone();
         let mut_index = index.start_modification();
         Self {
             base_repo,
             index: mut_index,
-            view: DirtyCell::with_clean(mut_view),
+            view: view.clone(),
             commit_predecessors: Default::default(),
             parent_mapping: Default::default(),
         }
@@ -1026,10 +1024,6 @@ impl MutableRepo {
 
     pub fn base_repo(&self) -> &Arc<ReadonlyRepo> {
         &self.base_repo
-    }
-
-    fn view_mut(&mut self) -> &mut View {
-        self.view.get_mut()
     }
 
     pub fn mutable_index(&self) -> &dyn MutableIndex {
@@ -1041,21 +1035,21 @@ impl MutableRepo {
     }
 
     pub fn has_changes(&self) -> bool {
-        self.view.ensure_clean(|v| self.enforce_view_invariants(v));
         !(self.commit_predecessors.is_empty()
             && self.parent_mapping.is_empty()
             && self.view() == &self.base_repo.view)
     }
 
+    #[expect(clippy::type_complexity)]
     pub(crate) fn consume(
-        self,
-    ) -> (
+        mut self,
+    ) -> IndexResult<(
         Box<dyn MutableIndex>,
         View,
         BTreeMap<CommitId, Vec<CommitId>>,
-    ) {
-        self.view.ensure_clean(|v| self.enforce_view_invariants(v));
-        (self.index, self.view.into_inner(), self.commit_predecessors)
+    )> {
+        self.normalize_heads()?;
+        Ok((self.index, self.view, self.commit_predecessors))
     }
 
     /// Returns a [`CommitBuilder`] to write new commit to the repo.
@@ -1154,6 +1148,13 @@ impl MutableRepo {
     /// drop parents that caused cycles.
     pub fn new_parents(&self, old_ids: &[CommitId]) -> Vec<CommitId> {
         self.rewritten_ids_with(old_ids, |rewrite| !matches!(rewrite, Rewrite::Divergent(_)))
+    }
+
+    fn normalize_heads(&mut self) -> IndexResult<()> {
+        self.view.normalize_heads(
+            self.index.as_index(),
+            self.base_repo.store().root_commit_id(),
+        )
     }
 
     fn rewritten_ids_with(
@@ -1332,6 +1333,10 @@ impl MutableRepo {
                 .await
                 .map_err(|err| match err {
                     EditCommitError::BackendError(backend_error) => backend_error,
+                    // TODO: index error shouldn't be a "BackendError"
+                    EditCommitError::IndexError(index_error) => {
+                        BackendError::Other(index_error.into())
+                    }
                     EditCommitError::WorkingCopyCommitNotFound(_)
                     | EditCommitError::RewriteRootCommit(_) => panic!("unexpected error: {err:?}"),
                 })?;
@@ -1358,6 +1363,9 @@ impl MutableRepo {
         }
         view.head_ids.extend(heads_to_add);
         self.set_view(view);
+        // TODO: indexing error shouldn't be a "RevsetEvaluationError"
+        self.normalize_heads()
+            .map_err(|err| RevsetEvaluationError::Other(Box::new(err)))?;
         Ok(())
     }
 
@@ -1610,13 +1618,13 @@ impl MutableRepo {
         if &commit_id == self.store().root_commit_id() {
             return Err(RewriteRootCommit);
         }
-        self.view_mut().set_wc_commit(name, commit_id);
+        self.view.set_wc_commit(name, commit_id);
         Ok(())
     }
 
     pub async fn remove_wc_commit(&mut self, name: &WorkspaceName) -> Result<(), EditCommitError> {
         self.maybe_abandon_wc_commit(name).await?;
-        self.view_mut().remove_wc_commit(name);
+        self.view.remove_wc_commit(name);
         Ok(())
     }
 
@@ -1628,8 +1636,7 @@ impl MutableRepo {
         base_id: Option<&CommitId>,
         other_id: Option<&CommitId>,
     ) {
-        let view = self.view.get_mut();
-        let self_id = view.get_wc_commit_id(name);
+        let self_id = self.view.get_wc_commit_id(name);
         // Not using merge_ref_targets(). Since the working-copy pointer moves
         // towards random direction, it doesn't make sense to resolve conflict
         // based on ancestry.
@@ -1645,8 +1652,8 @@ impl MutableRepo {
             self_id.cloned()
         };
         match new_id {
-            Some(id) => view.set_wc_commit(name.to_owned(), id),
-            None => view.remove_wc_commit(name),
+            Some(id) => self.view.set_wc_commit(name.to_owned(), id),
+            None => self.view.remove_wc_commit(name),
         }
     }
 
@@ -1655,7 +1662,7 @@ impl MutableRepo {
         old_name: &WorkspaceName,
         new_name: WorkspaceNameBuf,
     ) -> Result<(), RenameWorkspaceError> {
-        self.view_mut().rename_workspace(old_name, new_name)
+        self.view.rename_workspace(old_name, new_name)
     }
 
     pub async fn check_out(
@@ -1698,19 +1705,18 @@ impl MutableRepo {
             .any(|id| id == commit_id)
         };
 
-        let maybe_wc_commit_id = self
-            .view
-            .with_ref(|v| v.get_wc_commit_id(workspace_name).cloned());
+        let maybe_wc_commit_id = self.view.get_wc_commit_id(workspace_name).cloned();
         if let Some(wc_commit_id) = maybe_wc_commit_id {
             let wc_commit = self
                 .store()
                 .get_commit_async(&wc_commit_id)
                 .await
                 .map_err(EditCommitError::WorkingCopyCommitNotFound)?;
+            // Call normalized_heads() prior to .view().heads().contains() because
+            // the caller expects non-head revisions don't exist in the set.
+            self.normalize_heads()?;
             if wc_commit.is_discardable(self).await?
-                && self
-                    .view
-                    .with_ref(|v| !is_commit_referenced(v, wc_commit.id()))
+                && !is_commit_referenced(&self.view, wc_commit.id())
                 && self.view().heads().contains(wc_commit.id())
             {
                 // Abandon the working-copy commit we're leaving if it's
@@ -1721,28 +1727,6 @@ impl MutableRepo {
         }
 
         Ok(())
-    }
-
-    fn enforce_view_invariants(&self, view: &mut View) {
-        let view = view.store_view_mut();
-        let root_commit_id = self.store().root_commit_id();
-        if view.head_ids.is_empty() {
-            view.head_ids.insert(root_commit_id.clone());
-        } else if view.head_ids.len() > 1 {
-            // An empty head_ids set is padded with the root_commit_id, but the
-            // root id is unwanted during the heads resolution.
-            view.head_ids.remove(root_commit_id);
-            // It is unclear if `heads` can never fail for default implementation,
-            // but it can definitely fail for non-default implementations.
-            // TODO: propagate errors.
-            view.head_ids = self
-                .index()
-                .heads(&mut view.head_ids.iter())
-                .unwrap()
-                .into_iter()
-                .collect();
-        }
-        assert!(!view.head_ids.is_empty());
     }
 
     /// Ensures that the given `head` and ancestor commits are reachable from
@@ -1758,7 +1742,7 @@ impl MutableRepo {
     /// and ancestors of the other heads. The `heads` and ancestor commits
     /// should exist in the store.
     pub async fn add_heads(&mut self, heads: &[Commit]) -> BackendResult<()> {
-        let current_heads = self.view.get_mut().heads();
+        let current_heads = self.view.heads();
         // Use incremental update for common case of adding a single commit on top a
         // current head. TODO: Also use incremental update when adding a single
         // commit on top a non-head.
@@ -1775,25 +1759,21 @@ impl MutableRepo {
                     .await
                     // TODO: indexing error shouldn't be a "BackendError"
                     .map_err(|err| BackendError::Other(err.into()))?;
-                self.view.get_mut().add_head(head.id());
-                for parent_id in head.parent_ids() {
-                    self.view.get_mut().remove_head(parent_id);
-                }
+                self.view
+                    .replace_heads(head.id().clone(), head.parent_ids());
             }
             _ => {
                 self.index_commits(heads).await?;
                 for head in heads {
-                    self.view.get_mut().add_head(head.id());
+                    self.view.add_head(head.id());
                 }
-                self.view.mark_dirty();
             }
         }
         Ok(())
     }
 
     pub fn remove_head(&mut self, head: &CommitId) {
-        self.view_mut().remove_head(head);
-        self.view.mark_dirty();
+        self.view.remove_head(head);
     }
 
     /// Adds the given `heads` and ancestor commits to the index without making
@@ -1843,16 +1823,14 @@ impl MutableRepo {
     }
 
     pub fn get_local_bookmark(&self, name: &RefName) -> RefTarget {
-        self.view.with_ref(|v| v.get_local_bookmark(name).clone())
+        self.view.get_local_bookmark(name).clone()
     }
 
     pub fn set_local_bookmark_target(&mut self, name: &RefName, target: RefTarget) {
-        let view = self.view_mut();
         for id in target.added_ids() {
-            view.add_head(id);
+            self.view.add_head(id);
         }
-        view.set_local_bookmark_target(name, target);
-        self.view.mark_dirty();
+        self.view.set_local_bookmark_target(name, target);
     }
 
     pub fn merge_local_bookmark(
@@ -1861,21 +1839,19 @@ impl MutableRepo {
         base_target: &RefTarget,
         other_target: &RefTarget,
     ) -> IndexResult<()> {
-        let view = self.view.get_mut();
         let index = self.index.as_index();
-        let self_target = view.get_local_bookmark(name);
+        let self_target = self.view.get_local_bookmark(name);
         let new_target = merge_ref_targets(index, self_target, base_target, other_target)?;
         self.set_local_bookmark_target(name, new_target);
         Ok(())
     }
 
     pub fn get_remote_bookmark(&self, symbol: RemoteRefSymbol<'_>) -> RemoteRef {
-        self.view
-            .with_ref(|v| v.get_remote_bookmark(symbol).clone())
+        self.view.get_remote_bookmark(symbol).clone()
     }
 
     pub fn set_remote_bookmark(&mut self, symbol: RemoteRefSymbol<'_>, remote_ref: RemoteRef) {
-        self.view_mut().set_remote_bookmark(symbol, remote_ref);
+        self.view.set_remote_bookmark(symbol, remote_ref);
     }
 
     fn merge_remote_bookmark(
@@ -1884,11 +1860,10 @@ impl MutableRepo {
         base_ref: &RemoteRef,
         other_ref: &RemoteRef,
     ) -> IndexResult<()> {
-        let view = self.view.get_mut();
         let index = self.index.as_index();
-        let self_ref = view.get_remote_bookmark(symbol);
+        let self_ref = self.view.get_remote_bookmark(symbol);
         let new_ref = merge_remote_refs(index, self_ref, base_ref, other_ref)?;
-        view.set_remote_bookmark(symbol, new_ref);
+        self.view.set_remote_bookmark(symbol, new_ref);
         Ok(())
     }
 
@@ -1911,23 +1886,23 @@ impl MutableRepo {
     }
 
     pub fn ensure_remote(&mut self, remote_name: &RemoteName) {
-        self.view_mut().ensure_remote(remote_name);
+        self.view.ensure_remote(remote_name);
     }
 
     pub fn remove_remote(&mut self, remote_name: &RemoteName) {
-        self.view_mut().remove_remote(remote_name);
+        self.view.remove_remote(remote_name);
     }
 
     pub fn rename_remote(&mut self, old: &RemoteName, new: &RemoteName) {
-        self.view_mut().rename_remote(old, new);
+        self.view.rename_remote(old, new);
     }
 
     pub fn get_local_tag(&self, name: &RefName) -> RefTarget {
-        self.view.with_ref(|v| v.get_local_tag(name).clone())
+        self.view.get_local_tag(name).clone()
     }
 
     pub fn set_local_tag_target(&mut self, name: &RefName, target: RefTarget) {
-        self.view_mut().set_local_tag_target(name, target);
+        self.view.set_local_tag_target(name, target);
     }
 
     pub fn merge_local_tag(
@@ -1936,20 +1911,19 @@ impl MutableRepo {
         base_target: &RefTarget,
         other_target: &RefTarget,
     ) -> IndexResult<()> {
-        let view = self.view.get_mut();
         let index = self.index.as_index();
-        let self_target = view.get_local_tag(name);
+        let self_target = self.view.get_local_tag(name);
         let new_target = merge_ref_targets(index, self_target, base_target, other_target)?;
-        view.set_local_tag_target(name, new_target);
+        self.view.set_local_tag_target(name, new_target);
         Ok(())
     }
 
     pub fn get_remote_tag(&self, symbol: RemoteRefSymbol<'_>) -> RemoteRef {
-        self.view.with_ref(|v| v.get_remote_tag(symbol).clone())
+        self.view.get_remote_tag(symbol).clone()
     }
 
     pub fn set_remote_tag(&mut self, symbol: RemoteRefSymbol<'_>, remote_ref: RemoteRef) {
-        self.view_mut().set_remote_tag(symbol, remote_ref);
+        self.view.set_remote_tag(symbol, remote_ref);
     }
 
     fn merge_remote_tag(
@@ -1958,20 +1932,19 @@ impl MutableRepo {
         base_ref: &RemoteRef,
         other_ref: &RemoteRef,
     ) -> IndexResult<()> {
-        let view = self.view.get_mut();
         let index = self.index.as_index();
-        let self_ref = view.get_remote_tag(symbol);
+        let self_ref = self.view.get_remote_tag(symbol);
         let new_ref = merge_remote_refs(index, self_ref, base_ref, other_ref)?;
-        view.set_remote_tag(symbol, new_ref);
+        self.view.set_remote_tag(symbol, new_ref);
         Ok(())
     }
 
     pub fn get_git_ref(&self, name: &GitRefName) -> RefTarget {
-        self.view.with_ref(|v| v.get_git_ref(name).clone())
+        self.view.get_git_ref(name).clone()
     }
 
     pub fn set_git_ref_target(&mut self, name: &GitRefName, target: RefTarget) {
-        self.view_mut().set_git_ref_target(name, target);
+        self.view.set_git_ref_target(name, target);
     }
 
     fn merge_git_ref(
@@ -1980,25 +1953,24 @@ impl MutableRepo {
         base_target: &RefTarget,
         other_target: &RefTarget,
     ) -> IndexResult<()> {
-        let view = self.view.get_mut();
         let index = self.index.as_index();
-        let self_target = view.get_git_ref(name);
+        let self_target = self.view.get_git_ref(name);
         let new_target = merge_ref_targets(index, self_target, base_target, other_target)?;
-        view.set_git_ref_target(name, new_target);
+        self.view.set_git_ref_target(name, new_target);
         Ok(())
     }
 
     pub fn git_head(&self) -> RefTarget {
-        self.view.with_ref(|v| v.git_head().clone())
+        self.view.git_head().clone()
     }
 
     pub fn set_git_head_target(&mut self, target: RefTarget) {
-        self.view_mut().set_git_head_target(target);
+        self.view.set_git_head_target(target);
     }
 
     pub fn set_view(&mut self, data: op_store::View) {
-        self.view_mut().set_view(data);
-        self.view.mark_dirty();
+        let head_normalized = false;
+        self.view.set_view(data, head_normalized);
     }
 
     pub async fn merge(
@@ -2013,9 +1985,9 @@ impl MutableRepo {
         self.index.merge_in(base_repo.readonly_index())?;
         self.index.merge_in(other_repo.readonly_index())?;
 
-        self.view.ensure_clean(|v| self.enforce_view_invariants(v));
+        self.normalize_heads()?;
+
         self.merge_view(&base_repo.view, &other_repo.view).await?;
-        self.view.mark_dirty();
         Ok(())
     }
 
@@ -2046,11 +2018,11 @@ impl MutableRepo {
             // marked them abandoned or rewritten.
         } else {
             for removed_head in base.heads().difference(other.heads()) {
-                self.view_mut().remove_head(removed_head);
+                self.view.remove_head(removed_head);
             }
         }
         for added_head in other.heads().difference(base.heads()) {
-            self.view_mut().add_head(added_head);
+            self.view.add_head(added_head);
         }
 
         let changed_local_bookmarks =
@@ -2183,8 +2155,7 @@ impl Repo for MutableRepo {
     }
 
     fn view(&self) -> &View {
-        self.view
-            .get_or_ensure_clean(|v| self.enforce_view_invariants(v))
+        &self.view
     }
 
     fn submodule_store(&self) -> &Arc<dyn SubmoduleStore> {
@@ -2219,6 +2190,8 @@ pub enum EditCommitError {
     RewriteRootCommit(#[from] RewriteRootCommit),
     #[error(transparent)]
     BackendError(#[from] BackendError),
+    #[error(transparent)]
+    IndexError(#[from] IndexError),
 }
 
 /// Error from attempts to check out a commit
@@ -2228,71 +2201,4 @@ pub enum CheckOutCommitError {
     CreateCommit(#[from] BackendError),
     #[error("Failed to edit commit")]
     EditCommit(#[from] EditCommitError),
-}
-
-mod dirty_cell {
-    use std::cell::OnceCell;
-    use std::cell::RefCell;
-
-    /// Cell that lazily updates the value after `mark_dirty()`.
-    ///
-    /// A clean value can be immutably borrowed within the `self` lifetime.
-    #[derive(Clone, Debug)]
-    pub struct DirtyCell<T> {
-        // Either clean or dirty value is set. The value is boxed to reduce stack space
-        // and memcopy overhead.
-        clean: OnceCell<Box<T>>,
-        dirty: RefCell<Option<Box<T>>>,
-    }
-
-    impl<T> DirtyCell<T> {
-        pub fn with_clean(value: T) -> Self {
-            Self {
-                clean: OnceCell::from(Box::new(value)),
-                dirty: RefCell::new(None),
-            }
-        }
-
-        pub fn get_or_ensure_clean(&self, f: impl FnOnce(&mut T)) -> &T {
-            self.clean.get_or_init(|| {
-                // Panics if ensure_clean() is invoked from with_ref() callback for example.
-                let mut value = self.dirty.borrow_mut().take().unwrap();
-                f(&mut value);
-                value
-            })
-        }
-
-        pub fn ensure_clean(&self, f: impl FnOnce(&mut T)) {
-            self.get_or_ensure_clean(f);
-        }
-
-        pub fn into_inner(self) -> T {
-            *self
-                .clean
-                .into_inner()
-                .or_else(|| self.dirty.into_inner())
-                .unwrap()
-        }
-
-        pub fn with_ref<R>(&self, f: impl FnOnce(&T) -> R) -> R {
-            if let Some(value) = self.clean.get() {
-                f(value)
-            } else {
-                f(self.dirty.borrow().as_ref().unwrap())
-            }
-        }
-
-        pub fn get_mut(&mut self) -> &mut T {
-            self.clean
-                .get_mut()
-                .or_else(|| self.dirty.get_mut().as_mut())
-                .unwrap()
-        }
-
-        pub fn mark_dirty(&mut self) {
-            if let Some(value) = self.clean.take() {
-                *self.dirty.get_mut() = Some(value);
-            }
-        }
-    }
 }

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -3112,6 +3112,7 @@ fn resolve_visibility(
         referenced_commits: &[],
         visible_heads: &repo.view().heads().iter().cloned().collect_vec(),
         root: repo.store().root_commit_id(),
+        is_heads_normalized: repo.view().is_heads_normalized(),
     };
     context.resolve(expression)
 }
@@ -3121,6 +3122,7 @@ struct VisibilityResolutionContext<'a> {
     referenced_commits: &'a [CommitId],
     visible_heads: &'a [CommitId],
     root: &'a CommitId,
+    is_heads_normalized: bool,
 }
 
 impl VisibilityResolutionContext<'_> {
@@ -3234,6 +3236,7 @@ impl VisibilityResolutionContext<'_> {
                     referenced_commits: commits,
                     visible_heads: self.visible_heads,
                     root: self.root,
+                    is_heads_normalized: self.is_heads_normalized,
                 };
                 context.resolve(candidates)
             }
@@ -3245,6 +3248,7 @@ impl VisibilityResolutionContext<'_> {
                     referenced_commits: self.referenced_commits,
                     visible_heads,
                     root: self.root,
+                    is_heads_normalized: self.is_heads_normalized,
                 };
                 context.resolve(candidates)
             }
@@ -3294,7 +3298,12 @@ impl VisibilityResolutionContext<'_> {
     }
 
     fn resolve_visible_heads(&self) -> ResolvedExpression {
-        ResolvedExpression::Commits(self.visible_heads.to_owned())
+        let visible_heads = ResolvedExpression::Commits(self.visible_heads.to_owned());
+        if self.is_heads_normalized {
+            visible_heads
+        } else {
+            ResolvedExpression::Heads(visible_heads.into())
+        }
     }
 
     fn resolve_visible_heads_or_referenced(&self) -> ResolvedExpression {

--- a/lib/src/transaction.rs
+++ b/lib/src/transaction.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 use thiserror::Error;
 
 use crate::backend::Timestamp;
+use crate::index::IndexError;
 use crate::index::IndexStoreError;
 use crate::index::ReadonlyIndex;
 use crate::op_heads_store::OpHeadsStore;
@@ -41,6 +42,7 @@ use crate::view::View;
 #[derive(Debug, Error)]
 #[error("Failed to commit new operation")]
 pub enum TransactionCommitError {
+    Index(#[from] IndexError),
     IndexStore(#[from] IndexStoreError),
     OpHeadsStore(#[from] OpHeadsStoreError),
     OpStore(#[from] OpStoreError),
@@ -141,7 +143,11 @@ impl Transaction {
             "BUG: Descendants have not been rebased after the last rewrites."
         );
         let base_repo = mut_repo.base_repo().clone();
-        let (mut_index, view, predecessors) = mut_repo.consume();
+        let (mut_index, view, predecessors) = mut_repo.consume()?;
+        assert!(
+            view.is_heads_normalized(),
+            "BUG: View heads must be normalized before persisting in the database"
+        );
 
         let operation = {
             let view_id = base_repo.op_store().write_view(view.store_view()).await?;

--- a/lib/src/view.rs
+++ b/lib/src/view.rs
@@ -21,6 +21,8 @@ use itertools::Itertools as _;
 use thiserror::Error;
 
 use crate::backend::CommitId;
+use crate::index::Index;
+use crate::index::IndexResult;
 use crate::op_store;
 use crate::op_store::LocalRemoteRefTarget;
 use crate::op_store::RefTarget;
@@ -39,15 +41,23 @@ use crate::refs::LocalAndRemoteRef;
 use crate::str_util::StringMatcher;
 
 /// A wrapper around [`op_store::View`] that defines additional methods.
-#[derive(PartialEq, Eq, Debug, Clone)]
+#[derive(Eq, Debug, Clone)]
 pub struct View {
     data: op_store::View,
+    head_normalized: bool,
+}
+
+impl PartialEq for View {
+    fn eq(&self, other: &Self) -> bool {
+        self.data == other.data
+    }
 }
 
 impl View {
-    pub fn new(op_store_view: op_store::View) -> Self {
+    pub fn new(op_store_view: op_store::View, head_normalized: bool) -> Self {
         Self {
             data: op_store_view,
+            head_normalized,
         }
     }
 
@@ -130,10 +140,25 @@ impl View {
 
     pub fn add_head(&mut self, head_id: &CommitId) {
         self.data.head_ids.insert(head_id.clone());
+        self.head_normalized = false;
     }
 
     pub fn remove_head(&mut self, head_id: &CommitId) {
         self.data.head_ids.remove(head_id);
+        self.head_normalized = false;
+    }
+
+    /// Inserts and removes the provided head ids without flipping
+    /// the `head_normalized` bit. This serves as an optimization
+    /// for the common incremental update case. Normalization guarantees
+    /// is up to callers.
+    ///
+    /// `add_head_id` must be a descendant of `remove_head_ids`.
+    pub fn replace_heads(&mut self, add_head_id: CommitId, remove_head_ids: &[CommitId]) {
+        self.data.head_ids.insert(add_head_id);
+        for head_id in remove_head_ids {
+            self.data.head_ids.remove(head_id);
+        }
     }
 
     /// Iterates local bookmark `(name, target)`s in lexicographical order.
@@ -586,8 +611,9 @@ impl View {
         )
     }
 
-    pub fn set_view(&mut self, data: op_store::View) {
+    pub fn set_view(&mut self, data: op_store::View, head_normalized: bool) {
         self.data = data;
+        self.head_normalized = head_normalized;
     }
 
     pub fn store_view(&self) -> &op_store::View {
@@ -596,6 +622,35 @@ impl View {
 
     pub fn store_view_mut(&mut self) -> &mut op_store::View {
         &mut self.data
+    }
+
+    pub fn is_heads_normalized(&self) -> bool {
+        self.head_normalized
+    }
+    //
+    pub fn normalize_heads(
+        &mut self,
+        index: &dyn Index,
+        root_commit_id: &CommitId,
+    ) -> IndexResult<()> {
+        if self.head_normalized {
+            return Ok(());
+        }
+        let view = self.store_view_mut();
+        if view.head_ids.is_empty() {
+            view.head_ids.insert(root_commit_id.clone());
+        } else if view.head_ids.len() > 1 {
+            // An empty head_ids set is padded with the root_commit_id, but the
+            // root id is unwanted during the heads resolution.
+            view.head_ids.remove(root_commit_id);
+            view.head_ids = index
+                .heads(&mut view.head_ids.iter())?
+                .into_iter()
+                .collect();
+        }
+        assert!(!view.head_ids.is_empty());
+        self.head_normalized = true;
+        Ok(())
     }
 }
 
@@ -629,6 +684,7 @@ mod tests {
     fn test_absent_tracked_bookmarks() {
         let mut view = View {
             data: op_store::View::make_root(CommitId::from_hex("000000")),
+            head_normalized: true,
         };
         let absent_tracked_ref = RemoteRef {
             target: RefTarget::absent(),
@@ -680,6 +736,7 @@ mod tests {
     fn test_absent_tracked_tags() {
         let mut view = View {
             data: op_store::View::make_root(CommitId::from_hex("000000")),
+            head_normalized: true,
         };
         let absent_tracked_ref = RemoteRef {
             target: RefTarget::absent(),

--- a/lib/tests/test_revset.rs
+++ b/lib/tests/test_revset.rs
@@ -2458,6 +2458,14 @@ fn test_evaluate_expression_visible_heads() {
         resolve_commit_ids(mut_repo, "visible_heads()"),
         vec![commit3.id().clone(), commit2.id().clone()]
     );
+
+    // Un-normalized view containing redundant head nodes
+    mut_repo.add_head(&commit1).block_on().unwrap();
+    assert!(!mut_repo.view().is_heads_normalized());
+    assert_eq!(
+        resolve_commit_ids(mut_repo, "visible_heads()"),
+        vec![commit3.id().clone(), commit2.id().clone()]
+    );
 }
 
 #[test]


### PR DESCRIPTION
repo: Fix TODO about making `enforce_view_invariants()` return an error instead of panicking
At Google, we run jj lib on our servers. If jj lib panics, it causes the servers to crash, so we are trying to fix those. In this case, a network issue causes self.index.heads() to return an error, and unwrapping it crashed our servers.


# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
