### PR TITLE
wasm: Allow jj-lib compilation to wasip2

### DIFF
--- a/lib/src/file_util.rs
+++ b/lib/src/file_util.rs
@@ -454,6 +454,75 @@ mod platform {
     }
 }
 
+#[cfg(target_os = "wasi")]
+mod platform {
+    use std::fs;
+    use std::fs::File;
+    use std::io;
+    use std::path::Path;
+    use std::time::UNIX_EPOCH;
+
+    pub use super::fallback::BadOsStrEncoding;
+    pub use super::fallback::os_str_from_bytes;
+    pub use super::fallback::os_str_to_bytes;
+
+    /// Whether symlinks are supported. WASI preview 2 can expose symlinks, but
+    /// creating them requires the unstable `wasi_ext` std feature, so we report
+    /// them as unsupported on stable Rust.
+    pub fn check_symlink_support() -> io::Result<bool> {
+        Ok(false)
+    }
+
+    /// Creates a new symlink `link` pointing to the `original` path.
+    pub fn symlink_dir<P: AsRef<Path>, Q: AsRef<Path>>(_original: P, _link: Q) -> io::Result<()> {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "symlinks are not supported on WASI",
+        ))
+    }
+
+    /// Creates a new symlink `link` pointing to the `original` path.
+    pub fn symlink_file<P: AsRef<Path>, Q: AsRef<Path>>(_original: P, _link: Q) -> io::Result<()> {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "symlinks are not supported on WASI",
+        ))
+    }
+
+    /// A best-effort file identity for WASI, derived from stable metadata
+    /// fields. WASI's `MetadataExt` (which exposes device and inode numbers)
+    /// requires the unstable `wasi_ext` feature, so we fall back to size and
+    /// modification time.
+    #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+    pub struct FileIdentity {
+        size: u64,
+        mtime_nanos: u128,
+    }
+
+    impl FileIdentity {
+        fn from_metadata(metadata: fs::Metadata) -> Self {
+            let mtime_nanos = metadata
+                .modified()
+                .ok()
+                .and_then(|time| time.duration_since(UNIX_EPOCH).ok())
+                .map(|duration| duration.as_nanos())
+                .unwrap_or(0);
+            Self {
+                size: metadata.len(),
+                mtime_nanos,
+            }
+        }
+    }
+
+    pub fn file_identity_from_symlink_path(path: &Path) -> io::Result<FileIdentity> {
+        path.symlink_metadata().map(FileIdentity::from_metadata)
+    }
+
+    pub fn file_identity_from_file(file: File) -> io::Result<FileIdentity> {
+        file.metadata().map(FileIdentity::from_metadata)
+    }
+}
+
 #[cfg_attr(unix, expect(dead_code))]
 mod fallback {
     use std::ffi::OsStr;

--- a/lib/src/local_working_copy.rs
+++ b/lib/src/local_working_copy.rs
@@ -163,7 +163,7 @@ fn symlink_target_convert_to_disk(path: &str) -> PathBuf {
 #[derive(Clone, Copy, Debug)]
 enum ExecChangePolicy {
     Ignore,
-    #[cfg_attr(windows, expect(dead_code))]
+    #[cfg_attr(not(unix), expect(dead_code))]
     Respect,
 }
 
@@ -183,9 +183,9 @@ impl ExecChangePolicy {
     ///
     /// On Unix we check whether executable bits are supported in the working
     /// copy to determine respect/ignorance, but we default to respect.
-    #[cfg_attr(windows, expect(unused_variables))]
+    #[cfg_attr(not(unix), expect(unused_variables))]
     fn new(exec_change_setting: ExecChangeSetting, state_path: &Path) -> Self {
-        #[cfg(windows)]
+        #[cfg(not(unix))]
         return Self::Ignore;
         #[cfg(unix)]
         return match exec_change_setting {
@@ -253,11 +253,11 @@ impl ExecBit {
     }
 
     /// Load the on-disk executable bit from file metadata.
-    #[cfg_attr(windows, expect(unused_variables))]
+    #[cfg_attr(not(unix), expect(unused_variables))]
     fn new_from_disk(metadata: &Metadata) -> Self {
         #[cfg(unix)]
         return Self(metadata.permissions().mode() & 0o111 != 0);
-        #[cfg(windows)]
+        #[cfg(not(unix))]
         return Self(false);
     }
 }
@@ -267,7 +267,7 @@ impl ExecBit {
 /// On Unix, we manually set the executable bit to the previous value on-disk.
 /// This is necessary because we write all files by creating them new, so files
 /// won't preserve their permissions naturally.
-#[cfg_attr(windows, expect(unused_variables))]
+#[cfg_attr(not(unix), expect(unused_variables))]
 fn set_executable(exec_bit: ExecBit, disk_path: &Path) -> Result<(), io::Error> {
     #[cfg(unix)]
     {

--- a/lib/src/lock/backoff.rs
+++ b/lib/src/lock/backoff.rs
@@ -20,7 +20,6 @@ pub struct BackoffIterator {
 }
 
 impl BackoffIterator {
-    #[cfg_attr(unix, expect(dead_code))]
     pub fn new() -> Self {
         Self {
             next_sleep_secs: 0.001,

--- a/lib/src/lock/mod.rs
+++ b/lib/src/lock/mod.rs
@@ -14,9 +14,12 @@
 
 #![expect(missing_docs)]
 
+#[cfg(windows)]
 mod backoff;
 #[cfg(unix)]
 mod unix;
+#[cfg(target_os = "wasi")]
+mod wasi;
 #[cfg(windows)]
 mod windows;
 
@@ -27,6 +30,8 @@ use thiserror::Error;
 
 #[cfg(unix)]
 pub use self::unix::FileLock;
+#[cfg(target_os = "wasi")]
+pub use self::wasi::FileLock;
 #[cfg(windows)]
 pub use self::windows::FileLock;
 

--- a/lib/src/lock/wasi.rs
+++ b/lib/src/lock/wasi.rs
@@ -1,0 +1,97 @@
+// Copyright 2026 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![expect(missing_docs)]
+
+//! WASI file locking implementation.
+//!
+//! WASI preview 2 does not expose advisory file locks (flock/LockFileEx), so
+//! this implementation falls back to lockfile creation. This is safe in the
+//! typical single-threaded WASI runtime, but does not guard against concurrent
+//! access from other processes or instances sharing the same preopened
+//! directory.
+
+use std::fs::File;
+use std::fs::OpenOptions;
+use std::io;
+use std::path::PathBuf;
+
+use tracing::instrument;
+
+use super::FileLockError;
+
+pub struct FileLock {
+    path: PathBuf,
+    // Held open for the lifetime of the lock so that `Drop` can close it
+    // before the lockfile is removed. Not read directly.
+    #[expect(dead_code)]
+    file: File,
+}
+
+impl FileLock {
+    /// Acquire an exclusive lock on `path`, blocking until it's available.
+    pub fn lock(path: PathBuf) -> Result<Self, FileLockError> {
+        // In blocking mode, `lock_inner` never returns `Ok(None)`.
+        Ok(Self::lock_inner(path, true)?.expect("blocking lock should return a lock"))
+    }
+
+    /// Try to acquire an exclusive lock on `path` without blocking. Returns
+    /// `Ok(None)` if the lock is currently held by another process.
+    pub fn try_lock(path: PathBuf) -> Result<Option<Self>, FileLockError> {
+        Self::lock_inner(path, false)
+    }
+
+    fn lock_inner(path: PathBuf, blocking: bool) -> Result<Option<Self>, FileLockError> {
+        tracing::info!("Attempting to lock {path:?}");
+        // Create the lockfile exclusively. If it already exists, either block
+        // (retrying) or report that the lock is held.
+        loop {
+            match OpenOptions::new().create_new(true).write(true).open(&path) {
+                Ok(file) => {
+                    tracing::info!("Locked {path:?}");
+                    return Ok(Some(Self { path, file }));
+                }
+                Err(err) if err.kind() == io::ErrorKind::AlreadyExists => {
+                    if blocking {
+                        // WASI has no flock, so we cannot truly wait for the
+                        // lock to be released. Busy-wait briefly by yielding
+                        // the runtime, then retry.
+                        std::thread::yield_now();
+                        continue;
+                    }
+                    return Ok(None);
+                }
+                Err(err) => {
+                    return Err(FileLockError {
+                        message: "Failed to open lock file",
+                        path: path.clone(),
+                        err,
+                    });
+                }
+            }
+        }
+    }
+}
+
+impl Drop for FileLock {
+    #[instrument(skip_all)]
+    fn drop(&mut self) {
+        // Closing the handle before removing the file. Drop order runs fields
+        // in declaration order, so `file` is dropped after `path`, but we
+        // explicitly drop it first by leaving scope. The remove_file call
+        // below happens while `file` is still open on some platforms, but on
+        // WASI that is fine.
+        std::fs::remove_file(&self.path).ok();
+    }
+}

--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -216,7 +216,11 @@ impl ReadonlyRepo {
         index_store_initializer: &IndexStoreInitializer<'_>,
         submodule_store_initializer: &SubmoduleStoreInitializer<'_>,
     ) -> Result<Arc<Self>, RepoInitError> {
+        // WASI doesn't support path canonicalization.
+        #[cfg(not(target_os = "wasi"))]
         let repo_path = dunce::canonicalize(repo_path).context(repo_path)?;
+        #[cfg(target_os = "wasi")]
+        let repo_path = repo_path.to_path_buf();
 
         let store_path = repo_path.join("store");
         fs::create_dir(&store_path).context(&store_path)?;


### PR DESCRIPTION
I have applied the following patch to get `jj-lib` working for wasm to build the revset explorer tool. https://juju.bi/tools/revset

Since I couldn't compile it to `wasm-unknown-unknown`, I am not happy about this patch, but I still wanted to see if people are interested to get this in.

- I am not sure if I got this 100% correct and might have done something wrong but didn't catch because I wasn't using it.
- I think `dunce` itself should support `wasm` instead of using patching it here. What do you guys think?

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
