### PR TITLE
evolog: Support positional filesets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `revsets.log` now defaults to `builtin_log()`, so custom log revsets can
   reuse the built-in default instead of copying its full expression.
 
+* `jj evolog` now supports positional filesets to filter the evolution graph.
+
 ### Fixed bugs
 
 * Recursive alias definitions are detected more precisely. jj can now expand

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -3268,9 +3268,17 @@ pub fn print_unmatched_explicit_paths<'a>(
         // TODO: propagate errors
         explicit_paths.retain(|&path| tree.path_value(path).block_on().unwrap().is_absent());
     }
+    print_no_matching_entries_for_paths(ui, workspace_command, &explicit_paths)
+}
 
-    if !explicit_paths.is_empty() {
-        let ui_paths = explicit_paths
+/// Prints warning about the given paths not matching anything.
+pub fn print_no_matching_entries_for_paths(
+    ui: &Ui,
+    workspace_command: &WorkspaceCommandHelper,
+    paths: &Vec<&RepoPath>,
+) -> io::Result<()> {
+    if !paths.is_empty() {
+        let ui_paths = paths
             .iter()
             .map(|&path| workspace_command.format_file_path(path))
             .join(", ");
@@ -3279,7 +3287,6 @@ pub fn print_unmatched_explicit_paths<'a>(
             "No matching entries for paths: {ui_paths}"
         )?;
     }
-
     Ok(())
 }
 

--- a/cli/src/commands/evolog.rs
+++ b/cli/src/commands/evolog.rs
@@ -20,6 +20,8 @@ use futures::TryStreamExt as _;
 use futures::stream;
 use futures::stream::LocalBoxStream;
 use itertools::Itertools as _;
+use jj_lib::backend::BackendResult;
+use jj_lib::backend::CommitId;
 use jj_lib::commit::Commit;
 use jj_lib::evolution::CommitEvolutionEntry;
 use jj_lib::evolution::walk_predecessors;
@@ -27,12 +29,17 @@ use jj_lib::graph::GraphEdge;
 use jj_lib::graph::TopoGroupedGraph;
 use jj_lib::graph::reverse_graph;
 use jj_lib::matchers::EverythingMatcher;
+use jj_lib::matchers::Visit;
+use jj_lib::repo_path::RepoPath;
+use jj_lib::rewrite::merge_commit_trees;
+use pollster::FutureExt as _;
 use tracing::instrument;
 
 use crate::cli_util::CommandHelper;
 use crate::cli_util::LogContentFormat;
 use crate::cli_util::RevisionArg;
 use crate::cli_util::format_template;
+use crate::cli_util::print_no_matching_entries_for_paths;
 use crate::command_error::CommandError;
 use crate::complete;
 use crate::diff_util::DiffFormatArgs;
@@ -43,11 +50,11 @@ use crate::ui::Ui;
 
 /// Show how a change has evolved over time
 ///
-/// Lists the previous commits which a change has pointed to. The current commit
-/// of a change evolves when the change is updated, rebased, etc.
+/// Lists the previous commits which a change has pointed to. The commit of a
+/// change evolves when the change is updated, rebased, etc.
 #[derive(clap::Args, Clone, Debug)]
 pub(crate) struct EvologArgs {
-    /// Follow changes from these revisions
+    /// The revision(s) to follow changes for
     #[arg(
         long,
         short,
@@ -57,6 +64,11 @@ pub(crate) struct EvologArgs {
     )]
     #[arg(add = ArgValueCompleter::new(complete::revset_expression_all))]
     revisions: Vec<RevisionArg>,
+
+    /// Show revisions modifying the given paths
+    #[arg(value_name = "FILESETS", value_hint = clap::ValueHint::AnyPath)]
+    #[arg(add = ArgValueCompleter::new(complete::all_historical_modified_revision_files))]
+    paths: Vec<String>,
 
     /// Limit number of revisions to show
     ///
@@ -110,7 +122,14 @@ pub(crate) async fn cmd_evolog(
 ) -> Result<(), CommandError> {
     let workspace_command = command.workspace_helper(ui).await?;
 
-    let start_commit_ids: Vec<_> = workspace_command
+    let fileset_expression = workspace_command.parse_file_patterns(ui, &args.paths)?;
+    let mut explicit_paths = fileset_expression.explicit_paths().collect_vec();
+    let matcher = fileset_expression.to_matcher();
+    let fileset_matches_all = matcher.visit(RepoPath::root()) == Visit::AllRecursively;
+
+    // Do not filter by paths yet, since the requested paths might be in the
+    // evolution history rather than in the specific given revisions.
+    let start_commit_ids: Vec<CommitId> = workspace_command
         .parse_union_revsets(ui, &args.revisions)?
         .evaluate_to_commit_ids()?
         .try_collect()
@@ -142,6 +161,25 @@ pub(crate) async fn cmd_evolog(
             )?
             .labeled(["evolog", "commit", "node"]);
     }
+
+    // Returns whether `entry` matches the given fileset. Also keeps track of
+    // which explicit paths have been seen.
+    let mut evolution_entry_matches_fileset = async |entry: &CommitEvolutionEntry| {
+        if fileset_matches_all {
+            // Optimization for a common case.
+            return BackendResult::Ok(true);
+        }
+        let tree = entry.commit.tree();
+        // TODO: propagate errors
+        explicit_paths.retain(|&path| tree.path_value(path).block_on().unwrap().is_absent());
+        let predecessors = &entry.predecessors().await?;
+        let from_tree = merge_commit_trees(workspace_command.repo().as_ref(), predecessors).await?;
+        Ok(tree
+            .diff_stream(&from_tree, matcher.as_ref())
+            .next()
+            .await
+            .is_some())
+    };
 
     ui.request_pager();
     let mut formatter = ui.stdout_formatter();
@@ -181,6 +219,9 @@ pub(crate) async fn cmd_evolog(
         };
 
         while let Some((entry, edges)) = evolution_nodes.try_next().await? {
+            if !evolution_entry_matches_fileset(&entry).await? {
+                continue;
+            }
             let mut buffer = vec![];
             let within_graph =
                 with_content_format.sub_width(graph.width(entry.commit.id(), &edges));
@@ -221,6 +262,9 @@ pub(crate) async fn cmd_evolog(
         };
 
         while let Some(entry) = evolution_entries.try_next().await? {
+            if !evolution_entry_matches_fileset(&entry).await? {
+                continue;
+            }
             with_content_format
                 .write(formatter, async |formatter| {
                     template.format(&entry, formatter)
@@ -242,6 +286,8 @@ pub(crate) async fn cmd_evolog(
             }
         }
     }
+
+    print_no_matching_entries_for_paths(ui, &workspace_command, &explicit_paths)?;
 
     Ok(())
 }

--- a/cli/src/commands/evolog.rs
+++ b/cli/src/commands/evolog.rs
@@ -81,7 +81,7 @@ pub(crate) struct EvologArgs {
     #[arg(long)]
     reversed: bool,
 
-    /// Don't show the graph, show a flat list of revisions
+    /// Show a flat list of revisions instead of a graph
     #[arg(long, short = 'G')]
     no_graph: bool,
 

--- a/cli/src/commands/log.rs
+++ b/cli/src/commands/log.rs
@@ -39,6 +39,7 @@ use crate::cli_util::CommandHelper;
 use crate::cli_util::LogContentFormat;
 use crate::cli_util::RevisionArg;
 use crate::cli_util::format_template;
+use crate::cli_util::print_no_matching_entries_for_paths;
 use crate::command_error::CommandError;
 use crate::complete;
 use crate::diff_util::DiffFormatArgs;
@@ -359,16 +360,7 @@ pub(crate) async fn cmd_log(
             }
         }
 
-        if !explicit_paths.is_empty() {
-            let ui_paths = explicit_paths
-                .iter()
-                .map(|&path| workspace_command.format_file_path(path))
-                .join(", ");
-            writeln!(
-                ui.warning_default(),
-                "No matching entries for paths: {ui_paths}"
-            )?;
-        }
+        print_no_matching_entries_for_paths(ui, &workspace_command, &explicit_paths)?;
     }
 
     // Check to see if the user might have specified a path when they intended

--- a/cli/src/commands/log.rs
+++ b/cli/src/commands/log.rs
@@ -97,7 +97,7 @@ pub(crate) struct LogArgs {
     #[arg(long)]
     reversed: bool,
 
-    /// Don't show the graph, show a flat list of revisions
+    /// Show a flat list of revisions instead of a graph
     #[arg(long, short = 'G')]
     no_graph: bool,
 

--- a/cli/src/commands/operation/diff.rs
+++ b/cli/src/commands/operation/diff.rs
@@ -83,7 +83,7 @@ pub struct OperationDiffArgs {
     #[arg(add = ArgValueCandidates::new(complete::operations))]
     to: Option<String>,
 
-    /// Don't show the graph, show a flat list of modified changes
+    /// Show a flat list of modified changes instead of a graph
     #[arg(long, short = 'G')]
     no_graph: bool,
 

--- a/cli/src/commands/operation/log.rs
+++ b/cli/src/commands/operation/log.rs
@@ -62,7 +62,7 @@ pub struct OperationLogArgs {
     #[arg(long)]
     reversed: bool,
 
-    /// Don't show the graph, show a flat list of operations
+    /// Show a flat list of operations instead of a graph
     #[arg(long, short = 'G')]
     no_graph: bool,
 

--- a/cli/src/commands/operation/show.rs
+++ b/cli/src/commands/operation/show.rs
@@ -37,7 +37,7 @@ pub struct OperationShowArgs {
     #[arg(add = ArgValueCandidates::new(complete::operations))]
     operation: String,
 
-    /// Don't show the graph, show a flat list of modified changes
+    /// Show a flat list of modified changes instead of a graph
     #[arg(long, short = 'G')]
     no_graph: bool,
 

--- a/cli/src/complete.rs
+++ b/cli/src/complete.rs
@@ -902,8 +902,15 @@ fn all_files_from_rev(rev: String, current: &std::ffi::OsStr) -> Vec<CompletionC
     })
 }
 
-fn modified_files_from_rev_with_jj_cmd(
-    rev: (String, Option<String>),
+/// Returns the modified files candidates after running `cmd`, which is expected
+/// to have all revision and template arguments populated, with the given
+/// `current` fileset.
+///
+/// The templated output is expected to have the format:
+///   status ++ ' ' ++ path display ++ "\n"
+/// With an additional line for renamed entries:
+///   'renamed.source' ++ ' ' ++ source path display ++ "\n"
+fn modified_files_candidates_from_cmd(
     mut cmd: std::process::Command,
     current: &std::ffi::OsStr,
 ) -> Result<Vec<CompletionCandidate>, CommandError> {
@@ -914,21 +921,10 @@ fn modified_files_from_rev_with_jj_cmd(
     let normalized_prefix = normalize_path(Path::new(current));
     let normalized_prefix = slash_path(&normalized_prefix);
 
-    // In case of a rename, one entry of `diff` results in two suggestions.
-    let template = indoc! {r#"
-        concat(
-          status ++ ' ' ++ path.display() ++ "\n",
-          if(status == 'renamed', 'renamed.source ' ++ source.path().display() ++ "\n"),
-        )
-    "#};
-    cmd.arg("diff")
-        .args(["--template", template])
-        .arg(current_prefix_to_fileset(current));
-    match rev {
-        (rev, None) => cmd.arg("--revisions").arg(rev),
-        (from, Some(to)) => cmd.arg("--from").arg(from).arg("--to").arg(to),
-    };
-    let output = cmd.output().map_err(user_error)?;
+    let output = cmd
+        .arg(current_prefix_to_fileset(current))
+        .output()
+        .map_err(user_error)?;
     let stdout = String::from_utf8_lossy(&output.stdout);
 
     let mut include_renames = false;
@@ -960,11 +956,63 @@ fn modified_files_from_rev_with_jj_cmd(
     Ok(candidates)
 }
 
+fn modified_files_from_rev_with_jj_cmd(
+    rev: (String, Option<String>),
+    mut cmd: std::process::Command,
+    current: &std::ffi::OsStr,
+) -> Result<Vec<CompletionCandidate>, CommandError> {
+    // In case of a rename, one entry of `diff` results in two suggestions.
+    let template = indoc! {r#"
+        concat(
+          status ++ ' ' ++ path.display() ++ "\n",
+          if(status == 'renamed', 'renamed.source ' ++ source.path().display() ++ "\n"),
+        )
+    "#};
+    cmd.arg("diff").args(["--template", template]);
+    match rev {
+        (rev, None) => cmd.arg("--revisions").arg(rev),
+        (from, Some(to)) => cmd.arg("--from").arg(from).arg("--to").arg(to),
+    };
+    modified_files_candidates_from_cmd(cmd, current)
+}
+
+fn modified_files_from_rev_evolution_with_jj_cmd(
+    rev: String,
+    mut cmd: std::process::Command,
+    current: &std::ffi::OsStr,
+) -> Result<Vec<CompletionCandidate>, CommandError> {
+    // In case of a rename, one entry of `diff` results in two suggestions.
+    // Need the final `.join` so that the `List<String>` is turned into a single
+    // `String`; otherwise, it will be joined with spaces by default, so all
+    // files after the first one will be indented by one space.
+    let template = indoc! {r#"
+        self.inter_diff().files().map(|entry| concat(
+          entry.status() ++ ' ' ++ entry.path().entry() ++ "\n",
+          if(entry.status() == 'renamed',
+            'renamed.source ' ++ entry.source().path().display() ++ "\n"
+          ),
+        ).join('')
+    "#};
+    cmd.arg("evolog")
+        .arg("--no-graph")
+        .arg("--revisions")
+        .arg(rev)
+        .args(["--template", template]);
+    modified_files_candidates_from_cmd(cmd, current)
+}
+
 fn modified_files_from_rev(
     rev: (String, Option<String>),
     current: &std::ffi::OsStr,
 ) -> Vec<CompletionCandidate> {
     with_jj(|jj, _| modified_files_from_rev_with_jj_cmd(rev, jj.build(), current))
+}
+
+fn modified_files_from_rev_evolution(
+    rev: String,
+    current: &std::ffi::OsStr,
+) -> Vec<CompletionCandidate> {
+    with_jj(|jj, _| modified_files_from_rev_evolution_with_jj_cmd(rev, jj.build(), current))
 }
 
 fn conflicted_files_from_rev(rev: &str, current: &std::ffi::OsStr) -> Vec<CompletionCandidate> {
@@ -1019,6 +1067,14 @@ pub fn modified_range_files(current: &std::ffi::OsStr) -> Vec<CompletionCandidat
         Some((from, to)) => modified_files_from_rev((from, Some(to)), current),
         None => modified_files_from_rev(("@".into(), None), current),
     }
+}
+
+/// Completes files modified in `--revisions` (default `@`) and all their
+/// previous commits.
+pub fn all_historical_modified_revision_files(
+    current: &std::ffi::OsStr,
+) -> Vec<CompletionCandidate> {
+    modified_files_from_rev_evolution(parse::revision_or_wc(), current)
 }
 
 /// Completes files in `@` *or* the `--from` revision (not the diff between

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -1083,24 +1083,21 @@ Show how a change has evolved over time
 
 Lists the previous commits which a change has pointed to. The commit of a change evolves when the change is updated, rebased, etc.
 
-**Usage:** `jj evolog [OPTIONS] [FILESETS]...`
+**Usage:** `jj evolog [OPTIONS] [REVSETS]...`
 
 **Command Alias:** `evolution-log`
 
 ###### **Arguments:**
 
-* `<FILESETS>` — Show revisions modifying the given paths
+* `<REVSETS>` — The revision(s) to follow changes for (default: @) [aliases: -r]
 
 ###### **Options:**
 
-* `-r`, `--revisions <REVSETS>` — The revision(s) to follow changes for
-
-  Default value: `@`
 * `-n`, `--limit <LIMIT>` — Limit number of revisions to show
 
    Applied after revisions are reordered topologically, but before being reversed.
 * `--reversed` — Show revisions in the opposite order (older revisions first)
-* `-G`, `--no-graph` — Don't show the graph, show a flat list of revisions
+* `-G`, `--no-graph` — Show a flat list of revisions instead of a graph
 * `-T`, `--template <TEMPLATE>` — Render each revision using the given template
 
    All 0-argument methods of the [`CommitEvolutionEntry` type] are available as keywords in the template expression. See [`jj help -k templates`] for more information.
@@ -2072,7 +2069,7 @@ The working-copy commit is indicated by a `@` symbol in the graph. [Immutable re
 
    Applied after revisions are filtered and reordered topologically, but before being reversed.
 * `--reversed` — Show revisions in the opposite order (older revisions first)
-* `-G`, `--no-graph` — Don't show the graph, show a flat list of revisions
+* `-G`, `--no-graph` — Show a flat list of revisions instead of a graph
 * `-T`, `--template <TEMPLATE>` — Render each revision using the given template
 
    Run `jj log -T` to list the built-in templates.
@@ -2344,7 +2341,7 @@ Compare changes to the repository between two operations
 * `--operation <OPERATION>` [alias: `op`] — Show repository changes in this operation, compared to its parent
 * `-f`, `--from <FROM>` — Show repository changes from this operation
 * `-t`, `--to <TO>` — Show repository changes to this operation
-* `-G`, `--no-graph` — Don't show the graph, show a flat list of modified changes
+* `-G`, `--no-graph` — Show a flat list of modified changes instead of a graph
 * `-p`, `--patch` — Show patch of modifications to changes
 
    If the previous version has different parents, it will be temporarily rebased to the parents of the new version, so the diff is not contaminated by unrelated changes.
@@ -2400,7 +2397,7 @@ Like other commands, `jj op log` snapshots the current working-copy changes and 
 
    Applied after operations are reordered topologically, but before being reversed.
 * `--reversed` — Show operations in the opposite order (older operations first)
-* `-G`, `--no-graph` — Don't show the graph, show a flat list of operations
+* `-G`, `--no-graph` — Show a flat list of operations instead of a graph
 * `-T`, `--template <TEMPLATE>` — Render each operation using the given template
 
    You can specify arbitrary template expressions using the [built-in keywords]. See [`jj help -k templates`] for more information.
@@ -2512,7 +2509,7 @@ Show changes to the repository in an operation
 
 ###### **Options:**
 
-* `-G`, `--no-graph` — Don't show the graph, show a flat list of modified changes
+* `-G`, `--no-graph` — Show a flat list of modified changes instead of a graph
 * `-T`, `--template <TEMPLATE>` — Render the operation using the given template
 
    You can specify arbitrary template expressions using the [built-in keywords]. See [`jj help -k templates`] for more information.

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -1081,15 +1081,19 @@ Note: it is [generally recommended] to instead use `jj new` and `jj squash`.
 
 Show how a change has evolved over time
 
-Lists the previous commits which a change has pointed to. The current commit of a change evolves when the change is updated, rebased, etc.
+Lists the previous commits which a change has pointed to. The commit of a change evolves when the change is updated, rebased, etc.
 
-**Usage:** `jj evolog [OPTIONS]`
+**Usage:** `jj evolog [OPTIONS] [FILESETS]...`
 
 **Command Alias:** `evolution-log`
 
+###### **Arguments:**
+
+* `<FILESETS>` — Show revisions modifying the given paths
+
 ###### **Options:**
 
-* `-r`, `--revisions <REVSETS>` — Follow changes from these revisions
+* `-r`, `--revisions <REVSETS>` — The revision(s) to follow changes for
 
   Default value: `@`
 * `-n`, `--limit <LIMIT>` — Limit number of revisions to show

--- a/cli/tests/test_evolog_command.rs
+++ b/cli/tests/test_evolog_command.rs
@@ -577,6 +577,209 @@ fn test_evolog_abandoned_op() {
 }
 
 #[test]
+fn test_evolog_with_filesets() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    work_dir.run_jj(["describe", "-m", "commit1"]).success();
+    work_dir.write_file("file1", "foo\n");
+    work_dir.run_jj(["new", "-m", "commit2"]).success();
+    work_dir.write_file("file2", "abc\ndef\n");
+    work_dir.run_jj(["new", "-m", "commit3"]).success();
+    work_dir.write_file("file1", "foo\nbar\n");
+    work_dir.write_file("README.md", "# My Project\n");
+
+    // Revert to an old version.
+    work_dir.run_jj(["undo"]).success();
+    work_dir.run_jj(["new", "-m", "better commit3"]).success();
+    work_dir.write_file("file2", "ABC\nDEF\n");
+
+    work_dir
+        .run_jj(["squash", "-t", "subject(commit1)", "-m", "best commit"])
+        .success();
+
+    // Modify more files in the working copy.
+    work_dir.remove_file("file1");
+    work_dir.write_file("file2", "changed again\n");
+    work_dir.run_jj(["util", "snapshot"]).success();
+    work_dir.write_file("README.md", "I did more things\n");
+    work_dir.run_jj(["util", "snapshot"]).success();
+    work_dir.write_file("file3", "new file");
+
+    // Full evolog.
+    let output = work_dir.run_jj(["evolog", "-r..", "-p"]);
+    insta::assert_snapshot!(output, @r"
+    @  yqosqzyt test.user@example.com 2001-02-03 08:05:16 85c3cb39
+    │  (no description set)
+    │  -- operation 96602dbe17dc snapshot working copy
+    │  Added regular file file3:
+    │          1: new file
+    ○  yqosqzyt/1 test.user@example.com 2001-02-03 08:05:15 c6aca54c (hidden)
+    │  (no description set)
+    │  -- operation d964b0678350 snapshot working copy
+    │  Added regular file README.md:
+    │          1: I did more things
+    ○  yqosqzyt/2 test.user@example.com 2001-02-03 08:05:14 e993c6da (hidden)
+    │  (no description set)
+    │  -- operation 327df63897b6 snapshot working copy
+    │  Removed regular file file1:
+    │     1     : foo
+    │  Modified regular file file2:
+    │     1     : ABC
+    │     2     : DEF
+    │          1: changed again
+    ○  yqosqzyt/3 test.user@example.com 2001-02-03 08:05:13 e8854787 (hidden)
+       (empty) (no description set)
+       -- operation ef3274b9c1f8 squash commits into 6f48fb12aaf6833353a96bd8b8b8c8c0f546ee64
+    ○  zsuskuln test.user@example.com 2001-02-03 08:05:13 836922b0
+    │  (empty) commit3
+    │  -- operation ef3274b9c1f8 squash commits into 6f48fb12aaf6833353a96bd8b8b8c8c0f546ee64
+    ○  zsuskuln/2 test.user@example.com 2001-02-03 08:05:10 76a61f5f (hidden)
+       (empty) commit3
+       -- operation 77530b1b32ce new empty commit
+       Modified commit description:
+               1: commit3
+    ○  kkmpptxz test.user@example.com 2001-02-03 08:05:13 ebe9edd0
+    │  commit2
+    │  -- operation ef3274b9c1f8 squash commits into 6f48fb12aaf6833353a96bd8b8b8c8c0f546ee64
+    ○  kkmpptxz/1 test.user@example.com 2001-02-03 08:05:10 9a998c22 (hidden)
+    │  commit2
+    │  -- operation 2d5618b3a8ed snapshot working copy
+    │  Added regular file file2:
+    │          1: abc
+    │          2: def
+    ○  kkmpptxz/2 test.user@example.com 2001-02-03 08:05:09 4dffbc24 (hidden)
+       (empty) commit2
+       -- operation d32e67902fc1 new empty commit
+       Modified commit description:
+               1: commit2
+    ×    qpvuntsm test.user@example.com 2001-02-03 08:05:13 a9c28563 (conflict)
+    ├─╮  best commit
+    │ │  -- operation ef3274b9c1f8 squash commits into 6f48fb12aaf6833353a96bd8b8b8c8c0f546ee64
+    │ │  Modified commit description:
+    │ │     1     : <<<<<<< conflict 1 of 1
+    │ │     2     : %%%%%%% diff from: base
+    │ │     3     : \\\\\\\        to: side #1
+    │ │     4     : +commit1
+    │ │     5     : +++++++ side #2
+    │ │     6     : better commit3
+    │ │     7     : >>>>>>> conflict 1 of 1 ends
+    │ │          1: best commit
+    │ ○  royxmykx/0 test.user@example.com 2001-02-03 08:05:13 2f50bc34 (hidden)
+    │ │  better commit3
+    │ │  -- operation fe776c83dbcd snapshot working copy
+    │ │  Modified regular file file2:
+    │ │     1     : abc
+    │ │     2     : def
+    │ │          1: ABC
+    │ │          2: DEF
+    │ ○  royxmykx/1 test.user@example.com 2001-02-03 08:05:12 a40e3e34 (hidden)
+    │    (empty) better commit3
+    │    -- operation d1cb41df18bc new empty commit
+    │    Modified commit description:
+    │            1: better commit3
+    ○  qpvuntsm/1 test.user@example.com 2001-02-03 08:05:09 6f48fb12 (hidden)
+    │  commit1
+    │  -- operation 1e8d9c23221f snapshot working copy
+    │  Added regular file file1:
+    │          1: foo
+    ○  qpvuntsm/2 test.user@example.com 2001-02-03 08:05:08 b876c5f4 (hidden)
+    │  (empty) commit1
+    │  -- operation c83ae0f92707 describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
+    │  Modified commit description:
+    │          1: commit1
+    ○  qpvuntsm/3 test.user@example.com 2001-02-03 08:05:07 e8849ae1 (hidden)
+       (empty) (no description set)
+       -- operation 90267f31f904 add workspace 'default'
+    [EOF]
+    ");
+
+    // With filesets, only the commits matching the files are shown.
+    let output = work_dir.run_jj(["evolog", "--summary", "-rsubject('best commit')", "file2"]);
+    insta::assert_snapshot!(output, @r"
+    ×    qpvuntsm test.user@example.com 2001-02-03 08:05:13 a9c28563 (conflict)
+    ├─╮  best commit
+    │ │  -- operation ef3274b9c1f8 squash commits into 6f48fb12aaf6833353a96bd8b8b8c8c0f546ee64
+    │ ○  royxmykx/0 test.user@example.com 2001-02-03 08:05:13 2f50bc34 (hidden)
+    │ │  better commit3
+    │ │  -- operation fe776c83dbcd snapshot working copy
+    │ │  M file2
+    │ ○  royxmykx/1 test.user@example.com 2001-02-03 08:05:12 a40e3e34 (hidden)
+    │    (empty) better commit3
+    │    -- operation d1cb41df18bc new empty commit
+    [EOF]
+    ");
+
+    // Fileset can match non-contiguous commits.
+    let output = work_dir.run_jj(["evolog", "--summary", "-r..", "file1"]);
+    insta::assert_snapshot!(output, @r"
+    ○  yqosqzyt/2 test.user@example.com 2001-02-03 08:05:14 e993c6da (hidden)
+    │  (no description set)
+    │  -- operation 327df63897b6 snapshot working copy
+    │  D file1
+    │  M file2
+    ○  yqosqzyt/3 test.user@example.com 2001-02-03 08:05:13 e8854787 (hidden)
+       (empty) (no description set)
+       -- operation ef3274b9c1f8 squash commits into 6f48fb12aaf6833353a96bd8b8b8c8c0f546ee64
+    ○  zsuskuln/2 test.user@example.com 2001-02-03 08:05:10 76a61f5f (hidden)
+       (empty) commit3
+       -- operation 77530b1b32ce new empty commit
+    ○  kkmpptxz/2 test.user@example.com 2001-02-03 08:05:09 4dffbc24 (hidden)
+       (empty) commit2
+       -- operation d32e67902fc1 new empty commit
+    ○  royxmykx/1 test.user@example.com 2001-02-03 08:05:12 a40e3e34 (hidden)
+       (empty) better commit3
+       -- operation d1cb41df18bc new empty commit
+    ○  qpvuntsm/1 test.user@example.com 2001-02-03 08:05:09 6f48fb12 (hidden)
+    │  commit1
+    │  -- operation 1e8d9c23221f snapshot working copy
+    │  A file1
+    [EOF]
+    ");
+
+    // No revisions (defaults to `@`); only filesets.
+    let output = work_dir.run_jj(["evolog", "--summary", "file*"]);
+    insta::assert_snapshot!(output, @r"
+    @  yqosqzyt test.user@example.com 2001-02-03 08:05:16 85c3cb39
+    │  (no description set)
+    │  -- operation 96602dbe17dc snapshot working copy
+    │  A file3
+    │ ○  yqosqzyt/2 test.user@example.com 2001-02-03 08:05:14 e993c6da (hidden)
+    │ │  (no description set)
+    │ │  -- operation 327df63897b6 snapshot working copy
+    │ │  D file1
+    │ │  M file2
+    │ ○  yqosqzyt/3 test.user@example.com 2001-02-03 08:05:13 e8854787 (hidden)
+    │    (empty) (no description set)
+    │    -- operation ef3274b9c1f8 squash commits into 6f48fb12aaf6833353a96bd8b8b8c8c0f546ee64
+    [EOF]
+    ");
+
+    // No matching explicit filesets.
+    let output = work_dir.run_jj(["evolog", "--summary", "-rsubject(commit2)", "README.md"]);
+    insta::assert_snapshot!(output, @r"
+    ------- stderr -------
+    Warning: No matching entries for paths: README.md
+    [EOF]
+    ");
+
+    // Even if fileset matches everything, a warning is still printed for
+    // non-matching paths.
+    let output = work_dir.run_jj(["evolog", "--summary", "-r..", "-n", "*", "does-not-exist"]);
+    insta::assert_snapshot!(output, @r"
+    @  yqosqzyt test.user@example.com 2001-02-03 08:05:16 85c3cb39
+    │  (no description set)
+    │  -- operation 96602dbe17dc snapshot working copy
+    │  A file3
+    [EOF]
+    ------- stderr -------
+    Warning: No matching entries for paths: does-not-exist
+    [EOF]
+    ");
+}
+
+#[test]
 fn test_evolog_with_no_template() {
     let test_env = TestEnvironment::default();
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();


### PR DESCRIPTION
For review: I'm not quite sure if the fileset matching was done correctly. The test snapshots are not exactly what I expect (empty commits included when filesets are given), but not sure how to fix it. Any pointers would be appreciated.

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.