### PR TITLE
colocation: report proper error when enabling is unsupported

### DIFF
--- a/cli/src/commands/git/colocation.rs
+++ b/cli/src/commands/git/colocation.rs
@@ -132,6 +132,17 @@ async fn cmd_git_colocation_status(
             ui.hint_default(),
             "To disable colocation, run: `jj git colocation disable`"
         )?;
+    } else if !workspace_command
+        .repo_path()
+        .join("store")
+        .join("git")
+        .exists()
+    {
+        writeln!(
+            ui.hint_default(),
+            "Colocation cannot be enabled because the workspace is backed by an external Git \
+             repository."
+        )?;
     } else {
         writeln!(
             ui.hint_default(),
@@ -175,6 +186,17 @@ async fn cmd_git_colocation_enable(
     std::fs::rename(&git_store_path, &dot_git_path).map_err(|err| match err.kind() {
         ErrorKind::AlreadyExists | ErrorKind::DirectoryNotEmpty => {
             user_error("A .git directory already exists in the workspace root. Cannot colocate.")
+        }
+        // An external Git repository (e.g. created by `jj git init
+        // --git-repo=<path>`) isn't managed by jj and cannot be moved.
+        // workspace_supports_git_colocation_commands() already ensured that
+        // the backend is Git.
+        ErrorKind::NotFound => {
+            let git_backend = git::get_git_backend(workspace_command.repo().store()).unwrap();
+            user_error(format!(
+                "Cannot colocate a workspace backed by an external Git repository at {}",
+                git_backend.git_repo_path().display()
+            ))
         }
         _ => user_error_with_message(
             "Failed to move Git repository from .jj/repo/store/git to workspace root directory.",

--- a/cli/tests/test_git_colocation.rs
+++ b/cli/tests/test_git_colocation.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use testutils::TestResult;
+use testutils::git;
 
 use crate::common::CommandOutput;
 use crate::common::TestEnvironment;
@@ -182,6 +183,48 @@ fn test_git_colocation_enable_with_existing_git_dir() -> TestResult {
     [exit status: 1]
     ");
     Ok(())
+}
+
+#[test]
+fn test_git_colocation_enable_external_git_repo() {
+    let test_env = TestEnvironment::default();
+
+    // Initialize a Jujutsu workspace backed by an external Git repository
+    let git_repo_path = test_env.env_root().join("git-repo");
+    git::init(&git_repo_path);
+    test_env
+        .run_jj_in(
+            test_env.env_root(),
+            [
+                "git",
+                "init",
+                "repo",
+                "--git-repo",
+                git_repo_path.to_str().unwrap(),
+            ],
+        )
+        .success();
+    let work_dir = test_env.work_dir("repo");
+
+    // The status hint shouldn't suggest enabling colocation
+    let output = work_dir.run_jj(["git", "colocation", "status"]);
+    insta::assert_snapshot!(output, @"
+    Workspace is currently not colocated with Git.
+    Last imported/exported Git HEAD: (none)
+    [EOF]
+    ------- stderr -------
+    Hint: Colocation cannot be enabled because the workspace is backed by an external Git repository.
+    [EOF]
+    ");
+
+    // Trying to colocate should fail with a clean error
+    let output = work_dir.run_jj(["git", "colocation", "enable"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    Error: Cannot colocate a workspace backed by an external Git repository at $TEST_ENV/git-repo/.git
+    [EOF]
+    [exit status: 1]
+    ");
 }
 
 #[test]


### PR DESCRIPTION
If the repo was initialized with --git-repo pointing to an external Git repository, `jj git colocation enable` failed with a confusing "No such file or directory" error while trying to move .jj/repo/store/git. Detect this case and report a clean error instead. Also stop suggesting `jj git colocation enable` in the status output for such repos.

Fixes #9853

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
