### PR TITLE
cli: allow repeating arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,14 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `--name-only` for the previous behavior.
   [#9399](https://github.com/jj-vcs/jj/issues/9399)
 
+* Passing an argument more than once is no longer an error. The last occurrence
+  wins, so `jj --no-pager --no-pager version` and `jj log -n 5 -n 10` now work,
+  and an argument baked into an alias or a wrapper can be given explicitly as
+  well. Arguments that can be specified multiple times, such as `--config` and
+  `jj log -r`, are unaffected and still collect all of their values.
+  [#8101](https://github.com/jj-vcs/jj/issues/8101)
+  [#9859](https://github.com/jj-vcs/jj/issues/9859)
+
 ### Deprecations
 
 ### New features

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -91,6 +91,11 @@ const STYLES: Styles = Styles::styled()
 #[command(disable_help_subcommand = true)]
 #[command(after_long_help = help::show_keyword_hint_after_help())]
 #[command(add = SubcommandCandidates::new(complete::aliases))]
+// A repeated argument is accepted, and the last occurrence wins. This is a
+// propagated setting, so it also applies to subcommands and to custom commands
+// and global arguments registered by `CliRunner`. Arguments that can be
+// specified multiple times, such as `--config`, keep all of their values.
+#[command(args_override_self = true)]
 enum Command {
     Abandon(abandon::AbandonArgs),
     Absorb(absorb::AbsorbArgs),

--- a/cli/tests/test_global_opts.rs
+++ b/cli/tests/test_global_opts.rs
@@ -858,6 +858,66 @@ fn test_quiet() {
 }
 
 #[test]
+fn test_repeated_args() {
+    // Repeating an argument should be harmless rather than an error, so that an
+    // argument baked into an alias (or a wrapper command) can also be passed
+    // explicitly. See https://github.com/jj-vcs/jj/issues/9859 and
+    // https://github.com/jj-vcs/jj/issues/8101.
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    // `--no-pager` is parsed by the early args parser, `--ignore-working-copy`
+    // is not. The repetition is accepted wherever the occurrences sit relative
+    // to the subcommand.
+    for flag in ["--no-pager", "--ignore-working-copy"] {
+        work_dir.run_jj([flag, flag, "status"]).success();
+        work_dir.run_jj([flag, "status", flag]).success();
+        work_dir.run_jj(["status", flag, flag]).success();
+    }
+
+    // Arguments of subcommands are covered as well.
+    let output = work_dir.run_jj(["log", "--no-graph", "-T=description"]);
+    let repeated_output = work_dir.run_jj(["log", "--no-graph", "--no-graph", "-T=description"]);
+    assert_eq!(repeated_output, output);
+
+    // Repeating a flag must not disable it: `--quiet` twice still suppresses
+    // the message about the new working-copy commit.
+    let output = work_dir.run_jj(["--quiet", "--quiet", "describe", "-m=new description"]);
+    insta::assert_snapshot!(output, @"");
+
+    // For an option that takes a value, the last occurrence wins.
+    work_dir.run_jj(["new", "-m=child"]).success();
+    let output = work_dir.run_jj(["log", "--no-graph", "-T=description", "-n=1", "-n=2"]);
+    insta::assert_snapshot!(output, @r"
+    child
+    new description
+    [EOF]
+    ");
+    work_dir.run_jj(["status", "-R=.", "-R=."]).success();
+
+    // Options that can be specified multiple times keep all of their values.
+    let output = work_dir.run_jj([
+        "--config=user.name=Custom User",
+        "--config=user.email=custom@example.com",
+        "config",
+        "list",
+        "user",
+    ]);
+    insta::assert_snapshot!(output, @r#"
+    user.name = "Custom User"
+    user.email = "custom@example.com"
+    [EOF]
+    "#);
+    let output = work_dir.run_jj(["log", "--no-graph", "-T=description", "-r=@", "-r=@-"]);
+    insta::assert_snapshot!(output, @r"
+    child
+    new description
+    [EOF]
+    ");
+}
+
+#[test]
 fn test_early_args() {
     // Test that help output parses early args
     let test_env = TestEnvironment::default();


### PR DESCRIPTION
## Summary

`jj --no-pager --no-pager version` fails with:

```
error: the argument '--no-pager' cannot be used multiple times
```

clap rejects a repeated occurrence of an argument unless it is told otherwise. That is awkward when an argument is baked into an alias or a wrapper and then also passed explicitly, as in #8101, where the point of the alias is a default `-n` that can still be overridden on the command line. It is also inconsistent: as @zygoloid noted in #9859, `jj --no-pager version --no-pager` already works, because the early args parser runs with `ignore_errors`.

## Change

`args_override_self` is set on the root command, so a repeated argument is accepted and the last occurrence wins.

clap propagates the setting, which means it covers:

* the boolean global flags (`--no-pager`, `--quiet`, `--ignore-working-copy`, `--ignore-immutable`, `--no-integrate-operation`, `--debug`),
* the arguments of every subcommand, both flags such as `jj log --no-graph` and options such as `jj log -n`,
* custom commands and custom global arguments registered through `CliRunner`.

Arguments that can be specified multiple times, such as `--config` and a multi revision `-r`, are unaffected and still collect all of their values. `args_override_self` only relaxes the "cannot be used multiple times" check; it does not clear earlier occurrences the way a per argument `overrides_with = <self>` does on an `Append` argument. `ArgAction::Count` arguments, such as the `-h` of the early args parser, are unaffected as well.

The one visible behavior change beyond accepting repeats is that a single revision `-r`, as in `jj edit -r x -r y`, now resolves to `y` instead of erroring.

The patch itself is @martinvonz's, from his review of the first version of this PR, which added `overrides_with` to the six boolean global flags one by one. @yuja pointed out that options taking a value should be allowed to repeat too, and that repeated and conflicting arguments are better treated the same way. @josephlou5 laid out where a repeated value option reads as an error rather than a last one wins.

## Testing

`test_repeated_args` in `cli/tests/test_global_opts.rs` checks that each boolean global flag can be passed twice, that `jj log --no-graph --no-graph` matches a single `--no-graph`, that `--quiet --quiet` still suppresses output (so repeating does not toggle a flag off), that `jj log -n 1 -n 2` and `jj status -R . -R .` are accepted with the last value winning, and that repeated `--config` and repeated `-r` keep all of their values.

The custom command examples have no test harness, so those I checked by hand: `custom-global-flag --greet --greet status` greets once and runs, and `custom-command --no-pager --no-pager frobnicate @` works.

The full `jj-cli` test suite passes (1048 passed, 3 ignored), `cargo clippy -p jj-cli --all-targets` is clean, and `cargo fmt --check` is clean.

Fixes #9859
Fixes #8101
