### PR TITLE
Add copy-aware merge using CopyHistory graph

### DIFF
--- a/cli/src/merge_tools/builtin.rs
+++ b/cli/src/merge_tools/builtin.rs
@@ -834,14 +834,14 @@ mod tests {
         let unchanged = repo_path("unchanged");
         let changed_path = repo_path("changed");
         let added_path = repo_path("added");
-        let left_tree = testutils::create_tree(
+        let left_tree = testutils::create_tree_with_placeholder_copy_ids(
             &test_repo.repo,
             &[
                 (unchanged, "unchanged\n"),
                 (changed_path, "line1\nline2\nline3\n"),
             ],
         );
-        let right_tree = testutils::create_tree(
+        let right_tree = testutils::create_tree_with_placeholder_copy_ids(
             &test_repo.repo,
             &[
                 (unchanged, "unchanged\n"),
@@ -1231,7 +1231,10 @@ mod tests {
 
         let added_empty_file_path = repo_path("empty_file");
         let left_tree = testutils::create_tree(&test_repo.repo, &[]);
-        let right_tree = testutils::create_tree(&test_repo.repo, &[(added_empty_file_path, "")]);
+        let right_tree = testutils::create_tree_with_placeholder_copy_ids(
+            &test_repo.repo,
+            &[(added_empty_file_path, "")],
+        );
 
         let (changed_files, files) = make_diff(store, &left_tree, &right_tree);
         insta::assert_debug_snapshot!(changed_files, @r#"
@@ -1281,6 +1284,7 @@ mod tests {
         let right_tree = testutils::create_tree_with(&test_repo.repo, |builder| {
             builder
                 .file(added_executable_file_path, "executable")
+                .copy_id(CopyId::placeholder())
                 .executable(true);
         });
 
@@ -1959,7 +1963,9 @@ mod tests {
             builder.file(&file_in_folder_path, vec![]);
         });
         let right_tree = testutils::create_tree_with(&test_repo.repo, |builder| {
-            builder.file(folder_path, vec![]);
+            builder
+                .file(folder_path, vec![])
+                .copy_id(CopyId::placeholder());
         });
 
         let (changed_files, files) = make_diff(store, &left_tree, &right_tree);

--- a/lib/src/backend.rs
+++ b/lib/src/backend.rs
@@ -91,6 +91,11 @@ impl CopyId {
     pub fn placeholder() -> Self {
         Self::new(vec![])
     }
+
+    /// Returns true if this is a placeholder copy id.
+    pub fn is_placeholder(&self) -> bool {
+        self.0.is_empty()
+    }
 }
 
 /// Error that may occur when converting a `Timestamp` to a `Datetime``.

--- a/lib/src/backend.rs
+++ b/lib/src/backend.rs
@@ -86,6 +86,11 @@ impl CopyId {
     pub fn placeholder() -> Self {
         Self::new(vec![])
     }
+
+    /// Returns true if this is a placeholder copy id.
+    pub fn is_placeholder(&self) -> bool {
+        self.0.is_empty()
+    }
 }
 
 /// Error that may occur when converting a `Timestamp` to a `Datetime``.

--- a/lib/src/copies.rs
+++ b/lib/src/copies.rs
@@ -50,6 +50,7 @@ use crate::merged_tree::TreeDiffEntry;
 use crate::merged_tree::TreeDiffStream;
 use crate::repo_path::RepoPath;
 use crate::repo_path::RepoPathBuf;
+use crate::store::Store;
 
 /// A collection of CopyRecords.
 #[derive(Default, Debug)]
@@ -996,4 +997,86 @@ async fn get_ancestor_paths(
         }
     }
     Ok(ancestor_paths)
+}
+
+/// Merges conflicting `CopyId`s by finding DAG heads and writing a new
+/// `CopyHistory` if there are multiple heads.
+///
+/// If there is a `CopyId` that matches the current `path`, it is preferred.
+///
+/// When merging branches that have copy/rename history, a file might end up
+/// with multiple different `CopyId`s (e.g. because it was copied from different
+/// sources or has divergent history). To represent this merged history in the
+/// snapshot, we merge the `CopyId`s.
+///
+/// If one `CopyId` is a descendant of all others in the copy history DAG, it
+/// already contains the full history, so we can use it.
+/// If there are multiple independent heads in the history, we create a new
+/// `CopyHistory` node that lists all these heads as parents, effectively
+/// merging the history DAG.
+pub async fn merge_copy_ids(
+    store: &Store,
+    path: &RepoPath,
+    copy_id_merge: &Merge<Option<CopyId>>,
+) -> BackendResult<CopyId> {
+    let adds: HashSet<&CopyId> = copy_id_merge.adds().flatten().collect();
+    if adds.is_empty() {
+        return Err(BackendError::Other("Empty copy id merge".into()));
+    }
+    if adds.len() == 1 {
+        return Ok((*adds.iter().next().unwrap()).clone());
+    }
+
+    let mut copy_graph = CopyGraph::new();
+    // NOTE: this loop creates a CopyGraph that does not necessarily follow the rule
+    // that related copies are ordered with children before parents.
+    for id in &adds {
+        copy_graph.extend(
+            store
+                .backend()
+                .get_related_copies(id)
+                .await?
+                .into_iter()
+                .map(|related| (related.id, related.history)),
+        );
+    }
+
+    let matching_paths: Vec<&CopyId> = adds
+        .iter()
+        .filter(|id| {
+            copy_graph
+                .get(**id)
+                .is_some_and(|h| h.current_path.as_ref() == path)
+        })
+        .copied()
+        .collect();
+    if matching_paths.len() == 1 {
+        return Ok(matching_paths[0].clone());
+    }
+
+    let heads = dag_walk::heads(
+        adds.iter().copied(),
+        |id| *id,
+        |id| {
+            copy_graph
+                .get(*id)
+                .map_or(&[] as &[_], |h| &h.parents)
+                .iter()
+        },
+    );
+
+    if heads.len() == 1 {
+        return Ok((*heads.iter().next().unwrap()).clone());
+    }
+
+    let sorted_heads = heads.into_iter().cloned().sorted().collect_vec();
+
+    let new_history = CopyHistory {
+        current_path: path.to_owned(),
+        parents: sorted_heads,
+        salt: vec![],
+    };
+
+    let new_id = store.backend().write_copy(&new_history).await?;
+    Ok(new_id)
 }

--- a/lib/src/copies.rs
+++ b/lib/src/copies.rs
@@ -540,6 +540,12 @@ async fn diffs_from_copies(
     let copy_id = after_file.copy_id().ok_or(BackendError::Other(
         "Expected TreeValue::File with a CopyId".into(),
     ))?;
+    if copy_id.is_placeholder() {
+        return Ok(Merge::resolved(CopyHistoryDiffTerm {
+            target_value: Some(after_file),
+            sources: vec![],
+        }));
+    }
     let copy_graph: CopyGraph = before_tree
         .store()
         .backend()

--- a/lib/src/copies.rs
+++ b/lib/src/copies.rs
@@ -41,6 +41,7 @@ use crate::backend::CopyRecord;
 use crate::backend::MergedTreeValue;
 use crate::backend::TreeValue;
 use crate::dag_walk;
+use crate::matchers::EverythingMatcher;
 use crate::merge::Diff;
 use crate::merge::Merge;
 use crate::merge::SameChange;
@@ -251,6 +252,230 @@ impl Stream for CopiesTreeDiffStream<'_> {
 
         Poll::Ready(None)
     }
+}
+
+/// Maps a path in the output tree to the paths in each term of the input
+/// merge. The length of the inner Merge should be the same as the input
+/// merge.
+pub type RenameMap = HashMap<RepoPathBuf, Merge<Option<RepoPathBuf>>>;
+
+/// Computes renames between the terms of a merge.
+///
+/// When merging multiple trees (e.g. in a conflict or a merge commit), files
+/// may have been renamed or copied differently on different sides. To perform
+/// a copy-aware merge, we need to align these paths so that we can merge their
+/// contents correctly.
+///
+/// This function calculates a `RenameMap`, which maps each path that should
+/// exist in the merged output (an "active" path) to its corresponding path in
+/// each of the input terms.
+///
+/// The input `merge` represents the merge state as a `MergedTree`, which
+/// contains a list of terms (positive and negative) alternating:
+/// `A - C + B - E + D ...` where `C`, `E` are bases (negative terms) and
+/// `A`, `B`, `D` are sides (positive terms).
+pub async fn compute_rename_map(merge: &MergedTree) -> BackendResult<RenameMap> {
+    let store = merge.store();
+    let tree_ids = merge.tree_ids();
+    let num_sides = tree_ids.num_sides();
+    if num_sides < 2 {
+        return Ok(RenameMap::default());
+    }
+    let num_terms = num_sides * 2 - 1;
+    let trees = tree_ids
+        .iter()
+        .map(|id| MergedTree::resolved(store.clone(), id.clone()))
+        .collect_vec();
+
+    let mut parents: HashMap<RepoPathBuf, RepoPathBuf> = HashMap::new();
+    fn find<'a>(
+        parents: &'a HashMap<RepoPathBuf, RepoPathBuf>,
+        mut curr: &'a RepoPathBuf,
+    ) -> &'a RepoPathBuf {
+        while let Some(next) = parents.get(curr) {
+            if next == curr {
+                break;
+            }
+            curr = next;
+        }
+        curr
+    }
+    fn union(parents: &mut HashMap<RepoPathBuf, RepoPathBuf>, a: &RepoPathBuf, b: &RepoPathBuf) {
+        let root_a = find(parents, a).clone();
+        let root_b = find(parents, b).clone();
+        if root_a != root_b {
+            parents.insert(root_a, root_b);
+        }
+    }
+
+    // We'll be scanning diffs between the different merge terms soon. We want to
+    // track:
+    // * every path mentioned in the diff, including copy/rename parents
+    // * whether a path with diffs is present in each merge term
+    // * whether a path with diffs was renamed from a parent in each merge term
+    let mut all_mentioned_paths: HashSet<RepoPathBuf> = HashSet::new();
+    let mut presence: Vec<HashSet<RepoPathBuf>> = vec![HashSet::new(); num_terms];
+    let mut renamed_from: Vec<HashSet<RepoPathBuf>> = vec![HashSet::new(); num_terms];
+
+    // We chain the terms to find relations. We compare each negative term (base)
+    // with its adjacent positive terms (sides).
+    // For example, in `A - C + B`, we compare `C` with `A` and `C` with `B`.
+    // This allows us to track renames/copies from `C` to `A` and `C` to `B`.
+    // We use a union-find structure (`parents`) to group all paths that are
+    // related through these transitions.
+    for i in 1..num_sides {
+        let before_idx = 2 * i - 1; // remove[i - 1]
+        let before_tree = trees[before_idx].clone();
+        // after_idx <- add[i - 1] THEN add[i]
+        for after_idx in [2 * i - 2, 2 * i] {
+            let mut stream =
+                before_tree.diff_stream_with_copy_history(&trees[after_idx], &EverythingMatcher);
+            while let Some(entry) = stream.next().await {
+                let diffs = match entry.diffs {
+                    Ok(diffs) => diffs,
+                    Err(BackendError::Unsupported(_)) => return Ok(RenameMap::default()),
+                    Err(err) => return Err(err),
+                };
+                for diffterm in &diffs {
+                    all_mentioned_paths.insert(entry.target_path.clone());
+                    if diffterm.target_value.is_some() {
+                        presence[after_idx].insert(entry.target_path.clone());
+                    }
+                    for (source, value) in &diffterm.sources {
+                        if !value.is_resolved() {
+                            continue;
+                        }
+                        match source {
+                            CopyHistorySource::Normal => {
+                                if value.is_present() {
+                                    presence[before_idx].insert(entry.target_path.clone());
+                                }
+                            }
+                            CopyHistorySource::Copy(p) => {
+                                union(&mut parents, p, &entry.target_path);
+                                all_mentioned_paths.insert(p.clone());
+                                if value.is_present() {
+                                    presence[before_idx].insert(p.clone());
+                                }
+                            }
+                            CopyHistorySource::Rename(p) => {
+                                union(&mut parents, p, &entry.target_path);
+                                all_mentioned_paths.insert(p.clone());
+                                if value.is_present() {
+                                    presence[before_idx].insert(p.clone());
+                                }
+                                renamed_from[after_idx].insert(p.clone());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if all_mentioned_paths.is_empty() {
+        return Ok(RenameMap::default());
+    }
+
+    // Fill in missing presence info
+    for (term, tree) in presence.iter_mut().zip(trees) {
+        for p in &all_mentioned_paths {
+            if !term.contains(p) && tree.path_value(p).await?.is_present() {
+                term.insert(p.clone());
+            }
+        }
+    }
+
+    // Count how many merge terms had this path as a rename target
+    let mut rename_counts: HashMap<RepoPathBuf, usize> = HashMap::new();
+    for rf_term in renamed_from {
+        for path in rf_term {
+            rename_counts
+                .entry(path)
+                .and_modify(|c| *c += 1)
+                .or_insert(1);
+        }
+    }
+
+    let mut groups: HashMap<RepoPathBuf, Vec<RepoPathBuf>> = HashMap::new();
+    for path in all_mentioned_paths.into_iter().sorted() {
+        let root = find(&parents, &path).clone();
+        groups.entry(root).or_default().push(path);
+    }
+
+    // Now we process each group of related paths.
+    // A path is "active" if it is present in at least one of the positive terms
+    // and was not a rename target in any transition. Active paths are the
+    // candidates for existing in the merged output.
+    //
+    // For each active path, we construct its history across all terms.
+    // If there are no divergent renames (i.e. a path renamed to multiple different
+    // targets on different sides), we can simply map the active path to the
+    // first present path in each term within its group.
+    //
+    // If there are divergent renames (e.g. `foo` renamed to `bar` on one side and
+    // `baz` on another), we must be more careful. We use the copy history to find
+    // the ancestors of the active path and use those ancestors to fill in the
+    // path for terms where the active path itself is not present. This ensures
+    // that changes to the source file (`foo`) are correctly propagated to both
+    // rename targets (`bar` and `baz`), leading to conflicts at both paths.
+    let is_active = |p: &RepoPathBuf| -> bool {
+        !rename_counts.contains_key(p) && (0..num_sides).any(|i| presence[2 * i].contains(p))
+    };
+
+    let mut result = RenameMap::default();
+    for group_paths in groups.into_values() {
+        if group_paths.len() <= 1 {
+            continue;
+        }
+
+        let mut term_present_paths = vec![vec![]; num_terms];
+        let mut active_ancestors = HashMap::new();
+        let has_divergent_rename = group_paths
+            .iter()
+            .any(|p| rename_counts.get(p).copied().unwrap_or(0) >= 2);
+
+        for p in &group_paths {
+            if has_divergent_rename && is_active(p) {
+                let ancestors = get_ancestor_paths(merge, &presence, p).await?;
+                active_ancestors.insert(p.clone(), ancestors);
+            } else {
+                for j in 0..num_terms {
+                    if presence[j].contains(p) {
+                        term_present_paths[j].push(p.clone());
+                    }
+                }
+            }
+        }
+
+        for p in &group_paths {
+            if is_active(p) {
+                let mut terms: Vec<Option<RepoPathBuf>> = Vec::with_capacity(num_terms);
+                for j in 0..num_terms {
+                    if presence[j].contains(p) {
+                        terms.push(Some(p.clone()));
+                    } else if has_divergent_rename {
+                        let ancestors = active_ancestors
+                            .get(p)
+                            .and_then(|ancestors| {
+                                ancestors
+                                    .iter()
+                                    .find(|ancestor| presence[j].contains(*ancestor))
+                            })
+                            .cloned();
+                        terms.push(ancestors);
+                    } else {
+                        terms.push(term_present_paths[j].first().cloned());
+                    }
+                }
+                result.insert(p.clone(), Merge::from_vec(terms));
+            } else {
+                result.insert(p.clone(), Merge::absent());
+            }
+        }
+    }
+
+    Ok(result)
 }
 
 /// Maps `CopyId`s to `CopyHistory`s
@@ -716,4 +941,59 @@ async fn find_diff_sources_from_copies(
         }
     }
     Ok(sources)
+}
+
+async fn get_ancestor_paths(
+    merge: &MergedTree,
+    presence: &[HashSet<RepoPathBuf>],
+    path: &RepoPath,
+) -> BackendResult<Vec<RepoPathBuf>> {
+    let store = merge.store();
+    let tree_ids = merge.tree_ids();
+    let trees = tree_ids
+        .iter()
+        .map(|id| MergedTree::resolved(store.clone(), id.clone()))
+        .collect_vec();
+
+    // Find the copy ID of the path in the first merge term where the path is
+    // present.
+    let Some((_, tree)) = presence
+        .iter()
+        .zip(&trees)
+        .find(|(term, _)| term.contains(path))
+    else {
+        return Ok(vec![]);
+    };
+    let Some(TreeValue::File { copy_id, .. }) =
+        tree.path_value(path).await?.into_resolved().ok().flatten()
+    else {
+        return Ok(vec![]);
+    };
+
+    if copy_id.is_placeholder() {
+        return Ok(vec![]);
+    }
+
+    let copy_graph: CopyGraph = store
+        .backend()
+        .get_related_copies(&copy_id)
+        .await?
+        .into_iter()
+        .map(|related| (related.id, related.history))
+        .collect();
+
+    // Find ancestor paths which are actually present in at least one merge term.
+    let mut ancestor_paths = vec![];
+    for ancestor_id in iterate_ancestors(&copy_graph, &copy_id) {
+        if ancestor_id == &copy_id {
+            continue;
+        }
+        for tree in &trees {
+            if tree.copy_value(ancestor_id).await?.is_some() {
+                ancestor_paths.push(copy_graph[ancestor_id].current_path.clone());
+                break;
+            }
+        }
+    }
+    Ok(ancestor_paths)
 }

--- a/lib/src/copies.rs
+++ b/lib/src/copies.rs
@@ -40,6 +40,7 @@ use crate::backend::CopyId;
 use crate::backend::CopyRecord;
 use crate::backend::TreeValue;
 use crate::dag_walk;
+use crate::matchers::EverythingMatcher;
 use crate::merge::Diff;
 use crate::merge::Merge;
 use crate::merge::MergedTreeValue;
@@ -239,6 +240,230 @@ impl Stream for CopiesTreeDiffStream<'_> {
 
         Poll::Ready(None)
     }
+}
+
+/// Maps a path in the output tree to the paths in each term of the input
+/// merge. The length of the inner Merge should be the same as the input
+/// merge.
+pub type RenameMap = HashMap<RepoPathBuf, Merge<Option<RepoPathBuf>>>;
+
+/// Computes renames between the terms of a merge.
+///
+/// When merging multiple trees (e.g. in a conflict or a merge commit), files
+/// may have been renamed or copied differently on different sides. To perform
+/// a copy-aware merge, we need to align these paths so that we can merge their
+/// contents correctly.
+///
+/// This function calculates a `RenameMap`, which maps each path that should
+/// exist in the merged output (an "active" path) to its corresponding path in
+/// each of the input terms.
+///
+/// The input `merge` represents the merge state as a `MergedTree`, which
+/// contains a list of terms (positive and negative) alternating:
+/// `A - C + B - E + D ...` where `C`, `E` are bases (negative terms) and
+/// `A`, `B`, `D` are sides (positive terms).
+pub async fn compute_rename_map(merge: &MergedTree) -> BackendResult<RenameMap> {
+    let store = merge.store();
+    let tree_ids = merge.tree_ids();
+    let num_sides = tree_ids.num_sides();
+    if num_sides < 2 {
+        return Ok(RenameMap::default());
+    }
+    let num_terms = num_sides * 2 - 1;
+    let trees = tree_ids
+        .iter()
+        .map(|id| MergedTree::resolved(store.clone(), id.clone()))
+        .collect_vec();
+
+    let mut parents: HashMap<RepoPathBuf, RepoPathBuf> = HashMap::new();
+    fn find<'a>(
+        parents: &'a HashMap<RepoPathBuf, RepoPathBuf>,
+        mut curr: &'a RepoPathBuf,
+    ) -> &'a RepoPathBuf {
+        while let Some(next) = parents.get(curr) {
+            if next == curr {
+                break;
+            }
+            curr = next;
+        }
+        curr
+    }
+    fn union(parents: &mut HashMap<RepoPathBuf, RepoPathBuf>, a: &RepoPathBuf, b: &RepoPathBuf) {
+        let root_a = find(parents, a).clone();
+        let root_b = find(parents, b).clone();
+        if root_a != root_b {
+            parents.insert(root_a, root_b);
+        }
+    }
+
+    // We'll be scanning diffs between the different merge terms soon. We want to
+    // track:
+    // * every path mentioned in the diff, including copy/rename parents
+    // * whether a path with diffs is present in each merge term
+    // * whether a path with diffs was renamed from a parent in each merge term
+    let mut all_mentioned_paths: HashSet<RepoPathBuf> = HashSet::new();
+    let mut presence: Vec<HashSet<RepoPathBuf>> = vec![HashSet::new(); num_terms];
+    let mut renamed_from: Vec<HashSet<RepoPathBuf>> = vec![HashSet::new(); num_terms];
+
+    // We chain the terms to find relations. We compare each negative term (base)
+    // with its adjacent positive terms (sides).
+    // For example, in `A - C + B`, we compare `C` with `A` and `C` with `B`.
+    // This allows us to track renames/copies from `C` to `A` and `C` to `B`.
+    // We use a union-find structure (`parents`) to group all paths that are
+    // related through these transitions.
+    for i in 1..num_sides {
+        let before_idx = 2 * i - 1; // remove[i - 1]
+        let before_tree = trees[before_idx].clone();
+        // after_idx <- add[i - 1] THEN add[i]
+        for after_idx in [2 * i - 2, 2 * i] {
+            let mut stream =
+                before_tree.diff_stream_with_copy_history(&trees[after_idx], &EverythingMatcher);
+            while let Some(entry) = stream.next().await {
+                let diffs = match entry.diffs {
+                    Ok(diffs) => diffs,
+                    Err(BackendError::Unsupported(_)) => return Ok(RenameMap::default()),
+                    Err(err) => return Err(err),
+                };
+                for diffterm in &diffs {
+                    all_mentioned_paths.insert(entry.target_path.clone());
+                    if diffterm.target_value.is_some() {
+                        presence[after_idx].insert(entry.target_path.clone());
+                    }
+                    for (source, value) in &diffterm.sources {
+                        if !value.is_resolved() {
+                            continue;
+                        }
+                        match source {
+                            CopyHistorySource::Normal => {
+                                if value.is_present() {
+                                    presence[before_idx].insert(entry.target_path.clone());
+                                }
+                            }
+                            CopyHistorySource::Copy(p) => {
+                                union(&mut parents, p, &entry.target_path);
+                                all_mentioned_paths.insert(p.clone());
+                                if value.is_present() {
+                                    presence[before_idx].insert(p.clone());
+                                }
+                            }
+                            CopyHistorySource::Rename(p) => {
+                                union(&mut parents, p, &entry.target_path);
+                                all_mentioned_paths.insert(p.clone());
+                                if value.is_present() {
+                                    presence[before_idx].insert(p.clone());
+                                }
+                                renamed_from[after_idx].insert(p.clone());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if all_mentioned_paths.is_empty() {
+        return Ok(RenameMap::default());
+    }
+
+    // Fill in missing presence info
+    for (term, tree) in presence.iter_mut().zip(trees) {
+        for p in &all_mentioned_paths {
+            if !term.contains(p) && tree.path_value(p).await?.is_present() {
+                term.insert(p.clone());
+            }
+        }
+    }
+
+    // Count how many merge terms had this path as a rename target
+    let mut rename_counts: HashMap<RepoPathBuf, usize> = HashMap::new();
+    for rf_term in renamed_from {
+        for path in rf_term {
+            rename_counts
+                .entry(path)
+                .and_modify(|c| *c += 1)
+                .or_insert(1);
+        }
+    }
+
+    let mut groups: HashMap<RepoPathBuf, Vec<RepoPathBuf>> = HashMap::new();
+    for path in all_mentioned_paths.into_iter().sorted() {
+        let root = find(&parents, &path).clone();
+        groups.entry(root).or_default().push(path);
+    }
+
+    // Now we process each group of related paths.
+    // A path is "active" if it is present in at least one of the positive terms
+    // and was not a rename target in any transition. Active paths are the
+    // candidates for existing in the merged output.
+    //
+    // For each active path, we construct its history across all terms.
+    // If there are no divergent renames (i.e. a path renamed to multiple different
+    // targets on different sides), we can simply map the active path to the
+    // first present path in each term within its group.
+    //
+    // If there are divergent renames (e.g. `foo` renamed to `bar` on one side and
+    // `baz` on another), we must be more careful. We use the copy history to find
+    // the ancestors of the active path and use those ancestors to fill in the
+    // path for terms where the active path itself is not present. This ensures
+    // that changes to the source file (`foo`) are correctly propagated to both
+    // rename targets (`bar` and `baz`), leading to conflicts at both paths.
+    let is_active = |p: &RepoPathBuf| -> bool {
+        !rename_counts.contains_key(p) && (0..num_sides).any(|i| presence[2 * i].contains(p))
+    };
+
+    let mut result = RenameMap::default();
+    for group_paths in groups.into_values() {
+        if group_paths.len() <= 1 {
+            continue;
+        }
+
+        let mut term_present_paths = vec![vec![]; num_terms];
+        let mut active_ancestors = HashMap::new();
+        let has_divergent_rename = group_paths
+            .iter()
+            .any(|p| rename_counts.get(p).copied().unwrap_or(0) >= 2);
+
+        for p in &group_paths {
+            if has_divergent_rename && is_active(p) {
+                let ancestors = get_ancestor_paths(merge, &presence, p).await?;
+                active_ancestors.insert(p.clone(), ancestors);
+            } else {
+                for j in 0..num_terms {
+                    if presence[j].contains(p) {
+                        term_present_paths[j].push(p.clone());
+                    }
+                }
+            }
+        }
+
+        for p in &group_paths {
+            if is_active(p) {
+                let mut terms: Vec<Option<RepoPathBuf>> = Vec::with_capacity(num_terms);
+                for j in 0..num_terms {
+                    if presence[j].contains(p) {
+                        terms.push(Some(p.clone()));
+                    } else if has_divergent_rename {
+                        let ancestors = active_ancestors
+                            .get(p)
+                            .and_then(|ancestors| {
+                                ancestors
+                                    .iter()
+                                    .find(|ancestor| presence[j].contains(*ancestor))
+                            })
+                            .cloned();
+                        terms.push(ancestors);
+                    } else {
+                        terms.push(term_present_paths[j].first().cloned());
+                    }
+                }
+                result.insert(p.clone(), Merge::from_vec(terms));
+            } else {
+                result.insert(p.clone(), Merge::absent());
+            }
+        }
+    }
+
+    Ok(result)
 }
 
 /// Maps `CopyId`s to `CopyHistory`s
@@ -704,4 +929,59 @@ async fn find_diff_sources_from_copies(
         }
     }
     Ok(sources)
+}
+
+async fn get_ancestor_paths(
+    merge: &MergedTree,
+    presence: &[HashSet<RepoPathBuf>],
+    path: &RepoPath,
+) -> BackendResult<Vec<RepoPathBuf>> {
+    let store = merge.store();
+    let tree_ids = merge.tree_ids();
+    let trees = tree_ids
+        .iter()
+        .map(|id| MergedTree::resolved(store.clone(), id.clone()))
+        .collect_vec();
+
+    // Find the copy ID of the path in the first merge term where the path is
+    // present.
+    let Some((_, tree)) = presence
+        .iter()
+        .zip(&trees)
+        .find(|(term, _)| term.contains(path))
+    else {
+        return Ok(vec![]);
+    };
+    let Some(TreeValue::File { copy_id, .. }) =
+        tree.path_value(path).await?.into_resolved().ok().flatten()
+    else {
+        return Ok(vec![]);
+    };
+
+    if copy_id.is_placeholder() {
+        return Ok(vec![]);
+    }
+
+    let copy_graph: CopyGraph = store
+        .backend()
+        .get_related_copies(&copy_id)
+        .await?
+        .into_iter()
+        .map(|related| (related.id, related.history))
+        .collect();
+
+    // Find ancestor paths which are actually present in at least one merge term.
+    let mut ancestor_paths = vec![];
+    for ancestor_id in iterate_ancestors(&copy_graph, &copy_id) {
+        if ancestor_id == &copy_id {
+            continue;
+        }
+        for tree in &trees {
+            if tree.copy_value(ancestor_id).await?.is_some() {
+                ancestor_paths.push(copy_graph[ancestor_id].current_path.clone());
+                break;
+            }
+        }
+    }
+    Ok(ancestor_paths)
 }

--- a/lib/src/copies.rs
+++ b/lib/src/copies.rs
@@ -50,6 +50,7 @@ use crate::merged_tree::TreeDiffEntry;
 use crate::merged_tree::TreeDiffStream;
 use crate::repo_path::RepoPath;
 use crate::repo_path::RepoPathBuf;
+use crate::store::Store;
 
 /// A collection of CopyRecords.
 #[derive(Default, Debug)]
@@ -984,4 +985,86 @@ async fn get_ancestor_paths(
         }
     }
     Ok(ancestor_paths)
+}
+
+/// Merges conflicting `CopyId`s by finding DAG heads and writing a new
+/// `CopyHistory` if there are multiple heads.
+///
+/// If there is a `CopyId` that matches the current `path`, it is preferred.
+///
+/// When merging branches that have copy/rename history, a file might end up
+/// with multiple different `CopyId`s (e.g. because it was copied from different
+/// sources or has divergent history). To represent this merged history in the
+/// snapshot, we merge the `CopyId`s.
+///
+/// If one `CopyId` is a descendant of all others in the copy history DAG, it
+/// already contains the full history, so we can use it.
+/// If there are multiple independent heads in the history, we create a new
+/// `CopyHistory` node that lists all these heads as parents, effectively
+/// merging the history DAG.
+pub async fn merge_copy_ids(
+    store: &Store,
+    path: &RepoPath,
+    copy_id_merge: &Merge<Option<CopyId>>,
+) -> BackendResult<CopyId> {
+    let adds: HashSet<&CopyId> = copy_id_merge.adds().flatten().collect();
+    if adds.is_empty() {
+        return Err(BackendError::Other("Empty copy id merge".into()));
+    }
+    if adds.len() == 1 {
+        return Ok((*adds.iter().next().unwrap()).clone());
+    }
+
+    let mut copy_graph = CopyGraph::new();
+    // NOTE: this loop creates a CopyGraph that does not necessarily follow the rule
+    // that related copies are ordered with children before parents.
+    for id in &adds {
+        copy_graph.extend(
+            store
+                .backend()
+                .get_related_copies(id)
+                .await?
+                .into_iter()
+                .map(|related| (related.id, related.history)),
+        );
+    }
+
+    let matching_paths: Vec<&CopyId> = adds
+        .iter()
+        .filter(|id| {
+            copy_graph
+                .get(**id)
+                .is_some_and(|h| h.current_path.as_ref() == path)
+        })
+        .copied()
+        .collect();
+    if matching_paths.len() == 1 {
+        return Ok(matching_paths[0].clone());
+    }
+
+    let heads = dag_walk::heads(
+        adds.iter().copied(),
+        |id| *id,
+        |id| {
+            copy_graph
+                .get(*id)
+                .map_or(&[] as &[_], |h| &h.parents)
+                .iter()
+        },
+    );
+
+    if heads.len() == 1 {
+        return Ok((*heads.iter().next().unwrap()).clone());
+    }
+
+    let sorted_heads = heads.into_iter().cloned().sorted().collect_vec();
+
+    let new_history = CopyHistory {
+        current_path: path.to_owned(),
+        parents: sorted_heads,
+        salt: vec![],
+    };
+
+    let new_id = store.backend().write_copy(&new_history).await?;
+    Ok(new_id)
 }

--- a/lib/src/copies.rs
+++ b/lib/src/copies.rs
@@ -528,6 +528,12 @@ async fn diffs_from_copies(
     let copy_id = after_file.copy_id().ok_or(BackendError::Other(
         "Expected TreeValue::File with a CopyId".into(),
     ))?;
+    if copy_id.is_placeholder() {
+        return Ok(Merge::resolved(CopyHistoryDiffTerm {
+            target_value: Some(after_file),
+            sources: vec![],
+        }));
+    }
     let copy_graph: CopyGraph = before_tree
         .store()
         .backend()

--- a/lib/src/merge.rs
+++ b/lib/src/merge.rs
@@ -423,6 +423,19 @@ impl<T> Merge<T> {
         self.apply_simplified_mapping(&mapping)
     }
 
+    /// Simplify this merge and another merge together, using the other merge's
+    /// values to determine the simplification mapping.
+    pub fn simplify_with<U: PartialEq + Clone>(&self, other: &Merge<U>) -> (Self, Merge<U>)
+    where
+        T: Clone,
+    {
+        let mapping = other.get_simplified_mapping();
+        (
+            self.apply_simplified_mapping(&mapping),
+            other.apply_simplified_mapping(&mapping),
+        )
+    }
+
     /// Updates the merge based on the given simplified merge.
     pub fn update_from_simplified(mut self, simplified: Self) -> Self
     where

--- a/lib/src/merge.rs
+++ b/lib/src/merge.rs
@@ -435,6 +435,19 @@ impl<T> Merge<T> {
         self.apply_simplified_mapping(&mapping)
     }
 
+    /// Simplify this merge and another merge together, using the other merge's
+    /// values to determine the simplification mapping.
+    pub fn simplify_with<U: PartialEq + Clone>(&self, other: &Merge<U>) -> (Self, Merge<U>)
+    where
+        T: Clone,
+    {
+        let mapping = other.get_simplified_mapping();
+        (
+            self.apply_simplified_mapping(&mapping),
+            other.apply_simplified_mapping(&mapping),
+        )
+    }
+
     /// Updates the merge based on the given simplified merge.
     pub fn update_from_simplified(mut self, simplified: Self) -> Self
     where

--- a/lib/src/merged_tree.rs
+++ b/lib/src/merged_tree.rs
@@ -165,6 +165,9 @@ impl MergedTree {
     /// Tries to resolve any conflicts, resolving any conflicts that can be
     /// automatically resolved and leaving the rest unresolved.
     pub async fn resolve(self) -> BackendResult<Self> {
+        // TODO REVIEW: should we also pass in the conflict labels here? If so, should
+        // we just make merge_trees a method of MergedTree? It's not used
+        // anywhere else.
         let merged = merge_trees(&self.store, self.tree_ids).await?;
         // If the result can be resolved, then `merge_trees()` above would have returned
         // a resolved merge. However, that function will always preserve the arity of

--- a/lib/src/tree_merge.rs
+++ b/lib/src/tree_merge.rs
@@ -28,6 +28,7 @@ use futures::future::BoxFuture;
 use futures::future::try_join_all;
 use futures::stream::FuturesUnordered;
 use itertools::Itertools as _;
+use pollster::FutureExt as _;
 
 use crate::backend;
 use crate::backend::BackendError;
@@ -37,10 +38,14 @@ use crate::backend::MergedTreeValue;
 use crate::backend::TreeId;
 use crate::backend::TreeValue;
 use crate::config::ConfigGetError;
+use crate::conflict_labels::ConflictLabels;
+use crate::copies::RenameMap;
+use crate::copies::compute_rename_map;
 use crate::files;
 use crate::files::FileMergeHunkLevel;
 use crate::merge::Merge;
 use crate::merge::SameChange;
+use crate::merged_tree::MergedTree;
 use crate::merged_tree::all_merged_tree_entries;
 use crate::object_id::ObjectId as _;
 use crate::repo_path::RepoPath;
@@ -79,11 +84,17 @@ pub async fn merge_trees(store: &Arc<Store>, merge: Merge<TreeId>) -> BackendRes
         Err(merge) => merge,
     };
 
+    let root_merged_tree =
+        MergedTree::new(store.clone(), merge.clone(), ConflictLabels::unlabeled());
+    let rename_map = compute_rename_map(&root_merged_tree).await?;
+
     let mut merger = TreeMerger {
         store: store.clone(),
+        root_merge: root_merged_tree,
         trees_to_resolve: BTreeMap::new(),
         work: FuturesUnordered::new(),
         unstarted_work: BTreeMap::new(),
+        rename_map,
     };
     merger.enqueue_tree_read(
         RepoPathBuf::root(),
@@ -195,12 +206,15 @@ enum TreeMergeWorkItemKey {
 
 struct TreeMerger {
     store: Arc<Store>,
+    // The original trees in the merge, used for pulling values from arbitrary paths.
+    root_merge: MergedTree,
     // Trees we're currently working on.
     trees_to_resolve: BTreeMap<RepoPathBuf, MergedTreeInput>,
     // Futures we're currently processing. In order to respect the backend's concurrency limit.
     work: FuturesUnordered<BoxFuture<'static, TreeMergerWorkOutput>>,
     // Futures we haven't started polling yet, in order to respect the backend's concurrency limit.
     unstarted_work: BTreeMap<TreeMergeWorkItemKey, BoxFuture<'static, TreeMergerWorkOutput>>,
+    rename_map: RenameMap,
 }
 
 impl TreeMerger {
@@ -248,15 +262,80 @@ impl TreeMerger {
         // First resolve trivial merges (those that we don't need to load any more data
         // for)
         let same_change = self.store.merge_options().same_change;
+
+        // Find all basenames that belong in this directory according to the rename map.
+        let mut basenames: HashSet<RepoPathComponentBuf> = HashSet::new();
+        for target_path in self.rename_map.keys() {
+            if let Some((parent, basename)) = target_path.split()
+                && parent == dir.as_ref()
+            {
+                basenames.insert(basename.to_owned());
+            }
+        }
+
+        // Also include basenames present in the physical trees (in case they are not in
+        // rename_map).
+        for (basename, _) in all_merged_tree_entries(&tree) {
+            basenames.insert(basename.to_owned());
+        }
+
         let mut resolved = vec![];
         let mut non_trivial = vec![];
-        for (basename, path_merge) in all_merged_tree_entries(&tree) {
-            if let Some(value) = path_merge.resolve_trivial(same_change) {
-                if let Some(value) = value.cloned() {
-                    resolved.push((basename.to_owned(), value));
+
+        for basename in basenames.into_iter().sorted() {
+            let path = dir.join(&basename);
+
+            // Pull values for this path using the rename map.
+            let (path_merge, source_paths) = if let Some(term_paths) = self.rename_map.get(&path) {
+                use crate::merge::MergeBuilder;
+                let store = self.root_merge.store();
+                let tree_ids = self.root_merge.tree_ids();
+                let zipped = zip(term_paths.iter(), tree_ids.iter())
+                    .map(|(opt_source_path, tree_id)| {
+                        let value = if let Some(source_path) = opt_source_path {
+                            let root_tree = MergedTree::resolved(store.clone(), tree_id.clone());
+                            root_tree.path_value(source_path).block_on().unwrap()
+                        } else {
+                            MergedTreeValue::absent()
+                        };
+                        (value, Merge::resolved(opt_source_path.clone()))
+                    })
+                    .collect::<Vec<_>>();
+                let (path_merges, source_paths): (Vec<_>, Vec<_>) = zipped.into_iter().unzip();
+                let path_merge = path_merges
+                    .into_iter()
+                    .collect::<MergeBuilder<_>>()
+                    .build()
+                    .flatten();
+                let source_paths = source_paths
+                    .into_iter()
+                    .collect::<MergeBuilder<_>>()
+                    .build()
+                    .flatten();
+                (path_merge, source_paths)
+            } else {
+                let path_merge = tree.value(&basename).cloned();
+                let source_paths = Merge::repeated(Some(path.clone()), tree.num_sides());
+                (path_merge, source_paths)
+            };
+
+            let is_rename = source_paths
+                .iter()
+                .any(|opt_path| opt_path.as_ref().is_some_and(|p| p != &path));
+            let has_rename_descendant = self
+                .rename_map
+                .keys()
+                .any(|target_path| target_path.starts_with(&path) && target_path != &path);
+
+            if !is_rename
+                && !has_rename_descendant
+                && let Some(value) = path_merge.resolve_trivial(same_change)
+            {
+                if let Some(value) = value.as_ref() {
+                    resolved.push((basename, value.clone()));
                 }
             } else {
-                non_trivial.push((basename.to_owned(), path_merge.cloned()));
+                non_trivial.push((basename, path_merge, source_paths));
             }
         }
 
@@ -268,7 +347,7 @@ impl TreeMerger {
         }
 
         let mut unmerged_tree = MergedTreeInput::new(resolved.into_iter().collect());
-        for (basename, value) in non_trivial {
+        for (basename, value, source_paths) in non_trivial {
             let path = dir.join(&basename);
             unmerged_tree.pending_lookup.insert(basename);
             if value.is_tree() {
@@ -277,7 +356,7 @@ impl TreeMerger {
                 // TODO: If it's e.g. a dir/file conflict, there's no need to try to
                 // resolve it as a file. We should mark them to
                 // `unmerged_tree.conflicts` instead.
-                self.enqueue_file_merge(path, value);
+                self.enqueue_file_merge(path, value, source_paths);
             }
         }
 
@@ -303,10 +382,16 @@ impl TreeMerger {
         self.work.push(Box::pin(work_fut));
     }
 
-    fn enqueue_file_merge(&mut self, path: RepoPathBuf, value: MergedTreeValue) {
+    fn enqueue_file_merge(
+        &mut self,
+        path: RepoPathBuf,
+        value: MergedTreeValue,
+        source_paths: Merge<Option<RepoPathBuf>>,
+    ) {
         let key = TreeMergeWorkItemKey::MergeFiles { path: path.clone() };
-        let work_fut = resolve_file_values_owned(self.store.clone(), path.clone(), value)
-            .map(|result| TreeMergerWorkOutput::MergedFiles { path, result });
+        let work_fut =
+            resolve_file_values_owned(self.store.clone(), path.clone(), value, source_paths)
+                .map(|result| TreeMergerWorkOutput::MergedFiles { path, result });
         if self.work.len() < self.store.concurrency() {
             self.work.push(Box::pin(work_fut));
         } else {
@@ -360,9 +445,9 @@ async fn resolve_file_values_owned(
     store: Arc<Store>,
     path: RepoPathBuf,
     values: MergedTreeValue,
+    source_paths: Merge<Option<RepoPathBuf>>,
 ) -> BackendResult<MergedTreeValue> {
-    let maybe_resolved = try_resolve_file_values(&store, &path, &values).await?;
-    Ok(maybe_resolved.unwrap_or(values))
+    resolve_file_values_with_sources(&store, &path, values, source_paths).await
 }
 
 /// Tries to resolve file conflicts by merging the file contents. Treats missing
@@ -373,12 +458,43 @@ pub async fn resolve_file_values(
     path: &RepoPath,
     values: MergedTreeValue,
 ) -> BackendResult<MergedTreeValue> {
+    let source_paths = Merge::repeated(Some(path.to_owned()), values.num_sides());
+    resolve_file_values_with_sources(store, path, values, source_paths).await
+}
+
+/// Tries to resolve file conflicts by merging the file contents. Treats missing
+/// files as empty. If the file conflict cannot be resolved, returns the passed
+/// `values` unmodified.
+pub async fn resolve_file_values_with_sources(
+    store: &Arc<Store>,
+    path: &RepoPath,
+    values: MergedTreeValue,
+    source_paths: Merge<Option<RepoPathBuf>>,
+) -> BackendResult<MergedTreeValue> {
     let same_change = store.merge_options().same_change;
     if let Some(resolved) = values.resolve_trivial(same_change) {
+        if let Some(TreeValue::File { id, .. }) = resolved {
+            ensure_file_at_path(
+                store,
+                id,
+                path,
+                &source_paths,
+                &values.map(|opt| opt.as_ref()),
+            )
+            .await?;
+        }
         return Ok(Merge::resolved(resolved.clone()));
     }
 
-    let maybe_resolved = try_resolve_file_values(store, path, &values).await?;
+    let maybe_resolved = try_resolve_file_values(store, path, &values, &source_paths).await?;
+    if maybe_resolved.is_none() {
+        let values_ref = values.map(|opt| opt.as_ref());
+        for opt_val in &values {
+            if let Some(TreeValue::File { id, .. }) = opt_val {
+                ensure_file_at_path(store, id, path, &source_paths, &values_ref).await?;
+            }
+        }
+    }
     Ok(maybe_resolved.unwrap_or(values))
 }
 
@@ -386,15 +502,16 @@ async fn try_resolve_file_values<T: Borrow<TreeValue>>(
     store: &Arc<Store>,
     path: &RepoPath,
     values: &Merge<Option<T>>,
+    source_paths: &Merge<Option<RepoPathBuf>>,
 ) -> BackendResult<Option<MergedTreeValue>> {
-    // The values may contain trees canceling each other (notably padded absent
-    // trees), so we need to simplify them first.
-    let simplified = values
-        .map(|value| value.as_ref().map(Borrow::borrow))
-        .simplify();
+    let values_borrowed = values.map(|value| value.as_ref().map(Borrow::borrow));
+    let (simplified_source_paths, simplified_values) = source_paths.simplify_with(&values_borrowed);
+
     // No fast path for simplified.is_resolved(). If it could be resolved, it would
     // have been caught by values.resolve_trivial() above.
-    if let Some(resolved) = try_resolve_file_conflict(store, path, &simplified).await? {
+    if let Some(resolved) =
+        try_resolve_file_conflict(store, path, &simplified_values, &simplified_source_paths).await?
+    {
         Ok(Some(Merge::normal(resolved)))
     } else {
         // Failed to merge the files, or the paths are not files
@@ -410,55 +527,36 @@ async fn try_resolve_file_conflict(
     store: &Store,
     filename: &RepoPath,
     conflict: &MergedTreeVal<'_>,
+    source_paths: &Merge<Option<RepoPathBuf>>,
 ) -> BackendResult<Option<TreeValue>> {
     let options = store.merge_options();
-    // If there are any non-file or any missing parts in the conflict, we can't
-    // merge it. We check early so we don't waste time reading file contents if
-    // we can't merge them anyway. At the same time we determine whether the
-    // resulting file should be executable.
-    let Ok(file_id_conflict) = conflict.try_map(|term| match term {
-        Some(TreeValue::File {
-            id,
-            executable: _,
-            copy_id: _,
-        }) => Ok(id),
-        _ => Err(()),
-    }) else {
+    let Some(file_id_conflict) = conflict.to_file_merge() else {
         return Ok(None);
     };
-    let Ok(executable_conflict) = conflict.try_map(|term| match term {
-        Some(TreeValue::File {
-            id: _,
-            executable,
-            copy_id: _,
-        }) => Ok(executable),
-        _ => Err(()),
-    }) else {
+    let Some(executable_conflict) = conflict.to_executable_merge() else {
         return Ok(None);
     };
-    let Ok(copy_id_conflict) = conflict.try_map(|term| match term {
-        Some(TreeValue::File {
-            id: _,
-            executable: _,
-            copy_id,
-        }) => Ok(copy_id),
-        _ => Err(()),
-    }) else {
+    let Some(copy_id_conflict) = conflict.to_copy_id_merge() else {
         return Ok(None);
     };
     // TODO: Whether to respect options.same_change to merge executable and
     // copy_id? Should also update conflicts::resolve_file_executable().
-    let Some(&&executable) = executable_conflict.resolve_trivial(SameChange::Accept) else {
+    let Some(executable) = crate::conflicts::resolve_file_executable(&executable_conflict) else {
         // We're unable to determine whether the result should be executable
         return Ok(None);
     };
-    let Some(&copy_id) = copy_id_conflict.resolve_trivial(SameChange::Accept) else {
-        // We're unable to determine the file's copy ID
-        return Ok(None);
+    let copy_id = match copy_id_conflict.resolve_trivial(SameChange::Accept) {
+        Some(Some(copy_id)) => copy_id.clone(),
+        Some(None) => return Ok(None),
+        None => crate::copies::merge_copy_ids(store, filename, &copy_id_conflict).await?,
     };
-    if let Some(&resolved_file_id) = file_id_conflict.resolve_trivial(options.same_change) {
+    if let Some(resolved_file_id) = file_id_conflict.resolve_trivial(options.same_change) {
+        let Some(resolved_file_id) = resolved_file_id else {
+            return Ok(None);
+        };
         // Don't bother reading the file contents if the conflict can be trivially
         // resolved.
+        ensure_file_at_path(store, resolved_file_id, filename, source_paths, conflict).await?;
         return Ok(Some(TreeValue::File {
             id: resolved_file_id.clone(),
             executable,
@@ -472,20 +570,24 @@ async fn try_resolve_file_conflict(
     // 1. Avoid reading unchanged file contents
     // 2. The simplified conflict can sometimes be resolved when the unsimplfied one
     //    cannot
-    let file_id_conflict = file_id_conflict.simplify();
+    let (simplified_source_paths, file_id_conflict) = source_paths.simplify_with(&file_id_conflict);
 
-    let contents = file_id_conflict
-        .try_map_async(async |file_id| {
+    let zipped = file_id_conflict.clone().zip(simplified_source_paths);
+    let contents = zipped
+        .try_map_async(async |(opt_file_id, opt_source_path)| {
             let mut content = vec![];
-            let mut reader = store.read_file(filename, file_id).await?;
-            reader
-                .read_to_end(&mut content)
-                .await
-                .map_err(|err| BackendError::ReadObject {
-                    object_type: file_id.object_type(),
-                    hash: file_id.hex(),
-                    source: err.into(),
-                })?;
+            if let Some(file_id) = opt_file_id {
+                let source_path: &RepoPath = opt_source_path.as_deref().unwrap_or(filename);
+                let mut reader = store.read_file(source_path, file_id).await?;
+                reader
+                    .read_to_end(&mut content)
+                    .await
+                    .map_err(|err| BackendError::ReadObject {
+                        object_type: file_id.object_type(),
+                        hash: file_id.hex(),
+                        source: err.into(),
+                    })?;
+            }
             BackendResult::Ok(content)
         })
         .await?;
@@ -501,4 +603,35 @@ async fn try_resolve_file_conflict(
     } else {
         Ok(None)
     }
+}
+
+async fn ensure_file_at_path(
+    store: &Store,
+    id: &backend::FileId,
+    target_path: &RepoPath,
+    source_paths: &Merge<Option<RepoPathBuf>>,
+    values: &Merge<Option<&TreeValue>>,
+) -> BackendResult<()> {
+    let mut already_at_target = false;
+    let mut source_to_copy = None;
+
+    for (opt_val, opt_src_path) in zip(values.iter(), source_paths.iter()) {
+        if let Some(TreeValue::File { id: val_id, .. }) = opt_val
+            && val_id == id
+            && let Some(src_path) = opt_src_path
+        {
+            if src_path.as_ref() == target_path {
+                already_at_target = true;
+                break;
+            } else {
+                source_to_copy = Some(src_path);
+            }
+        }
+    }
+
+    if !already_at_target && let Some(source_path) = source_to_copy {
+        let mut reader = store.read_file(source_path, id).await?;
+        store.write_file(target_path, &mut reader).await?;
+    }
+    Ok(())
 }

--- a/lib/src/tree_merge.rs
+++ b/lib/src/tree_merge.rs
@@ -28,6 +28,7 @@ use futures::future::BoxFuture;
 use futures::future::try_join_all;
 use futures::stream::FuturesUnordered;
 use itertools::Itertools as _;
+use pollster::FutureExt as _;
 
 use crate::backend;
 use crate::backend::BackendError;
@@ -35,12 +36,16 @@ use crate::backend::BackendResult;
 use crate::backend::TreeId;
 use crate::backend::TreeValue;
 use crate::config::ConfigGetError;
+use crate::conflict_labels::ConflictLabels;
+use crate::copies::RenameMap;
+use crate::copies::compute_rename_map;
 use crate::files;
 use crate::files::FileMergeHunkLevel;
 use crate::merge::Merge;
 use crate::merge::MergedTreeVal;
 use crate::merge::MergedTreeValue;
 use crate::merge::SameChange;
+use crate::merged_tree::MergedTree;
 use crate::merged_tree::all_merged_tree_entries;
 use crate::object_id::ObjectId as _;
 use crate::repo_path::RepoPath;
@@ -79,11 +84,17 @@ pub async fn merge_trees(store: &Arc<Store>, merge: Merge<TreeId>) -> BackendRes
         Err(merge) => merge,
     };
 
+    let root_merged_tree =
+        MergedTree::new(store.clone(), merge.clone(), ConflictLabels::unlabeled());
+    let rename_map = compute_rename_map(&root_merged_tree).await?;
+
     let mut merger = TreeMerger {
         store: store.clone(),
+        root_merge: root_merged_tree,
         trees_to_resolve: BTreeMap::new(),
         work: FuturesUnordered::new(),
         unstarted_work: BTreeMap::new(),
+        rename_map,
     };
     merger.enqueue_tree_read(
         RepoPathBuf::root(),
@@ -195,12 +206,15 @@ enum TreeMergeWorkItemKey {
 
 struct TreeMerger {
     store: Arc<Store>,
+    // The original trees in the merge, used for pulling values from arbitrary paths.
+    root_merge: MergedTree,
     // Trees we're currently working on.
     trees_to_resolve: BTreeMap<RepoPathBuf, MergedTreeInput>,
     // Futures we're currently processing. In order to respect the backend's concurrency limit.
     work: FuturesUnordered<BoxFuture<'static, TreeMergerWorkOutput>>,
     // Futures we haven't started polling yet, in order to respect the backend's concurrency limit.
     unstarted_work: BTreeMap<TreeMergeWorkItemKey, BoxFuture<'static, TreeMergerWorkOutput>>,
+    rename_map: RenameMap,
 }
 
 impl TreeMerger {
@@ -248,15 +262,80 @@ impl TreeMerger {
         // First resolve trivial merges (those that we don't need to load any more data
         // for)
         let same_change = self.store.merge_options().same_change;
+
+        // Find all basenames that belong in this directory according to the rename map.
+        let mut basenames: HashSet<RepoPathComponentBuf> = HashSet::new();
+        for target_path in self.rename_map.keys() {
+            if let Some((parent, basename)) = target_path.split()
+                && parent == dir.as_ref()
+            {
+                basenames.insert(basename.to_owned());
+            }
+        }
+
+        // Also include basenames present in the physical trees (in case they are not in
+        // rename_map).
+        for (basename, _) in all_merged_tree_entries(&tree) {
+            basenames.insert(basename.to_owned());
+        }
+
         let mut resolved = vec![];
         let mut non_trivial = vec![];
-        for (basename, path_merge) in all_merged_tree_entries(&tree) {
-            if let Some(value) = path_merge.resolve_trivial(same_change) {
-                if let Some(value) = value.cloned() {
-                    resolved.push((basename.to_owned(), value));
+
+        for basename in basenames.into_iter().sorted() {
+            let path = dir.join(&basename);
+
+            // Pull values for this path using the rename map.
+            let (path_merge, source_paths) = if let Some(term_paths) = self.rename_map.get(&path) {
+                use crate::merge::MergeBuilder;
+                let store = self.root_merge.store();
+                let tree_ids = self.root_merge.tree_ids();
+                let zipped = zip(term_paths.iter(), tree_ids.iter())
+                    .map(|(opt_source_path, tree_id)| {
+                        let value = if let Some(source_path) = opt_source_path {
+                            let root_tree = MergedTree::resolved(store.clone(), tree_id.clone());
+                            root_tree.path_value(source_path).block_on().unwrap()
+                        } else {
+                            MergedTreeValue::absent()
+                        };
+                        (value, Merge::resolved(opt_source_path.clone()))
+                    })
+                    .collect::<Vec<_>>();
+                let (path_merges, source_paths): (Vec<_>, Vec<_>) = zipped.into_iter().unzip();
+                let path_merge = path_merges
+                    .into_iter()
+                    .collect::<MergeBuilder<_>>()
+                    .build()
+                    .flatten();
+                let source_paths = source_paths
+                    .into_iter()
+                    .collect::<MergeBuilder<_>>()
+                    .build()
+                    .flatten();
+                (path_merge, source_paths)
+            } else {
+                let path_merge = tree.value(&basename).cloned();
+                let source_paths = Merge::repeated(Some(path.clone()), tree.num_sides());
+                (path_merge, source_paths)
+            };
+
+            let is_rename = source_paths
+                .iter()
+                .any(|opt_path| opt_path.as_ref().is_some_and(|p| p != &path));
+            let has_rename_descendant = self
+                .rename_map
+                .keys()
+                .any(|target_path| target_path.starts_with(&path) && target_path != &path);
+
+            if !is_rename
+                && !has_rename_descendant
+                && let Some(value) = path_merge.resolve_trivial(same_change)
+            {
+                if let Some(value) = value.as_ref() {
+                    resolved.push((basename, value.clone()));
                 }
             } else {
-                non_trivial.push((basename.to_owned(), path_merge.cloned()));
+                non_trivial.push((basename, path_merge, source_paths));
             }
         }
 
@@ -268,7 +347,7 @@ impl TreeMerger {
         }
 
         let mut unmerged_tree = MergedTreeInput::new(resolved.into_iter().collect());
-        for (basename, value) in non_trivial {
+        for (basename, value, source_paths) in non_trivial {
             let path = dir.join(&basename);
             unmerged_tree.pending_lookup.insert(basename);
             if value.is_tree() {
@@ -277,7 +356,7 @@ impl TreeMerger {
                 // TODO: If it's e.g. a dir/file conflict, there's no need to try to
                 // resolve it as a file. We should mark them to
                 // `unmerged_tree.conflicts` instead.
-                self.enqueue_file_merge(path, value);
+                self.enqueue_file_merge(path, value, source_paths);
             }
         }
 
@@ -303,10 +382,16 @@ impl TreeMerger {
         self.work.push(Box::pin(work_fut));
     }
 
-    fn enqueue_file_merge(&mut self, path: RepoPathBuf, value: MergedTreeValue) {
+    fn enqueue_file_merge(
+        &mut self,
+        path: RepoPathBuf,
+        value: MergedTreeValue,
+        source_paths: Merge<Option<RepoPathBuf>>,
+    ) {
         let key = TreeMergeWorkItemKey::MergeFiles { path: path.clone() };
-        let work_fut = resolve_file_values_owned(self.store.clone(), path.clone(), value)
-            .map(|result| TreeMergerWorkOutput::MergedFiles { path, result });
+        let work_fut =
+            resolve_file_values_owned(self.store.clone(), path.clone(), value, source_paths)
+                .map(|result| TreeMergerWorkOutput::MergedFiles { path, result });
         if self.work.len() < self.store.concurrency() {
             self.work.push(Box::pin(work_fut));
         } else {
@@ -360,9 +445,9 @@ async fn resolve_file_values_owned(
     store: Arc<Store>,
     path: RepoPathBuf,
     values: MergedTreeValue,
+    source_paths: Merge<Option<RepoPathBuf>>,
 ) -> BackendResult<MergedTreeValue> {
-    let maybe_resolved = try_resolve_file_values(&store, &path, &values).await?;
-    Ok(maybe_resolved.unwrap_or(values))
+    resolve_file_values_with_sources(&store, &path, values, source_paths).await
 }
 
 /// Tries to resolve file conflicts by merging the file contents. Treats missing
@@ -373,12 +458,43 @@ pub async fn resolve_file_values(
     path: &RepoPath,
     values: MergedTreeValue,
 ) -> BackendResult<MergedTreeValue> {
+    let source_paths = Merge::repeated(Some(path.to_owned()), values.num_sides());
+    resolve_file_values_with_sources(store, path, values, source_paths).await
+}
+
+/// Tries to resolve file conflicts by merging the file contents. Treats missing
+/// files as empty. If the file conflict cannot be resolved, returns the passed
+/// `values` unmodified.
+pub async fn resolve_file_values_with_sources(
+    store: &Arc<Store>,
+    path: &RepoPath,
+    values: MergedTreeValue,
+    source_paths: Merge<Option<RepoPathBuf>>,
+) -> BackendResult<MergedTreeValue> {
     let same_change = store.merge_options().same_change;
     if let Some(resolved) = values.resolve_trivial(same_change) {
+        if let Some(TreeValue::File { id, .. }) = resolved {
+            ensure_file_at_path(
+                store,
+                id,
+                path,
+                &source_paths,
+                &values.map(|opt| opt.as_ref()),
+            )
+            .await?;
+        }
         return Ok(Merge::resolved(resolved.clone()));
     }
 
-    let maybe_resolved = try_resolve_file_values(store, path, &values).await?;
+    let maybe_resolved = try_resolve_file_values(store, path, &values, &source_paths).await?;
+    if maybe_resolved.is_none() {
+        let values_ref = values.map(|opt| opt.as_ref());
+        for opt_val in &values {
+            if let Some(TreeValue::File { id, .. }) = opt_val {
+                ensure_file_at_path(store, id, path, &source_paths, &values_ref).await?;
+            }
+        }
+    }
     Ok(maybe_resolved.unwrap_or(values))
 }
 
@@ -386,15 +502,16 @@ async fn try_resolve_file_values<T: Borrow<TreeValue>>(
     store: &Arc<Store>,
     path: &RepoPath,
     values: &Merge<Option<T>>,
+    source_paths: &Merge<Option<RepoPathBuf>>,
 ) -> BackendResult<Option<MergedTreeValue>> {
-    // The values may contain trees canceling each other (notably padded absent
-    // trees), so we need to simplify them first.
-    let simplified = values
-        .map(|value| value.as_ref().map(Borrow::borrow))
-        .simplify();
+    let values_borrowed = values.map(|value| value.as_ref().map(Borrow::borrow));
+    let (simplified_source_paths, simplified_values) = source_paths.simplify_with(&values_borrowed);
+
     // No fast path for simplified.is_resolved(). If it could be resolved, it would
     // have been caught by values.resolve_trivial() above.
-    if let Some(resolved) = try_resolve_file_conflict(store, path, &simplified).await? {
+    if let Some(resolved) =
+        try_resolve_file_conflict(store, path, &simplified_values, &simplified_source_paths).await?
+    {
         Ok(Some(Merge::normal(resolved)))
     } else {
         // Failed to merge the files, or the paths are not files
@@ -410,55 +527,36 @@ async fn try_resolve_file_conflict(
     store: &Store,
     filename: &RepoPath,
     conflict: &MergedTreeVal<'_>,
+    source_paths: &Merge<Option<RepoPathBuf>>,
 ) -> BackendResult<Option<TreeValue>> {
     let options = store.merge_options();
-    // If there are any non-file or any missing parts in the conflict, we can't
-    // merge it. We check early so we don't waste time reading file contents if
-    // we can't merge them anyway. At the same time we determine whether the
-    // resulting file should be executable.
-    let Ok(file_id_conflict) = conflict.try_map(|term| match term {
-        Some(TreeValue::File {
-            id,
-            executable: _,
-            copy_id: _,
-        }) => Ok(id),
-        _ => Err(()),
-    }) else {
+    let Some(file_id_conflict) = conflict.to_file_merge() else {
         return Ok(None);
     };
-    let Ok(executable_conflict) = conflict.try_map(|term| match term {
-        Some(TreeValue::File {
-            id: _,
-            executable,
-            copy_id: _,
-        }) => Ok(executable),
-        _ => Err(()),
-    }) else {
+    let Some(executable_conflict) = conflict.to_executable_merge() else {
         return Ok(None);
     };
-    let Ok(copy_id_conflict) = conflict.try_map(|term| match term {
-        Some(TreeValue::File {
-            id: _,
-            executable: _,
-            copy_id,
-        }) => Ok(copy_id),
-        _ => Err(()),
-    }) else {
+    let Some(copy_id_conflict) = conflict.to_copy_id_merge() else {
         return Ok(None);
     };
     // TODO: Whether to respect options.same_change to merge executable and
     // copy_id? Should also update conflicts::resolve_file_executable().
-    let Some(&&executable) = executable_conflict.resolve_trivial(SameChange::Accept) else {
+    let Some(executable) = crate::conflicts::resolve_file_executable(&executable_conflict) else {
         // We're unable to determine whether the result should be executable
         return Ok(None);
     };
-    let Some(&copy_id) = copy_id_conflict.resolve_trivial(SameChange::Accept) else {
-        // We're unable to determine the file's copy ID
-        return Ok(None);
+    let copy_id = match copy_id_conflict.resolve_trivial(SameChange::Accept) {
+        Some(Some(copy_id)) => copy_id.clone(),
+        Some(None) => return Ok(None),
+        None => crate::copies::merge_copy_ids(store, filename, &copy_id_conflict).await?,
     };
-    if let Some(&resolved_file_id) = file_id_conflict.resolve_trivial(options.same_change) {
+    if let Some(resolved_file_id) = file_id_conflict.resolve_trivial(options.same_change) {
+        let Some(resolved_file_id) = resolved_file_id else {
+            return Ok(None);
+        };
         // Don't bother reading the file contents if the conflict can be trivially
         // resolved.
+        ensure_file_at_path(store, resolved_file_id, filename, source_paths, conflict).await?;
         return Ok(Some(TreeValue::File {
             id: resolved_file_id.clone(),
             executable,
@@ -472,20 +570,24 @@ async fn try_resolve_file_conflict(
     // 1. Avoid reading unchanged file contents
     // 2. The simplified conflict can sometimes be resolved when the unsimplfied one
     //    cannot
-    let file_id_conflict = file_id_conflict.simplify();
+    let (simplified_source_paths, file_id_conflict) = source_paths.simplify_with(&file_id_conflict);
 
-    let contents = file_id_conflict
-        .try_map_async(async |file_id| {
+    let zipped = file_id_conflict.clone().zip(simplified_source_paths);
+    let contents = zipped
+        .try_map_async(async |(opt_file_id, opt_source_path)| {
             let mut content = vec![];
-            let mut reader = store.read_file(filename, file_id).await?;
-            reader
-                .read_to_end(&mut content)
-                .await
-                .map_err(|err| BackendError::ReadObject {
-                    object_type: file_id.object_type(),
-                    hash: file_id.hex(),
-                    source: err.into(),
-                })?;
+            if let Some(file_id) = opt_file_id {
+                let source_path: &RepoPath = opt_source_path.as_deref().unwrap_or(filename);
+                let mut reader = store.read_file(source_path, file_id).await?;
+                reader
+                    .read_to_end(&mut content)
+                    .await
+                    .map_err(|err| BackendError::ReadObject {
+                        object_type: file_id.object_type(),
+                        hash: file_id.hex(),
+                        source: err.into(),
+                    })?;
+            }
             BackendResult::Ok(content)
         })
         .await?;
@@ -501,4 +603,35 @@ async fn try_resolve_file_conflict(
     } else {
         Ok(None)
     }
+}
+
+async fn ensure_file_at_path(
+    store: &Store,
+    id: &backend::FileId,
+    target_path: &RepoPath,
+    source_paths: &Merge<Option<RepoPathBuf>>,
+    values: &Merge<Option<&TreeValue>>,
+) -> BackendResult<()> {
+    let mut already_at_target = false;
+    let mut source_to_copy = None;
+
+    for (opt_val, opt_src_path) in zip(values.iter(), source_paths.iter()) {
+        if let Some(TreeValue::File { id: val_id, .. }) = opt_val
+            && val_id == id
+            && let Some(src_path) = opt_src_path
+        {
+            if src_path.as_ref() == target_path {
+                already_at_target = true;
+                break;
+            } else {
+                source_to_copy = Some(src_path);
+            }
+        }
+    }
+
+    if !already_at_target && let Some(source_path) = source_to_copy {
+        let mut reader = store.read_file(source_path, id).await?;
+        store.write_file(target_path, &mut reader).await?;
+    }
+    Ok(())
 }

--- a/lib/tests/test_local_working_copy.rs
+++ b/lib/tests/test_local_working_copy.rs
@@ -79,6 +79,7 @@ use testutils::assert_tree_eq;
 use testutils::commit_with_tree;
 use testutils::create_tree;
 use testutils::create_tree_with;
+use testutils::create_tree_with_placeholder_copy_ids;
 use testutils::empty_snapshot_options;
 use testutils::repo_path;
 use testutils::repo_path_buf;
@@ -834,8 +835,10 @@ fn test_snapshot_file_directory_transition() -> TestResult {
     let file1p_path = file1_path.parent().unwrap();
     let file2p_path = file2_path.parent().unwrap();
 
-    let tree1 = create_tree(&repo, &[(file1p_path, "1p"), (file2p_path, "2p")]);
-    let tree2 = create_tree(&repo, &[(file1_path, "1"), (file2_path, "2")]);
+    let tree1 =
+        create_tree_with_placeholder_copy_ids(&repo, &[(file1p_path, "1p"), (file2p_path, "2p")]);
+    let tree2 =
+        create_tree_with_placeholder_copy_ids(&repo, &[(file1_path, "1"), (file2_path, "2")]);
     let commit1 = commit_with_tree(repo.store(), tree1.clone());
     let commit2 = commit_with_tree(repo.store(), tree2.clone());
 
@@ -2841,7 +2844,8 @@ fn track_ignored_with_flag_and_fsmonitor() -> TestResult {
     let force_tracking_matcher = FilesMatcher::new([ignored_path]);
     let tree_state = snapshot(&[], Some(&force_tracking_matcher));
 
-    let expected_tree = create_tree(repo, &[(ignored_path, "contents\n")]);
+    let expected_tree =
+        create_tree_with_placeholder_copy_ids(repo, &[(ignored_path, "contents\n")]);
     assert_tree_eq!(*tree_state.current_tree(), expected_tree);
     Ok(())
 }
@@ -2892,12 +2896,16 @@ fn fsmonitor_gitignore_rescan_subtree() -> TestResult {
     };
 
     let tree_state = snapshot(&[gitignore_path, ignored_path]);
-    let expected_tree = create_tree(repo, &[(gitignore_path, "*.ignored\n")]);
+    let expected_tree =
+        create_tree_with_placeholder_copy_ids(repo, &[(gitignore_path, "*.ignored\n")]);
     assert_tree_eq!(*tree_state.current_tree(), expected_tree);
 
     testutils::write_working_copy_file(&workspace_root, gitignore_path, "");
     let tree_state = snapshot(&[gitignore_path]);
-    let expected_tree = create_tree(repo, &[(gitignore_path, ""), (ignored_path, "contents\n")]);
+    let expected_tree = create_tree_with_placeholder_copy_ids(
+        repo,
+        &[(gitignore_path, ""), (ignored_path, "contents\n")],
+    );
     assert_tree_eq!(*tree_state.current_tree(), expected_tree);
     Ok(())
 }

--- a/lib/tests/test_local_working_copy.rs
+++ b/lib/tests/test_local_working_copy.rs
@@ -79,6 +79,7 @@ use testutils::assert_tree_eq;
 use testutils::commit_with_tree;
 use testutils::create_tree;
 use testutils::create_tree_with;
+use testutils::create_tree_with_placeholder_copy_ids;
 use testutils::empty_snapshot_options;
 use testutils::repo_path;
 use testutils::repo_path_buf;
@@ -834,8 +835,10 @@ fn test_snapshot_file_directory_transition() -> TestResult {
     let file1p_path = file1_path.parent().unwrap();
     let file2p_path = file2_path.parent().unwrap();
 
-    let tree1 = create_tree(&repo, &[(file1p_path, "1p"), (file2p_path, "2p")]);
-    let tree2 = create_tree(&repo, &[(file1_path, "1"), (file2_path, "2")]);
+    let tree1 =
+        create_tree_with_placeholder_copy_ids(&repo, &[(file1p_path, "1p"), (file2p_path, "2p")]);
+    let tree2 =
+        create_tree_with_placeholder_copy_ids(&repo, &[(file1_path, "1"), (file2_path, "2")]);
     let commit1 = commit_with_tree(repo.store(), tree1.clone());
     let commit2 = commit_with_tree(repo.store(), tree2.clone());
 
@@ -2785,7 +2788,8 @@ fn track_ignored_with_flag_and_fsmonitor() -> TestResult {
     let force_tracking_matcher = FilesMatcher::new([ignored_path]);
     let tree_state = snapshot(&[], Some(&force_tracking_matcher));
 
-    let expected_tree = create_tree(repo, &[(ignored_path, "contents\n")]);
+    let expected_tree =
+        create_tree_with_placeholder_copy_ids(repo, &[(ignored_path, "contents\n")]);
     assert_tree_eq!(*tree_state.current_tree(), expected_tree);
     Ok(())
 }
@@ -2836,12 +2840,16 @@ fn fsmonitor_gitignore_rescan_subtree() -> TestResult {
     };
 
     let tree_state = snapshot(&[gitignore_path, ignored_path]);
-    let expected_tree = create_tree(repo, &[(gitignore_path, "*.ignored\n")]);
+    let expected_tree =
+        create_tree_with_placeholder_copy_ids(repo, &[(gitignore_path, "*.ignored\n")]);
     assert_tree_eq!(*tree_state.current_tree(), expected_tree);
 
     testutils::write_working_copy_file(&workspace_root, gitignore_path, "");
     let tree_state = snapshot(&[gitignore_path]);
-    let expected_tree = create_tree(repo, &[(gitignore_path, ""), (ignored_path, "contents\n")]);
+    let expected_tree = create_tree_with_placeholder_copy_ids(
+        repo,
+        &[(gitignore_path, ""), (ignored_path, "contents\n")],
+    );
     assert_tree_eq!(*tree_state.current_tree(), expected_tree);
     Ok(())
 }

--- a/lib/tests/test_merged_tree.rs
+++ b/lib/tests/test_merged_tree.rs
@@ -56,6 +56,7 @@ use testutils::create_single_tree;
 use testutils::create_tree;
 use testutils::create_tree_with_copy_history;
 use testutils::create_tree_with_copy_id;
+use testutils::read_file;
 use testutils::repo_path;
 use testutils::repo_path_buf;
 use testutils::repo_path_component;
@@ -2391,23 +2392,25 @@ fn test_copy_diffstream_dest_conflict() -> TestResult {
     ]))
     .block_on()
     .expect("Expected successful merge");
+    let r1_val = right1.path_value(bar).block_on()?.into_resolved().unwrap();
+    let r2_val = right2.path_value(bar).block_on()?.into_resolved().unwrap();
     let expected = [
-        // bar.txt is conflicted, and does not show copy-history sources despite being renamed from
-        // foo.txt
+        // bar.txt is conflicted, and now DOES show copy-history sources because of copy-aware
+        // merge
         (
             bar.to_owned(),
             Merge::from_removes_adds(
                 [CopyHistoryDiffTerm {
-                    target_value: None,
+                    target_value: foo_val.as_resolved().unwrap().clone(),
                     sources: vec![],
                 }],
                 [
                     CopyHistoryDiffTerm {
-                        target_value: right1.path_value(bar).block_on()?.first().clone(),
+                        target_value: r1_val.clone(),
                         sources: vec![],
                     },
                     CopyHistoryDiffTerm {
-                        target_value: right2.path_value(bar).block_on()?.first().clone(),
+                        target_value: r2_val.clone(),
                         sources: vec![],
                     },
                 ],
@@ -2511,7 +2514,7 @@ fn test_copy_diffstream_source_and_dest_conflicts() -> TestResult {
             bar.to_owned(),
             Merge::from_removes_adds(
                 [CopyHistoryDiffTerm {
-                    target_value: None,
+                    target_value: foo_val.as_resolved().unwrap().clone(),
                     sources: vec![],
                 }],
                 [
@@ -3162,6 +3165,191 @@ fn test_edit_plus_rename() {
     assert_eq!(bar_renames.get_add(0).unwrap(), &Some(foo.to_owned()));
     assert_eq!(bar_renames.get_remove(0).unwrap(), &Some(foo.to_owned()));
     assert_eq!(bar_renames.get_add(1).unwrap(), &Some(bar.to_owned()));
+
+    let merged_ids = jj_lib::tree_merge::merge_trees(store, merge)
+        .block_on()
+        .unwrap();
+    let merged_tree = MergedTree::new(store.clone(), merged_ids, ConflictLabels::unlabeled());
+    assert!(!merged_tree.has_conflict());
+
+    let foo_val = merged_tree.path_value(foo).block_on().unwrap();
+    assert!(foo_val.is_resolved());
+    assert!(foo_val.is_absent());
+
+    let bar_val = merged_tree.path_value(bar).block_on().unwrap();
+    assert!(bar_val.is_resolved());
+    assert!(bar_val.is_present());
+    let TreeValue::File {
+        id,
+        executable: _,
+        copy_id,
+    } = bar_val.into_resolved().unwrap().unwrap()
+    else {
+        panic!("Expected bar_val to be a TreeValue::File");
+    };
+    let bar_history = store.backend().read_copy(&copy_id).block_on().unwrap();
+    assert_eq!(bar_history, histories[bar]);
+    let bar_contents = read_file(store, bar, &id);
+    assert_eq!(bar_contents, "foo plus edits".as_bytes());
+}
+
+#[test]
+fn test_rename_with_hunk_merging() {
+    let test_repo = TestRepo::init();
+    let repo = &test_repo.repo;
+    let store = repo.store();
+
+    let foo = repo_path("foo");
+    let bar = repo_path("bar");
+
+    // Define copy history: file1 -> file2 -> file3
+    let histories = write_copy_histories(repo, &[(foo, vec![]), (bar, vec![foo])]);
+
+    let add0 = create_tree_with_copy_history(repo, &histories, &[(foo, "foo\npost-foo\n")]);
+    let rem0 = create_tree_with_copy_history(repo, &histories, &[(foo, "foo\n")]);
+    let add1 = create_tree_with_copy_history(repo, &histories, &[(bar, "pre-foo\nfoo\n")]);
+
+    let merge = Merge::from_vec(vec![
+        add0.tree_ids().get_add(0).unwrap().clone(),
+        rem0.tree_ids().get_add(0).unwrap().clone(),
+        add1.tree_ids().get_add(0).unwrap().clone(),
+    ]);
+
+    let merged_ids = jj_lib::tree_merge::merge_trees(store, merge)
+        .block_on()
+        .unwrap();
+    let merged_tree = MergedTree::new(
+        store.clone(),
+        merged_ids,
+        jj_lib::conflict_labels::ConflictLabels::unlabeled(),
+    );
+    assert!(!merged_tree.has_conflict());
+
+    let foo_val = merged_tree.path_value(foo).block_on().unwrap();
+    assert!(foo_val.is_resolved());
+    assert!(foo_val.is_absent());
+
+    let bar_val = merged_tree.path_value(bar).block_on().unwrap();
+    assert!(bar_val.is_resolved());
+    assert!(bar_val.is_present());
+    let TreeValue::File {
+        id,
+        executable: _,
+        copy_id,
+    } = bar_val.into_resolved().unwrap().unwrap()
+    else {
+        panic!("Expected bar_val to be a TreeValue::File");
+    };
+    let bar_history = store.backend().read_copy(&copy_id).block_on().unwrap();
+    assert_eq!(bar_history, histories[bar]);
+    let bar_contents = read_file(store, bar, &id);
+    assert_eq!(bar_contents, "pre-foo\nfoo\npost-foo\n".as_bytes());
+}
+
+#[test]
+fn test_edit_plus_rename_across_trees() {
+    let test_repo = TestRepo::init();
+    let repo = &test_repo.repo;
+    let store = repo.store();
+
+    let foo = repo_path("foo");
+    let bar = repo_path("subdir/bar");
+
+    // Define copy history: file1 -> file2 -> file3
+    let histories = write_copy_histories(repo, &[(foo, vec![]), (bar, vec![foo])]);
+
+    let add0 = create_tree_with_copy_history(repo, &histories, &[(foo, "foo plus edits")]);
+    let rem0 = create_tree_with_copy_history(repo, &histories, &[(foo, "foo")]);
+    let add1 = create_tree_with_copy_history(repo, &histories, &[(bar, "foo")]);
+
+    let merge = Merge::from_vec(vec![
+        add0.tree_ids().get_add(0).unwrap().clone(),
+        rem0.tree_ids().get_add(0).unwrap().clone(),
+        add1.tree_ids().get_add(0).unwrap().clone(),
+    ]);
+
+    let merged_ids = jj_lib::tree_merge::merge_trees(store, merge)
+        .block_on()
+        .unwrap();
+    let merged_tree = MergedTree::new(
+        store.clone(),
+        merged_ids,
+        jj_lib::conflict_labels::ConflictLabels::unlabeled(),
+    );
+    assert!(!merged_tree.has_conflict());
+
+    let foo_val = merged_tree.path_value(foo).block_on().unwrap();
+    assert!(foo_val.is_resolved());
+    assert!(foo_val.is_absent());
+
+    let bar_val = merged_tree.path_value(bar).block_on().unwrap();
+    assert!(bar_val.is_resolved());
+    assert!(bar_val.is_present());
+    let TreeValue::File {
+        id,
+        executable: _,
+        copy_id,
+    } = bar_val.into_resolved().unwrap().unwrap()
+    else {
+        panic!("Expected bar_val to be a TreeValue::File");
+    };
+    let bar_history = store.backend().read_copy(&copy_id).block_on().unwrap();
+    assert_eq!(bar_history, histories[bar]);
+    let bar_contents = read_file(store, bar, &id);
+    assert_eq!(bar_contents, "foo plus edits".as_bytes());
+}
+
+#[test]
+fn test_edit_plus_rename_across_unrelated_trees() {
+    let test_repo = TestRepo::init();
+    let repo = &test_repo.repo;
+    let store = repo.store();
+
+    let foo = repo_path("subdir1/foo");
+    let bar = repo_path("subdir2/bar");
+
+    // Define copy history: file1 -> file2 -> file3
+    let histories = write_copy_histories(repo, &[(foo, vec![]), (bar, vec![foo])]);
+
+    let add0 = create_tree_with_copy_history(repo, &histories, &[(foo, "foo plus edits")]);
+    let rem0 = create_tree_with_copy_history(repo, &histories, &[(foo, "foo")]);
+    let add1 = create_tree_with_copy_history(repo, &histories, &[(bar, "foo")]);
+
+    let merge = Merge::from_vec(vec![
+        add0.tree_ids().get_add(0).unwrap().clone(),
+        rem0.tree_ids().get_add(0).unwrap().clone(),
+        add1.tree_ids().get_add(0).unwrap().clone(),
+    ]);
+
+    let merged_ids = jj_lib::tree_merge::merge_trees(store, merge)
+        .block_on()
+        .unwrap();
+    let merged_tree = MergedTree::new(
+        store.clone(),
+        merged_ids,
+        jj_lib::conflict_labels::ConflictLabels::unlabeled(),
+    );
+    assert!(!merged_tree.has_conflict());
+
+    let foo_val = merged_tree.path_value(foo).block_on().unwrap();
+    assert!(foo_val.is_resolved());
+    assert!(foo_val.is_absent());
+
+    let bar_val = merged_tree.path_value(bar).block_on().unwrap();
+    assert!(bar_val.is_resolved());
+    assert!(bar_val.is_present());
+    let TreeValue::File {
+        id,
+        executable: _,
+        copy_id,
+    } = bar_val.into_resolved().unwrap().unwrap()
+    else {
+        panic!("Expected bar_val to be a TreeValue::File");
+    };
+    let bar_history = store.backend().read_copy(&copy_id).block_on().unwrap();
+    assert_eq!(bar_history, histories[bar]);
+    let bar_contents = read_file(store, bar, &id);
+    assert_eq!(bar_contents, "foo plus edits".as_bytes());
 }
 
 #[test]
@@ -3200,6 +3388,48 @@ fn test_edit_plus_copy() {
     assert_eq!(bar_renames.get_add(0).unwrap(), &Some(foo.to_owned()));
     assert_eq!(bar_renames.get_remove(0).unwrap(), &Some(foo.to_owned()));
     assert_eq!(bar_renames.get_add(1).unwrap(), &Some(bar.to_owned()));
+
+    let merged_ids = jj_lib::tree_merge::merge_trees(store, merge)
+        .block_on()
+        .unwrap();
+    let merged_tree = MergedTree::new(
+        store.clone(),
+        merged_ids,
+        jj_lib::conflict_labels::ConflictLabels::unlabeled(),
+    );
+    assert!(!merged_tree.has_conflict());
+
+    let foo_val = merged_tree.path_value(foo).block_on().unwrap();
+    assert!(foo_val.is_resolved());
+    assert!(foo_val.is_present());
+    let TreeValue::File {
+        id,
+        executable: _,
+        copy_id,
+    } = foo_val.into_resolved().unwrap().unwrap()
+    else {
+        panic!("Expected foo_val to be a TreeValue::File");
+    };
+    let foo_history = store.backend().read_copy(&copy_id).block_on().unwrap();
+    assert_eq!(foo_history, histories[foo]);
+    let foo_contents = read_file(store, foo, &id);
+    assert_eq!(foo_contents, "foo plus edits".as_bytes());
+
+    let bar_val = merged_tree.path_value(bar).block_on().unwrap();
+    assert!(bar_val.is_resolved());
+    assert!(bar_val.is_present());
+    let TreeValue::File {
+        id,
+        executable: _,
+        copy_id,
+    } = bar_val.into_resolved().unwrap().unwrap()
+    else {
+        panic!("Expected bar_val to be a TreeValue::File");
+    };
+    let bar_history = store.backend().read_copy(&copy_id).block_on().unwrap();
+    assert_eq!(bar_history, histories[bar]);
+    let bar_contents = read_file(store, bar, &id);
+    assert_eq!(bar_contents, "foo plus edits".as_bytes());
 }
 
 #[test]
@@ -3244,4 +3474,412 @@ fn test_five_way_rename_and_copy_merge() {
     assert_eq!(bar_renames.get_add(1).unwrap(), &Some(bar.to_owned()));
     assert_eq!(bar_renames.get_remove(1).unwrap(), &Some(foo.to_owned()));
     assert_eq!(bar_renames.get_add(2).unwrap(), &Some(baz.to_owned()));
+
+    let merged_ids = jj_lib::tree_merge::merge_trees(store, merge)
+        .block_on()
+        .unwrap();
+    let merged_tree = MergedTree::new(
+        store.clone(),
+        merged_ids,
+        jj_lib::conflict_labels::ConflictLabels::unlabeled(),
+    );
+    assert!(!merged_tree.has_conflict());
+
+    let foo_val = merged_tree.path_value(foo).block_on().unwrap();
+    assert!(foo_val.is_resolved());
+    assert!(foo_val.is_absent());
+
+    let bar_val = merged_tree.path_value(bar).block_on().unwrap();
+    assert!(bar_val.is_resolved());
+    assert!(bar_val.is_present());
+    let TreeValue::File {
+        id,
+        executable: _,
+        copy_id,
+    } = bar_val.into_resolved().unwrap().unwrap()
+    else {
+        panic!("Expected bar_val to be a TreeValue::File");
+    };
+    let bar_history = store.backend().read_copy(&copy_id).block_on().unwrap();
+    assert_eq!(bar_history, histories[bar]);
+    let bar_contents = read_file(store, bar, &id);
+    assert_eq!(bar_contents, "foo plus edits".as_bytes());
+
+    let baz_val = merged_tree.path_value(baz).block_on().unwrap();
+    assert!(baz_val.is_resolved());
+    assert!(baz_val.is_present());
+    let TreeValue::File {
+        id,
+        executable: _,
+        copy_id,
+    } = baz_val.into_resolved().unwrap().unwrap()
+    else {
+        panic!("Expected baz_val to be a TreeValue::File");
+    };
+    let baz_history = store.backend().read_copy(&copy_id).block_on().unwrap();
+    assert_eq!(baz_history, histories[baz]);
+    let baz_contents = read_file(store, baz, &id);
+    assert_eq!(baz_contents, "foo plus edits".as_bytes());
+}
+
+#[test]
+fn test_divergent_renames() {
+    let test_repo = TestRepo::init();
+    let repo = &test_repo.repo;
+    let store = repo.store();
+
+    let foo = repo_path("foo");
+    let bar = repo_path("bar");
+    let baz = repo_path("baz");
+
+    // Define copy history: foo -> bar and foo -> baz
+    let histories =
+        write_copy_histories(repo, &[(foo, vec![]), (bar, vec![foo]), (baz, vec![foo])]);
+
+    let add0 = create_tree_with_copy_history(repo, &histories, &[(bar, "foo")]);
+    let rem0 = create_tree_with_copy_history(repo, &histories, &[(foo, "foo")]);
+    let add1 = create_tree_with_copy_history(repo, &histories, &[(baz, "foo")]);
+
+    let merge = Merge::from_vec(vec![
+        add0.tree_ids().get_add(0).unwrap().clone(),
+        rem0.tree_ids().get_add(0).unwrap().clone(),
+        add1.tree_ids().get_add(0).unwrap().clone(),
+    ]);
+
+    let merged_ids = jj_lib::tree_merge::merge_trees(store, merge)
+        .block_on()
+        .unwrap();
+    let merged_tree = MergedTree::new(
+        store.clone(),
+        merged_ids,
+        jj_lib::conflict_labels::ConflictLabels::unlabeled(),
+    );
+
+    // We expect conflicts because the same file was renamed to two different
+    // places.
+    assert!(merged_tree.has_conflict());
+
+    // foo should be gone
+    let foo_val = merged_tree.path_value(foo).block_on().unwrap();
+    assert!(foo_val.is_resolved());
+    assert!(foo_val.is_absent());
+
+    // bar should have a conflict
+    let bar_val = merged_tree.path_value(bar).block_on().unwrap();
+    assert!(!bar_val.is_resolved());
+
+    // baz should have a conflict
+    let baz_val = merged_tree.path_value(baz).block_on().unwrap();
+    assert!(!baz_val.is_resolved());
+}
+
+#[test]
+fn test_convergent_renames() {
+    let test_repo = TestRepo::init();
+    let repo = &test_repo.repo;
+    let store = repo.store();
+
+    let foo = repo_path("foo");
+    let bar = repo_path("bar");
+    let baz = repo_path("baz");
+
+    // 1. foo history (no parents)
+    let foo_history = CopyHistory {
+        current_path: foo.to_owned(),
+        parents: vec![],
+        salt: vec![],
+    };
+    let foo_copy_id = store.backend().write_copy(&foo_history).block_on().unwrap();
+
+    // 2. bar history (no parents)
+    let bar_history = CopyHistory {
+        current_path: bar.to_owned(),
+        parents: vec![],
+        salt: vec![],
+    };
+    let bar_copy_id = store.backend().write_copy(&bar_history).block_on().unwrap();
+
+    // 3. baz <- foo history (for Side 1)
+    let baz_from_foo_history = CopyHistory {
+        current_path: baz.to_owned(),
+        parents: vec![foo_copy_id.clone()],
+        salt: vec![],
+    };
+    let baz_from_foo_copy_id = store
+        .backend()
+        .write_copy(&baz_from_foo_history)
+        .block_on()
+        .unwrap();
+
+    // 4. baz <- bar history (for Side 2)
+    let baz_from_bar_history = CopyHistory {
+        current_path: baz.to_owned(),
+        parents: vec![bar_copy_id.clone()],
+        salt: vec![],
+    };
+    let baz_from_bar_copy_id = store
+        .backend()
+        .write_copy(&baz_from_bar_history)
+        .block_on()
+        .unwrap();
+
+    // Base Tree (rem0): foo (present, foo_copy_id), bar (present, bar_copy_id)
+    let rem0 = create_tree_with_copy_id(
+        repo,
+        &[(foo, "common", &foo_copy_id), (bar, "common", &bar_copy_id)],
+    );
+
+    // Side 1 Tree (add0): bar (present, bar_copy_id), baz (present,
+    // baz_from_foo_copy_id) foo is absent.
+    let add0 = create_tree_with_copy_id(
+        repo,
+        &[
+            (bar, "common", &bar_copy_id),
+            (baz, "common", &baz_from_foo_copy_id),
+        ],
+    );
+
+    // Side 2 Tree (add1): foo (present, foo_copy_id), baz (present,
+    // baz_from_bar_copy_id) bar is absent.
+    let add1 = create_tree_with_copy_id(
+        repo,
+        &[
+            (foo, "common", &foo_copy_id),
+            (baz, "common", &baz_from_bar_copy_id),
+        ],
+    );
+
+    let merge = Merge::from_vec(vec![
+        add0.tree_ids().get_add(0).unwrap().clone(),
+        rem0.tree_ids().get_add(0).unwrap().clone(),
+        add1.tree_ids().get_add(0).unwrap().clone(),
+    ]);
+
+    let merged_ids = jj_lib::tree_merge::merge_trees(store, merge)
+        .block_on()
+        .unwrap();
+    let merged_tree = MergedTree::new(
+        store.clone(),
+        merged_ids,
+        jj_lib::conflict_labels::ConflictLabels::unlabeled(),
+    );
+
+    // We expect NO conflicts because contents are same and we expect copy history
+    // to merge.
+    assert!(!merged_tree.has_conflict());
+
+    // foo should be gone
+    let foo_val = merged_tree.path_value(foo).block_on().unwrap();
+    assert!(foo_val.is_resolved());
+    assert!(foo_val.is_absent());
+
+    // bar should be gone
+    let bar_val = merged_tree.path_value(bar).block_on().unwrap();
+    assert!(bar_val.is_resolved());
+    assert!(bar_val.is_absent());
+
+    // baz should be present and resolved
+    let baz_val = merged_tree.path_value(baz).block_on().unwrap();
+    assert!(baz_val.is_resolved());
+    assert!(baz_val.is_present());
+
+    let TreeValue::File {
+        id: _,
+        executable: _,
+        copy_id: merged_baz_copy_id,
+    } = baz_val.into_resolved().unwrap().unwrap()
+    else {
+        panic!("Expected baz_val to be a TreeValue::File");
+    };
+
+    // Read the merged copy history of baz
+    let baz_history = store
+        .backend()
+        .read_copy(&merged_baz_copy_id)
+        .block_on()
+        .unwrap();
+
+    // We expect baz's history to have both baz_from_foo and baz_from_bar as
+    // parents.
+    assert_eq!(baz_history.parents.len(), 2);
+    assert!(baz_history.parents.contains(&baz_from_foo_copy_id));
+    assert!(baz_history.parents.contains(&baz_from_bar_copy_id));
+
+    // The current path should still be baz
+    assert_eq!(baz_history.current_path, baz.to_owned());
+}
+
+#[test]
+fn test_independent_copies_get_merged_history() {
+    let test_repo = TestRepo::init();
+    let repo = &test_repo.repo;
+    let store = repo.store();
+
+    let foo = repo_path("foo");
+
+    // foo independent creation #1
+    let foo1_history = CopyHistory {
+        current_path: foo.to_owned(),
+        parents: vec![],
+        salt: vec![1],
+    };
+    let foo1_copy_id = store
+        .backend()
+        .write_copy(&foo1_history)
+        .block_on()
+        .unwrap();
+
+    let foo2_history = CopyHistory {
+        current_path: foo.to_owned(),
+        parents: vec![],
+        salt: vec![2],
+    };
+    let foo2_copy_id = store
+        .backend()
+        .write_copy(&foo2_history)
+        .block_on()
+        .unwrap();
+
+    // Base tree (empty)
+    let rem0 = create_tree_with_copy_id(repo, &[]);
+
+    // Add0: create independent foo1
+    let add0 = create_tree_with_copy_id(repo, &[(foo, "foo", &foo1_copy_id)]);
+
+    // Add1: create independent foo2
+    let add1 = create_tree_with_copy_id(repo, &[(foo, "foo", &foo2_copy_id)]);
+
+    // Even though the histories are independent, since the files have the same path
+    // and the same content, we want to merge their history into a common graph
+    // with both origins.
+    let merge = Merge::from_vec(vec![
+        add0.tree_ids().get_add(0).unwrap().clone(),
+        rem0.tree_ids().get_add(0).unwrap().clone(),
+        add1.tree_ids().get_add(0).unwrap().clone(),
+    ]);
+    let merged_ids = jj_lib::tree_merge::merge_trees(store, merge)
+        .block_on()
+        .unwrap();
+    let merged_tree = MergedTree::new(
+        store.clone(),
+        merged_ids,
+        jj_lib::conflict_labels::ConflictLabels::unlabeled(),
+    );
+
+    // We expect NO conflicts because contents are same and we expect copy history
+    // to merge.
+    assert!(!merged_tree.has_conflict());
+
+    // foo should be present and resolved
+    let foo_val = merged_tree.path_value(foo).block_on().unwrap();
+    assert!(foo_val.is_resolved());
+    assert!(foo_val.is_present());
+
+    let TreeValue::File {
+        id: _,
+        executable: _,
+        copy_id: merged_foo_copy_id,
+    } = foo_val.into_resolved().unwrap().unwrap()
+    else {
+        panic!("Expected foo_val to be a TreeValue::File");
+    };
+
+    let merged_foo_history = store
+        .backend()
+        .read_copy(&merged_foo_copy_id)
+        .block_on()
+        .unwrap();
+
+    // We expect foo's history to have independent foo histories as parents.
+    assert_eq!(merged_foo_history.parents.len(), 2);
+    assert!(merged_foo_history.parents.contains(&foo1_copy_id));
+    assert!(merged_foo_history.parents.contains(&foo2_copy_id));
+}
+
+#[test]
+fn test_divergent_renames_with_unrelated_ancient_ancestor() {
+    let test_repo = TestRepo::init();
+    let repo = &test_repo.repo;
+    let store = repo.store();
+
+    let orig = repo_path("orig");
+    let foo = repo_path("foo");
+    let bar = repo_path("bar");
+    let baz = repo_path("baz");
+
+    // Define copy history: orig -> foo -> bar AND orig -> foo -> baz
+    let histories = write_copy_histories(
+        repo,
+        &[
+            (orig, vec![]),
+            (foo, vec![orig]),
+            (bar, vec![foo]),
+            (baz, vec![foo]),
+        ],
+    );
+
+    // Base tree (rem0): has `foo` (content "foo content"), and NO `orig`.
+    let rem0 = create_tree_with_copy_history(repo, &histories, &[(foo, "foo content")]);
+
+    // Side 1 tree (add0): `foo` renamed to `bar` (content "bar content").
+    let add0 = create_tree_with_copy_history(repo, &histories, &[(bar, "bar content")]);
+
+    // Side 2 tree (add1): `foo` renamed to `baz` (content "baz content"),
+    // AND an UNRELATED file is created at `orig` (content "unrelated orig").
+    let unrelated_orig_history = CopyHistory {
+        current_path: orig.to_owned(),
+        parents: vec![],
+        salt: vec![42],
+    };
+    let add1 = testutils::create_tree_with(repo, |builder| {
+        builder
+            .file(baz, "baz content")
+            .copy_history(&histories[baz]);
+        builder
+            .file(orig, "unrelated orig")
+            .copy_history(&unrelated_orig_history);
+    });
+
+    let merge = Merge::from_vec(vec![
+        add0.tree_ids().get_add(0).unwrap().clone(),
+        rem0.tree_ids().get_add(0).unwrap().clone(),
+        add1.tree_ids().get_add(0).unwrap().clone(),
+    ]);
+
+    let trees = MergedTree::new(store.clone(), merge.clone(), ConflictLabels::unlabeled());
+    let rename_map = compute_rename_map(&trees).block_on().unwrap();
+
+    assert!(rename_map.contains_key(bar));
+    let bar_renames = &rename_map[bar];
+    assert_eq!(bar_renames.num_sides(), merge.num_sides());
+    assert_eq!(bar_renames.get_add(0).unwrap(), &Some(bar.to_owned()));
+    assert_eq!(bar_renames.get_remove(0).unwrap(), &Some(foo.to_owned()));
+    // bar should NOT map to orig on side 1, because orig is an ancient ancestor
+    // that did not exist in the merge base (rem0).
+    assert_eq!(bar_renames.get_add(1).unwrap(), &None);
+
+    let merged_ids = jj_lib::tree_merge::merge_trees(store, merge)
+        .block_on()
+        .unwrap();
+    let merged_tree = MergedTree::new(store.clone(), merged_ids, ConflictLabels::unlabeled());
+
+    let bar_val = merged_tree.path_value(bar).block_on().unwrap();
+    let expected_bar_val = Merge::from_removes_adds(
+        vec![
+            rem0.path_value(foo)
+                .block_on()
+                .unwrap()
+                .into_resolved()
+                .unwrap(),
+        ],
+        vec![
+            add0.path_value(bar)
+                .block_on()
+                .unwrap()
+                .into_resolved()
+                .unwrap(),
+            None,
+        ],
+    );
+    assert_eq!(bar_val, expected_bar_val);
 }

--- a/lib/tests/test_merged_tree.rs
+++ b/lib/tests/test_merged_tree.rs
@@ -29,6 +29,7 @@ use jj_lib::copies::CopyHistoryDiffTerm;
 use jj_lib::copies::CopyHistorySource;
 use jj_lib::copies::CopyOperation;
 use jj_lib::copies::CopyRecords;
+use jj_lib::copies::compute_rename_map;
 use jj_lib::files;
 use jj_lib::matchers::EverythingMatcher;
 use jj_lib::matchers::FilesMatcher;
@@ -3125,4 +3126,122 @@ fn test_copy_diffstream_double_rename() -> TestResult {
         ],
     );
     Ok(())
+}
+
+#[test]
+fn test_edit_plus_rename() {
+    let test_repo = TestRepo::init();
+    let repo = &test_repo.repo;
+    let store = repo.store();
+
+    let foo = repo_path("foo");
+    let bar = repo_path("bar");
+
+    // Define copy history: file1 -> file2 -> file3
+    let histories = write_copy_histories(repo, &[(foo, vec![]), (bar, vec![foo])]);
+
+    let add0 = create_tree_with_copy_history(repo, &histories, &[(foo, "foo plus edits")]);
+    let rem0 = create_tree_with_copy_history(repo, &histories, &[(foo, "foo")]);
+    let add1 = create_tree_with_copy_history(repo, &histories, &[(bar, "foo")]);
+
+    let merge = Merge::from_vec(vec![
+        add0.tree_ids().get_add(0).unwrap().clone(),
+        rem0.tree_ids().get_add(0).unwrap().clone(),
+        add1.tree_ids().get_add(0).unwrap().clone(),
+    ]);
+
+    let trees = MergedTree::new(store.clone(), merge.clone(), ConflictLabels::unlabeled());
+    let rename_map = compute_rename_map(&trees).block_on().unwrap();
+    assert!(rename_map.contains_key(foo));
+    let foo_renames = &rename_map[foo];
+    assert!(foo_renames.is_resolved());
+    assert_eq!(foo_renames.get_add(0).unwrap(), &None);
+    assert!(rename_map.contains_key(bar));
+    let bar_renames = &rename_map[bar];
+    assert_eq!(bar_renames.num_sides(), merge.num_sides());
+    assert_eq!(bar_renames.get_add(0).unwrap(), &Some(foo.to_owned()));
+    assert_eq!(bar_renames.get_remove(0).unwrap(), &Some(foo.to_owned()));
+    assert_eq!(bar_renames.get_add(1).unwrap(), &Some(bar.to_owned()));
+}
+
+#[test]
+fn test_edit_plus_copy() {
+    let test_repo = TestRepo::init();
+    let repo = &test_repo.repo;
+    let store = repo.store();
+
+    let foo = repo_path("foo");
+    let bar = repo_path("bar");
+
+    // Define copy history: file1 -> file2 -> file3
+    let histories = write_copy_histories(repo, &[(foo, vec![]), (bar, vec![foo])]);
+
+    let add0 = create_tree_with_copy_history(repo, &histories, &[(foo, "foo plus edits")]);
+    let rem0 = create_tree_with_copy_history(repo, &histories, &[(foo, "foo")]);
+    let add1 = create_tree_with_copy_history(repo, &histories, &[(foo, "foo"), (bar, "foo")]);
+
+    let merge = Merge::from_vec(vec![
+        add0.tree_ids().get_add(0).unwrap().clone(),
+        rem0.tree_ids().get_add(0).unwrap().clone(),
+        add1.tree_ids().get_add(0).unwrap().clone(),
+    ]);
+
+    let trees = MergedTree::new(store.clone(), merge.clone(), ConflictLabels::unlabeled());
+    let rename_map = compute_rename_map(&trees).block_on().unwrap();
+    assert!(rename_map.contains_key(foo));
+    let foo_renames = &rename_map[foo];
+    assert_eq!(foo_renames.num_sides(), merge.num_sides());
+    assert_eq!(foo_renames.get_add(0).unwrap(), &Some(foo.to_owned()));
+    assert_eq!(foo_renames.get_remove(0).unwrap(), &Some(foo.to_owned()));
+    assert_eq!(foo_renames.get_add(1).unwrap(), &Some(foo.to_owned()));
+    assert!(rename_map.contains_key(bar));
+    let bar_renames = &rename_map[bar];
+    assert_eq!(bar_renames.num_sides(), merge.num_sides());
+    assert_eq!(bar_renames.get_add(0).unwrap(), &Some(foo.to_owned()));
+    assert_eq!(bar_renames.get_remove(0).unwrap(), &Some(foo.to_owned()));
+    assert_eq!(bar_renames.get_add(1).unwrap(), &Some(bar.to_owned()));
+}
+
+#[test]
+fn test_five_way_rename_and_copy_merge() {
+    let test_repo = TestRepo::init();
+    let repo = &test_repo.repo;
+    let store = repo.store();
+
+    let foo = repo_path("foo");
+    let bar = repo_path("bar");
+    let baz = repo_path("baz");
+
+    // Define copy history: file1 -> file2 -> file3
+    let histories =
+        write_copy_histories(repo, &[(foo, vec![]), (bar, vec![foo]), (baz, vec![foo])]);
+
+    let add0 = create_tree_with_copy_history(repo, &histories, &[(foo, "foo plus edits")]);
+    let rem0 = create_tree_with_copy_history(repo, &histories, &[(foo, "foo")]);
+    let add1 = create_tree_with_copy_history(repo, &histories, &[(foo, "foo"), (bar, "foo")]);
+    // rem1 == rem0
+    let add2 = create_tree_with_copy_history(repo, &histories, &[(baz, "foo")]);
+
+    let merge = Merge::from_vec(vec![
+        add0.tree_ids().get_add(0).unwrap().clone(),
+        rem0.tree_ids().get_add(0).unwrap().clone(),
+        add1.tree_ids().get_add(0).unwrap().clone(),
+        rem0.tree_ids().get_add(0).unwrap().clone(),
+        add2.tree_ids().get_add(0).unwrap().clone(),
+    ]);
+
+    let trees = MergedTree::new(store.clone(), merge.clone(), ConflictLabels::unlabeled());
+    let rename_map = compute_rename_map(&trees).block_on().unwrap();
+    assert!(rename_map.contains_key(foo));
+    let foo_renames = &rename_map[foo];
+    assert!(foo_renames.is_resolved());
+    assert_eq!(foo_renames.get_add(0).unwrap(), &None); // TODO: this seems incorrect
+    assert!(rename_map.contains_key(bar));
+    let bar_renames = &rename_map[bar];
+    assert_eq!(bar_renames.num_sides(), merge.num_sides());
+    assert_eq!(bar_renames.get_add(0).unwrap(), &Some(foo.to_owned()));
+    assert_eq!(bar_renames.get_remove(0).unwrap(), &Some(foo.to_owned()));
+    assert_eq!(bar_renames.get_add(1).unwrap(), &Some(bar.to_owned()));
+    assert_eq!(bar_renames.get_remove(1).unwrap(), &Some(foo.to_owned()));
+    assert_eq!(bar_renames.get_add(2).unwrap(), &Some(baz.to_owned()));
 }

--- a/lib/tests/test_merged_tree.rs
+++ b/lib/tests/test_merged_tree.rs
@@ -28,6 +28,7 @@ use jj_lib::copies::CopyHistoryDiffTerm;
 use jj_lib::copies::CopyHistorySource;
 use jj_lib::copies::CopyOperation;
 use jj_lib::copies::CopyRecords;
+use jj_lib::copies::compute_rename_map;
 use jj_lib::files;
 use jj_lib::matchers::EverythingMatcher;
 use jj_lib::matchers::FilesMatcher;
@@ -3125,4 +3126,122 @@ fn test_copy_diffstream_double_rename() -> TestResult {
         ],
     );
     Ok(())
+}
+
+#[test]
+fn test_edit_plus_rename() {
+    let test_repo = TestRepo::init();
+    let repo = &test_repo.repo;
+    let store = repo.store();
+
+    let foo = repo_path("foo");
+    let bar = repo_path("bar");
+
+    // Define copy history: file1 -> file2 -> file3
+    let histories = write_copy_histories(repo, &[(foo, vec![]), (bar, vec![foo])]);
+
+    let add0 = create_tree_with_copy_history(repo, &histories, &[(foo, "foo plus edits")]);
+    let rem0 = create_tree_with_copy_history(repo, &histories, &[(foo, "foo")]);
+    let add1 = create_tree_with_copy_history(repo, &histories, &[(bar, "foo")]);
+
+    let merge = Merge::from_vec(vec![
+        add0.tree_ids().get_add(0).unwrap().clone(),
+        rem0.tree_ids().get_add(0).unwrap().clone(),
+        add1.tree_ids().get_add(0).unwrap().clone(),
+    ]);
+
+    let trees = MergedTree::new(store.clone(), merge.clone(), ConflictLabels::unlabeled());
+    let rename_map = compute_rename_map(&trees).block_on().unwrap();
+    assert!(rename_map.contains_key(foo));
+    let foo_renames = &rename_map[foo];
+    assert!(foo_renames.is_resolved());
+    assert_eq!(foo_renames.get_add(0).unwrap(), &None);
+    assert!(rename_map.contains_key(bar));
+    let bar_renames = &rename_map[bar];
+    assert_eq!(bar_renames.num_sides(), merge.num_sides());
+    assert_eq!(bar_renames.get_add(0).unwrap(), &Some(foo.to_owned()));
+    assert_eq!(bar_renames.get_remove(0).unwrap(), &Some(foo.to_owned()));
+    assert_eq!(bar_renames.get_add(1).unwrap(), &Some(bar.to_owned()));
+}
+
+#[test]
+fn test_edit_plus_copy() {
+    let test_repo = TestRepo::init();
+    let repo = &test_repo.repo;
+    let store = repo.store();
+
+    let foo = repo_path("foo");
+    let bar = repo_path("bar");
+
+    // Define copy history: file1 -> file2 -> file3
+    let histories = write_copy_histories(repo, &[(foo, vec![]), (bar, vec![foo])]);
+
+    let add0 = create_tree_with_copy_history(repo, &histories, &[(foo, "foo plus edits")]);
+    let rem0 = create_tree_with_copy_history(repo, &histories, &[(foo, "foo")]);
+    let add1 = create_tree_with_copy_history(repo, &histories, &[(foo, "foo"), (bar, "foo")]);
+
+    let merge = Merge::from_vec(vec![
+        add0.tree_ids().get_add(0).unwrap().clone(),
+        rem0.tree_ids().get_add(0).unwrap().clone(),
+        add1.tree_ids().get_add(0).unwrap().clone(),
+    ]);
+
+    let trees = MergedTree::new(store.clone(), merge.clone(), ConflictLabels::unlabeled());
+    let rename_map = compute_rename_map(&trees).block_on().unwrap();
+    assert!(rename_map.contains_key(foo));
+    let foo_renames = &rename_map[foo];
+    assert_eq!(foo_renames.num_sides(), merge.num_sides());
+    assert_eq!(foo_renames.get_add(0).unwrap(), &Some(foo.to_owned()));
+    assert_eq!(foo_renames.get_remove(0).unwrap(), &Some(foo.to_owned()));
+    assert_eq!(foo_renames.get_add(1).unwrap(), &Some(foo.to_owned()));
+    assert!(rename_map.contains_key(bar));
+    let bar_renames = &rename_map[bar];
+    assert_eq!(bar_renames.num_sides(), merge.num_sides());
+    assert_eq!(bar_renames.get_add(0).unwrap(), &Some(foo.to_owned()));
+    assert_eq!(bar_renames.get_remove(0).unwrap(), &Some(foo.to_owned()));
+    assert_eq!(bar_renames.get_add(1).unwrap(), &Some(bar.to_owned()));
+}
+
+#[test]
+fn test_five_way_rename_and_copy_merge() {
+    let test_repo = TestRepo::init();
+    let repo = &test_repo.repo;
+    let store = repo.store();
+
+    let foo = repo_path("foo");
+    let bar = repo_path("bar");
+    let baz = repo_path("baz");
+
+    // Define copy history: file1 -> file2 -> file3
+    let histories =
+        write_copy_histories(repo, &[(foo, vec![]), (bar, vec![foo]), (baz, vec![foo])]);
+
+    let add0 = create_tree_with_copy_history(repo, &histories, &[(foo, "foo plus edits")]);
+    let rem0 = create_tree_with_copy_history(repo, &histories, &[(foo, "foo")]);
+    let add1 = create_tree_with_copy_history(repo, &histories, &[(foo, "foo"), (bar, "foo")]);
+    // rem1 == rem0
+    let add2 = create_tree_with_copy_history(repo, &histories, &[(baz, "foo")]);
+
+    let merge = Merge::from_vec(vec![
+        add0.tree_ids().get_add(0).unwrap().clone(),
+        rem0.tree_ids().get_add(0).unwrap().clone(),
+        add1.tree_ids().get_add(0).unwrap().clone(),
+        rem0.tree_ids().get_add(0).unwrap().clone(),
+        add2.tree_ids().get_add(0).unwrap().clone(),
+    ]);
+
+    let trees = MergedTree::new(store.clone(), merge.clone(), ConflictLabels::unlabeled());
+    let rename_map = compute_rename_map(&trees).block_on().unwrap();
+    assert!(rename_map.contains_key(foo));
+    let foo_renames = &rename_map[foo];
+    assert!(foo_renames.is_resolved());
+    assert_eq!(foo_renames.get_add(0).unwrap(), &None); // TODO: this seems incorrect
+    assert!(rename_map.contains_key(bar));
+    let bar_renames = &rename_map[bar];
+    assert_eq!(bar_renames.num_sides(), merge.num_sides());
+    assert_eq!(bar_renames.get_add(0).unwrap(), &Some(foo.to_owned()));
+    assert_eq!(bar_renames.get_remove(0).unwrap(), &Some(foo.to_owned()));
+    assert_eq!(bar_renames.get_add(1).unwrap(), &Some(bar.to_owned()));
+    assert_eq!(bar_renames.get_remove(1).unwrap(), &Some(foo.to_owned()));
+    assert_eq!(bar_renames.get_add(2).unwrap(), &Some(baz.to_owned()));
 }

--- a/lib/testutils/src/lib.rs
+++ b/lib/testutils/src/lib.rs
@@ -29,6 +29,7 @@ use futures::AsyncReadExt as _;
 use itertools::Itertools as _;
 use jj_lib::backend;
 use jj_lib::backend::Backend;
+use jj_lib::backend::BackendError;
 use jj_lib::backend::BackendInitError;
 use jj_lib::backend::ChangeId;
 use jj_lib::backend::CommitId;
@@ -463,7 +464,7 @@ impl TestTreeBuilder {
             contents: contents.as_ref().to_vec(),
             executable: false,
             copy_history: None,
-            copy_id: CopyId::placeholder(),
+            copy_id: None,
         }
     }
 
@@ -498,7 +499,7 @@ pub struct TestTreeFileEntryBuilder<'a> {
     contents: Vec<u8>,
     executable: bool,
     copy_history: Option<CopyHistory>,
-    copy_id: CopyId,
+    copy_id: Option<CopyId>,
 }
 
 impl TestTreeFileEntryBuilder<'_> {
@@ -511,14 +512,14 @@ impl TestTreeFileEntryBuilder<'_> {
     /// calls.
     pub fn copy_history(mut self, copy_history: &CopyHistory) -> Self {
         self.copy_history = Some(copy_history.clone());
-        self.copy_id = CopyId::placeholder();
+        self.copy_id = None;
         self
     }
 
     /// Setting an explicit `CopyId` overrides any previous `.copy_history()`
     /// calls.
     pub fn copy_id(mut self, copy_id: CopyId) -> Self {
-        self.copy_id = copy_id;
+        self.copy_id = Some(copy_id);
         self.copy_history = None;
         self
     }
@@ -540,8 +541,24 @@ impl Drop for TestTreeFileEntryBuilder<'_> {
                 .write_copy(copy_history)
                 .block_on()
                 .unwrap()
+        } else if let Some(copy_id) = &self.copy_id {
+            copy_id.clone()
         } else {
-            self.copy_id.clone()
+            let res = self
+                .tree_builder
+                .store()
+                .backend()
+                .write_copy(&CopyHistory {
+                    current_path: path.clone(),
+                    parents: vec![],
+                    salt: vec![],
+                })
+                .block_on();
+            match res {
+                Err(BackendError::Unsupported(_)) => Ok(CopyId::placeholder()),
+                r => r,
+            }
+            .unwrap()
         };
         self.tree_builder.set(
             path,
@@ -651,6 +668,17 @@ pub fn create_tree_with_copy_id(
     create_tree_with(repo, |builder| {
         for (path, contents, id) in path_contents_id {
             builder.file(path, contents).copy_id((*id).clone());
+        }
+    })
+}
+
+pub fn create_tree_with_placeholder_copy_ids(
+    repo: &Arc<ReadonlyRepo>,
+    path_contents: &[(&RepoPath, &str)],
+) -> MergedTree {
+    create_tree_with(repo, |builder| {
+        for (path, contents) in path_contents {
+            builder.file(path, contents).copy_id(CopyId::placeholder());
         }
     })
 }

--- a/lib/testutils/src/lib.rs
+++ b/lib/testutils/src/lib.rs
@@ -29,6 +29,7 @@ use futures::AsyncReadExt as _;
 use itertools::Itertools as _;
 use jj_lib::backend;
 use jj_lib::backend::Backend;
+use jj_lib::backend::BackendError;
 use jj_lib::backend::BackendInitError;
 use jj_lib::backend::ChangeId;
 use jj_lib::backend::CommitId;
@@ -462,7 +463,7 @@ impl TestTreeBuilder {
             contents: contents.as_ref().to_vec(),
             executable: false,
             copy_history: None,
-            copy_id: CopyId::placeholder(),
+            copy_id: None,
         }
     }
 
@@ -497,7 +498,7 @@ pub struct TestTreeFileEntryBuilder<'a> {
     contents: Vec<u8>,
     executable: bool,
     copy_history: Option<CopyHistory>,
-    copy_id: CopyId,
+    copy_id: Option<CopyId>,
 }
 
 impl TestTreeFileEntryBuilder<'_> {
@@ -510,14 +511,14 @@ impl TestTreeFileEntryBuilder<'_> {
     /// calls.
     pub fn copy_history(mut self, copy_history: &CopyHistory) -> Self {
         self.copy_history = Some(copy_history.clone());
-        self.copy_id = CopyId::placeholder();
+        self.copy_id = None;
         self
     }
 
     /// Setting an explicit `CopyId` overrides any previous `.copy_history()`
     /// calls.
     pub fn copy_id(mut self, copy_id: CopyId) -> Self {
-        self.copy_id = copy_id;
+        self.copy_id = Some(copy_id);
         self.copy_history = None;
         self
     }
@@ -539,8 +540,24 @@ impl Drop for TestTreeFileEntryBuilder<'_> {
                 .write_copy(copy_history)
                 .block_on()
                 .unwrap()
+        } else if let Some(copy_id) = &self.copy_id {
+            copy_id.clone()
         } else {
-            self.copy_id.clone()
+            let res = self
+                .tree_builder
+                .store()
+                .backend()
+                .write_copy(&CopyHistory {
+                    current_path: path.clone(),
+                    parents: vec![],
+                    salt: vec![],
+                })
+                .block_on();
+            match res {
+                Err(BackendError::Unsupported(_)) => Ok(CopyId::placeholder()),
+                r => r,
+            }
+            .unwrap()
         };
         self.tree_builder.set(
             path,
@@ -650,6 +667,17 @@ pub fn create_tree_with_copy_id(
     create_tree_with(repo, |builder| {
         for (path, contents, id) in path_contents_id {
             builder.file(path, contents).copy_id((*id).clone());
+        }
+    })
+}
+
+pub fn create_tree_with_placeholder_copy_ids(
+    repo: &Arc<ReadonlyRepo>,
+    path_contents: &[(&RepoPath, &str)],
+) -> MergedTree {
+    create_tree_with(repo, |builder| {
+        for (path, contents) in path_contents {
+            builder.file(path, contents).copy_id(CopyId::placeholder());
         }
     })
 }

--- a/lib/testutils/src/proptest.rs
+++ b/lib/testutils/src/proptest.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 
 use itertools::Itertools as _;
 use jj_lib::backend::CommitId;
+use jj_lib::backend::CopyId;
 use jj_lib::merged_tree::MergedTree;
 use jj_lib::repo::ReadonlyRepo;
 use jj_lib::repo_path::RepoPath;
@@ -116,7 +117,10 @@ impl WorkingCopyReferenceStateMachine {
                         contents,
                         executable,
                     } => {
-                        builder.file(path, contents).executable(executable);
+                        builder
+                            .file(path, contents)
+                            .executable(executable)
+                            .copy_id(CopyId::placeholder());
                     }
                     DirEntry::Symlink { target } => builder.symlink(path, &target),
                     DirEntry::GitSubmodule { commit } => builder.submodule(path, commit),


### PR DESCRIPTION
Implement the next step of `docs/design/copy-tracking.md` by making the tree merge process copy-aware. We do so by computing a map of copied/renamed files across the terms of the merge, and then using that as an input to the TreeMerger.

This probably needs more / better test cases, but I am approaching burnout on this PR. I would appreciate it if reviewers could suggest new test cases, and I'll be happy to implement them.

# Checklist

If applicable:

- ~[ ] I have updated `CHANGELOG.md`~
- ~[ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)~
- ~[ ] I have updated the config schema (`cli/src/config-schema.json`)~
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- ~[ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.~
