### PR TITLE
cli: add option to limit diff stat bar width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `revsets.log` now defaults to `builtin_log()`, so custom log revsets can
   reuse the built-in default instead of copying its full expression.
 
+* Added config option `diff.stat.max-bar-width` for use with `--stat` to limit
+  the `++--` bar width. In the templating language, `diff.stat()` can optionally
+  take a second (positional or named) argument `max_bar_width` for an equivalent
+  effect.
+
 ### Fixed bugs
 
 * Recursive alias definitions are detected more precisely. jj can now expand

--- a/cli/src/commit_templater.rs
+++ b/cli/src/commit_templater.rs
@@ -93,6 +93,7 @@ use serde::Serialize as _;
 
 use crate::diff_util;
 use crate::diff_util::DiffStatEntry;
+use crate::diff_util::DiffStatOptions;
 use crate::diff_util::DiffStats;
 use crate::formatter::Formatter;
 use crate::git_util;
@@ -2469,7 +2470,8 @@ fn builtin_tree_diff_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, T
     map.insert(
         "stat",
         |language, diagnostics, build_ctx, self_property, function| {
-            let ([], [width_node]) = function.expect_arguments()?;
+            let ([], [width_node, max_bar_width_node]) =
+                function.expect_named_arguments(&["", "max_bar_width"])?;
             let width_property = width_node
                 .map(|node| {
                     template_builder::expect_usize_expression(
@@ -2480,23 +2482,44 @@ fn builtin_tree_diff_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, T
                     )
                 })
                 .transpose()?;
+            let max_bar_width_property = max_bar_width_node
+                .map(|node| {
+                    template_builder::expect_usize_expression(
+                        language,
+                        diagnostics,
+                        build_ctx,
+                        node,
+                    )
+                })
+                .transpose()?;
             let path_converter = language.path_converter;
-            // No user configuration exists for diff stat.
-            let options = diff_util::DiffStatOptions::default();
+            let options =
+                diff_util::DiffStatOptions::from_settings(language.settings()).map_err(|err| {
+                    let message = "Failed to load diff settings";
+                    TemplateParseError::expression(message, function.name_span).with_source(err)
+                })?;
             let conflict_marker_style = language.conflict_marker_style;
             // TODO: cache and reuse stats within the current evaluation?
-            let out_property = (self_property, width_property).and_then(move |(diff, width)| {
-                let store = diff.from_tree.store();
-                let tree_diff = diff.diff_stream();
-                let stats = DiffStats::calculate(store, tree_diff, &options, conflict_marker_style)
-                    .block_on()?;
-                Ok(DiffStatsFormatted {
-                    stats,
-                    path_converter,
-                    // TODO: fall back to current available width
-                    width: width.unwrap_or(80),
-                })
-            });
+            let out_property = (self_property, width_property, max_bar_width_property).and_then(
+                move |(diff, width, max_bar_width)| {
+                    let mut options = options.clone();
+                    if let Some(max_bar_width) = max_bar_width {
+                        options.max_bar_width = Some(max_bar_width);
+                    }
+                    let store = diff.from_tree.store();
+                    let tree_diff = diff.diff_stream();
+                    let stats =
+                        DiffStats::calculate(store, tree_diff, &options, conflict_marker_style)
+                            .block_on()?;
+                    Ok(DiffStatsFormatted {
+                        stats,
+                        path_converter,
+                        // TODO: fall back to current available width
+                        width: width.unwrap_or(80),
+                        options,
+                    })
+                },
+            );
             Ok(out_property.into_dyn_wrapped())
         },
     );
@@ -2701,6 +2724,7 @@ pub struct DiffStatsFormatted<'a> {
     stats: DiffStats,
     path_converter: &'a RepoPathUiConverter,
     width: usize,
+    options: DiffStatOptions,
 }
 
 impl Template for DiffStatsFormatted<'_> {
@@ -2710,6 +2734,7 @@ impl Template for DiffStatsFormatted<'_> {
             &self.stats,
             self.path_converter,
             self.width,
+            &self.options,
         )
     }
 }

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -452,6 +452,16 @@
                             "default": true
                         }
                     }
+                },
+                "stat": {
+                    "type": "object",
+                    "description": "Options for the diff stat display",
+                    "properties": {
+                        "context": {
+                            "type": "integer",
+                            "description": "Maximum number of characters to show in the `++--` stat bar"
+                        }
+                    }
                 }
             }
         },

--- a/cli/src/diff_util.rs
+++ b/cli/src/diff_util.rs
@@ -14,6 +14,7 @@
 
 use std::borrow::Cow;
 use std::cmp::max;
+use std::cmp::min;
 use std::future;
 use std::io;
 use std::iter;
@@ -35,6 +36,7 @@ use jj_lib::backend::CopyRecord;
 use jj_lib::backend::TreeValue;
 use jj_lib::commit::Commit;
 use jj_lib::config::ConfigGetError;
+use jj_lib::config::ConfigGetResultExt as _;
 use jj_lib::conflict_labels::ConflictLabels;
 use jj_lib::conflicts::ConflictMarkerStyle;
 use jj_lib::conflicts::ConflictMaterializeOptions;
@@ -255,7 +257,7 @@ impl BuiltinFormatKind {
         match self {
             Self::Summary => Ok(DiffFormat::Summary),
             Self::Stat => {
-                let mut options = DiffStatOptions::default();
+                let mut options = DiffStatOptions::from_settings(settings)?;
                 options.merge_args(args);
                 Ok(DiffFormat::Stat(Box::new(options)))
             }
@@ -489,7 +491,13 @@ impl<'a> DiffRenderer<'a> {
                     let stats =
                         DiffStats::calculate(store, tree_diff, options, self.conflict_marker_style)
                             .await?;
-                    show_diff_stats(*formatter.labeled("stat"), &stats, path_converter, width)?;
+                    show_diff_stats(
+                        *formatter.labeled("stat"),
+                        &stats,
+                        path_converter,
+                        width,
+                        options,
+                    )?;
                 }
                 DiffFormat::Types => {
                     let tree_diff = diff_stream();
@@ -1891,9 +1899,19 @@ pub fn diff_status(
 pub struct DiffStatOptions {
     /// How lines are tokenized and compared.
     pub line_diff: LineDiffOptions,
+    /// How many characters to use at most, for the bar portion.
+    /// If None, there is no width limit.
+    pub max_bar_width: Option<usize>,
 }
 
 impl DiffStatOptions {
+    pub fn from_settings(settings: &UserSettings) -> Result<Self, ConfigGetError> {
+        Ok(Self {
+            line_diff: LineDiffOptions::default(),
+            max_bar_width: settings.get("diff.stat.max-bar-width").optional()?,
+        })
+    }
+
     fn merge_args(&mut self, args: &DiffFormatArgs) {
         self.line_diff.merge_args(args);
     }
@@ -2048,7 +2066,8 @@ pub fn show_diff_stats(
     formatter: &mut dyn Formatter,
     stats: &DiffStats,
     path_converter: &RepoPathUiConverter,
-    display_width: usize,
+    total_display_width: usize,
+    options: &DiffStatOptions,
 ) -> io::Result<()> {
     let ui_paths = stats
         .entries()
@@ -2073,7 +2092,7 @@ pub fn show_diff_stats(
 
     // Fit to the available display width, but always assume at least a tiny bit of
     // room.
-    let available_width = max(display_width.saturating_sub(" | ".len()), 8);
+    let available_width = max(total_display_width.saturating_sub(" | ".len()), 8);
 
     // Measure the widest right side for line diffs and reduce max_path_width if
     // needed.
@@ -2112,8 +2131,13 @@ pub fn show_diff_stats(
 
     // Now that we've chosen the path width, use the rest of the space for the ++--
     // bar.
-    let max_bar_width =
+
+    let mut max_bar_width =
         available_width.saturating_sub(max_path_width + diff_number_width + " ".len());
+    if let Some(bar_width) = options.max_bar_width {
+        max_bar_width = min(max_bar_width, bar_width);
+    }
+
     let factor = match max_diffs {
         Some(max) if max > max_bar_width => max_bar_width as f64 / max as f64,
         _ => 1.0,

--- a/cli/tests/test_diff_command.rs
+++ b/cli/tests/test_diff_command.rs
@@ -4118,3 +4118,68 @@ fn test_diff_rename_in_merge_commit() {
     [EOF]
     ");
 }
+
+#[test]
+fn test_diff_stat_max_bar_width() {
+    let test_env = TestEnvironment::default();
+    test_env.add_config(
+        r#"
+    [diff.stat]
+    max-bar-width = 10
+    "#,
+    );
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    // A file adding 50 lines should occupy
+    // all 10 characters of the max bar width
+    let mut file_contents: String = "\n".repeat(50);
+    work_dir.write_file("file", file_contents);
+    let output = work_dir.run_jj(["diff", "--stat"]);
+    insta::assert_snapshot!(output, @"
+    file | 50 ++++++++++
+    1 file changed, 50 insertions(+), 0 deletions(-)
+    [EOF]
+    ");
+    work_dir.run_jj(["new"]).success();
+    // Modify the last 25 lines for a total of 50 removed+added lines.
+    // (Modified lines are interpreted as removing and then adding a line.)
+    // the diff stat should be half + and half -
+    file_contents = "\n".repeat(25);
+    file_contents.push_str(&"A\n".repeat(25));
+    // There is a second file which takes up 20% of the space by lines changed
+    let file2_contents: String = "\n".repeat(10);
+    work_dir.write_file("file", file_contents);
+    work_dir.write_file("file2", file2_contents);
+    let output = work_dir.run_jj(["diff", "--stat"]);
+    insta::assert_snapshot!(output, @"
+    file  | 50 +++++-----
+    file2 | 10 ++
+    2 files changed, 35 insertions(+), 25 deletions(-)
+    [EOF]
+    ");
+
+    // Setting the max-bar-width higher than the column space shouldn't overflow
+    let output = work_dir.run_jj_with(|cmd| {
+        cmd.args(["diff", "--stat", "--config=diff.stat.max-bar-width=100"])
+            .env("COLUMNS", "30")
+    });
+    insta::assert_snapshot!(output, @"
+    file  | 50 +++++++++----------
+    file2 | 10 +++
+    2 files changed, 35 insertions(+), 25 deletions(-)
+    [EOF]
+    ");
+
+    // Setting max-bar-width=0 should not crash. The current implementation
+    // cannot reduce the max width below 2. Currently, setting max-bar-width=0
+    // with the following test writes '++' instead of '+-'.
+    let output = work_dir
+        .run_jj_with(|cmd| cmd.args(["diff", "--stat", "--config=diff.stat.max-bar-width=0"]));
+    insta::assert_snapshot!(output, @"
+    file  | 50 ++
+    file2 | 10 +
+    2 files changed, 35 insertions(+), 25 deletions(-)
+    [EOF]
+    ");
+}

--- a/docs/config.md
+++ b/docs/config.md
@@ -487,6 +487,20 @@ context = 3
 show-path-prefix = true
 ```
 
+#### Diff stat options
+
+When using a subcommand that displays the diff stat menu like `jj show --stat`,
+the bar portion that renders as `++--` can be limited to a maximum width in
+characters.
+
+```toml
+[diff.stat]
+max-bar-width = 10
+```
+
+By default without this option set, the bar width is unbounded and will use the
+remaining available space, with a minimum of 30% of the total width.
+
 ### Generating diffs by external command
 
 If `ui.diff-formatter` is not a builtin format, the specified diff command will

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -760,7 +760,10 @@ This type cannot be printed. The following methods are defined.
 * `.color_words([context: Integer]) -> Template`: Format as a word-level diff
   with changes indicated only by color.
 * `.git([context: Integer]) -> Template`: Format as a Git diff.
-* `.stat([width: Integer]) -> DiffStats`: Calculate stats of changed lines.
+* `.stat([width: Integer], [max_bar_width: Integer]) -> DiffStats`: Calculate
+  stats of changed lines. `width` sets the entire width of the diff stat
+  including paths, and `max_bar_width` limits the maximum character length of
+  the `++--` bar.
 * `.summary() -> Template`: Format as a list of status code and path pairs.
 
 ### `TreeDiffEntry` type


### PR DESCRIPTION
I posted on the discord about wanting this since it bothered me when moving between diffs, the `+-` symbols change in relative significance based on the length of the filepaths. it seemed easy enough to add, and is backwards compatible. I didn't otherwise modify the stat rendering, so there is still no fallback width for the template method.

this can be done with the `diff.stat()` template function, which can now optionally take a second argument for the bar width, or it can be provided as a diff formatting argument `--stat-bar-width` with `--stat`.

Example usage in config.toml which renders the stat bar with `jj show`:

```toml
[template-aliases]
log_stat = "builtin_log_compact ++ diff.stat(80, 10)"

[templates]
show = "log_stat"
```

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`docs/`)
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized). I do not use LLMs.