### PR TITLE
cli: complete workspace working-copy symbols as revisions

### DIFF
--- a/cli/src/complete.rs
+++ b/cli/src/complete.rs
@@ -313,8 +313,9 @@ fn revisions(match_prefix: &str, revset_filter: Option<&str>) -> Vec<CompletionC
         const LOCAL_BOOKMARK: usize = 0;
         const TAG: usize = 1;
         const CHANGE_ID: usize = 2;
-        const REMOTE_BOOKMARK: usize = 3;
-        const REVSET_ALIAS: usize = 4;
+        const WORKSPACE: usize = 3;
+        const REMOTE_BOOKMARK: usize = 4;
+        const REVSET_ALIAS: usize = 5;
 
         let mut candidates = Vec::new();
 
@@ -378,6 +379,37 @@ fn revisions(match_prefix: &str, revset_filter: Option<&str>) -> Vec<CompletionC
                 CompletionCandidate::new(name)
                     .help(desc)
                     .display_order(Some(TAG))
+            }));
+        }
+
+        // workspace names
+
+        let output = jj
+            .build()
+            .arg("workspace")
+            .arg("list")
+            .arg("--template")
+            .arg(r#"name ++ "\n""#)
+            .output()
+            .map_err(user_error)?;
+        let stdout = String::from_utf8_lossy(&output.stdout);
+
+        // If there's only one workspace, the user can just use `@`, and they may even
+        // be confused if they see `default@` as an option.
+        if stdout.lines().count() > 1 {
+            candidates.extend(stdout.lines().filter_map(|name| {
+                let symbol = format!("{name}@");
+                if symbol.starts_with(match_prefix) {
+                    Some(
+                        CompletionCandidate::new(symbol)
+                            .help(Some(
+                                format!("The working copy for workspace `{name}`").into(),
+                            ))
+                            .display_order(Some(WORKSPACE)),
+                    )
+                } else {
+                    None
+                }
             }));
         }
 

--- a/cli/tests/test_completion.rs
+++ b/cli/tests/test_completion.rs
@@ -1256,6 +1256,42 @@ fn test_revisions() {
 }
 
 #[test]
+fn test_revisions_workspace_symbols() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    work_dir
+        .run_jj(["describe", "-m", "main workspace"])
+        .success();
+
+    // workspace working-copy symbols are not completed when there is only one
+    // workspace
+    let output = work_dir.complete_fish(["show", "def"]);
+    insta::assert_snapshot!(output, @"
+    ");
+
+    work_dir
+        .run_jj(["workspace", "add", "--name", "secondary", "../secondary"])
+        .success();
+
+    // workspace working-copy symbols are completed
+    let output = work_dir.complete_fish(["show", "def"]);
+    insta::assert_snapshot!(output, @"
+    default@	The working copy for workspace `default`
+    [EOF]
+    ");
+
+    // they are also completed within revset expressions and respect the
+    // mutable-revisions filter
+    let output = work_dir.complete_fish(["abandon", "..def"]);
+    insta::assert_snapshot!(output, @"
+    ..default@	The working copy for workspace `default`
+    [EOF]
+    ");
+}
+
+#[test]
 fn test_operations() {
     let test_env = TestEnvironment::default();
 


### PR DESCRIPTION
In repositories with multiple workspaces, revision completion now suggests `<name>@` symbols for each workspace, so e.g. `jj show se<TAB>` completes to `secondary@`. The candidates respect the revset filter used for mutable-only completions, and nothing is suggested in single-workspace repositories (where plain `@` covers the working copy).

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
