### PR TITLE
run: stop running remaining revisions after a command fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   Git HEAD to the parent of the fresh working-copy commit.
   [#9936](https://github.com/jj-vcs/jj/issues/9936)
 
+* `jj run` no longer runs against the remaining revisions if a process exits
+  with a nonzero exit code.
+
 ## [0.44.0] - 2026-08-05
 
 ### Release highlights

--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -56,7 +56,6 @@ use jj_lib::object_id::ObjectId as _;
 use jj_lib::repo::Repo as _;
 use jj_lib::working_copy::SnapshotOptions;
 use tokio::runtime::Builder;
-use tokio::sync::Semaphore;
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::Sender;
 use tokio::task::JoinError;
@@ -386,42 +385,47 @@ async fn run_inner(
     commits: &[Commit],
     jobs: usize,
     passthrough: bool,
+    ignore_errors: bool,
 ) -> Result<(), RunError> {
     let base_ignores = tx.base_workspace_helper().base_ignores().unwrap().clone();
-    let semaphore = Arc::new(Semaphore::new(jobs));
     let mut command_futures: JoinSet<Result<RunJob, RunError>> = JoinSet::new();
-    for commit in commits {
-        // Acquire the permit before spawning so tasks start in commit order.
-        let permit = semaphore
-            .clone()
-            .acquire_owned()
-            .await
-            .expect("semaphore not closed");
-        let base_ignores = base_ignores.clone();
-        let pool = pool.clone();
-        let commit = commit.clone();
-        let spec = spec.clone();
-        command_futures.spawn_on(
-            async move {
-                let _permit = permit;
-                // TODO: handle/propagate error here
-                rewrite_commit(base_ignores, pool, commit, spec, passthrough).await
-            },
-            handle,
-        );
-    }
+    let mut commits_iter = commits.iter();
+    loop {
+        // Launch commits in order, keeping at most `jobs` in flight so tasks
+        // start in commit order and the pool is never oversubscribed.
+        while command_futures.len() < jobs {
+            let Some(commit) = commits_iter.next() else {
+                break;
+            };
+            let base_ignores = base_ignores.clone();
+            let pool = pool.clone();
+            let commit = commit.clone();
+            let spec = spec.clone();
+            command_futures.spawn_on(
+                async move { rewrite_commit(base_ignores, pool, commit, spec, passthrough).await },
+                handle,
+            );
+        }
 
-    while let Some(res) = command_futures.join_next().await {
+        let Some(res) = command_futures.join_next().await else {
+            break;
+        };
         let done = match res {
             Ok(rj) => rj?,
             Err(err) => return Err(RunError::JobFailure(err)),
         };
+        let failed = done.status.is_some_and(|status| !status.success());
         let should_quit = sender.send(done).await.is_err();
         if should_quit {
             tracing::debug!(
                 ?should_quit,
                 "receiver is no longer available, exiting loop"
             );
+            break;
+        }
+        if failed && !ignore_errors {
+            // Any remaining commands in the JoinSet will be canceled due to
+            // `kill_on_drop(true)`
             break;
         }
     }
@@ -792,6 +796,7 @@ pub async fn cmd_run(
                 &resolved_commits,
                 jobs.get(),
                 args.passthrough,
+                args.ignore_errors,
             )
             .await
             .map_err(CommandError::from)

--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -56,7 +56,6 @@ use jj_lib::object_id::ObjectId as _;
 use jj_lib::repo::Repo as _;
 use jj_lib::working_copy::SnapshotOptions;
 use tokio::runtime::Builder;
-use tokio::sync::Semaphore;
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::Sender;
 use tokio::task::JoinError;
@@ -386,42 +385,49 @@ async fn run_inner(
     commits: &[Commit],
     jobs: usize,
     passthrough: bool,
+    ignore_errors: bool,
 ) -> Result<(), RunError> {
     let base_ignores = tx.base_workspace_helper().base_ignores().unwrap().clone();
-    let semaphore = Arc::new(Semaphore::new(jobs));
     let mut command_futures: JoinSet<Result<RunJob, RunError>> = JoinSet::new();
-    for commit in commits {
-        // Acquire the permit before spawning so tasks start in commit order.
-        let permit = semaphore
-            .clone()
-            .acquire_owned()
-            .await
-            .expect("semaphore not closed");
-        let base_ignores = base_ignores.clone();
-        let pool = pool.clone();
-        let commit = commit.clone();
-        let spec = spec.clone();
-        command_futures.spawn_on(
-            async move {
-                let _permit = permit;
-                // TODO: handle/propagate error here
-                rewrite_commit(base_ignores, pool, commit, spec, passthrough).await
-            },
-            handle,
-        );
-    }
+    let mut commits_iter = commits.iter().fuse();
+    loop {
+        // Launch commits in order, keeping at most `jobs` in flight so tasks
+        // start in commit order and the pool is never oversubscribed.
+        while command_futures.len() < jobs {
+            let Some(commit) = commits_iter.next() else {
+                break;
+            };
+            let base_ignores = base_ignores.clone();
+            let pool = pool.clone();
+            let commit = commit.clone();
+            let spec = spec.clone();
+            command_futures.spawn_on(
+                async move { rewrite_commit(base_ignores, pool, commit, spec, passthrough).await },
+                handle,
+            );
+        }
 
-    while let Some(res) = command_futures.join_next().await {
+        let Some(res) = command_futures.join_next().await else {
+            break;
+        };
         let done = match res {
             Ok(rj) => rj?,
             Err(err) => return Err(RunError::JobFailure(err)),
         };
+        let failed = done.status.is_some_and(|status| !status.success());
         let should_quit = sender.send(done).await.is_err();
         if should_quit {
             tracing::debug!(
                 ?should_quit,
                 "receiver is no longer available, exiting loop"
             );
+            break;
+        }
+        if failed && !ignore_errors {
+            // Kill any running processes and wait for them to exit so we don't
+            // leave zombie processes, which may not get cleaned up by Tokio
+            // before our process exits
+            command_futures.shutdown().await;
             break;
         }
     }
@@ -792,6 +798,7 @@ pub async fn cmd_run(
                 &resolved_commits,
                 jobs.get(),
                 args.passthrough,
+                args.ignore_errors,
             )
             .await
             .map_err(CommandError::from)

--- a/cli/tests/test_run_command.rs
+++ b/cli/tests/test_run_command.rs
@@ -545,6 +545,153 @@ fn test_run_ignore_errors_all_fail() {
     assert_eq!(get_log_output(&work_dir), log_before);
 }
 
+/// `jj run --passthrough` must fail fast: once a command exits non-zero it
+/// should stop, not keep running the command against every remaining revision.
+/// `--passthrough` forces a single job, so the revisions run sequentially and
+/// the output is deterministic.
+#[test]
+fn test_run_passthrough_stops_after_first_failure() {
+    let mut test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let fake_formatter = assert_cmd::cargo::cargo_bin("fake-formatter");
+    assert!(fake_formatter.is_file());
+    let fake_formatter_path = fake_formatter.to_string_lossy().into_owned();
+    test_env.add_paths_to_normalize(fake_formatter.clone(), "$FAKE_FORMATTER_PATH");
+    let work_dir = test_env.work_dir("repo");
+    work_dir.write_file("a.txt", "a");
+    work_dir.run_jj(&["commit", "-m", "A"]).success();
+    work_dir.write_file("b.txt", "b");
+    work_dir.run_jj(&["commit", "-m", "B"]).success();
+    work_dir.write_file("c.txt", "c");
+    work_dir.run_jj(&["commit", "-m", "C"]).success();
+
+    // Each invocation prints "x" (no newline) and exits non-zero. With
+    // `--passthrough` the command's stdout is streamed straight through, so the
+    // number of "x"es tells us how many revisions the command ran against.
+    // `jj run` must stop after the first failure, printing "x" exactly once
+    // rather than once per revision in `..@`.
+    let output = work_dir.run_jj(&[
+        "run",
+        "--passthrough",
+        "-r",
+        "..@",
+        "--",
+        &fake_formatter_path,
+        "--stdout",
+        "x",
+        "--fail",
+    ]);
+    insta::with_settings!({
+        filters => [
+            ("exit code", "exit status"), // Windows
+        ],
+    }, {
+        insta::assert_snapshot!(output, @r"
+        x[EOF]
+        ------- stderr -------
+        Error: the command '$FAKE_FORMATTER_PATH --stdout x --fail' failed with exit status: 1
+        Hint: Failed revision: qpvuntsm ffa1359e A
+        [EOF]
+        [exit status: 1]
+        ");
+    });
+
+    // With `--ignore-errors` the command runs against every revision in `..@`
+    // (A, B, C and the empty working-copy commit), so "x" is printed once per
+    // commit.
+    let output = work_dir.run_jj(&[
+        "run",
+        "--passthrough",
+        "--ignore-errors",
+        "-r",
+        "..@",
+        "--",
+        &fake_formatter_path,
+        "--stdout",
+        "x",
+        "--fail",
+    ]);
+    insta::assert_snapshot!(output.success(), @r"
+    xxxx[EOF]
+    ------- stderr -------
+    Nothing changed.
+    [EOF]
+    ");
+}
+
+#[test]
+fn test_run_stops_after_first_failure() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let fake_formatter = assert_cmd::cargo::cargo_bin("fake-formatter");
+    assert!(fake_formatter.is_file());
+    let fake_formatter_path = fake_formatter.to_string_lossy().into_owned();
+    let work_dir = test_env.work_dir("repo");
+    work_dir.write_file("a.txt", "a");
+    work_dir.run_jj(&["commit", "-m", "A"]).success();
+    work_dir.write_file("b.txt", "b");
+    work_dir.run_jj(&["commit", "-m", "B"]).success();
+    work_dir.write_file("c.txt", "c");
+    work_dir.run_jj(&["commit", "-m", "C"]).success();
+
+    // The counter lives outside every ephemeral working copy, so all invocations
+    // append to the same file and its byte length is the execution count.
+    let counter = test_env.env_root().join("run-count.txt");
+    let counter_arg = counter.to_str().unwrap();
+
+    // Default (no `--ignore-errors`): the command fails on the first revision,
+    // so `jj run` must not touch the remaining revisions in `..@`.
+    let output = work_dir.run_jj(&[
+        "run",
+        "--jobs",
+        "1",
+        "-r",
+        "..@",
+        "--",
+        &fake_formatter_path,
+        "--stdout",
+        "x",
+        "--tee",
+        counter_arg,
+        "--fail",
+    ]);
+    assert!(!output.status.success(), "expected `jj run` to fail");
+    assert_eq!(
+        fs::read(&counter).unwrap().len(),
+        1,
+        "command should have run against exactly one revision before stopping"
+    );
+
+    // Verify with `--ignore-errors` the same command runs against every
+    // revision in `..@` (A, B, C and the empty working-copy commit)
+    let counter_all = test_env.env_root().join("run-count-all.txt");
+    let counter_all_arg = counter_all.to_str().unwrap();
+    let output = work_dir.run_jj(&[
+        "run",
+        "--ignore-errors",
+        "--jobs",
+        "1",
+        "-r",
+        "..@",
+        "--",
+        &fake_formatter_path,
+        "--stdout",
+        "x",
+        "--tee",
+        counter_all_arg,
+        "--fail",
+    ]);
+    assert!(
+        output.status.success(),
+        "expected `jj run --ignore-errors` to succeed"
+    );
+    assert_eq!(
+        fs::read(&counter_all).unwrap().len(),
+        4,
+        "with --ignore-errors the command should run against all four revisions"
+    );
+}
+
 #[test]
 fn test_run_recovers_after_failure() {
     let test_env = TestEnvironment::default();


### PR DESCRIPTION
Without `--ignore-errors`, `jj run` should stop after the first command exits with a nonzero status. Instead, it was running the command against all revisions and just not emitting the output.

Change the run_inner loop so it interleaves launching jobs and waiting for a running job complete. This lets us detect a failure early and stop spawning new commands.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [X] I have added/updated tests to cover my changes
- [X] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [X] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
