### PR TITLE
Fix typo in squash --into help text

### DIFF
--- a/cli/src/commands/squash.rs
+++ b/cli/src/commands/squash.rs
@@ -95,7 +95,7 @@ pub(crate) struct SquashArgs {
     #[arg(add = ArgValueCompleter::new(complete::revset_expression_mutable))]
     from: Vec<RevisionArg>,
 
-    /// Revision to squash into (default: @)
+    /// Revision to squash into (default: @-)
     #[arg(
         long,
         short = 't',


### PR DESCRIPTION
--into defaults to @-, not @.