### PR TITLE
local_working_copy: skip paths that aren't valid UTF-8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   workspace becomes immutable, as well as during snapshotting. This brings the
   behavior closer to `jj` 0.42 and earlier.
 
+* Snapshotting no longer fails if the working copy contains a path whose name
+  isn't valid UTF-8. Such paths can't be tracked, so they are now skipped and
+  reported as a warning instead.
+  [#9774](https://github.com/jj-vcs/jj/issues/9774)
+
 * Fixed failure when reading configuration in copied repo with an empty
   repo-level configuration directory.
 

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -15,6 +15,7 @@
 use std::borrow::Cow;
 use std::cell::OnceCell;
 use std::collections::BTreeMap;
+use std::collections::BTreeSet;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::env;
@@ -666,9 +667,14 @@ impl CommandHelper {
                 let merged_stats = {
                     let SnapshotStats {
                         mut untracked_paths,
+                        mut invalid_utf8_paths,
                     } = stale_stats;
                     untracked_paths.extend(fresh_stats.untracked_paths);
-                    SnapshotStats { untracked_paths }
+                    invalid_utf8_paths.extend(fresh_stats.invalid_utf8_paths);
+                    SnapshotStats {
+                        untracked_paths,
+                        invalid_utf8_paths,
+                    }
                 };
                 Ok((workspace_command, merged_stats))
             }
@@ -3168,12 +3174,38 @@ pub fn print_untracked_files(
     Ok(())
 }
 
+/// Print a warning listing paths that were skipped because their names aren't
+/// valid UTF-8.
+fn print_invalid_utf8_paths(
+    ui: &Ui,
+    paths: &BTreeSet<(RepoPathBuf, OsString)>,
+    path_converter: &RepoPathUiConverter,
+) -> io::Result<()> {
+    if paths.is_empty() {
+        return Ok(());
+    }
+    writeln!(
+        ui.warning_default(),
+        "Skipped some paths because they are not valid UTF-8:"
+    )?;
+    let mut formatter = ui.stderr_formatter();
+    for (dir, name) in paths {
+        writeln!(
+            formatter,
+            "  {}: {name:?}",
+            path_converter.format_file_path(dir)
+        )?;
+    }
+    Ok(())
+}
+
 pub fn print_snapshot_stats(
     ui: &Ui,
     stats: &SnapshotStats,
     path_converter: &RepoPathUiConverter,
 ) -> io::Result<()> {
     print_untracked_files(ui, &stats.untracked_paths, path_converter)?;
+    print_invalid_utf8_paths(ui, &stats.invalid_utf8_paths, path_converter)?;
 
     let large_files_sizes = stats
         .untracked_paths

--- a/cli/tests/test_working_copy.rs
+++ b/cli/tests/test_working_copy.rs
@@ -290,6 +290,62 @@ fn test_snapshot_invalid_ignore_pattern() {
     ");
 }
 
+#[cfg(unix)]
+#[test]
+fn test_snapshot_non_utf8_path() {
+    use std::ffi::OsStr;
+    use std::os::unix::ffi::OsStrExt as _;
+
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    if testutils::check_strict_utf8_fs(work_dir.root()) {
+        eprintln!(
+            "Skipping test \"test_snapshot_non_utf8_path\" due to strict UTF-8 filesystem for \
+             path {:?}",
+            work_dir.root()
+        );
+        return;
+    }
+
+    std::fs::write(work_dir.root().join(OsStr::from_bytes(b"file\xe0")), "").unwrap();
+    std::fs::create_dir(work_dir.root().join(OsStr::from_bytes(b"dir\xe0"))).unwrap();
+    work_dir.write_file("file", "");
+
+    // The paths that can't be represented as RepoPaths are skipped, and the
+    // snapshot succeeds.
+    insta::assert_snapshot!(work_dir.run_jj(["st"]), @r#"
+    Working copy changes:
+    A file
+    Working copy  (@) : qpvuntsm 3dcf981e (no description set)
+    Parent commit (@-): zzzzzzzz 00000000 (empty) (no description set)
+    [EOF]
+    ------- stderr -------
+    Warning: Skipped some paths because they are not valid UTF-8:
+      .: "dir\xE0"
+      .: "file\xE0"
+    [EOF]
+    "#);
+
+    // .gitignore doesn't apply because we can't build a RepoPath to match
+    // against, so the paths are still reported.
+    work_dir.write_file(".gitignore", b"dir\xe0\nfile\xe0\n");
+    insta::assert_snapshot!(work_dir.run_jj(["st"]), @r#"
+    Working copy changes:
+    A .gitignore
+    A file
+    Working copy  (@) : qpvuntsm 0fbe2679 (no description set)
+    Parent commit (@-): zzzzzzzz 00000000 (empty) (no description set)
+    [EOF]
+    ------- stderr -------
+    Warning: Skipped some paths because they are not valid UTF-8:
+      .: "dir\xE0"
+      .: "file\xE0"
+    [EOF]
+    "#);
+}
+
 #[test]
 fn test_conflict_marker_length_stored_in_working_copy() -> TestResult {
     let test_env = TestEnvironment::default();

--- a/lib/src/local_working_copy.rs
+++ b/lib/src/local_working_copy.rs
@@ -19,6 +19,7 @@ use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::error::Error;
+use std::ffi::OsString;
 use std::fs;
 use std::fs::DirEntry;
 use std::fs::File;
@@ -1328,6 +1329,7 @@ impl TreeState {
         let (tree_entries_tx, tree_entries_rx) = channel();
         let (file_states_tx, file_states_rx) = channel();
         let (untracked_paths_tx, untracked_paths_rx) = channel();
+        let (invalid_utf8_paths_tx, invalid_utf8_paths_rx) = channel();
         let (deleted_files_tx, deleted_files_rx) = channel();
 
         trace_span!("traverse filesystem").in_scope(|| -> Result<(), SnapshotError> {
@@ -1341,6 +1343,7 @@ impl TreeState {
                 tree_entries_tx,
                 file_states_tx,
                 untracked_paths_tx,
+                invalid_utf8_paths_tx,
                 deleted_files_tx,
                 error: OnceLock::new(),
                 progress: *progress,
@@ -1363,6 +1366,7 @@ impl TreeState {
 
         let stats = SnapshotStats {
             untracked_paths: untracked_paths_rx.into_iter().collect(),
+            invalid_utf8_paths: invalid_utf8_paths_rx.into_iter().collect(),
         };
         let mut tree_builder = MergedTreeBuilder::new(self.tree.clone());
         trace_span!("process tree entries").in_scope(|| {
@@ -1408,7 +1412,9 @@ impl TreeState {
         // Since untracked paths aren't cached in the tree state, we'll need to
         // rescan the working directory changes to report or track them later.
         // TODO: store untracked paths and update watchman_clock?
-        if stats.untracked_paths.is_empty() || watchman_clock.is_none() {
+        if (stats.untracked_paths.is_empty() && stats.invalid_utf8_paths.is_empty())
+            || watchman_clock.is_none()
+        {
             self.watchman_clock = watchman_clock;
         } else {
             tracing::info!("not updating watchman clock because there are untracked files");
@@ -1512,6 +1518,7 @@ struct FileSnapshotter<'a> {
     tree_entries_tx: Sender<(RepoPathBuf, MergedTreeValue)>,
     file_states_tx: Sender<(RepoPathBuf, FileState)>,
     untracked_paths_tx: Sender<(RepoPathBuf, UntrackedReason)>,
+    invalid_utf8_paths_tx: Sender<(RepoPathBuf, OsString)>,
     deleted_files_tx: Sender<RepoPathBuf>,
     error: OnceLock<SnapshotError>,
     progress: Option<&'a SnapshotProgress<'a>>,
@@ -1595,9 +1602,16 @@ impl FileSnapshotter<'_> {
     ) -> Result<Option<(PresentDirEntryKind, String)>, SnapshotError> {
         let file_type = entry.file_type().unwrap();
         let file_name = entry.file_name();
-        let name_string = file_name
-            .into_string()
-            .map_err(|path| SnapshotError::InvalidUtf8Path { path })?;
+        let name_string = match file_name.into_string() {
+            Ok(name_string) => name_string,
+            Err(name) => {
+                // A path that isn't valid UTF-8 can't be represented as a
+                // RepoPath, so it can never be tracked. Skip it instead of
+                // failing the whole snapshot, and let the caller report it.
+                self.invalid_utf8_paths_tx.send((dir.to_owned(), name)).ok();
+                return Ok(None);
+            }
+        };
 
         if RESERVED_DIR_NAMES.contains(&name_string.as_str()) {
             return Ok(None);

--- a/lib/src/working_copy.rs
+++ b/lib/src/working_copy.rs
@@ -17,6 +17,7 @@
 
 use std::any::Any;
 use std::collections::BTreeMap;
+use std::collections::BTreeSet;
 use std::ffi::OsString;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -172,12 +173,6 @@ pub enum SnapshotError {
     /// A tracked path contained invalid component such as `..`.
     #[error(transparent)]
     InvalidRepoPath(#[from] InvalidRepoPathError),
-    /// A path in the working copy was not valid UTF-8.
-    #[error("Working copy path {} is not valid UTF-8", path.to_string_lossy())]
-    InvalidUtf8Path {
-        /// The path with invalid UTF-8.
-        path: OsString,
-    },
     /// A symlink target in the working copy was not valid UTF-8.
     #[error("Symlink {path} target is not valid UTF-8")]
     InvalidUtf8SymlinkTarget {
@@ -239,6 +234,10 @@ pub type SnapshotProgress<'a> = dyn Fn(&RepoPath) + 'a + Sync;
 pub struct SnapshotStats {
     /// List of new (previously untracked) files which are still untracked.
     pub untracked_paths: BTreeMap<RepoPathBuf, UntrackedReason>,
+    /// Paths that were skipped because their file names aren't valid UTF-8,
+    /// as (directory, file name) pairs. These paths cannot be represented as
+    /// `RepoPath`s.
+    pub invalid_utf8_paths: BTreeSet<(RepoPathBuf, OsString)>,
 }
 
 /// Reason why the new path isn't tracked.

--- a/lib/tests/test_local_working_copy.rs
+++ b/lib/tests/test_local_working_copy.rs
@@ -1482,6 +1482,62 @@ fn test_snapshot_special_file() -> TestResult {
     Ok(())
 }
 
+#[cfg(unix)]
+#[test]
+fn test_snapshot_non_utf8_path() -> TestResult {
+    // Tests that paths that can't be represented as RepoPaths are skipped
+    // instead of failing the whole snapshot. #9774
+    use std::ffi::OsStr;
+    use std::os::unix::ffi::OsStrExt as _;
+
+    let mut test_workspace = TestWorkspace::init();
+    let workspace_root = test_workspace.workspace.workspace_root().to_owned();
+
+    if testutils::check_strict_utf8_fs(&workspace_root) {
+        eprintln!(
+            "Skipping test \"test_snapshot_non_utf8_path\" due to strict UTF-8 filesystem for \
+             path {workspace_root:?}"
+        );
+        return Ok(());
+    }
+
+    let file_path = repo_path("file");
+    std::fs::write(file_path.to_fs_path_unchecked(&workspace_root), "contents")?;
+    let bad_file_name = OsStr::from_bytes(b"file\xe0");
+    std::fs::write(workspace_root.join(bad_file_name), "contents")?;
+    let bad_dir_name = OsStr::from_bytes(b"dir\xe0");
+    let bad_dir_disk_path = workspace_root.join(bad_dir_name);
+    std::fs::create_dir(&bad_dir_disk_path)?;
+    std::fs::write(bad_dir_disk_path.join("file"), "contents")?;
+
+    let ws = &mut test_workspace.workspace;
+    let mut locked_ws = ws.start_working_copy_mutation().block_on()?;
+    let (tree, stats) = locked_ws
+        .locked_wc()
+        .snapshot(&empty_snapshot_options())
+        .block_on()?;
+    locked_ws
+        .finish(OperationId::from_hex("abc123"))
+        .block_on()?;
+
+    // Only the path with a valid UTF-8 name should be in the tree. The
+    // directory isn't descended into, so it's reported as a single path.
+    assert_eq!(
+        tree.entries().map(|(path, _value)| path).collect_vec(),
+        to_owned_path_vec(&[file_path])
+    );
+    assert_eq!(
+        stats.invalid_utf8_paths,
+        [
+            (RepoPathBuf::root(), bad_dir_name.to_owned()),
+            (RepoPathBuf::root(), bad_file_name.to_owned()),
+        ]
+        .into()
+    );
+    assert!(stats.untracked_paths.is_empty());
+    Ok(())
+}
+
 #[test]
 fn test_gitignores() -> TestResult {
     // Tests that .gitignore files are respected.


### PR DESCRIPTION
# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
