### PR TITLE
views: a hash preserving prefix filter over git history

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2706,6 +2706,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "jj-views"
+version = "0.43.0"
+dependencies = [
+ "bstr",
+ "gix",
+ "tempfile",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@ cargo-features = []
 
 [workspace]
 resolver = "3"
-members = ["cli", "lib", "lib/gen-protos", "lib/proc-macros", "lib/testutils"]
+members = ["cli", "lib", "lib/gen-protos", "lib/proc-macros", "lib/testutils", "views"]
 
 [workspace.package]
 version = "0.43.0"
@@ -141,6 +141,7 @@ winreg = "0.56"
 # their own (alphabetically sorted) block
 jj-lib = { path = "lib", version = "0.43.0", default-features = false }
 jj-lib-proc-macros = { path = "lib/proc-macros", version = "0.43.0" }
+jj-views = { path = "views", version = "0.43.0" }
 testutils = { path = "lib/testutils" }
 
 [workspace.lints.clippy]

--- a/views/Cargo.toml
+++ b/views/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "jj-views"
+description = "Deterministic path filters over git history, deriving a child view from a parent monorepo"
+version = { workspace = true }
+license = { workspace = true }
+rust-version = { workspace = true }
+edition = { workspace = true }
+readme = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+documentation = { workspace = true }
+categories = { workspace = true }
+keywords = { workspace = true }
+
+[dependencies]
+bstr = { workspace = true }
+gix = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/views/examples/fixture_repo.rs
+++ b/views/examples/fixture_repo.rs
@@ -1,0 +1,38 @@
+//! Materializes the test fixture into a real repository, for inspection with
+//! git itself.
+//!
+//! The fixture is assembled from raw bytes, so `git fsck` on the result is the
+//! check that its hand folded headers and its tree entry ordering are what git
+//! actually expects, rather than only what this crate agrees with itself about.
+//!
+//! ```text
+//! cargo run --example fixture_repo -- /tmp/fixture.git
+//! git -C /tmp/fixture.git fsck --strict
+//! git -C /tmp/fixture.git log --graph --format='%h %d %s'
+//! ```
+
+use std::path::Path;
+
+type Failure = Box<dyn std::error::Error + Send + Sync>;
+
+fn main() -> Result<(), Failure> {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let [dir] = args.as_slice() else {
+        return Err("usage: fixture_repo <dir.git>".into());
+    };
+    let dir = Path::new(dir);
+    if dir.exists() {
+        std::fs::remove_dir_all(dir)?;
+    }
+    let repo = gix::init_bare(dir)?;
+    let upstream = jj_views::fixture::write_upstream(&repo)?;
+    for (label, commit) in &upstream.commits {
+        println!("{commit} {label}");
+        std::fs::write(
+            dir.join("refs").join("heads").join(label),
+            format!("{commit}\n"),
+        )?;
+    }
+    println!("head {}", upstream.head);
+    Ok(())
+}

--- a/views/examples/roundtrip.rs
+++ b/views/examples/roundtrip.rs
@@ -55,6 +55,7 @@ fn main() -> Result<(), Failure> {
         other => return Err(format!("unknown elide rule {other:?}").into()),
     };
     let survey_only = rest.iter().any(|arg| arg == "--survey-only");
+    let derive_only = rest.iter().any(|arg| arg == "--derive-only");
 
     let source = gix::open(source)?;
     let filter = Filter::prefix(path)?.elide(elide);
@@ -65,6 +66,20 @@ fn main() -> Result<(), Failure> {
         let order = topological_order(&source)?;
         println!("commits reachable from refs: {}", order.len());
         return survey(&source, &order);
+    }
+
+    // Deriving a path that is already in the source repository, with no
+    // injection step. This measures the walk itself: reading every commit,
+    // descending the path, and deciding what to keep. It exists because the
+    // injection half of the round trip is dominated by writing one loose object
+    // per tree per commit, which is an artifact of how this experiment stores
+    // things rather than a property of the filter, and at kernel scale that write
+    // amplification hides the number worth knowing.
+    if derive_only {
+        let parent = open_parent(Path::new(work), source.git_dir(), rule)?;
+        let order = topological_order(&source)?;
+        println!("commits reachable from refs: {}", order.len());
+        return derive_only_run(&parent, &order, &filter);
     }
 
     let parent = open_parent(Path::new(work), source.git_dir(), rule)?;
@@ -124,6 +139,48 @@ fn main() -> Result<(), Failure> {
     incremental(&parent, &injected, &order, &filter, &mut derive_cache)?;
 
     report(&parent, &order, &injected, &filter, &derive_cache)
+}
+
+/// Derives a filter over a repository's own history and reports what it cost.
+fn derive_only_run(
+    parent: &gix::Repository,
+    order: &[ObjectId],
+    filter: &Filter,
+) -> Result<(), Failure> {
+    let mut cache = Cache::new();
+    let started = std::time::Instant::now();
+    let mut mapped = 0_usize;
+    let mut absent = 0_usize;
+    for commit in order {
+        match jj_views::derive(parent, commit, filter, &mut cache)? {
+            Some(_) => mapped += 1,
+            None => absent += 1,
+        }
+    }
+    let elapsed = started.elapsed().as_secs_f64();
+
+    // How many commits kept a distinct view commit, as opposed to collapsing onto
+    // an ancestor. The gap is what elision removed, and on a real subdirectory of
+    // a large repository it is most of history.
+    let mut distinct: Vec<ObjectId> = order
+        .iter()
+        .filter_map(|commit| cache.derived(commit, filter).flatten())
+        .collect();
+    distinct.sort();
+    distinct.dedup();
+
+    println!(
+        "\nderived {} commits in {elapsed:.1}s ({:.0} commits/s)",
+        order.len(),
+        order.len() as f64 / elapsed
+    );
+    println!("  with a view:             {mapped}");
+    println!("  no counterpart at all:   {absent}");
+    println!("  distinct view commits:   {}", distinct.len());
+    println!("  tree reads:              {}", cache.tree_reads());
+    println!("  memoized trees:          {}", cache.tree_entries());
+    println!("  memoized commits:        {}", cache.commit_entries());
+    Ok(())
 }
 
 /// Times a re-derivation after new commits land, with the cache warm.

--- a/views/examples/roundtrip.rs
+++ b/views/examples/roundtrip.rs
@@ -142,10 +142,9 @@ fn report(
         // Elision maps a commit onto one of its own parents, so it has no
         // distinct counterpart. That is not the same failure as a commit that
         // was rebuilt wrongly, and counting them together hides which is which.
-        let parents: Vec<ObjectId> =
-            gix::objs::CommitRef::from_bytes(&raw, parent.object_hash())?
-                .parents()
-                .collect();
+        let parents: Vec<ObjectId> = gix::objs::CommitRef::from_bytes(&raw, parent.object_hash())?
+            .parents()
+            .collect();
         let onto_a_parent = parents.iter().any(|source| {
             injected
                 .get(source)

--- a/views/examples/roundtrip.rs
+++ b/views/examples/roundtrip.rs
@@ -119,7 +119,84 @@ fn main() -> Result<(), Failure> {
         derive_cache.commit_entries()
     );
 
+    // The production cost is not the cold filter, it is what a fetch costs
+    // afterwards. Add commits on top and re-derive with the cache still warm.
+    incremental(&parent, &injected, &order, &filter, &mut derive_cache)?;
+
     report(&parent, &order, &injected, &filter, &derive_cache)
+}
+
+/// Times a re-derivation after new commits land, with the cache warm.
+///
+/// This is the number that decides whether a view is usable day to day: a fetch
+/// adds a handful of commits and the derivation has to cost something
+/// proportional to those, not to the size of history.
+fn incremental(
+    parent: &gix::Repository,
+    injected: &HashMap<ObjectId, ObjectId>,
+    order: &[ObjectId],
+    filter: &Filter,
+    cache: &mut Cache,
+) -> Result<(), Failure> {
+    const NEW: usize = 10;
+
+    let Some(tip) = order.last().and_then(|last| injected.get(last)) else {
+        return Ok(());
+    };
+    let mut head = *tip;
+    for step in 0..NEW {
+        head = append_monorepo_commit(parent, &head, step)?;
+    }
+
+    let reads_before = cache.tree_reads();
+    let started = std::time::Instant::now();
+    jj_views::derive(parent, &head, filter, cache)?;
+    println!(
+        "\nincremental: {NEW} new commits re-derived in {:.4}s, {} tree reads",
+        started.elapsed().as_secs_f64(),
+        cache.tree_reads() - reads_before
+    );
+    Ok(())
+}
+
+/// A commit on top of `parent_commit` that rewrites one monorepo file and
+/// nothing under the filtered path.
+fn append_monorepo_commit(
+    repo: &gix::Repository,
+    parent_commit: &ObjectId,
+    step: usize,
+) -> Result<ObjectId, Failure> {
+    let raw = repo.find_object(*parent_commit)?.detach().data;
+    let base = gix::objs::CommitRef::from_bytes(&raw, repo.object_hash())?.tree();
+    let blob = repo
+        .write_blob(format!("monorepo revision {step}\n").as_bytes())?
+        .detach();
+
+    let tree_raw = repo.find_object(base)?.detach().data;
+    let decoded = gix::objs::TreeRef::from_bytes(&tree_raw, repo.object_hash())?;
+    let mut entries: Vec<gix::objs::tree::Entry> = decoded
+        .entries
+        .iter()
+        .map(|entry| gix::objs::tree::Entry {
+            mode: entry.mode,
+            filename: entry.filename.to_owned(),
+            oid: entry.oid.to_owned(),
+        })
+        .collect();
+    for entry in &mut entries {
+        if entry.filename == "README" {
+            entry.oid = blob;
+        }
+    }
+    entries.sort();
+    let tree = repo.write_object(&gix::objs::Tree { entries })?.detach();
+
+    let raw = format!(
+        "tree {tree}\nparent {parent_commit}\nauthor Monorepo <mono@example.invalid> \
+         100000000{step} +0000\ncommitter Monorepo <mono@example.invalid> 100000000{step} \
+         +0000\n\nmonorepo change {step}\n"
+    );
+    gix::objs::Write::write_buf(&repo.objects, gix::objs::Kind::Commit, raw.as_bytes())
 }
 
 /// Compares every derived commit against the upstream commit it came from and

--- a/views/examples/roundtrip.rs
+++ b/views/examples/roundtrip.rs
@@ -9,8 +9,12 @@
 //! fresh repository, so the source is never touched and no objects are copied.
 //!
 //! ```text
-//! cargo run --release --example roundtrip -- <source.git> <work-dir> vendor/linux [--elide]
+//! cargo run --release --example roundtrip -- <source.git> <work-dir> vendor/linux [--elide=RULE]
 //! ```
+//!
+//! `--elide=` takes `nothing`, `unchanged` (the default, and josh's) or
+//! `including-already-empty`, the rule that looks right and silently breaks
+//! hash identity.
 //!
 //! `--survey-only` skips the injection and reports just which commit shapes the
 //! source contains. That works on a treeless clone (`--filter=tree:0`), so the
@@ -25,6 +29,7 @@ use std::path::PathBuf;
 
 use gix::ObjectId;
 use jj_views::Cache;
+use jj_views::Elide;
 use jj_views::Filter;
 use jj_views::fixture;
 
@@ -34,14 +39,25 @@ fn main() -> Result<(), Failure> {
     let args: Vec<String> = std::env::args().skip(1).collect();
     let [source, work, path, rest @ ..] = args.as_slice() else {
         return Err(
-            "usage: roundtrip <source.git> <work-dir> <prefix> [--elide] [--survey-only]".into(),
+            "usage: roundtrip <source.git> <work-dir> <prefix> [--elide=RULE] [--survey-only]"
+                .into(),
         );
     };
-    let elide = rest.iter().any(|arg| arg == "--elide");
+    let rule = rest
+        .iter()
+        .filter_map(|arg| arg.strip_prefix("--elide="))
+        .next_back()
+        .unwrap_or("unchanged");
+    let elide = match rule {
+        "nothing" => Elide::Nothing,
+        "unchanged" => Elide::Unchanged,
+        "including-already-empty" => Elide::UnchangedIncludingAlreadyEmpty,
+        other => return Err(format!("unknown elide rule {other:?}").into()),
+    };
     let survey_only = rest.iter().any(|arg| arg == "--survey-only");
 
     let source = gix::open(source)?;
-    let filter = Filter::prefix(path)?.elide_empty(elide);
+    let filter = Filter::prefix(path)?.elide(elide);
 
     // Surveying reads only, so it neither needs nor may create the work
     // directory; doing so would clobber a concurrent injection using it.
@@ -51,9 +67,9 @@ fn main() -> Result<(), Failure> {
         return survey(&source, &order);
     }
 
-    let parent = open_parent(Path::new(work), source.git_dir(), elide)?;
+    let parent = open_parent(Path::new(work), source.git_dir(), rule)?;
     println!(
-        "source {:?}\nparent {:?}\nfilter {} (elide_empty={elide})",
+        "source {:?}\nparent {:?}\nfilter {} (elide={rule})",
         source.git_dir(),
         parent.git_dir(),
         filter.path()
@@ -286,7 +302,7 @@ fn same_but_for_parents(expected: &[u8], actual: &[u8]) -> bool {
 /// Which extra headers a commit carries, as a stable label for grouping.
 fn header_summary(raw: &[u8], hash: gix::hash::Kind) -> String {
     let Ok(parsed) = gix::objs::CommitRef::from_bytes(raw, hash) else {
-        return "an unparseable header block".to_owned();
+        return "a header block that will not parse".to_owned();
     };
     let mut names: Vec<String> = parsed
         .extra_headers
@@ -309,13 +325,9 @@ fn header_summary(raw: &[u8], hash: gix::hash::Kind) -> String {
 
 /// A fresh repository that reads the source's objects through an alternate and
 /// writes only its own.
-fn open_parent(
-    work: &Path,
-    source_objects: &Path,
-    elide: bool,
-) -> Result<gix::Repository, Failure> {
+fn open_parent(work: &Path, source_objects: &Path, rule: &str) -> Result<gix::Repository, Failure> {
     std::fs::create_dir_all(work)?;
-    let dir: PathBuf = work.join(format!("parent-elide-{elide}.git"));
+    let dir: PathBuf = work.join(format!("parent-elide-{rule}.git"));
     if dir.exists() {
         std::fs::remove_dir_all(&dir)?;
     }

--- a/views/examples/roundtrip.rs
+++ b/views/examples/roundtrip.rs
@@ -1,0 +1,386 @@
+//! Round trip hash identity, measured against a real repository.
+//!
+//! Injects every commit reachable from a source repository's refs under a
+//! prefix, derives the prefix back out, and reports how many of the original
+//! commit hashes came back. Every mismatch is classified, so the report says
+//! which byte moved rather than only that something did.
+//!
+//! Objects are read from the source through a git alternate and written into a
+//! fresh repository, so the source is never touched and no objects are copied.
+//!
+//! ```text
+//! cargo run --release --example roundtrip -- <source.git> <work-dir> vendor/linux [--elide]
+//! ```
+//!
+//! `--survey-only` skips the injection and reports just which commit shapes the
+//! source contains. That works on a treeless clone (`--filter=tree:0`), so the
+//! question "does this repository contain commits a naive rewrite corrupts" can
+//! be answered for a repository far too large to inject.
+
+use std::collections::HashMap;
+use std::collections::HashSet;
+use std::fmt::Write as _;
+use std::path::Path;
+use std::path::PathBuf;
+
+use gix::ObjectId;
+use jj_views::Cache;
+use jj_views::Filter;
+use jj_views::fixture;
+
+type Failure = Box<dyn std::error::Error + Send + Sync>;
+
+fn main() -> Result<(), Failure> {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let [source, work, path, rest @ ..] = args.as_slice() else {
+        return Err(
+            "usage: roundtrip <source.git> <work-dir> <prefix> [--elide] [--survey-only]".into(),
+        );
+    };
+    let elide = rest.iter().any(|arg| arg == "--elide");
+    let survey_only = rest.iter().any(|arg| arg == "--survey-only");
+
+    let source = gix::open(source)?;
+    let parent = open_parent(Path::new(work), source.git_dir(), elide)?;
+    let filter = Filter::prefix(path)?.elide_empty(elide);
+    println!(
+        "source {:?}\nparent {:?}\nfilter {} (elide_empty={elide})",
+        source.git_dir(),
+        parent.git_dir(),
+        filter.path()
+    );
+
+    let order = topological_order(&source)?;
+    println!("upstream commits reachable from refs: {}", order.len());
+
+    if survey_only {
+        return survey(&source, &order);
+    }
+
+    // A monorepo the vendored history lands inside, so the injected trees are
+    // not just the prefix and the experiment is not accidentally easier than
+    // the real case.
+    let base = write_base(&parent)?;
+
+    let mut inject = Cache::new();
+    let mut injected: HashMap<ObjectId, ObjectId> = HashMap::new();
+    let started = std::time::Instant::now();
+    for upstream in &order {
+        let raw = parent.find_object(*upstream)?.detach().data;
+        let first_parent = gix::objs::CommitRef::from_bytes(&raw, parent.object_hash())?
+            .parents()
+            .next();
+        let onto = first_parent
+            .and_then(|first| injected.get(&first).copied())
+            .unwrap_or(base);
+        let id = jj_views::unfilter(&parent, upstream, &onto, &filter, &mut inject)?;
+        injected.insert(*upstream, id);
+    }
+    println!(
+        "injected {} commits under {} in {:.1}s",
+        injected.len(),
+        filter.path(),
+        started.elapsed().as_secs_f64()
+    );
+
+    let mut derive_cache = Cache::new();
+    let started = std::time::Instant::now();
+    for upstream in &order {
+        let Some(id) = injected.get(upstream) else {
+            continue;
+        };
+        jj_views::derive(&parent, id, &filter, &mut derive_cache)?;
+    }
+    println!(
+        "derived in {:.1}s, cache holds {} trees and {} commits",
+        started.elapsed().as_secs_f64(),
+        derive_cache.tree_entries(),
+        derive_cache.commit_entries()
+    );
+
+    report(&parent, &order, &injected, &filter, &derive_cache)
+}
+
+/// Compares every derived commit against the upstream commit it came from and
+/// prints the tally plus a cause for each mismatch.
+fn report(
+    parent: &gix::Repository,
+    order: &[ObjectId],
+    injected: &HashMap<ObjectId, ObjectId>,
+    filter: &Filter,
+    cache: &Cache,
+) -> Result<(), Failure> {
+    let mut matched = 0_usize;
+    let mut absent = 0_usize;
+    let mut elided = 0_usize;
+    let mut inherited = 0_usize;
+    let mut collapsed = 0_usize;
+    // Cause to (count, one example), so a systematic failure reports once.
+    let mut primary: HashMap<String, (usize, ObjectId)> = HashMap::new();
+    let mut naive_would_break: HashMap<String, usize> = HashMap::new();
+
+    for upstream in order {
+        let raw = parent.find_object(*upstream)?.detach().data;
+        if !fixture::naive_rebuild_matches(&raw, parent.object_hash()) {
+            *naive_would_break
+                .entry(header_summary(&raw, parent.object_hash()))
+                .or_default() += 1;
+        }
+
+        let Some(id) = injected.get(upstream) else {
+            continue;
+        };
+        let derived = cache.derived(id, filter).flatten();
+        let Some(derived) = derived else {
+            absent += 1;
+            continue;
+        };
+        if derived == *upstream {
+            matched += 1;
+            continue;
+        }
+        // Elision maps a commit onto one of its own parents, so it has no
+        // distinct counterpart. That is not the same failure as a commit that
+        // was rebuilt wrongly, and counting them together hides which is which.
+        let parents: Vec<ObjectId> =
+            gix::objs::CommitRef::from_bytes(&raw, parent.object_hash())?
+                .parents()
+                .collect();
+        let onto_a_parent = parents.iter().any(|source| {
+            injected
+                .get(source)
+                .and_then(|injected| cache.derived(injected, filter).flatten())
+                == Some(derived)
+        });
+        if onto_a_parent {
+            elided += 1;
+            continue;
+        }
+        let actual = parent.find_object(derived)?.detach().data;
+        // Separate a commit whose own bytes did not survive from one that only
+        // inherited a parent whose hash had already moved, and from a merge
+        // whose parent list got shorter because elision collapsed two sides
+        // onto one commit.
+        let expected_parents = count_parent_lines(&raw);
+        if same_but_for_parents(&raw, &actual) {
+            inherited += 1;
+        } else if expected_parents != count_parent_lines(&actual) {
+            collapsed += 1;
+        } else {
+            let cause = fixture::describe_difference(&raw, &actual);
+            let entry = primary.entry(cause).or_insert((0, *upstream));
+            entry.0 += 1;
+        }
+    }
+
+    let total = order.len();
+    println!("\n=== round trip against {total} upstream commits");
+    println!("  matched byte for byte:            {matched}");
+    println!("  no counterpart at all:            {absent}");
+    println!("  elided onto one of their parents: {elided}");
+    println!("  moved, inherited a parent:        {inherited}");
+    println!("  moved, merge arity collapsed:     {collapsed}");
+    let primary_total: usize = primary.values().map(|(count, _)| *count).sum();
+    println!("  moved in their own bytes:         {primary_total}");
+    for (cause, (count, example)) in &primary {
+        println!("    {count} commits, e.g. {example}: {cause}");
+    }
+
+    print_naive_tally(&naive_would_break, total);
+    Ok(())
+}
+
+/// Reports which commit shapes a repository contains, reading commits only.
+fn survey(repo: &gix::Repository, order: &[ObjectId]) -> Result<(), Failure> {
+    let mut naive_would_break: HashMap<String, usize> = HashMap::new();
+    let mut shapes: HashMap<&'static str, usize> = HashMap::new();
+    let mut offsets: HashMap<String, usize> = HashMap::new();
+    for id in order {
+        let raw = repo.find_object(*id)?.detach().data;
+        if !fixture::naive_rebuild_matches(&raw, repo.object_hash()) {
+            *naive_would_break
+                .entry(header_summary(&raw, repo.object_hash()))
+                .or_default() += 1;
+        }
+        let parsed = gix::objs::CommitRef::from_bytes(&raw, repo.object_hash())?;
+        let parents: Vec<ObjectId> = parsed.parents().collect();
+        let mut unique = parents.clone();
+        unique.sort();
+        unique.dedup();
+        if unique.len() < parents.len() {
+            *shapes.entry("duplicate parents").or_default() += 1;
+        }
+        if parents.len() > 2 {
+            *shapes.entry("octopus merge").or_default() += 1;
+        }
+        for (name, _) in &parsed.extra_headers {
+            *shapes
+                .entry(match AsRef::<[u8]>::as_ref(name) {
+                    b"gpgsig" => "gpgsig",
+                    b"gpgsig-sha256" => "gpgsig-sha256",
+                    b"mergetag" => "mergetag",
+                    b"encoding" => "encoding (late)",
+                    _ => "some other extra header",
+                })
+                .or_default() += 1;
+        }
+        if parsed.encoding.is_some() {
+            *shapes.entry("encoding").or_default() += 1;
+        }
+        if let Some(offset) = parsed.author.rsplit(|byte| *byte == b' ').next()
+            && offset.len() != 5
+        {
+            *offsets
+                .entry(String::from_utf8_lossy(offset).into_owned())
+                .or_default() += 1;
+        }
+    }
+
+    println!("\n=== shapes among {} commits", order.len());
+    let mut counted: Vec<(&&str, &usize)> = shapes.iter().collect();
+    counted.sort_by(|left, right| right.1.cmp(left.1));
+    for (shape, count) in counted {
+        println!("  {count:>8} {shape}");
+    }
+    println!("\n=== author timezone offsets that are not [+-]NNNN");
+    if offsets.is_empty() {
+        println!("  none");
+    }
+    let mut counted: Vec<(&String, &usize)> = offsets.iter().collect();
+    counted.sort_by(|left, right| right.1.cmp(left.1));
+    for (offset, count) in counted.iter().take(20) {
+        println!("  {count:>8} {offset:?}");
+    }
+    print_naive_tally(&naive_would_break, order.len());
+    Ok(())
+}
+
+fn print_naive_tally(tally: &HashMap<String, usize>, total: usize) {
+    println!("\n=== commits a parse-and-reserialize rewrite would corrupt");
+    let broken: usize = tally.values().sum();
+    println!("  {broken} of {total}");
+    let mut summaries: Vec<(&String, &usize)> = tally.iter().collect();
+    summaries.sort_by(|left, right| right.1.cmp(left.1));
+    for (summary, count) in summaries {
+        println!("    {count} carrying {summary}");
+    }
+}
+
+/// How many `parent` lines a commit object carries.
+fn count_parent_lines(raw: &[u8]) -> usize {
+    raw.split_inclusive(|byte| *byte == b'\n')
+        .filter(|line| line.starts_with(b"parent "))
+        .count()
+}
+
+/// True when two commit objects differ only in their `parent` lines.
+fn same_but_for_parents(expected: &[u8], actual: &[u8]) -> bool {
+    let strip = |raw: &[u8]| -> Vec<u8> {
+        raw.split_inclusive(|byte| *byte == b'\n')
+            .filter(|line| !line.starts_with(b"parent "))
+            .flatten()
+            .copied()
+            .collect()
+    };
+    strip(expected) == strip(actual)
+}
+
+/// Which extra headers a commit carries, as a stable label for grouping.
+fn header_summary(raw: &[u8], hash: gix::hash::Kind) -> String {
+    let Ok(parsed) = gix::objs::CommitRef::from_bytes(raw, hash) else {
+        return "an unparseable header block".to_owned();
+    };
+    let mut names: Vec<String> = parsed
+        .extra_headers
+        .iter()
+        .map(|(name, _)| name.to_string())
+        .collect();
+    if parsed.encoding.is_some() {
+        names.push("encoding".to_owned());
+    }
+    if names.is_empty() {
+        let mut out = String::from("no extra headers (author or committer line)");
+        if let Some(author) = parsed.author.split(|byte| *byte == b'>').next_back() {
+            let _ = write!(out, ", author suffix {:?}", String::from_utf8_lossy(author));
+        }
+        return out;
+    }
+    names.sort();
+    names.join(" + ")
+}
+
+/// A fresh repository that reads the source's objects through an alternate and
+/// writes only its own.
+fn open_parent(
+    work: &Path,
+    source_objects: &Path,
+    elide: bool,
+) -> Result<gix::Repository, Failure> {
+    let dir: PathBuf = work.join(format!("parent-elide-{elide}.git"));
+    if dir.exists() {
+        std::fs::remove_dir_all(&dir)?;
+    }
+    gix::init_bare(&dir)?;
+    let alternates = dir.join("objects").join("info").join("alternates");
+    std::fs::write(
+        &alternates,
+        format!("{}\n", source_objects.join("objects").display()),
+    )?;
+    Ok(gix::open(&dir)?)
+}
+
+/// A monorepo commit for the vendored history to sit inside.
+fn write_base(repo: &gix::Repository) -> Result<ObjectId, Failure> {
+    let blob = repo.write_blob(b"the monorepo\n")?.detach();
+    let tree = repo.write_object(&gix::objs::Tree {
+        entries: vec![gix::objs::tree::Entry {
+            mode: gix::objs::tree::EntryKind::Blob.into(),
+            filename: "README".into(),
+            oid: blob,
+        }],
+    })?;
+    let raw = format!(
+        "tree {}\nauthor Monorepo <mono@example.invalid> 1000000000 +0000\ncommitter Monorepo \
+         <mono@example.invalid> 1000000000 +0000\n\nthe monorepo\n",
+        tree.detach()
+    );
+    gix::objs::Write::write_buf(&repo.objects, gix::objs::Kind::Commit, raw.as_bytes())
+}
+
+/// Every commit reachable from any ref, parents before children.
+fn topological_order(repo: &gix::Repository) -> Result<Vec<ObjectId>, Failure> {
+    let mut tips: Vec<ObjectId> = Vec::new();
+    for reference in repo.references()?.all()?.filter_map(Result::ok) {
+        let mut reference = reference;
+        if let Ok(id) = reference.peel_to_id()
+            && let Ok(object) = id.object()
+            && object.kind == gix::objs::Kind::Commit
+        {
+            tips.push(object.id);
+        }
+    }
+    tips.sort();
+    tips.dedup();
+
+    let mut order: Vec<ObjectId> = Vec::new();
+    let mut done: HashSet<ObjectId> = HashSet::new();
+    let mut stack: Vec<(ObjectId, bool)> = tips.into_iter().map(|tip| (tip, false)).collect();
+    while let Some((id, expanded)) = stack.pop() {
+        if done.contains(&id) {
+            continue;
+        }
+        if expanded {
+            done.insert(id);
+            order.push(id);
+            continue;
+        }
+        let raw = repo.find_object(id)?.detach().data;
+        let parents: Vec<ObjectId> = gix::objs::CommitRef::from_bytes(&raw, repo.object_hash())?
+            .parents()
+            .filter(|parent| !done.contains(parent))
+            .collect();
+        stack.push((id, true));
+        stack.extend(parents.into_iter().map(|parent| (parent, false)));
+    }
+    Ok(order)
+}

--- a/views/examples/roundtrip.rs
+++ b/views/examples/roundtrip.rs
@@ -41,8 +41,17 @@ fn main() -> Result<(), Failure> {
     let survey_only = rest.iter().any(|arg| arg == "--survey-only");
 
     let source = gix::open(source)?;
-    let parent = open_parent(Path::new(work), source.git_dir(), elide)?;
     let filter = Filter::prefix(path)?.elide_empty(elide);
+
+    // Surveying reads only, so it neither needs nor may create the work
+    // directory; doing so would clobber a concurrent injection using it.
+    if survey_only {
+        let order = topological_order(&source)?;
+        println!("commits reachable from refs: {}", order.len());
+        return survey(&source, &order);
+    }
+
+    let parent = open_parent(Path::new(work), source.git_dir(), elide)?;
     println!(
         "source {:?}\nparent {:?}\nfilter {} (elide_empty={elide})",
         source.git_dir(),
@@ -52,10 +61,6 @@ fn main() -> Result<(), Failure> {
 
     let order = topological_order(&source)?;
     println!("upstream commits reachable from refs: {}", order.len());
-
-    if survey_only {
-        return survey(&source, &order);
-    }
 
     // A monorepo the vendored history lands inside, so the injected trees are
     // not just the prefix and the experiment is not accidentally easier than
@@ -192,7 +197,7 @@ fn report(
 /// Reports which commit shapes a repository contains, reading commits only.
 fn survey(repo: &gix::Repository, order: &[ObjectId]) -> Result<(), Failure> {
     let mut naive_would_break: HashMap<String, usize> = HashMap::new();
-    let mut shapes: HashMap<&'static str, usize> = HashMap::new();
+    let mut shapes: HashMap<String, usize> = HashMap::new();
     let mut offsets: HashMap<String, usize> = HashMap::new();
     for id in order {
         let raw = repo.find_object(*id)?.detach().data;
@@ -207,24 +212,18 @@ fn survey(repo: &gix::Repository, order: &[ObjectId]) -> Result<(), Failure> {
         unique.sort();
         unique.dedup();
         if unique.len() < parents.len() {
-            *shapes.entry("duplicate parents").or_default() += 1;
+            *shapes.entry("duplicate parents".to_owned()).or_default() += 1;
         }
         if parents.len() > 2 {
-            *shapes.entry("octopus merge").or_default() += 1;
+            *shapes.entry("octopus merge".to_owned()).or_default() += 1;
         }
         for (name, _) in &parsed.extra_headers {
-            *shapes
-                .entry(match AsRef::<[u8]>::as_ref(name) {
-                    b"gpgsig" => "gpgsig",
-                    b"gpgsig-sha256" => "gpgsig-sha256",
-                    b"mergetag" => "mergetag",
-                    b"encoding" => "encoding (late)",
-                    _ => "some other extra header",
-                })
-                .or_default() += 1;
+            // Named rather than bucketed. A header nobody expected is exactly
+            // the thing a survey is for, and "some other header" hides it.
+            *shapes.entry(format!("{name} header")).or_default() += 1;
         }
         if parsed.encoding.is_some() {
-            *shapes.entry("encoding").or_default() += 1;
+            *shapes.entry("encoding header".to_owned()).or_default() += 1;
         }
         if let Some(offset) = parsed.author.rsplit(|byte| *byte == b' ').next()
             && offset.len() != 5
@@ -236,7 +235,7 @@ fn survey(repo: &gix::Repository, order: &[ObjectId]) -> Result<(), Failure> {
     }
 
     println!("\n=== shapes among {} commits", order.len());
-    let mut counted: Vec<(&&str, &usize)> = shapes.iter().collect();
+    let mut counted: Vec<(&String, &usize)> = shapes.iter().collect();
     counted.sort_by(|left, right| right.1.cmp(left.1));
     for (shape, count) in counted {
         println!("  {count:>8} {shape}");
@@ -315,6 +314,7 @@ fn open_parent(
     source_objects: &Path,
     elide: bool,
 ) -> Result<gix::Repository, Failure> {
+    std::fs::create_dir_all(work)?;
     let dir: PathBuf = work.join(format!("parent-elide-{elide}.git"));
     if dir.exists() {
         std::fs::remove_dir_all(&dir)?;

--- a/views/src/fixture.rs
+++ b/views/src/fixture.rs
@@ -1,0 +1,549 @@
+//! A deterministic upstream history built from raw objects, plus the byte level
+//! diagnostics used to explain a hash that moved.
+//!
+//! This exists so the round trip check is a test rather than an errand. It
+//! reaches no network, it produces the same object ids on every run and every
+//! platform, and it contains the shapes that a naive rewrite gets wrong. The
+//! commits are assembled byte by byte rather than through git plumbing, because
+//! some of the interesting cases cannot be produced by the git CLI at all: an
+//! `encoding` header placed after `gpgsig`, and a timezone offset outside the
+//! range a normalizing serializer can reproduce.
+//!
+//! What it covers, one commit each unless noted: a root commit, a non-ASCII
+//! author and message, an `encoding` header with a non-UTF-8 message body, a
+//! `gpgsig` header, `gpgsig` *before* `encoding`, a negative zero timezone
+//! offset, an offset no hour and minute pair can hold, an empty commit whose
+//! tree equals its parent's, a mode change from `100644` to `100755`, a
+//! symlink, a submodule gitlink pointing at an absent commit, two branches
+//! joined by a merge carrying a `mergetag`, an octopus merge with three
+//! parents, a commit listing the same parent twice, a message with no trailing
+//! newline, and sibling names (`foo` as a directory next to `foo.txt`) whose
+//! tree order differs between plain byte ordering and git's.
+
+use std::collections::BTreeMap;
+
+use bstr::BString;
+use bstr::ByteSlice as _;
+use gix::ObjectId;
+use gix::objs::Write as _;
+
+use crate::Error;
+
+/// The upstream history written by [`write_upstream`].
+pub struct Upstream {
+    /// Every commit, in an order where parents precede children, paired with
+    /// the label naming the corner case it carries.
+    pub commits: Vec<(&'static str, ObjectId)>,
+    /// The tip, the commit whose ancestry is the whole fixture.
+    pub head: ObjectId,
+}
+
+/// One file in a snapshot.
+#[derive(Clone, Copy)]
+enum Content {
+    /// A regular file, mode `100644`.
+    File(&'static [u8]),
+    /// An executable file, mode `100755`.
+    Exec(&'static [u8]),
+    /// A symlink, mode `120000`, whose blob holds the target path.
+    Link(&'static str),
+    /// A submodule, mode `160000`. The commit it names is deliberately absent
+    /// from the repository, which is the normal state of a gitlink.
+    Gitlink,
+}
+
+/// A gitlink target that exists in no repository, so the fixture also proves a
+/// dangling `160000` entry survives the round trip.
+const ABSENT_SUBMODULE: &str = "0123456789abcdef0123456789abcdef01234567";
+
+/// A multi-line header value shaped like what `git commit -S` writes, one
+/// element per line.
+///
+/// Held as lines rather than as one string with `\n` escapes because rustfmt's
+/// `format_strings` reflows a long literal and has been observed splitting an
+/// escape sequence across the break, which silently changes the value. Lines
+/// also match the shape of the on disk format, which is per line folding.
+///
+/// The bytes are not a real signature and are not meant to verify. What matters
+/// is that this is a header git stores verbatim and a rewrite must not touch.
+const FAKE_SIGNATURE: &[&str] = &[
+    "-----BEGIN PGP SIGNATURE-----",
+    "",
+    "iQEcBAABCgAGBQJmAAAAAAoJEAAAAAAAAAAAdGVzdA==",
+    "=abcd",
+    "-----END PGP SIGNATURE-----",
+];
+
+/// A `mergetag` value, the shape git writes when merging a signed tag. The
+/// blank line is the separator inside the embedded tag object, and it folds to
+/// a line holding a single space.
+const FAKE_MERGETAG: &[&str] = &[
+    "object 0000000000000000000000000000000000000000",
+    "type commit",
+    "tag v1.0",
+    "tagger Tag Signer <tag@example.invalid> 1200000000 +0000",
+    "",
+    "release v1.0",
+];
+
+struct CommitSpec {
+    tree: ObjectId,
+    parents: Vec<ObjectId>,
+    /// The raw `author` value, spelled exactly as it must appear on disk.
+    author: &'static str,
+    /// The raw `committer` value.
+    committer: &'static str,
+    /// Extra headers in the exact order they must be emitted, after
+    /// `committer`, each value given as its lines and folded on write.
+    headers: &'static [(&'static str, &'static [&'static str])],
+    message: &'static [u8],
+}
+
+/// Writes the fixture history into `repo` and returns its commits.
+///
+/// `repo` may be bare. Nothing but objects is written, so no refs are created
+/// and the caller decides what to point at [`Upstream::head`].
+pub fn write_upstream(repo: &gix::Repository) -> Result<Upstream, Error> {
+    let mut files: BTreeMap<&'static str, Content> = BTreeMap::new();
+    let mut commits: Vec<(&'static str, ObjectId)> = Vec::new();
+
+    // A plain root commit, so the interesting commits all have a parent.
+    files.insert("README", Content::File(b"upstream\n"));
+    files.insert("src/main.rs", Content::File(b"fn main() {}\n"));
+    let root = write_commit(
+        repo,
+        &CommitSpec {
+            tree: write_snapshot(repo, &files)?,
+            parents: vec![],
+            author: "Ada Lovelace <ada@example.invalid> 1100000000 +0000",
+            committer: "Ada Lovelace <ada@example.invalid> 1100000000 +0000",
+            headers: &[],
+            message: b"root commit\n",
+        },
+    )?;
+    commits.push(("root", root));
+
+    // Non-ASCII in both the author name and the message, stored as UTF-8.
+    files.insert(
+        "docs/\u{e9}t\u{e9}.txt",
+        Content::File("caf\u{e9}\n".as_bytes()),
+    );
+    let non_ascii = write_commit(
+        repo,
+        &CommitSpec {
+            tree: write_snapshot(repo, &files)?,
+            parents: vec![root],
+            author: "Bj\u{f6}rn \u{5f20}\u{4f1f} <bjorn@example.invalid> 1100000100 +0200",
+            committer: "Bj\u{f6}rn \u{5f20}\u{4f1f} <bjorn@example.invalid> 1100000100 +0200",
+            headers: &[],
+            message: "add caf\u{e9} \u{2014} \u{4e2d}\u{6587}\n".as_bytes(),
+        },
+    )?;
+    commits.push(("non-ascii", non_ascii));
+
+    // An `encoding` header, with a message body that is Latin-1 and therefore
+    // not valid UTF-8. A rewrite that goes through `String` loses these bytes.
+    files.insert("CHANGELOG", Content::File(b"1\n"));
+    let encoded = write_commit(
+        repo,
+        &CommitSpec {
+            tree: write_snapshot(repo, &files)?,
+            parents: vec![non_ascii],
+            author: "Ren\u{e9} <rene@example.invalid> 1100000200 +0100",
+            committer: "Ren\u{e9} <rene@example.invalid> 1100000200 +0100",
+            headers: &[("encoding", &["ISO-8859-1"])],
+            // 0xE9 is `e` acute in Latin-1 and an invalid UTF-8 sequence.
+            message: b"caf\xe9 in latin-1\n",
+        },
+    )?;
+    commits.push(("encoding-latin1", encoded));
+
+    // A signature header on its own.
+    files.insert("src/lib.rs", Content::File(b"pub fn f() {}\n"));
+    let signed = write_commit(
+        repo,
+        &CommitSpec {
+            tree: write_snapshot(repo, &files)?,
+            parents: vec![encoded],
+            author: "Ada Lovelace <ada@example.invalid> 1100000300 +0000",
+            committer: "Ada Lovelace <ada@example.invalid> 1100000300 +0000",
+            headers: &[("gpgsig", FAKE_SIGNATURE)],
+            message: b"signed commit\n",
+        },
+    )?;
+    commits.push(("gpgsig", signed));
+
+    // `gpgsig` before `encoding`. A representation with a dedicated `encoding`
+    // field emits it directly after `committer`, so this order can only survive
+    // if the parser leaves `encoding` in the general extra header list when it
+    // is not the first header. gix does exactly that, so this case does round
+    // trip; it is kept because a regression would be silent and would move the
+    // hash of every commit after it.
+    files.insert("CHANGELOG", Content::File(b"1\n2\n"));
+    let signed_then_encoding = write_commit(
+        repo,
+        &CommitSpec {
+            tree: write_snapshot(repo, &files)?,
+            parents: vec![signed],
+            author: "Ada Lovelace <ada@example.invalid> 1100000400 +0000",
+            committer: "Ada Lovelace <ada@example.invalid> 1100000400 +0000",
+            headers: &[("gpgsig", FAKE_SIGNATURE), ("encoding", &["ISO-8859-1"])],
+            message: b"signed, then encoded\n",
+        },
+    )?;
+    commits.push(("gpgsig-before-encoding", signed_then_encoding));
+
+    // A negative zero timezone offset. git accepts it and `git fsck` is happy
+    // with it, so this shape is present in ordinary history; it is nonetheless
+    // distinct from `+0000` on disk and identical to it after parsing.
+    files.insert("src/main.rs", Content::File(b"fn main() { f() }\n"));
+    let negative_zero = write_commit(
+        repo,
+        &CommitSpec {
+            tree: write_snapshot(repo, &files)?,
+            parents: vec![signed_then_encoding],
+            author: "Neg Zero <neg@example.invalid> 1100000500 -0000",
+            committer: "Neg Zero <neg@example.invalid> 1100000500 -0000",
+            headers: &[],
+            message: b"a negative zero offset\n",
+        },
+    )?;
+    commits.push(("negative-zero-offset", negative_zero));
+
+    // A timezone offset outside what a `(hours, minutes)` pair can hold: five
+    // hours eighteen minutes and zero seconds, spelled with six digits. `git
+    // fsck` reports `badTimezone` for this and that is the point. The check
+    // exists because such commits are in the wild, importers produced them, and
+    // a filter that must preserve hashes has to carry them through unaltered
+    // rather than quietly repairing them.
+    files.insert("NOTES", Content::File(b"imported\n"));
+    let odd_offset = write_commit(
+        repo,
+        &CommitSpec {
+            tree: write_snapshot(repo, &files)?,
+            parents: vec![negative_zero],
+            author: "Odd Zone <odd@example.invalid> 1100000600 +051800",
+            committer: "Odd Zone <odd@example.invalid> 1100000600 +051800",
+            headers: &[],
+            message: b"an offset no hour and minute pair can hold\n",
+        },
+    )?;
+    commits.push(("odd-timezone-offset", odd_offset));
+
+    // An empty commit: same tree as its parent. This is the shape that empty
+    // commit elision drops, and dropping it is what breaks hash identity.
+    let empty = write_commit(
+        repo,
+        &CommitSpec {
+            tree: write_snapshot(repo, &files)?,
+            parents: vec![odd_offset],
+            author: "Ada Lovelace <ada@example.invalid> 1100000600 +0000",
+            committer: "Ada Lovelace <ada@example.invalid> 1100000600 +0000",
+            headers: &[],
+            message: b"deliberately empty\n",
+        },
+    )?;
+    commits.push(("empty", empty));
+
+    // A mode change with no content change, a symlink, and a gitlink whose
+    // target is absent.
+    files.insert("src/main.rs", Content::Exec(b"fn main() { f() }\n"));
+    files.insert("link", Content::Link("README"));
+    files.insert("vendor/submodule", Content::Gitlink);
+    let modes = write_commit(
+        repo,
+        &CommitSpec {
+            tree: write_snapshot(repo, &files)?,
+            parents: vec![empty],
+            author: "Ada Lovelace <ada@example.invalid> 1100000700 +0000",
+            committer: "Ada Lovelace <ada@example.invalid> 1100000700 +0000",
+            headers: &[],
+            message: b"modes, symlink, gitlink\n",
+        },
+    )?;
+    commits.push(("modes-symlink-gitlink", modes));
+
+    // Sibling names whose git ordering differs from plain byte ordering: `foo`
+    // as a directory sorts as `foo/`, and `/` is above `.`, so `foo.txt` comes
+    // first. A tree writer using plain byte order writes them the other way and
+    // produces a different tree hash.
+    files.insert("foo.txt", Content::File(b"file\n"));
+    files.insert("foo/inner", Content::File(b"inner\n"));
+    let siblings = write_commit(
+        repo,
+        &CommitSpec {
+            tree: write_snapshot(repo, &files)?,
+            parents: vec![modes],
+            author: "Ada Lovelace <ada@example.invalid> 1100000800 +0000",
+            committer: "Ada Lovelace <ada@example.invalid> 1100000800 +0000",
+            headers: &[],
+            // No trailing newline, which git preserves.
+            message: b"foo vs foo.txt",
+        },
+    )?;
+    commits.push(("tree-order-siblings", siblings));
+
+    // Two side branches off `siblings`, to build merges from.
+    let mut left_files = files.clone();
+    left_files.insert("left", Content::File(b"left\n"));
+    let left = write_commit(
+        repo,
+        &CommitSpec {
+            tree: write_snapshot(repo, &left_files)?,
+            parents: vec![siblings],
+            author: "Left Author <left@example.invalid> 1100000900 -0700",
+            committer: "Left Author <left@example.invalid> 1100000900 -0700",
+            headers: &[],
+            message: b"left side\n",
+        },
+    )?;
+    commits.push(("left", left));
+
+    let mut right_files = files.clone();
+    right_files.insert("right", Content::File(b"right\n"));
+    let right = write_commit(
+        repo,
+        &CommitSpec {
+            tree: write_snapshot(repo, &right_files)?,
+            parents: vec![siblings],
+            author: "Right Author <right@example.invalid> 1100001000 +0530",
+            committer: "Right Author <right@example.invalid> 1100001000 +0530",
+            headers: &[],
+            message: b"right side\n",
+        },
+    )?;
+    commits.push(("right", right));
+
+    let mut third_files = files.clone();
+    third_files.insert("third", Content::File(b"third\n"));
+    let third = write_commit(
+        repo,
+        &CommitSpec {
+            tree: write_snapshot(repo, &third_files)?,
+            parents: vec![siblings],
+            author: "Third Author <third@example.invalid> 1100001100 +0000",
+            committer: "Third Author <third@example.invalid> 1100001100 +0000",
+            headers: &[],
+            message: b"third side\n",
+        },
+    )?;
+    commits.push(("third", third));
+
+    // A merge carrying a `mergetag`, the header git adds when merging a signed
+    // tag. It is folded over many lines and includes blank lines, so it also
+    // exercises the fold and unfold path.
+    let mut merged_files = left_files.clone();
+    merged_files.insert("right", Content::File(b"right\n"));
+    let merge = write_commit(
+        repo,
+        &CommitSpec {
+            tree: write_snapshot(repo, &merged_files)?,
+            parents: vec![left, right],
+            author: "Ada Lovelace <ada@example.invalid> 1100001200 +0000",
+            committer: "Ada Lovelace <ada@example.invalid> 1100001200 +0000",
+            headers: &[("mergetag", FAKE_MERGETAG), ("gpgsig", FAKE_SIGNATURE)],
+            message: b"merge left and right\n",
+        },
+    )?;
+    commits.push(("merge-with-mergetag", merge));
+
+    // An octopus merge.
+    let mut octopus_files = merged_files.clone();
+    octopus_files.insert("third", Content::File(b"third\n"));
+    let octopus = write_commit(
+        repo,
+        &CommitSpec {
+            tree: write_snapshot(repo, &octopus_files)?,
+            parents: vec![merge, third, siblings],
+            author: "Ada Lovelace <ada@example.invalid> 1100001300 +0000",
+            committer: "Ada Lovelace <ada@example.invalid> 1100001300 +0000",
+            headers: &[],
+            message: b"octopus merge\n",
+        },
+    )?;
+    commits.push(("octopus", octopus));
+
+    // The same parent listed twice. git accepts this and preserves it; a
+    // rewrite that deduplicates parents turns it into a non-merge and moves
+    // its hash.
+    let twins = write_commit(
+        repo,
+        &CommitSpec {
+            tree: write_snapshot(repo, &octopus_files)?,
+            parents: vec![octopus, octopus],
+            author: "Ada Lovelace <ada@example.invalid> 1100001400 +0000",
+            committer: "Ada Lovelace <ada@example.invalid> 1100001400 +0000",
+            headers: &[],
+            message: b"the same parent twice\n",
+        },
+    )?;
+    commits.push(("duplicate-parents", twins));
+
+    Ok(Upstream {
+        commits,
+        head: twins,
+    })
+}
+
+/// Whether a parse and reserialize round trip through the owned commit
+/// representation reproduces `raw` byte for byte.
+///
+/// This is the naive rewrite, and the reason the real one works on raw bytes.
+#[must_use]
+pub fn naive_rebuild_matches(raw: &[u8], hash: gix::hash::Kind) -> bool {
+    let Ok(parsed) = gix::objs::CommitRef::from_bytes(raw, hash) else {
+        return false;
+    };
+    let Ok(owned) = gix::objs::Commit::try_from(parsed) else {
+        return false;
+    };
+    let mut out = Vec::with_capacity(raw.len());
+    if gix::objs::WriteTo::write_to(&owned, &mut out).is_err() {
+        return false;
+    }
+    out == raw
+}
+
+/// Names the first difference between two commit objects, for a report that
+/// says which byte moved rather than only that a hash did.
+#[must_use]
+pub fn describe_difference(expected: &[u8], actual: &[u8]) -> String {
+    if expected == actual {
+        return "identical".to_owned();
+    }
+    let at = expected
+        .iter()
+        .zip(actual)
+        .position(|(left, right)| left != right)
+        .unwrap_or_else(|| expected.len().min(actual.len()));
+    let line_of = |bytes: &[u8]| -> String {
+        let start = bytes.get(..at).map_or(0, |head| {
+            head.iter()
+                .rposition(|byte| *byte == b'\n')
+                .map_or(0, |nl| nl + 1)
+        });
+        let rest = bytes.get(start..).unwrap_or_default();
+        let end = rest
+            .iter()
+            .position(|byte| *byte == b'\n')
+            .unwrap_or(rest.len());
+        rest.get(..end).unwrap_or_default().as_bstr().to_string()
+    };
+    format!(
+        "first differing byte at offset {at}; expected line {:?}, got {:?}",
+        line_of(expected),
+        line_of(actual)
+    )
+}
+
+/// Writes the blobs and trees for a snapshot and returns its root tree.
+fn write_snapshot(
+    repo: &gix::Repository,
+    files: &BTreeMap<&'static str, Content>,
+) -> Result<ObjectId, Error> {
+    let mut leaves: Vec<(Vec<BString>, gix::objs::tree::EntryKind, ObjectId)> = Vec::new();
+    for (path, content) in files {
+        let components: Vec<BString> = path
+            .split('/')
+            .map(|part| BString::from(part.as_bytes()))
+            .collect();
+        let (kind, oid) = match *content {
+            Content::File(bytes) => (
+                gix::objs::tree::EntryKind::Blob,
+                repo.objects.write_buf(gix::objs::Kind::Blob, bytes)?,
+            ),
+            Content::Exec(bytes) => (
+                gix::objs::tree::EntryKind::BlobExecutable,
+                repo.objects.write_buf(gix::objs::Kind::Blob, bytes)?,
+            ),
+            Content::Link(target) => (
+                gix::objs::tree::EntryKind::Link,
+                repo.objects
+                    .write_buf(gix::objs::Kind::Blob, target.as_bytes())?,
+            ),
+            Content::Gitlink => (
+                gix::objs::tree::EntryKind::Commit,
+                ObjectId::from_hex(ABSENT_SUBMODULE.as_bytes())
+                    .expect("fixture constant is valid hex"),
+            ),
+        };
+        leaves.push((components, kind, oid));
+    }
+    write_tree(repo, &leaves, 0)
+}
+
+fn write_tree(
+    repo: &gix::Repository,
+    leaves: &[(Vec<BString>, gix::objs::tree::EntryKind, ObjectId)],
+    depth: usize,
+) -> Result<ObjectId, Error> {
+    let mut entries: Vec<gix::objs::tree::Entry> = Vec::new();
+    let mut at = 0;
+    while at < leaves.len() {
+        let Some((path, kind, oid)) = leaves.get(at) else {
+            break;
+        };
+        let Some(name) = path.get(depth) else {
+            at += 1;
+            continue;
+        };
+        if path.len() == depth + 1 {
+            entries.push(gix::objs::tree::Entry {
+                mode: (*kind).into(),
+                filename: name.clone(),
+                oid: *oid,
+            });
+            at += 1;
+            continue;
+        }
+        // The input is sorted by path, so every leaf under this directory is a
+        // contiguous run starting here.
+        let end = leaves
+            .iter()
+            .skip(at)
+            .position(|(other, _, _)| other.get(depth) != Some(name))
+            .map_or(leaves.len(), |offset| at + offset);
+        let group = leaves.get(at..end).unwrap_or_default();
+        entries.push(gix::objs::tree::Entry {
+            mode: gix::objs::tree::EntryKind::Tree.into(),
+            filename: name.clone(),
+            oid: write_tree(repo, group, depth + 1)?,
+        });
+        at = end;
+    }
+    entries.sort();
+    Ok(repo.objects.write(&gix::objs::Tree { entries })?)
+}
+
+fn write_commit(repo: &gix::Repository, spec: &CommitSpec) -> Result<ObjectId, Error> {
+    let mut out = Vec::new();
+    let mut hex = [0_u8; gix::hash::Kind::longest().len_in_hex()];
+    out.extend_from_slice(b"tree ");
+    out.extend_from_slice(spec.tree.hex_to_buf(&mut hex).as_bytes());
+    out.push(b'\n');
+    for parent in &spec.parents {
+        out.extend_from_slice(b"parent ");
+        out.extend_from_slice(parent.hex_to_buf(&mut hex).as_bytes());
+        out.push(b'\n');
+    }
+    out.extend_from_slice(b"author ");
+    out.extend_from_slice(spec.author.as_bytes());
+    out.push(b'\n');
+    out.extend_from_slice(b"committer ");
+    out.extend_from_slice(spec.committer.as_bytes());
+    out.push(b'\n');
+    for (name, lines) in spec.headers {
+        out.extend_from_slice(name.as_bytes());
+        // git folds a multi-line header value by prefixing every continuation
+        // line with one space, so a blank line inside the value becomes a line
+        // holding a single space.
+        for line in *lines {
+            out.push(b' ');
+            out.extend_from_slice(line.as_bytes());
+            out.push(b'\n');
+        }
+    }
+    out.push(b'\n');
+    out.extend_from_slice(spec.message);
+    Ok(repo.objects.write_buf(gix::objs::Kind::Commit, &out)?)
+}

--- a/views/src/fixture.rs
+++ b/views/src/fixture.rs
@@ -5,9 +5,17 @@
 //! reaches no network, it produces the same object ids on every run and every
 //! platform, and it contains the shapes that a naive rewrite gets wrong. The
 //! commits are assembled byte by byte rather than through git plumbing, because
-//! some of the interesting cases cannot be produced by the git CLI at all: an
-//! `encoding` header placed after `gpgsig`, and a timezone offset outside the
-//! range a normalizing serializer can reproduce.
+//! ordinary git commands will not produce some of the interesting cases: git
+//! appends `gpgsig` last, so it never writes `encoding` after it, and it will
+//! not author a timezone offset that a normalizing serializer cannot reproduce.
+//!
+//! `git fsck --strict` accepts every commit here except one, which deliberately
+//! carries an offset git reports as `badTimezone`. That check exists because
+//! such commits are in the wild, and a filter that must preserve hashes has to
+//! carry them through rather than quietly repair them. The `fixture_repo`
+//! example writes this history into a real repository so git can be pointed at
+//! it, which is how its hand folded headers and its tree entry ordering were
+//! checked against the real implementation rather than only against gix.
 //!
 //! What it covers, one commit each unless noted: a root commit, a non-ASCII
 //! author and message, an `encoding` header with a non-UTF-8 message body, a

--- a/views/src/fixture.rs
+++ b/views/src/fixture.rs
@@ -132,19 +132,16 @@ pub fn write_upstream(repo: &gix::Repository) -> Result<Upstream, Error> {
     commits.push(("root", root));
 
     // Non-ASCII in both the author name and the message, stored as UTF-8.
-    files.insert(
-        "docs/\u{e9}t\u{e9}.txt",
-        Content::File("caf\u{e9}\n".as_bytes()),
-    );
+    files.insert("docs/été.txt", Content::File("café\n".as_bytes()));
     let non_ascii = write_commit(
         repo,
         &CommitSpec {
             tree: write_snapshot(repo, &files)?,
             parents: vec![root],
-            author: "Bj\u{f6}rn \u{5f20}\u{4f1f} <bjorn@example.invalid> 1100000100 +0200",
-            committer: "Bj\u{f6}rn \u{5f20}\u{4f1f} <bjorn@example.invalid> 1100000100 +0200",
+            author: "Björn 张伟 <bjorn@example.invalid> 1100000100 +0200",
+            committer: "Björn 张伟 <bjorn@example.invalid> 1100000100 +0200",
             headers: &[],
-            message: "add caf\u{e9} \u{2014} \u{4e2d}\u{6587}\n".as_bytes(),
+            message: "add café · 中文\n".as_bytes(),
         },
     )?;
     commits.push(("non-ascii", non_ascii));
@@ -157,11 +154,11 @@ pub fn write_upstream(repo: &gix::Repository) -> Result<Upstream, Error> {
         &CommitSpec {
             tree: write_snapshot(repo, &files)?,
             parents: vec![non_ascii],
-            author: "Ren\u{e9} <rene@example.invalid> 1100000200 +0100",
-            committer: "Ren\u{e9} <rene@example.invalid> 1100000200 +0100",
+            author: "René <rene@example.invalid> 1100000200 +0100",
+            committer: "René <rene@example.invalid> 1100000200 +0100",
             headers: &[("encoding", &["ISO-8859-1"])],
             // 0xE9 is `e` acute in Latin-1 and an invalid UTF-8 sequence.
-            message: b"caf\xe9 in latin-1\n",
+            message: b"latin-1 body \xe9\n",
         },
     )?;
     commits.push(("encoding-latin1", encoded));

--- a/views/src/lib.rs
+++ b/views/src/lib.rs
@@ -1,0 +1,564 @@
+//! Deterministic path filters over git history.
+//!
+//! A *view* is a child repository that is nothing but a pure function of a
+//! parent monorepo's history. [`derive`] computes it: given a parent commit and
+//! a path, it produces the commit of the history restricted to that path.
+//! [`unfilter`] is the inverse, lifting a commit of the view back into the
+//! parent.
+//!
+//! The property the rest of the design rests on is *round trip hash identity*.
+//! Take an upstream repository, inject all of its history into a parent repo by
+//! moving every tree under `vendor/upstream/` and copying commit metadata
+//! verbatim, then [`derive`] the parent with the filter `vendor/upstream`. The
+//! commits that come back out carry upstream's original hashes, byte for byte.
+//! That is what makes the view share real ancestry with upstream, so merge
+//! bases are correct and syncing is an ordinary fetch and rebase rather than a
+//! translation layer.
+//!
+//! Identity is not unconditional, and [`Filter::elide_empty`] is where it
+//! breaks. See that method for the exact trade.
+//!
+//! Only prefix filters are supported.
+
+#![deny(missing_docs)]
+
+use std::collections::HashMap;
+
+use bstr::BString;
+use bstr::ByteSlice as _;
+use gix::ObjectId;
+use gix::hash::oid;
+use gix::objs::Write as _;
+
+mod raw;
+
+pub mod fixture;
+
+/// Anything that can go wrong deriving or unfiltering a view.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum Error {
+    /// The filter path was not usable as a prefix.
+    #[error("filter path {path:?} must be relative, with no empty or dot components")]
+    BadFilterPath {
+        /// The rejected path.
+        path: String,
+    },
+    /// An object could not be read from the repository.
+    #[error("could not read object {id}")]
+    Find {
+        /// The object that could not be read.
+        id: ObjectId,
+        /// The underlying object database error.
+        #[source]
+        source: Box<gix::object::find::existing::Error>,
+    },
+    /// An object could not be written.
+    #[error("could not write object")]
+    Write(#[from] gix::objs::write::Error),
+    /// A commit object did not begin with a `tree` line followed by its
+    /// `parent` lines.
+    #[error("commit object is malformed")]
+    MalformedCommit,
+    /// An object was not the kind its referrer claimed.
+    #[error("expected object {id} to be a {expected}")]
+    WrongKind {
+        /// The object in question.
+        id: ObjectId,
+        /// The kind that was expected.
+        expected: gix::objs::Kind,
+    },
+    /// A commit of the view could not be lifted back into the parent, because
+    /// one of its parents has no known position there.
+    #[error("commit {id} of the view has no counterpart in the parent repository")]
+    Ungrafted {
+        /// The view commit with no counterpart.
+        id: ObjectId,
+    },
+}
+
+/// A path prefix to restrict history to.
+///
+/// Two filters differing only in [`elide_empty`](Self::elide_empty) are
+/// distinct filters and get distinct cache entries, because they produce
+/// different commits.
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+pub struct Filter {
+    components: Vec<BString>,
+    elide_empty: bool,
+}
+
+impl Filter {
+    /// A filter keeping only what lives under `path`.
+    ///
+    /// Empty commits are elided by default, matching what a josh style filter
+    /// does. See [`elide_empty`](Self::elide_empty) for when you do not want
+    /// that.
+    pub fn prefix(path: &str) -> Result<Self, Error> {
+        let components: Vec<BString> = path
+            .trim_matches('/')
+            .split('/')
+            .map(|part| BString::from(part.as_bytes()))
+            .collect();
+        // An empty component comes from a doubled slash, and a dot component
+        // would make it ambiguous which tree entry the filter names.
+        let usable = components
+            .iter()
+            .all(|part| !matches!(part.as_slice(), b"" | b"." | b".."));
+        if !usable {
+            return Err(Error::BadFilterPath {
+                path: path.to_owned(),
+            });
+        }
+        Ok(Self {
+            components,
+            elide_empty: true,
+        })
+    }
+
+    /// Whether a commit that leaves the filtered tree unchanged is dropped in
+    /// favour of its parent.
+    ///
+    /// Elision is what makes a view read like a repository of its own: a
+    /// monorepo commit that only touched some other directory should not show
+    /// up as an empty commit in the view. It is also the one thing that breaks
+    /// round trip hash identity, and it breaks it transitively.
+    ///
+    /// Upstream histories contain commits whose tree equals their parent's:
+    /// deliberate empty commits, and merges that resolve entirely to one side.
+    /// Under a full prefix injection the filtered tree of such a commit equals
+    /// its parent's, so elision drops it, so it has no counterpart whose hash
+    /// could match. Every descendant is then built on a different parent list
+    /// and its hash moves too, so one elided commit near the root invalidates
+    /// everything after it.
+    ///
+    /// Set this to `false` for a view that must stay hash compatible with the
+    /// history it was injected from. Leave it `true` for a view carved out of
+    /// history that only ever existed in the monorepo.
+    #[must_use]
+    pub fn elide_empty(mut self, elide: bool) -> Self {
+        self.elide_empty = elide;
+        self
+    }
+
+    /// The path this filter keeps, as `a/b/c`.
+    #[must_use]
+    pub fn path(&self) -> BString {
+        let mut out = BString::default();
+        for (at, component) in self.components.iter().enumerate() {
+            if at > 0 {
+                out.push(b'/');
+            }
+            out.extend_from_slice(component);
+        }
+        out
+    }
+}
+
+/// Memoized results, safe to reuse across calls and across filters.
+///
+/// The cache is keyed on `(tree, filter)` rather than on commits, because that
+/// is where the sharing is: a monorepo commit that did not touch the filtered
+/// path has the same subtree as its parent, and in a real history the large
+/// majority of commits are in that position. Reusing a cache is what keeps an
+/// incremental derivation proportional to what changed rather than to the size
+/// of history.
+#[derive(Default)]
+pub struct Cache {
+    per_filter: HashMap<Filter, FilterCache>,
+}
+
+#[derive(Default)]
+struct FilterCache {
+    /// Parent tree to filtered tree, `None` when the path is absent there.
+    trees: HashMap<ObjectId, Option<ObjectId>>,
+    /// Parent commit to view commit, `None` when nothing of the path exists in
+    /// its ancestry.
+    commits: HashMap<ObjectId, Option<ObjectId>>,
+    /// View commit to its own tree, so elision does not have to re-read the
+    /// parent's commit object once per commit.
+    view_trees: HashMap<ObjectId, ObjectId>,
+    /// View commit back to the parent commit it came from, for [`unfilter`].
+    grafts: HashMap<ObjectId, ObjectId>,
+}
+
+impl Cache {
+    /// An empty cache.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// How many `(tree, filter)` pairs are memoized, over all filters.
+    #[must_use]
+    pub fn tree_entries(&self) -> usize {
+        self.per_filter.values().map(|per| per.trees.len()).sum()
+    }
+
+    /// How many commits are memoized, over all filters.
+    #[must_use]
+    pub fn commit_entries(&self) -> usize {
+        self.per_filter.values().map(|per| per.commits.len()).sum()
+    }
+
+    /// The view commit `commit` maps to, if this cache has already derived it.
+    ///
+    /// `Some(None)` means the commit was derived and has no counterpart,
+    /// because nothing of the filtered path exists in its ancestry.
+    #[must_use]
+    pub fn derived(&self, commit: &oid, filter: &Filter) -> Option<Option<ObjectId>> {
+        self.per_filter.get(filter)?.commits.get(commit).copied()
+    }
+}
+
+/// Derives the view commit for `commit` under `filter`.
+///
+/// Returns `None` when no commit reachable from `commit` contains the filtered
+/// path at all, since there is then no history to show.
+///
+/// This is a pure function of `(commit, filter)` and the contents of `repo`.
+/// It writes the objects it produces into `repo`, which for a derived view is
+/// the same store the parent lives in.
+pub fn derive(
+    repo: &gix::Repository,
+    commit: &oid,
+    filter: &Filter,
+    cache: &mut Cache,
+) -> Result<Option<ObjectId>, Error> {
+    let per_filter = cache.per_filter.entry(filter.clone()).or_default();
+    Deriver {
+        repo,
+        filter,
+        cache: per_filter,
+    }
+    .run(commit)
+}
+
+/// Lifts `commit`, a commit of a view, back into the parent repository on top
+/// of `onto`.
+///
+/// The result has `onto`'s tree with the filtered path replaced by `commit`'s
+/// tree, and keeps `commit`'s metadata verbatim. Its parents are the parent
+/// repo counterparts of `commit`'s parents where `cache` knows them, which is
+/// the case when `commit` came out of [`derive`] or an earlier `unfilter` with
+/// the same cache; a root or an unknown single parent lands on `onto`.
+///
+/// `cache` is updated so a later `unfilter` of a descendant finds this commit.
+/// Applying this over an entire history, parents first with `onto` set to the
+/// previous result, is exactly the prefix injection that round trip identity is
+/// about.
+///
+/// # Errors
+///
+/// Prefix filters cannot conflict on content, since the result is a pure tree
+/// overlay. They can conflict on topology: a merge in the view whose sides were
+/// grafted into unrelated places in the parent has no single answer, and a side
+/// with no counterpart at all surfaces as [`Error::Ungrafted`].
+pub fn unfilter(
+    repo: &gix::Repository,
+    commit: &oid,
+    onto: &oid,
+    filter: &Filter,
+    cache: &mut Cache,
+) -> Result<ObjectId, Error> {
+    let per_filter = cache.per_filter.entry(filter.clone()).or_default();
+    let raw = read_commit(repo, commit)?;
+    let parsed = gix::objs::CommitRef::from_bytes(&raw, repo.object_hash())
+        .map_err(|_| Error::MalformedCommit)?;
+
+    let mut parents = Vec::with_capacity(parsed.parents.len());
+    for parent in parsed.parents() {
+        match per_filter.grafts.get(&parent) {
+            Some(grafted) => parents.push(*grafted),
+            // A single unknown parent means the view commit sits on history
+            // this cache did not inject, so `onto` is the only position it can
+            // take. A merge has no such fallback.
+            None if parsed.parents.len() == 1 => parents.push(onto.to_owned()),
+            None => return Err(Error::Ungrafted { id: parent }),
+        }
+    }
+
+    let onto_tree = commit_tree(repo, onto)?;
+    let tree = graft_tree(repo, &onto_tree, &filter.components, &parsed.tree())?;
+    let bytes = raw::replace_ids(&raw, &tree, &parents)?;
+    let id = repo.objects.write_buf(gix::objs::Kind::Commit, &bytes)?;
+    per_filter.grafts.insert(commit.to_owned(), id);
+    per_filter
+        .view_trees
+        .insert(commit.to_owned(), parsed.tree());
+    // Deliberately *not* recording `id -> commit` in `commits`. That the
+    // injected commit derives back to `commit` is the claim this crate exists
+    // to make good on, not an assumption it may seed itself with; caching it
+    // here would turn any round trip check into a lookup of its own input.
+    Ok(id)
+}
+
+struct Deriver<'a> {
+    repo: &'a gix::Repository,
+    filter: &'a Filter,
+    cache: &'a mut FilterCache,
+}
+
+/// One step of the explicit traversal stack.
+enum Step {
+    /// Resolve the commit's parents first.
+    Enter(ObjectId),
+    /// Parents are resolved, so map this commit.
+    Map(ObjectId),
+}
+
+impl Deriver<'_> {
+    fn run(&mut self, head: &oid) -> Result<Option<ObjectId>, Error> {
+        // An explicit stack rather than recursion: the histories this is for
+        // run hundreds of thousands of commits deep on a single chain, which
+        // overflows the default stack long before it runs out of memory.
+        let mut stack = vec![Step::Enter(head.to_owned())];
+        while let Some(step) = stack.pop() {
+            let (id, expanded) = match step {
+                Step::Enter(id) => (id, false),
+                Step::Map(id) => (id, true),
+            };
+            if self.cache.commits.contains_key(&id) {
+                continue;
+            }
+            let raw = read_commit(self.repo, &id)?;
+            if expanded {
+                self.map(&id, &raw)?;
+                continue;
+            }
+            let parsed = gix::objs::CommitRef::from_bytes(&raw, self.repo.object_hash())
+                .map_err(|_| Error::MalformedCommit)?;
+            let pending: Vec<ObjectId> = parsed
+                .parents()
+                .filter(|parent| !self.cache.commits.contains_key(parent))
+                .collect();
+            if pending.is_empty() {
+                self.map(&id, &raw)?;
+            } else {
+                stack.push(Step::Map(id));
+                stack.extend(pending.into_iter().map(Step::Enter));
+            }
+        }
+        Ok(self.cache.commits.get(head).copied().flatten())
+    }
+
+    /// Maps one commit whose parents are already mapped.
+    fn map(&mut self, id: &oid, raw: &[u8]) -> Result<(), Error> {
+        let parsed = gix::objs::CommitRef::from_bytes(raw, self.repo.object_hash())
+            .map_err(|_| Error::MalformedCommit)?;
+        let subtree = self.derive_tree(&parsed.tree())?;
+
+        // Two *distinct* parents can map to the same view commit once elision
+        // collapses one onto the other, and a merge with twin parents is not a
+        // merge, so that duplicate is dropped. A commit that already listed the
+        // same parent twice is a different matter: git stores and preserves it,
+        // so collapsing it would move the commit's hash for no reason. Only
+        // duplicates the filter introduced are removed.
+        let sources: Vec<ObjectId> = parsed.parents().collect();
+        let mut parents: Vec<ObjectId> = Vec::with_capacity(sources.len());
+        for (at, source) in sources.iter().enumerate() {
+            let Some(mapped) = self.cache.commits.get(source).copied().flatten() else {
+                continue;
+            };
+            let introduced = sources.iter().take(at).any(|earlier| {
+                earlier != source
+                    && self.cache.commits.get(earlier).copied().flatten() == Some(mapped)
+            });
+            if !introduced {
+                parents.push(mapped);
+            }
+        }
+
+        let single = match parents.as_slice() {
+            [only] => Some(*only),
+            _ => None,
+        };
+        let mapped = match subtree {
+            // Nothing of the filtered path here. A single line of history just
+            // continues at the parent; a merge is kept, with an empty tree, so
+            // the view does not silently lose a branch point.
+            None if parents.len() < 2 => single,
+            None => {
+                let empty = ObjectId::empty_tree(self.repo.object_hash());
+                Some(self.build(id, raw, &empty, &parents)?)
+            }
+            Some(subtree) => {
+                let elide = self.filter.elide_empty
+                    && single
+                        .is_some_and(|parent| self.cache.view_trees.get(&parent) == Some(&subtree));
+                if elide {
+                    single
+                } else {
+                    Some(self.build(id, raw, &subtree, &parents)?)
+                }
+            }
+        };
+
+        self.cache.commits.insert(id.to_owned(), mapped);
+        Ok(())
+    }
+
+    fn build(
+        &mut self,
+        source: &oid,
+        raw: &[u8],
+        tree: &oid,
+        parents: &[ObjectId],
+    ) -> Result<ObjectId, Error> {
+        // Referred to by a commit, so the object has to exist or the view
+        // fails `git fsck`. git itself is happy to write it lazily.
+        if *tree == *ObjectId::empty_tree(self.repo.object_hash()) {
+            self.repo.objects.write(&gix::objs::Tree::default())?;
+        }
+        let bytes = raw::replace_ids(raw, tree, parents)?;
+        let id = self
+            .repo
+            .objects
+            .write_buf(gix::objs::Kind::Commit, &bytes)?;
+        self.cache.view_trees.insert(id, tree.to_owned());
+        self.cache
+            .grafts
+            .entry(id)
+            .or_insert_with(|| source.to_owned());
+        Ok(id)
+    }
+
+    /// The subtree of `tree` at the filter's path, memoized.
+    fn derive_tree(&mut self, tree: &oid) -> Result<Option<ObjectId>, Error> {
+        if let Some(hit) = self.cache.trees.get(tree) {
+            return Ok(*hit);
+        }
+        let mut current = tree.to_owned();
+        let mut found = Some(current);
+        for component in &self.filter.components {
+            let entry = lookup(self.repo, &current, component.as_bstr())?;
+            // A blob where the filter expects a directory means the path is
+            // absent at this revision, not that the history is broken.
+            match entry {
+                Some((mode, oid)) if mode.is_tree() => {
+                    current = oid;
+                    found = Some(current);
+                }
+                _ => {
+                    found = None;
+                    break;
+                }
+            }
+        }
+        self.cache.trees.insert(tree.to_owned(), found);
+        Ok(found)
+    }
+}
+
+/// Replaces the subtree at `components` inside `base` with `sub`, creating any
+/// missing intermediate trees.
+fn graft_tree(
+    repo: &gix::Repository,
+    base: &oid,
+    components: &[BString],
+    sub: &oid,
+) -> Result<ObjectId, Error> {
+    let Some((name, rest)) = components.split_first() else {
+        return Ok(sub.to_owned());
+    };
+
+    let mut entries = decode_entries(repo, base)?;
+    let existing = entries
+        .iter()
+        .position(|entry| entry.filename == name.as_bstr());
+    let child_base = match existing.and_then(|at| entries.get(at)) {
+        Some(entry) if entry.mode.is_tree() => entry.oid,
+        // Absent, or shadowed by a blob of the same name. The graft replaces
+        // it, since the filtered path is authoritative for its own subtree.
+        _ => ObjectId::empty_tree(repo.object_hash()),
+    };
+    let child = graft_tree(repo, &child_base, rest, sub)?;
+
+    let entry = gix::objs::tree::Entry {
+        mode: gix::objs::tree::EntryKind::Tree.into(),
+        filename: name.clone(),
+        oid: child,
+    };
+    match existing.and_then(|at| entries.get_mut(at)) {
+        Some(slot) => *slot = entry,
+        None => entries.push(entry),
+    }
+    // git requires tree entries sorted with directory names compared as if
+    // they ended in a slash; `gix_object::tree::Entry`'s ordering does that.
+    entries.sort();
+    Ok(repo.objects.write(&gix::objs::Tree { entries })?)
+}
+
+fn lookup(
+    repo: &gix::Repository,
+    tree: &oid,
+    name: &bstr::BStr,
+) -> Result<Option<(gix::objs::tree::EntryMode, ObjectId)>, Error> {
+    if *tree == *ObjectId::empty_tree(repo.object_hash()) {
+        return Ok(None);
+    }
+    let object = find(repo, tree)?;
+    let decoded =
+        gix::objs::TreeRef::from_bytes(&object.data, repo.object_hash()).map_err(|_| {
+            Error::WrongKind {
+                id: tree.to_owned(),
+                expected: gix::objs::Kind::Tree,
+            }
+        })?;
+    Ok(decoded
+        .entries
+        .iter()
+        .find(|entry| entry.filename == name)
+        .map(|entry| (entry.mode, entry.oid.to_owned())))
+}
+
+fn decode_entries(
+    repo: &gix::Repository,
+    tree: &oid,
+) -> Result<Vec<gix::objs::tree::Entry>, Error> {
+    if *tree == *ObjectId::empty_tree(repo.object_hash()) {
+        return Ok(Vec::new());
+    }
+    let object = find(repo, tree)?;
+    let decoded =
+        gix::objs::TreeRef::from_bytes(&object.data, repo.object_hash()).map_err(|_| {
+            Error::WrongKind {
+                id: tree.to_owned(),
+                expected: gix::objs::Kind::Tree,
+            }
+        })?;
+    Ok(decoded
+        .entries
+        .iter()
+        .map(|entry| gix::objs::tree::Entry {
+            mode: entry.mode,
+            filename: entry.filename.to_owned(),
+            oid: entry.oid.to_owned(),
+        })
+        .collect())
+}
+
+fn find<'repo>(repo: &'repo gix::Repository, id: &oid) -> Result<gix::Object<'repo>, Error> {
+    repo.find_object(id).map_err(|source| Error::Find {
+        id: id.to_owned(),
+        source: Box::new(source),
+    })
+}
+
+fn read_commit(repo: &gix::Repository, id: &oid) -> Result<Vec<u8>, Error> {
+    let object = find(repo, id)?;
+    if object.kind != gix::objs::Kind::Commit {
+        return Err(Error::WrongKind {
+            id: id.to_owned(),
+            expected: gix::objs::Kind::Commit,
+        });
+    }
+    Ok(object.detach().data)
+}
+
+fn commit_tree(repo: &gix::Repository, id: &oid) -> Result<ObjectId, Error> {
+    let raw = read_commit(repo, id)?;
+    let parsed = gix::objs::CommitRef::from_bytes(&raw, repo.object_hash())
+        .map_err(|_| Error::MalformedCommit)?;
+    Ok(parsed.tree())
+}

--- a/views/src/lib.rs
+++ b/views/src/lib.rs
@@ -170,8 +170,17 @@ pub struct Cache {
 
 #[derive(Default)]
 struct FilterCache {
-    /// Parent tree to filtered tree, `None` when the path is absent there.
-    trees: HashMap<ObjectId, Option<ObjectId>>,
+    /// Subtree lookups, keyed on the tree and how many path components have
+    /// been consumed so far, `None` when the path is absent below it.
+    ///
+    /// Keying on the root tree alone gives almost no sharing, which is worth
+    /// spelling out because it is the opposite of what one expects: a monorepo
+    /// commit that touched some other directory has a *different* root tree and
+    /// the *same* filtered subtree, and that is the common case. The sharing is
+    /// one level down, so every level is memoized and a commit that left the
+    /// filtered path alone is answered from the first shared tree on the way
+    /// in.
+    trees: HashMap<(ObjectId, usize), Option<ObjectId>>,
     /// Parent commit to view commit, `None` when nothing of the path exists in
     /// its ancestry.
     commits: HashMap<ObjectId, Option<ObjectId>>,
@@ -180,6 +189,9 @@ struct FilterCache {
     view_trees: HashMap<ObjectId, ObjectId>,
     /// View commit back to the parent commit it came from, for [`unfilter`].
     grafts: HashMap<ObjectId, ObjectId>,
+    /// Tree objects read while descending, so the cost of a derivation can be
+    /// measured rather than assumed.
+    tree_reads: usize,
 }
 
 impl Cache {
@@ -199,6 +211,17 @@ impl Cache {
     #[must_use]
     pub fn commit_entries(&self) -> usize {
         self.per_filter.values().map(|per| per.commits.len()).sum()
+    }
+
+    /// How many tree objects have been read, over all filters.
+    ///
+    /// This is the number the cache exists to hold down. A commit that did not
+    /// touch the filtered path should cost one read, not one per path
+    /// component, because every tree on the way in except the changed root
+    /// is shared with its parent commit.
+    #[must_use]
+    pub fn tree_reads(&self) -> usize {
+        self.per_filter.values().map(|per| per.tree_reads).sum()
     }
 
     /// The view commit `commit` maps to, if this cache has already derived it.
@@ -423,29 +446,28 @@ impl Deriver<'_> {
         Ok(id)
     }
 
-    /// The subtree of `tree` at the filter's path, memoized.
+    /// The subtree of `tree` at the filter's path, memoized at every level.
     fn derive_tree(&mut self, tree: &oid) -> Result<Option<ObjectId>, Error> {
-        if let Some(hit) = self.cache.trees.get(tree) {
+        self.descend(tree.to_owned(), 0)
+    }
+
+    /// Recursion depth is the filter's path depth, a handful of components, not
+    /// anything that grows with the size of history.
+    fn descend(&mut self, tree: ObjectId, depth: usize) -> Result<Option<ObjectId>, Error> {
+        let Some(component) = self.filter.components.get(depth) else {
+            return Ok(Some(tree));
+        };
+        if let Some(hit) = self.cache.trees.get(&(tree, depth)) {
             return Ok(*hit);
         }
-        let mut current = tree.to_owned();
-        let mut found = Some(current);
-        for component in &self.filter.components {
-            let entry = lookup(self.repo, &current, component.as_bstr())?;
-            // A blob where the filter expects a directory means the path is
-            // absent at this revision, not that the history is broken.
-            match entry {
-                Some((mode, oid)) if mode.is_tree() => {
-                    current = oid;
-                    found = Some(current);
-                }
-                _ => {
-                    found = None;
-                    break;
-                }
-            }
-        }
-        self.cache.trees.insert(tree.to_owned(), found);
+        self.cache.tree_reads += 1;
+        // A blob where the filter expects a directory means the path is absent
+        // at this revision, not that the history is broken.
+        let found = match lookup(self.repo, &tree, component.as_bstr())? {
+            Some((mode, child)) if mode.is_tree() => self.descend(child, depth + 1)?,
+            _ => None,
+        };
+        self.cache.trees.insert((tree, depth), found);
         Ok(found)
     }
 }

--- a/views/src/lib.rs
+++ b/views/src/lib.rs
@@ -138,6 +138,12 @@ pub enum Semantics {
     ///    that was already trivial before filtering is never dropped.
     /// 6. Tree entries are ordered by git's rule, with a directory name
     ///    compared as though it ended in a slash.
+    ///
+    /// Rule 1 has a useful consequence: a commit message trailer convention for
+    /// per-commit upstream provenance, of the `UPSTREAM:` or `Git-commit:` kind
+    /// that kernel forks converge on, rides through derivation and lifting in
+    /// both directions untouched. Adopting one is a decision about how commits
+    /// are written, not about this filter, and needs no version bump here.
     #[default]
     V1,
 }

--- a/views/src/lib.rs
+++ b/views/src/lib.rs
@@ -1,22 +1,24 @@
 //! Deterministic path filters over git history.
 //!
 //! A *view* is a child repository that is nothing but a pure function of a
-//! parent monorepo's history. [`derive`] computes it: given a parent commit and
-//! a path, it produces the commit of the history restricted to that path.
+//! parent monorepo's history. [`derive()`] computes it: given a parent commit
+//! and a path, it produces the commit of the history restricted to that path.
 //! [`unfilter`] is the inverse, lifting a commit of the view back into the
 //! parent.
 //!
 //! The property the rest of the design rests on is *round trip hash identity*.
 //! Take an upstream repository, inject all of its history into a parent repo by
 //! moving every tree under `vendor/upstream/` and copying commit metadata
-//! verbatim, then [`derive`] the parent with the filter `vendor/upstream`. The
-//! commits that come back out carry upstream's original hashes, byte for byte.
-//! That is what makes the view share real ancestry with upstream, so merge
-//! bases are correct and syncing is an ordinary fetch and rebase rather than a
-//! translation layer.
+//! verbatim, then [`derive()`] the parent with the filter `vendor/upstream`.
+//! The commits that come back out carry upstream's original hashes, byte for
+//! byte. That is what makes the view share real ancestry with upstream, so
+//! merge bases are correct and syncing is an ordinary fetch and rebase rather
+//! than a translation layer.
 //!
-//! Identity is not unconditional, and [`Filter::elide_empty`] is where it
-//! breaks. See that method for the exact trade.
+//! Identity survives elision, but only because the elision rule asks whether a
+//! commit was empty *before* filtering rather than only after. See [`Elide`]
+//! for why that one condition is what makes a view both clean and hash
+//! compatible.
 //!
 //! Only prefix filters are supported.
 
@@ -79,21 +81,53 @@ pub enum Error {
 
 /// A path prefix to restrict history to.
 ///
-/// Two filters differing only in [`elide_empty`](Self::elide_empty) are
-/// distinct filters and get distinct cache entries, because they produce
-/// different commits.
+/// Two filters differing only in their [`Elide`] policy or their trivial merge
+/// policy are distinct filters and get distinct cache entries, because they
+/// produce different commits.
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct Filter {
     components: Vec<BString>,
-    elide_empty: bool,
+    elide: Elide,
+    keep_trivial_merges: bool,
+}
+
+/// What to do with a commit whose filtered tree is unchanged from its parent's.
+///
+/// This is hash affecting, so it is part of the filter's identity and belongs
+/// in a recorded semantics version rather than in a caller's discretion.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+pub enum Elide {
+    /// Keep every commit. The view has one commit per parent commit.
+    Nothing,
+    /// Drop it, unless the commit was already empty *before* filtering.
+    ///
+    /// The exception is the whole trick, and it is what lets a view be both
+    /// clean and hash compatible. A monorepo commit that touched only some
+    /// other directory has a tree that differs from its parent's, so it is
+    /// dropped and does not clutter the view. An upstream commit that was
+    /// deliberately empty has a tree identical to its parent's before
+    /// filtering as well as after, so it survives, and the hashes of it and
+    /// everything after it are preserved.
+    ///
+    /// This matches josh's default, implemented in `select_parent_commits` in
+    /// `josh-core/src/history.rs` as `if affects_filtered || all_diffs_empty`.
+    Unchanged,
+    /// Drop it whether or not it was already empty before filtering.
+    ///
+    /// Do not use this on a history whose hashes must match an upstream. It is
+    /// here because it is the rule one writes by accident, it looks correct,
+    /// and the damage is invisible until something compares hashes: on
+    /// git.git's 85050 commits it drops 7 deliberately empty commits and,
+    /// because a moved hash changes every descendant's parent line, moves
+    /// 78500 more.
+    UnchangedIncludingAlreadyEmpty,
 }
 
 impl Filter {
     /// A filter keeping only what lives under `path`.
     ///
-    /// Empty commits are elided by default, matching what a josh style filter
-    /// does. See [`elide_empty`](Self::elide_empty) for when you do not want
-    /// that.
+    /// Defaults to [`Elide::Unchanged`] and to dropping trivial merges, which
+    /// is what josh does by default and what preserves hash identity.
     pub fn prefix(path: &str) -> Result<Self, Error> {
         let components: Vec<BString> = path
             .trim_matches('/')
@@ -112,32 +146,33 @@ impl Filter {
         }
         Ok(Self {
             components,
-            elide_empty: true,
+            elide: Elide::Unchanged,
+            keep_trivial_merges: false,
         })
     }
 
-    /// Whether a commit that leaves the filtered tree unchanged is dropped in
-    /// favour of its parent.
-    ///
-    /// Elision is what makes a view read like a repository of its own: a
-    /// monorepo commit that only touched some other directory should not show
-    /// up as an empty commit in the view. It is also the one thing that breaks
-    /// round trip hash identity, and it breaks it transitively.
-    ///
-    /// Upstream histories contain commits whose tree equals their parent's:
-    /// deliberate empty commits, and merges that resolve entirely to one side.
-    /// Under a full prefix injection the filtered tree of such a commit equals
-    /// its parent's, so elision drops it, so it has no counterpart whose hash
-    /// could match. Every descendant is then built on a different parent list
-    /// and its hash moves too, so one elided commit near the root invalidates
-    /// everything after it.
-    ///
-    /// Set this to `false` for a view that must stay hash compatible with the
-    /// history it was injected from. Leave it `true` for a view carved out of
-    /// history that only ever existed in the monorepo.
+    /// Sets what happens to a commit whose filtered tree is unchanged.
     #[must_use]
-    pub fn elide_empty(mut self, elide: bool) -> Self {
-        self.elide_empty = elide;
+    pub fn elide(mut self, elide: Elide) -> Self {
+        self.elide = elide;
+        self
+    }
+
+    /// Whether a merge whose filtered tree equals its first filtered parent's
+    /// is kept.
+    ///
+    /// Dropping them, the default, is what keeps a view from filling up with
+    /// merges that say nothing about the filtered path; rust-lang called the
+    /// merge flood the main problem they hit with josh, over 10000 merges for
+    /// one initial sync. Keeping them preserves the branch structure at the
+    /// cost of degenerate merges whose parents collapse onto one chain.
+    ///
+    /// A merge that was *already* trivial before filtering is never dropped,
+    /// for the same reason an already empty commit is not: dropping it would
+    /// move its hash and every descendant's.
+    #[must_use]
+    pub fn keep_trivial_merges(mut self, keep: bool) -> Self {
+        self.keep_trivial_merges = keep;
         self
     }
 
@@ -187,6 +222,10 @@ struct FilterCache {
     /// View commit to its own tree, so elision does not have to re-read the
     /// parent's commit object once per commit.
     view_trees: HashMap<ObjectId, ObjectId>,
+    /// Parent-repo commit to its own unfiltered tree. Needed because the
+    /// elision rule turns on whether a commit was empty *before* filtering, so
+    /// the unfiltered trees of its parents have to be on hand.
+    source_trees: HashMap<ObjectId, ObjectId>,
     /// View commit back to the parent commit it came from, for [`unfilter`].
     grafts: HashMap<ObjectId, ObjectId>,
     /// Tree objects read while descending, so the cost of a derivation can be
@@ -249,7 +288,7 @@ pub fn derive(
     cache: &mut Cache,
 ) -> Result<Option<ObjectId>, Error> {
     let per_filter = cache.per_filter.entry(filter.clone()).or_default();
-    Deriver {
+    Derivation {
         repo,
         filter,
         cache: per_filter,
@@ -263,8 +302,8 @@ pub fn derive(
 /// The result has `onto`'s tree with the filtered path replaced by `commit`'s
 /// tree, and keeps `commit`'s metadata verbatim. Its parents are the parent
 /// repo counterparts of `commit`'s parents where `cache` knows them, which is
-/// the case when `commit` came out of [`derive`] or an earlier `unfilter` with
-/// the same cache; a root or an unknown single parent lands on `onto`.
+/// the case when `commit` came out of [`derive()`] or an earlier `unfilter`
+/// with the same cache; a root or an unknown single parent lands on `onto`.
 ///
 /// `cache` is updated so a later `unfilter` of a descendant finds this commit.
 /// Applying this over an entire history, parents first with `onto` set to the
@@ -316,7 +355,7 @@ pub fn unfilter(
     Ok(id)
 }
 
-struct Deriver<'a> {
+struct Derivation<'a> {
     repo: &'a gix::Repository,
     filter: &'a Filter,
     cache: &'a mut FilterCache,
@@ -330,7 +369,7 @@ enum Step {
     Map(ObjectId),
 }
 
-impl Deriver<'_> {
+impl Derivation<'_> {
     fn run(&mut self, head: &oid) -> Result<Option<ObjectId>, Error> {
         // An explicit stack rather than recursion: the histories this is for
         // run hundreds of thousands of commits deep on a single chain, which
@@ -366,18 +405,111 @@ impl Deriver<'_> {
     }
 
     /// Maps one commit whose parents are already mapped.
+    ///
+    /// The order of the decisions here follows `create_filtered_commit2` in
+    /// josh's `josh-core/src/history.rs`, because the two rules that keep hash
+    /// identity are both easy to get wrong in the same direction and both live
+    /// in that order: a trivial merge is spared if it was already trivial, and
+    /// an unchanged commit is spared if it was already empty.
     fn map(&mut self, id: &oid, raw: &[u8]) -> Result<(), Error> {
         let parsed = gix::objs::CommitRef::from_bytes(raw, self.repo.object_hash())
             .map_err(|_| Error::MalformedCommit)?;
-        let subtree = self.derive_tree(&parsed.tree())?;
-
-        // Two *distinct* parents can map to the same view commit once elision
-        // collapses one onto the other, and a merge with twin parents is not a
-        // merge, so that duplicate is dropped. A commit that already listed the
-        // same parent twice is a different matter: git stores and preserves it,
-        // so collapsing it would move the commit's hash for no reason. Only
-        // duplicates the filter introduced are removed.
+        let source_tree = parsed.tree();
         let sources: Vec<ObjectId> = parsed.parents().collect();
+        let subtree = self.derive_tree(&source_tree)?;
+        self.cache.source_trees.insert(id.to_owned(), source_tree);
+
+        // An absent path is the empty tree, not a special case. Treating it
+        // uniformly is what makes a commit that *deletes* the filtered
+        // directory show up in the view as a commit that empties it, rather
+        // than vanishing.
+        let filtered_tree =
+            subtree.unwrap_or_else(|| ObjectId::empty_tree(self.repo.object_hash()));
+        let parents = self.derived_parents(&sources);
+
+        // Did this commit change the filtered path relative to any parent?
+        let mut affects_filtered = false;
+        for parent in &parents {
+            if self.view_tree(parent)? != filtered_tree {
+                affects_filtered = true;
+                break;
+            }
+        }
+        // Was the commit already empty before filtering? Vacuously true for a
+        // root, matching josh, so a root is never dropped for being unchanged.
+        let already_empty = sources
+            .iter()
+            .all(|parent| self.cache.source_trees.get(parent) == Some(&source_tree));
+
+        let mapped = if let Some(collapsed) =
+            self.trivial_merge_target(&sources, source_tree, filtered_tree, &parents)?
+        {
+            Some(collapsed)
+        } else {
+            let unchanged = !affects_filtered;
+            let drop = match self.filter.elide {
+                Elide::Nothing => false,
+                Elide::Unchanged => unchanged && !already_empty,
+                Elide::UnchangedIncludingAlreadyEmpty => unchanged,
+            };
+            match (drop, parents.first()) {
+                // Dropped, and the parent takes its place in the view.
+                (true, Some(first)) => Some(*first),
+                // Dropped with nothing to fall back to, and nothing of the path
+                // here, so there is no counterpart at all.
+                (true, None) if subtree.is_none() => None,
+                _ if subtree.is_none() && parents.is_empty() => None,
+                _ => Some(self.build(id, raw, &filtered_tree, &parents)?),
+            }
+        };
+
+        self.cache.commits.insert(id.to_owned(), mapped);
+        Ok(())
+    }
+
+    /// The view commit a trivial merge collapses onto, if it collapses.
+    ///
+    /// A merge whose filtered tree equals its first filtered parent's says
+    /// nothing about the filtered path. It is dropped unless it was already
+    /// trivial before filtering, in which case dropping it would move its hash.
+    fn trivial_merge_target(
+        &mut self,
+        sources: &[ObjectId],
+        source_tree: ObjectId,
+        filtered_tree: ObjectId,
+        parents: &[ObjectId],
+    ) -> Result<Option<ObjectId>, Error> {
+        if self.filter.keep_trivial_merges || parents.len() < 2 {
+            return Ok(None);
+        }
+        let Some(first) = parents.first() else {
+            return Ok(None);
+        };
+        if self.view_tree(first)? != filtered_tree {
+            return Ok(None);
+        }
+        let was_trivial = sources
+            .first()
+            .and_then(|parent| self.cache.source_trees.get(parent))
+            == Some(&source_tree);
+        Ok((!was_trivial).then_some(*first))
+    }
+
+    /// The view commits this commit's parents map to.
+    ///
+    /// Two *distinct* parents can map to the same view commit once elision
+    /// collapses one onto the other, and a merge with twin parents is not a
+    /// merge, so that duplicate is dropped. A commit that already listed the
+    /// same parent twice is a different matter: git stores and preserves it, so
+    /// collapsing it would move the commit's hash for no reason. The linux
+    /// kernel has four such commits and the earliest, from 2005, has 1458483 of
+    /// its 1464098 commits as descendants, so a blind dedupe moves 99.6% of
+    /// that history. Only duplicates the filter introduced are removed.
+    ///
+    /// josh does not dedupe at all here, so it can emit a merge whose parents
+    /// are the same commit twice. That difference is deliberate and is part of
+    /// this filter's semantics.
+    fn derived_parents(&self, sources: &[ObjectId]) -> Vec<ObjectId> {
         let mut parents: Vec<ObjectId> = Vec::with_capacity(sources.len());
         for (at, source) in sources.iter().enumerate() {
             let Some(mapped) = self.cache.commits.get(source).copied().flatten() else {
@@ -391,34 +523,17 @@ impl Deriver<'_> {
                 parents.push(mapped);
             }
         }
+        parents
+    }
 
-        let single = match parents.as_slice() {
-            [only] => Some(*only),
-            _ => None,
-        };
-        let mapped = match subtree {
-            // Nothing of the filtered path here. A single line of history just
-            // continues at the parent; a merge is kept, with an empty tree, so
-            // the view does not silently lose a branch point.
-            None if parents.len() < 2 => single,
-            None => {
-                let empty = ObjectId::empty_tree(self.repo.object_hash());
-                Some(self.build(id, raw, &empty, &parents)?)
-            }
-            Some(subtree) => {
-                let elide = self.filter.elide_empty
-                    && single
-                        .is_some_and(|parent| self.cache.view_trees.get(&parent) == Some(&subtree));
-                if elide {
-                    single
-                } else {
-                    Some(self.build(id, raw, &subtree, &parents)?)
-                }
-            }
-        };
-
-        self.cache.commits.insert(id.to_owned(), mapped);
-        Ok(())
+    /// The tree of a view commit, from the cache where possible.
+    fn view_tree(&mut self, view: &oid) -> Result<ObjectId, Error> {
+        if let Some(hit) = self.cache.view_trees.get(view) {
+            return Ok(*hit);
+        }
+        let tree = commit_tree(self.repo, view)?;
+        self.cache.view_trees.insert(view.to_owned(), tree);
+        Ok(tree)
     }
 
     fn build(

--- a/views/src/lib.rs
+++ b/views/src/lib.rs
@@ -351,6 +351,15 @@ impl Filter {
 /// majority of commits are in that position. Reusing a cache is what keeps an
 /// incremental derivation proportional to what changed rather than to the size
 /// of history.
+///
+/// Measured, because that claim is worth nothing unmeasured. Injecting all
+/// 85050 commits of git.git under a two component prefix and deriving them back
+/// takes about 45 seconds each way on one core, most of it writing one loose
+/// object per tree per commit. Adding ten commits on top and re-deriving with
+/// the same cache takes 0.0007 seconds and exactly ten tree reads, one per
+/// commit for the one tree that changed. The first number is a one time import
+/// cost; the second is what a fetch costs, and it is the one that decides
+/// whether a view is usable.
 #[derive(Default)]
 pub struct Cache {
     per_filter: HashMap<Filter, FilterCache>,

--- a/views/src/lib.rs
+++ b/views/src/lib.rs
@@ -446,11 +446,17 @@ pub fn derive(
 /// Lifts `commit`, a commit of a view, back into the parent repository on top
 /// of `onto`.
 ///
-/// The result has `onto`'s tree with the filtered path replaced by `commit`'s
-/// tree, and keeps `commit`'s metadata verbatim. Its parents are the parent
+/// The result keeps `commit`'s metadata verbatim. Its parents are the parent
 /// repo counterparts of `commit`'s parents where `cache` knows them, which is
 /// the case when `commit` came out of [`derive()`] or an earlier `unfilter`
 /// with the same cache; a root or an unknown single parent lands on `onto`.
+///
+/// Its tree is the FIRST PARENT's tree with the filtered path replaced, falling
+/// back to `onto`'s tree only when no parent has a counterpart. So `onto`
+/// positions a commit whose ancestry is unknown here; it does not pull in
+/// monorepo changes that the commit's own parent does not have. Putting a
+/// lifted patch on top of a monorepo that has moved is two operations, this one
+/// and then a merge, and this one will not silently do the second.
 ///
 /// `cache` is updated so a later `unfilter` of a descendant finds this commit.
 /// Applying this over an entire history, parents first with `onto` set to the
@@ -487,8 +493,17 @@ pub fn unfilter(
         }
     }
 
-    let onto_tree = commit_tree(repo, onto)?;
-    let tree = graft_tree(repo, &onto_tree, &filter.components, &parsed.tree())?;
+    // The base for the tree is the first parent's counterpart when there is one,
+    // and only otherwise `onto`. Taking `onto`'s tree while parenting the result
+    // on a different commit is not a graft, it is a fabrication: the result would
+    // carry every change `onto` made outside the prefix while naming a parent that
+    // does not contain them, so those changes would look like this commit's own
+    // work and `onto` would be an ancestor of nothing. Lifting a patch and merging
+    // the monorepo forward are two operations, and conflating them is how
+    // reverse-applying a rewritten view ends up rewriting the monorepo.
+    let base = parents.first().copied().unwrap_or_else(|| onto.to_owned());
+    let base_tree = commit_tree(repo, &base)?;
+    let tree = graft_tree(repo, &base_tree, &filter.components, &parsed.tree())?;
     let bytes = raw::replace_ids(&raw, &tree, &parents)?;
     let id = repo.objects.write_buf(gix::objs::Kind::Commit, &bytes)?;
     per_filter.grafts.insert(commit.to_owned(), id);

--- a/views/src/lib.rs
+++ b/views/src/lib.rs
@@ -40,6 +40,13 @@ pub mod fixture;
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum Error {
+    /// A filter spec was missing a field, had an unknown field, or named a
+    /// value this version does not know.
+    #[error("filter spec {spec:?} is not one this version can read")]
+    BadSpec {
+        /// The rejected spec.
+        spec: String,
+    },
     /// The filter path was not usable as a prefix.
     #[error("filter path {path:?} must be relative, with no empty or dot components")]
     BadFilterPath {
@@ -89,6 +96,60 @@ pub struct Filter {
     components: Vec<BString>,
     elide: Elide,
     keep_trivial_merges: bool,
+    semantics: Semantics,
+}
+
+/// The version of the hash affecting rules a filter follows.
+///
+/// Every decision that can change an output commit hash is pinned by this
+/// number, and the number is written into the repository next to the filter so
+/// a view records what produced it. Without that, a change to any rule silently
+/// produces a different history from the same input, and the only symptom is
+/// that hashes stop matching a view somebody already has.
+///
+/// This is not hypothetical. josh has broken its own output hashes at least
+/// twice and its compatibility flags are the fossils: `gpgsig="norm-lf"` exists
+/// only to reproduce histories from a josh that normalized CRLF inside
+/// `gpgsig`, and `history="keep-trivial-merges"` was the default before it
+/// became opt in. rust-lang generated commits with a josh that stripped
+/// signatures and had to force push the entire history of rustc-dev-guide to
+/// recover, and their README now pins an exact josh tag with the reason written
+/// down.
+///
+/// Adding a rule, or changing one, means adding a variant here. Old variants
+/// keep their old behavior forever; that is the entire point of them.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Hash)]
+#[non_exhaustive]
+pub enum Semantics {
+    /// The initial rules.
+    ///
+    /// 1. Only the `tree` and `parent` lines of a commit object are rewritten.
+    ///    Every other byte, including `author`, `committer`, `encoding`,
+    ///    `gpgsig`, `mergetag`, any unknown extra header, their relative order,
+    ///    and the message, is copied through untouched.
+    /// 2. A path absent from a commit's tree filters to the empty tree, so a
+    ///    commit that deletes the filtered directory appears in the view as a
+    ///    commit that empties it.
+    /// 3. Derived parents keep duplicates the source commit already had, and
+    ///    drop only duplicates the filter itself introduced by collapsing two
+    ///    distinct parents onto one view commit.
+    /// 4. Elision follows the filter's [`Elide`] policy.
+    /// 5. Trivial merges follow the filter's trivial merge policy, and a merge
+    ///    that was already trivial before filtering is never dropped.
+    /// 6. Tree entries are ordered by git's rule, with a directory name
+    ///    compared as though it ended in a slash.
+    #[default]
+    V1,
+}
+
+impl Semantics {
+    /// The number as it appears in a filter spec.
+    #[must_use]
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::V1 => "1",
+        }
+    }
 }
 
 /// What to do with a commit whose filtered tree is unchanged from its parent's.
@@ -135,10 +196,16 @@ impl Filter {
             .map(|part| BString::from(part.as_bytes()))
             .collect();
         // An empty component comes from a doubled slash, and a dot component
-        // would make it ambiguous which tree entry the filter names.
-        let usable = components
-            .iter()
-            .all(|part| !matches!(part.as_slice(), b"" | b"." | b".."));
+        // would make it ambiguous which tree entry the filter names. A `;` or a
+        // control byte is refused so that a filter spec, which separates its
+        // fields with `;`, can be parsed back without an escaping scheme. git
+        // permits both in a path; no vendoring mount point needs them.
+        let usable = components.iter().all(|part| {
+            !matches!(part.as_slice(), b"" | b"." | b"..")
+                && !part
+                    .iter()
+                    .any(|byte| *byte == b';' || byte.is_ascii_control())
+        });
         if !usable {
             return Err(Error::BadFilterPath {
                 path: path.to_owned(),
@@ -148,6 +215,7 @@ impl Filter {
             components,
             elide: Elide::Unchanged,
             keep_trivial_merges: false,
+            semantics: Semantics::default(),
         })
     }
 
@@ -174,6 +242,85 @@ impl Filter {
     pub fn keep_trivial_merges(mut self, keep: bool) -> Self {
         self.keep_trivial_merges = keep;
         self
+    }
+
+    /// Sets the semantics version.
+    ///
+    /// Only needed to reproduce a view built by an older version of this crate.
+    #[must_use]
+    pub fn semantics(mut self, semantics: Semantics) -> Self {
+        self.semantics = semantics;
+        self
+    }
+
+    /// The canonical spec string, which is what gets written into a repository
+    /// beside the view so it records the rules that produced it.
+    ///
+    /// Round trips through [`parse`](Self::parse).
+    #[must_use]
+    pub fn spec(&self) -> String {
+        let elide = match self.elide {
+            Elide::Nothing => "nothing",
+            Elide::Unchanged => "unchanged",
+            Elide::UnchangedIncludingAlreadyEmpty => "including-already-empty",
+        };
+        let merges = if self.keep_trivial_merges {
+            "keep"
+        } else {
+            "drop"
+        };
+        format!(
+            "semantics={};prefix={};elide={elide};trivial-merges={merges}",
+            self.semantics.as_str(),
+            self.path()
+        )
+    }
+
+    /// Reads a filter back from its [`spec`](Self::spec).
+    ///
+    /// Every field is required and unknown fields are refused, so a spec
+    /// written by a newer version fails loudly here rather than being read
+    /// as though the missing rules did not exist.
+    pub fn parse(spec: &str) -> Result<Self, Error> {
+        let bad = || Error::BadSpec {
+            spec: spec.to_owned(),
+        };
+        let mut semantics = None;
+        let mut prefix = None;
+        let mut elide = None;
+        let mut merges = None;
+        for field in spec.split(';') {
+            let (key, value) = field.split_once('=').ok_or_else(bad)?;
+            match key {
+                "semantics" => {
+                    semantics = Some(match value {
+                        "1" => Semantics::V1,
+                        _ => return Err(bad()),
+                    });
+                }
+                "prefix" => prefix = Some(value),
+                "elide" => {
+                    elide = Some(match value {
+                        "nothing" => Elide::Nothing,
+                        "unchanged" => Elide::Unchanged,
+                        "including-already-empty" => Elide::UnchangedIncludingAlreadyEmpty,
+                        _ => return Err(bad()),
+                    });
+                }
+                "trivial-merges" => {
+                    merges = Some(match value {
+                        "keep" => true,
+                        "drop" => false,
+                        _ => return Err(bad()),
+                    });
+                }
+                _ => return Err(bad()),
+            }
+        }
+        Ok(Self::prefix(prefix.ok_or_else(bad)?)?
+            .semantics(semantics.ok_or_else(bad)?)
+            .elide(elide.ok_or_else(bad)?)
+            .keep_trivial_merges(merges.ok_or_else(bad)?))
     }
 
     /// The path this filter keeps, as `a/b/c`.

--- a/views/src/raw.rs
+++ b/views/src/raw.rs
@@ -8,15 +8,25 @@ use crate::Error;
 /// Replaces the `tree` and `parent` lines of a commit object, copying every
 /// remaining byte through unchanged.
 ///
-/// Rebuilding the commit from a parsed representation instead loses the hash.
-/// git accepts, and stores verbatim, author and committer lines that a parse
-/// and reserialize round trip normalizes away: timezone offsets outside the
-/// range a `(hours, minutes)` pair can hold, a negative zero offset, and
-/// timestamps too large for the parser's integer type. It also preserves the
-/// relative order of `encoding`, `gpgsig` and `mergetag`, which a struct with
-/// a dedicated `encoding` field cannot express. Either difference moves the
-/// commit hash, and a filtered history whose hashes moved no longer shares
-/// ancestry with upstream, which is the whole point of deriving it.
+/// Which representation a rewrite goes through decides whether the hash moves,
+/// and the two gix commit types differ on exactly this. `CommitRef` keeps the
+/// author and committer as raw byte slices and writes them back untouched, so
+/// it is safe; josh relies on that. The owned `Commit` parses them into
+/// `gix_actor::Signature`, whose `time` is a decoded `Time` rather than the
+/// original text, so a round trip through it rewrites any offset git stored but
+/// would not itself write: `-0000`, which `git fsck` accepts without complaint,
+/// and offsets outside the range an hour and minute pair can hold.
+///
+/// Copying the bytes sidesteps the question rather than answering it correctly
+/// once. Nothing here has to know which fields a given gix version happens to
+/// normalize, or notice when that changes, and `encoding`, `gpgsig` and
+/// `mergetag` keep their relative order for free rather than because a struct
+/// happens to be able to express it.
+///
+/// Worth knowing how rare the offsets are, so this is not mistaken for a bug
+/// anyone has hit: across all 1464098 commits of linux and all 85050 of
+/// git.git, there is not one malformed or negative zero offset. The hazard is
+/// real and cheap to avoid, not observed in the wild.
 pub(crate) fn replace_ids(raw: &[u8], tree: &oid, parents: &[ObjectId]) -> Result<Vec<u8>, Error> {
     let tail_at = ids_end(raw)?;
     let tail = raw.get(tail_at..).ok_or(Error::MalformedCommit)?;

--- a/views/src/raw.rs
+++ b/views/src/raw.rs
@@ -1,0 +1,112 @@
+//! Byte level surgery on the identifier block at the head of a commit object.
+
+use gix::ObjectId;
+use gix::hash::oid;
+
+use crate::Error;
+
+/// Replaces the `tree` and `parent` lines of a commit object, copying every
+/// remaining byte through unchanged.
+///
+/// Rebuilding the commit from a parsed representation instead loses the hash.
+/// git accepts, and stores verbatim, author and committer lines that a parse
+/// and reserialize round trip normalizes away: timezone offsets outside the
+/// range a `(hours, minutes)` pair can hold, a negative zero offset, and
+/// timestamps too large for the parser's integer type. It also preserves the
+/// relative order of `encoding`, `gpgsig` and `mergetag`, which a struct with
+/// a dedicated `encoding` field cannot express. Either difference moves the
+/// commit hash, and a filtered history whose hashes moved no longer shares
+/// ancestry with upstream, which is the whole point of deriving it.
+pub(crate) fn replace_ids(raw: &[u8], tree: &oid, parents: &[ObjectId]) -> Result<Vec<u8>, Error> {
+    let tail_at = ids_end(raw)?;
+    let tail = raw.get(tail_at..).ok_or(Error::MalformedCommit)?;
+
+    let hex_len = tree.kind().len_in_hex();
+    let line_len = |name: usize| name + 1 + hex_len + 1;
+    let mut out = Vec::with_capacity(line_len(4) + parents.len() * line_len(6) + tail.len());
+    write_id_line(&mut out, b"tree", tree);
+    for parent in parents {
+        write_id_line(&mut out, b"parent", parent);
+    }
+    out.extend_from_slice(tail);
+    Ok(out)
+}
+
+/// Byte offset just past the last `parent` line, or past the `tree` line when
+/// the commit is a root.
+fn ids_end(raw: &[u8]) -> Result<usize, Error> {
+    let mut cursor = skip_header_line(raw, 0, b"tree").ok_or(Error::MalformedCommit)?;
+    while let Some(next) = skip_header_line(raw, cursor, b"parent") {
+        cursor = next;
+    }
+    Ok(cursor)
+}
+
+fn skip_header_line(raw: &[u8], cursor: usize, name: &[u8]) -> Option<usize> {
+    let rest = raw.get(cursor..)?;
+    let rest = rest.strip_prefix(name)?;
+    let rest = rest.strip_prefix(b" ")?;
+    let newline = rest.iter().position(|byte| *byte == b'\n')?;
+    Some(cursor + name.len() + 1 + newline + 1)
+}
+
+fn write_id_line(out: &mut Vec<u8>, name: &[u8], id: &oid) {
+    // Wide enough for every hash gix knows, so the slice never reallocates.
+    let mut hex = [0_u8; gix::hash::Kind::longest().len_in_hex()];
+    let hex = id.hex_to_buf(&mut hex);
+    out.extend_from_slice(name);
+    out.push(b' ');
+    out.extend_from_slice(hex.as_bytes());
+    out.push(b'\n');
+}
+
+#[cfg(test)]
+mod tests {
+    use gix::ObjectId;
+
+    use super::replace_ids;
+
+    const A: &str = "1111111111111111111111111111111111111111";
+    const B: &str = "2222222222222222222222222222222222222222";
+
+    fn oid(hex: &str) -> ObjectId {
+        ObjectId::from_hex(hex.as_bytes()).expect("test constant is valid hex")
+    }
+
+    #[test]
+    fn keeps_every_byte_after_the_parent_lines() {
+        // A committer line with a timezone offset git stores but cannot
+        // normalize, an `encoding` header placed *after* `gpgsig`, and a
+        // folded multi line value: all three are dropped or reordered by a
+        // parse and reserialize round trip.
+        let raw = format!(
+            "tree {A}\nparent {A}\nauthor A <a@e> 1000000000 +051800\ncommitter C <c@e> \
+             1000000000 -0000\ngpgsig -----BEGIN-----\n body\n -----END-----\nencoding \
+             ISO-8859-1\n\nsubject\n"
+        );
+        let out =
+            replace_ids(raw.as_bytes(), &oid(B), &[oid(B), oid(A)]).expect("well formed commit");
+        let expected = raw.replacen(
+            &format!("tree {A}\nparent {A}\n"),
+            &format!("tree {B}\nparent {B}\nparent {A}\n"),
+            1,
+        );
+        assert_eq!(String::from_utf8_lossy(&out), expected);
+    }
+
+    #[test]
+    fn handles_a_root_commit() {
+        let raw = format!("tree {A}\nauthor A <a@e> 1 +0000\ncommitter A <a@e> 1 +0000\n\nm\n");
+        let out = replace_ids(raw.as_bytes(), &oid(B), &[]).expect("well formed commit");
+        assert_eq!(String::from_utf8_lossy(&out), raw.replace(A, B));
+    }
+
+    #[test]
+    fn rejects_an_object_that_does_not_start_with_a_tree_line() {
+        let err = replace_ids(b"parent x\n\nm\n", &oid(A), &[]);
+        assert!(
+            err.is_err(),
+            "expected a malformed commit error, got {err:?}"
+        );
+    }
+}

--- a/views/tests/roundtrip.rs
+++ b/views/tests/roundtrip.rs
@@ -731,3 +731,127 @@ fn a_spec_this_version_cannot_read_is_refused() {
         );
     }
 }
+
+/// josh's `--check-roundtrip`, as a test: take a commit of the view, lift it
+/// back into the monorepo, filter it out again, and require the same commit
+/// back.
+///
+/// The round trip test above covers this for commits that came from an
+/// injection, where `unfilter` is doing nothing but wrapping trees. This covers
+/// the case the design actually needs and which nothing else here reaches: a
+/// view commit that DIVERGED from what was injected, which is what a local
+/// patch on the vendored copy is, grafted onto a monorepo head that has moved
+/// on its own since.
+#[test]
+fn a_divergent_view_commit_survives_unfilter_then_derive() {
+    let filter = Filter::prefix(PREFIX).expect("a valid prefix");
+    let world = inject(&filter);
+    let injected_head = *world
+        .map
+        .get(&world.upstream.head)
+        .expect("the head was injected");
+
+    // The monorepo moves on its own, so the graft is not onto the commit the
+    // view was derived from. This is the part that makes it a graft rather than
+    // a continuation.
+    let monorepo_head = append_monorepo_commit(&world.repo, &injected_head, 7);
+
+    let mut cache = Cache::new();
+    let view_head = jj_views::derive(&world.repo, &injected_head, &filter, &mut cache)
+        .expect("a derivation")
+        .expect("the head has a view");
+
+    // A local patch, authored against the view: a commit whose tree is a
+    // different vendored subtree, parented on the view's head.
+    let patch = append_commit(&world.repo, &[view_head], &vendored_subtree(&world, "left"));
+
+    let lifted = jj_views::unfilter(&world.repo, &patch, &monorepo_head, &filter, &mut cache)
+        .expect("a prefix graft cannot conflict on content");
+
+    // The lifted commit must sit on the monorepo head, and must carry the
+    // monorepo's own files as well as the patched subtree, or the graft dropped
+    // something outside the prefix.
+    let lifted_raw = world
+        .repo
+        .find_object(lifted)
+        .expect("the lifted commit")
+        .detach()
+        .data;
+    let lifted_parents: Vec<ObjectId> =
+        gix::objs::CommitRef::from_bytes(&lifted_raw, world.repo.object_hash())
+            .expect("a well formed commit")
+            .parents()
+            .collect();
+    assert_eq!(
+        lifted_parents,
+        vec![injected_head],
+        "the patch's parent is the view head, whose counterpart is known, so the lifted commit \
+         belongs on that and not on a monorepo head it has never seen"
+    );
+    let lifted_tree = tree_of(&world.repo, &lifted);
+    assert!(
+        has_entry(&world.repo, &lifted_tree, "MONOREPO"),
+        "the graft must keep the monorepo's own files, not just the filtered subtree"
+    );
+    // The important negative, and it has to compare the content OUTSIDE the
+    // prefix to mean anything. Comparing whole trees passes either way, because
+    // the patched subtree differs from the monorepo head's regardless. What
+    // distinguishes a graft from a fabrication is whose `MONOREPO` blob comes
+    // through: its own parent's, or the one the monorepo changed behind it.
+    assert_eq!(
+        entry_oid(&world.repo, &lifted_tree, "MONOREPO"),
+        entry_oid(
+            &world.repo,
+            &tree_of(&world.repo, &injected_head),
+            "MONOREPO"
+        ),
+        "the lifted commit must carry its own parent's content outside the prefix"
+    );
+    assert_ne!(
+        entry_oid(&world.repo, &lifted_tree, "MONOREPO"),
+        entry_oid(
+            &world.repo,
+            &tree_of(&world.repo, &monorepo_head),
+            "MONOREPO"
+        ),
+        "lifting must not absorb what the monorepo did behind this commit's back; those changes \
+         would look like its own work and the monorepo head would be an ancestor of nothing"
+    );
+
+    let round_tripped = jj_views::derive(&world.repo, &lifted, &filter, &mut cache)
+        .expect("a derivation")
+        .expect("the lifted commit has a view");
+    assert_eq!(
+        round_tripped, patch,
+        "filtering the lifted commit must give back the view commit it came from"
+    );
+}
+
+/// Whether a tree has a top level entry with this name.
+fn has_entry(repo: &gix::Repository, tree: &ObjectId, name: &str) -> bool {
+    entry_oid(repo, tree, name).is_some()
+}
+
+/// The object a tree's top level entry points at.
+fn entry_oid(repo: &gix::Repository, tree: &ObjectId, name: &str) -> Option<ObjectId> {
+    let raw = repo.find_object(*tree).expect("a tree").detach().data;
+    gix::objs::TreeRef::from_bytes(&raw, repo.object_hash())
+        .expect("a well formed tree")
+        .entries
+        .iter()
+        .find(|entry| entry.filename == name)
+        .map(|entry| entry.oid.to_owned())
+}
+
+/// The filtered subtree of the injected form of the fixture commit with this
+/// label, which is a valid tree for a view commit to carry.
+fn vendored_subtree(world: &Injected, label: &str) -> ObjectId {
+    let upstream = world
+        .upstream
+        .commits
+        .iter()
+        .find(|(candidate, _)| *candidate == label)
+        .map(|(_, commit)| commit)
+        .expect("the fixture has this commit");
+    tree_of(&world.repo, upstream)
+}

--- a/views/tests/roundtrip.rs
+++ b/views/tests/roundtrip.rs
@@ -90,9 +90,10 @@ fn write_base(repo: &gix::Repository) -> ObjectId {
 /// commit comes back with its own hash, byte for byte.
 #[test]
 fn every_injected_commit_derives_back_to_its_own_hash() {
-    let filter = Filter::prefix(PREFIX)
-        .expect("a valid prefix")
-        .elide_empty(false);
+    // The DEFAULT filter, elision included. Identity does not require turning
+    // elision off; it requires elision to ask whether the commit was empty
+    // before filtering, which `Elide::Unchanged` does.
+    let filter = Filter::prefix(PREFIX).expect("a valid prefix");
     let world = inject(&filter);
 
     let mut cache = Cache::new();
@@ -133,52 +134,165 @@ fn every_injected_commit_derives_back_to_its_own_hash() {
     );
 }
 
-/// Elision is the documented exception, and it is transitive. The empty commit
-/// loses its counterpart, and everything after it is rebuilt on a different
-/// parent list, so its hash moves too.
+/// The check on the check, part one. A comparison loop that matched nothing
+/// prints the same "0 mismatches" as one that passed, so the round trip
+/// assertion is worthless until it has been watched to fail for a known reason.
+///
+/// Corrupting the tip gives the clean single-mismatch case: the tip has no
+/// descendants, so exactly one commit may be reported and it must be that one.
 #[test]
-fn elision_costs_the_empty_commit_and_every_descendant() {
+fn corrupting_the_tip_is_detected_as_exactly_one_mismatch() {
+    let moved = corrupt_and_collect_moved("duplicate-parents");
+    assert_eq!(
+        moved,
+        vec!["duplicate-parents"],
+        "corrupting the tip must be reported as exactly that one commit moving; anything else \
+         means the comparison is not comparing"
+    );
+}
+
+/// The check on the check, part two. Corrupting a commit in the middle must
+/// report the victim *and* every descendant, because a moved hash changes its
+/// children's parent lines. Requiring only the victim here would be requiring
+/// the wrong answer; what matters is that the victim is named and comes first.
+#[test]
+fn corrupting_a_middle_commit_is_detected_on_it_and_its_descendants() {
+    let moved = corrupt_and_collect_moved("modes-symlink-gitlink");
+    assert_eq!(
+        moved,
+        vec![
+            "modes-symlink-gitlink",
+            "tree-order-siblings",
+            "left",
+            "right",
+            "third",
+            "merge-with-mergetag",
+            "octopus",
+            "duplicate-parents",
+        ],
+        "the corrupted commit and exactly its descendants must be reported, in order"
+    );
+}
+
+/// Injects the fixture, corrupts the message of the commit labeled `label`,
+/// repoints its descendants at the corrupted commit, and returns the labels the
+/// round trip check reports as moved, in topological order.
+fn corrupt_and_collect_moved(label: &str) -> Vec<&'static str> {
     let filter = Filter::prefix(PREFIX).expect("a valid prefix");
     let world = inject(&filter);
 
-    let mut cache = Cache::new();
-    let mut matched: Vec<&str> = Vec::new();
-    let mut moved: Vec<&str> = Vec::new();
-    let mut dropped: Vec<&str> = Vec::new();
-    for (label, commit) in &world.upstream.commits {
-        let injected = world.map.get(commit).expect("every commit was injected");
-        let derived = jj_views::derive(&world.repo, injected, &filter, &mut cache)
-            .expect("deriving a prefix cannot fail on a well formed history");
-        match derived {
-            Some(derived) if derived == *commit => matched.push(label),
-            Some(_) => moved.push(label),
-            None => dropped.push(label),
-        }
+    let (_, victim) = *world
+        .upstream
+        .commits
+        .iter()
+        .find(|(candidate, _)| *candidate == label)
+        .expect("the fixture has this commit");
+    let injected_victim = *world.map.get(&victim).expect("it was injected");
+
+    let corrupted = corrupt_message(&world.repo, &injected_victim);
+    let mut map = world.map.clone();
+    let mut rewritten: HashMap<ObjectId, ObjectId> = HashMap::new();
+    rewritten.insert(injected_victim, corrupted);
+    // The victim's own entry has to move too, not just its children's parent
+    // lines, or the derivation walks the pristine commit and the corruption is
+    // reported against its descendants instead of itself.
+    map.insert(victim, corrupted);
+    for (_, upstream) in &world.upstream.commits {
+        let injected = *map.get(upstream).expect("it was injected");
+        let Some(fresh) = repoint_parents(&world.repo, &injected, &rewritten) else {
+            continue;
+        };
+        rewritten.insert(injected, fresh);
+        map.insert(*upstream, fresh);
     }
 
-    // Everything up to and including the commit before the empty one keeps its
-    // hash, because nothing before it was elided.
-    assert_eq!(
-        matched,
-        vec![
-            "root",
-            "non-ascii",
-            "encoding-latin1",
-            "gpgsig",
-            "gpgsig-before-encoding",
-            "negative-zero-offset",
-            "odd-timezone-offset",
-        ],
-        "commits before the first elision must be unaffected"
-    );
-    // The empty commit derives to its own parent, so it is not dropped from the
-    // view, it just stops being a distinct commit.
+    let mut cache = Cache::new();
+    let mut moved: Vec<&'static str> = Vec::new();
+    for (candidate, upstream) in &world.upstream.commits {
+        let injected = map.get(upstream).expect("it was injected");
+        let derived =
+            jj_views::derive(&world.repo, injected, &filter, &mut cache).expect("a derivation");
+        if derived != Some(*upstream) {
+            moved.push(candidate);
+        }
+    }
+    moved
+}
+
+/// Rewrites a commit with one byte of its message changed, keeping everything
+/// else including its tree and parents.
+fn corrupt_message(repo: &gix::Repository, commit: &ObjectId) -> ObjectId {
+    let raw = repo.find_object(*commit).expect("a commit").detach().data;
+    let mut corrupted = raw.clone();
+    // The message starts after the blank line that ends the header block.
+    let at = corrupted
+        .windows(2)
+        .position(|pair| pair == b"\n\n")
+        .expect("a commit has a header block")
+        + 2;
+    let byte = corrupted.get_mut(at).expect("the message is not empty");
+    *byte = if *byte == b'X' { b'Y' } else { b'X' };
+    let id = gix::objs::Write::write_buf(&repo.objects, gix::objs::Kind::Commit, &corrupted)
+        .expect("a commit");
+    assert_ne!(id, *commit, "the corruption must change the hash");
+    id
+}
+
+/// Rewrites `commit` with any parent found in `rewritten` replaced, or returns
+/// `None` when none of its parents moved.
+fn repoint_parents(
+    repo: &gix::Repository,
+    commit: &ObjectId,
+    rewritten: &HashMap<ObjectId, ObjectId>,
+) -> Option<ObjectId> {
+    let raw = repo.find_object(*commit).expect("a commit").detach().data;
+    let parsed =
+        gix::objs::CommitRef::from_bytes(&raw, repo.object_hash()).expect("a well formed commit");
+    let parents: Vec<ObjectId> = parsed.parents().collect();
+    if !parents.iter().any(|parent| rewritten.contains_key(parent)) {
+        return None;
+    }
+    let mut out = Vec::new();
+    for line in raw.split_inclusive(|byte| *byte == b'\n') {
+        if line.starts_with(b"parent ") {
+            continue;
+        }
+        if line.starts_with(b"author ") {
+            for parent in &parents {
+                let mapped = rewritten.get(parent).unwrap_or(parent);
+                out.extend_from_slice(format!("parent {mapped}\n").as_bytes());
+            }
+        }
+        out.extend_from_slice(line);
+    }
+    Some(
+        gix::objs::Write::write_buf(&repo.objects, gix::objs::Kind::Commit, &out)
+            .expect("a commit"),
+    )
+}
+
+/// The one condition that makes elision compatible with hash identity, pinned
+/// from both sides.
+///
+/// `Elide::Unchanged` spares a commit that was already empty before filtering,
+/// so every hash survives. `Elide::UnchangedIncludingAlreadyEmpty` is the rule
+/// one writes by accident: it looks the same, it drops the deliberately empty
+/// commit, and because a moved hash changes every descendant's parent line it
+/// takes the rest of history with it.
+#[test]
+fn eliding_an_already_empty_commit_is_what_breaks_identity() {
+    let safe = Filter::prefix(PREFIX).expect("a valid prefix");
+    let unsafe_rule = Filter::prefix(PREFIX)
+        .expect("a valid prefix")
+        .elide(jj_views::Elide::UnchangedIncludingAlreadyEmpty);
+
     assert!(
-        dropped.is_empty(),
-        "nothing should lose its counterpart outright: {dropped:?}"
+        moved_labels(&safe).is_empty(),
+        "the default rule must move nothing: {:?}",
+        moved_labels(&safe)
     );
     assert_eq!(
-        moved,
+        moved_labels(&unsafe_rule),
         vec![
             "empty",
             "modes-symlink-gitlink",
@@ -190,8 +304,25 @@ fn elision_costs_the_empty_commit_and_every_descendant() {
             "octopus",
             "duplicate-parents",
         ],
-        "the elided commit and every descendant must be reported as moved"
+        "eliding the already empty commit must take it and every descendant"
     );
+}
+
+/// Injects the fixture under `filter` and returns the labels whose derived
+/// commit is not the upstream commit it came from.
+fn moved_labels(filter: &Filter) -> Vec<&'static str> {
+    let world = inject(filter);
+    let mut cache = Cache::new();
+    let mut moved: Vec<&'static str> = Vec::new();
+    for (label, commit) in &world.upstream.commits {
+        let injected = world.map.get(commit).expect("every commit was injected");
+        let derived =
+            jj_views::derive(&world.repo, injected, filter, &mut cache).expect("a derivation");
+        if derived != Some(*commit) {
+            moved.push(label);
+        }
+    }
+    moved
 }
 
 /// Derivation is a pure function, so a second run over the same input has to
@@ -338,7 +469,7 @@ fn a_merge_whose_side_elides_stops_being_a_merge() {
         .iter()
         .find(|(label, _)| *label == "left")
         .map(|(_, commit)| world.map.get(commit).expect("it was injected"))
-        .expect("the fixture has a commit labelled left");
+        .expect("the fixture has a commit labeled left");
     let merge = append_merge(&world.repo, &[head, side], &tree_of(&world.repo, elsewhere));
 
     let mut cache = Cache::new();

--- a/views/tests/roundtrip.rs
+++ b/views/tests/roundtrip.rs
@@ -470,7 +470,7 @@ fn a_merge_whose_side_elides_stops_being_a_merge() {
         .find(|(label, _)| *label == "left")
         .map(|(_, commit)| world.map.get(commit).expect("it was injected"))
         .expect("the fixture has a commit labeled left");
-    let merge = append_merge(&world.repo, &[head, side], &tree_of(&world.repo, elsewhere));
+    let merge = append_commit(&world.repo, &[head, side], &tree_of(&world.repo, elsewhere));
 
     let mut cache = Cache::new();
     let base = jj_views::derive(&world.repo, &head, &filter, &mut cache)
@@ -501,6 +501,21 @@ fn a_merge_whose_side_elides_stops_being_a_merge() {
     );
 }
 
+/// The tree of the injected form of the fixture commit with this label.
+fn injected_tree(world: &Injected, label: &str) -> ObjectId {
+    let upstream = world
+        .upstream
+        .commits
+        .iter()
+        .find(|(candidate, _)| *candidate == label)
+        .map(|(_, commit)| commit)
+        .expect("the fixture has this commit");
+    tree_of(
+        &world.repo,
+        world.map.get(upstream).expect("it was injected"),
+    )
+}
+
 fn tree_of(repo: &gix::Repository, commit: &ObjectId) -> ObjectId {
     let raw = repo.find_object(*commit).expect("a commit").detach().data;
     gix::objs::CommitRef::from_bytes(&raw, repo.object_hash())
@@ -508,8 +523,8 @@ fn tree_of(repo: &gix::Repository, commit: &ObjectId) -> ObjectId {
         .tree()
 }
 
-/// A merge commit over `parents` with the given `tree`.
-fn append_merge(repo: &gix::Repository, parents: &[ObjectId], tree: &ObjectId) -> ObjectId {
+/// A commit over `parents` with the given `tree`.
+fn append_commit(repo: &gix::Repository, parents: &[ObjectId], tree: &ObjectId) -> ObjectId {
     let mut raw = format!("tree {tree}\n");
     for parent in parents {
         writeln!(raw, "parent {parent}").expect("writing to a String cannot fail");
@@ -591,4 +606,128 @@ fn unusable_filter_paths_are_refused() {
         "vendor/linux",
         "a josh style spelling should normalize to the same filter"
     );
+}
+
+/// A version number nobody checks is decoration. This pins the exact object id
+/// each policy derives to, so any change to a hash affecting rule fails here
+/// and names the version that has to be bumped rather than silently producing a
+/// different history from the same input.
+///
+/// The scenario has to contain something each policy treats differently, or the
+/// test pins nothing about the policies. So it is the fixture injected, then a
+/// monorepo commit that touches nothing under the prefix, then a merge whose
+/// filtered tree equals its first parent's. The three specs must therefore give
+/// three DIFFERENT hashes, and that is asserted too.
+///
+/// If you are here because this test failed: do not update the constants. Add a
+/// `Semantics` variant, keep the old one behaving as it did, and add a line.
+#[test]
+fn semantics_v1_output_hashes_are_pinned() {
+    // The fixture's own tip, pinned separately so that a change to the fixture
+    // fails with its own message instead of looking like a rule change.
+    const FIXTURE_HEAD: &str = "4da40074cd503a78762551c225efd95e714a86f7";
+
+    let pinned = [
+        (
+            "semantics=1;prefix=vendor/upstream;elide=unchanged;trivial-merges=drop",
+            "66fd0506342cb5453fa460f045ecff8f0f14698c",
+        ),
+        (
+            "semantics=1;prefix=vendor/upstream;elide=nothing;trivial-merges=drop",
+            "981a00d7560fa5df6bffe2d8dc560dfa65b4c508",
+        ),
+        (
+            "semantics=1;prefix=vendor/upstream;elide=unchanged;trivial-merges=keep",
+            "2bcfd8401aa24a06ecc342de6846161a8c1d3964",
+        ),
+    ];
+
+    let mut actual: Vec<String> = Vec::new();
+    for (spec, _) in &pinned {
+        let filter = Filter::parse(spec).expect("a spec this version can read");
+        assert_eq!(&filter.spec(), spec, "a spec must round trip unchanged");
+        let world = inject(&filter);
+        assert_eq!(
+            format!("{}", world.upstream.head),
+            FIXTURE_HEAD,
+            "the fixture history changed; that is a separate matter from a rule change"
+        );
+
+        let head = *world
+            .map
+            .get(&world.upstream.head)
+            .expect("the head was injected");
+        // Two trees whose vendored subtrees differ, borrowed from injected
+        // commits, so a commit carrying one is a commit the filter must keep.
+        // They have to differ from EACH OTHER as well: if both sides of the merge
+        // below filtered to the same subtree, the elide rule would drop that
+        // merge on its own and mask what the trivial merge policy does.
+        let vendored = injected_tree(&world, "left");
+        let vendored_other = injected_tree(&world, "right");
+
+        // Two monorepo-only commits, which only the elide policy has an opinion
+        // about, with a commit that does touch the vendored path between them so
+        // that dropping them changes what its view is built on.
+        let quiet_one = append_monorepo_commit(&world.repo, &head, 0);
+        let touches = append_commit(&world.repo, &[quiet_one], &vendored);
+        let quiet_two = append_monorepo_commit(&world.repo, &touches, 1);
+        // A second line that also touches the vendored path, so the merge below
+        // keeps two distinct derived parents and the trivial merge rule is
+        // reachable at all.
+        let other_line = append_commit(&world.repo, &[head], &vendored_other);
+        // A merge resolving entirely to its first side under the filter, but not
+        // before it: its tree differs from that side's outside the prefix, so the
+        // "was already trivial" guard does not spare it and the trivial merge
+        // policy decides.
+        let trivial_source = append_monorepo_commit(&world.repo, &quiet_two, 2);
+        let trivial = append_commit(
+            &world.repo,
+            &[quiet_two, other_line],
+            &tree_of(&world.repo, &trivial_source),
+        );
+
+        let mut cache = Cache::new();
+        let derived = jj_views::derive(&world.repo, &trivial, &filter, &mut cache)
+            .expect("a derivation")
+            .expect("the tip has a view");
+        actual.push(format!("{derived}"));
+    }
+
+    let mut distinct = actual.clone();
+    distinct.sort();
+    distinct.dedup();
+    assert_eq!(
+        distinct.len(),
+        actual.len(),
+        "the three policies must produce three different hashes or this test pins nothing about \
+         them: {actual:?}"
+    );
+
+    let expected: Vec<String> = pinned.iter().map(|(_, id)| (*id).to_owned()).collect();
+    assert_eq!(
+        actual, expected,
+        "semantics v1 output hashes changed; add a Semantics variant rather than editing these \
+         constants"
+    );
+}
+
+/// A spec that a newer version wrote must fail loudly rather than being read as
+/// though its unknown rules did not apply.
+#[test]
+fn a_spec_this_version_cannot_read_is_refused() {
+    for spec in [
+        // A semantics version from the future.
+        "semantics=2;prefix=vendor/upstream;elide=unchanged;trivial-merges=drop",
+        // A rule this version does not have.
+        "semantics=1;prefix=vendor/upstream;elide=unchanged;trivial-merges=drop;squash=yes",
+        // A missing field, which would otherwise silently take a default.
+        "semantics=1;prefix=vendor/upstream;elide=unchanged",
+        // A value this version does not know.
+        "semantics=1;prefix=vendor/upstream;elide=sometimes;trivial-merges=drop",
+    ] {
+        assert!(
+            Filter::parse(spec).is_err(),
+            "{spec:?} must be refused, not read with defaults filled in"
+        );
+    }
 }

--- a/views/tests/roundtrip.rs
+++ b/views/tests/roundtrip.rs
@@ -218,26 +218,98 @@ fn derivation_is_deterministic_and_cache_independent() {
     );
 }
 
-/// The cache is keyed on trees, and the fixture's monorepo files are shared by
-/// every commit, so the number of distinct filtered trees stays below the
-/// number of commits. That ratio is what makes incremental derivation cheap.
+/// The direction elision is actually for: monorepo commits that leave the
+/// vendored path alone. Each one should vanish from the view, and each one
+/// should cost a single tree read rather than one per path component, since
+/// every tree on the way in except the changed root is shared with its parent.
 #[test]
-fn the_tree_cache_is_smaller_than_the_history() {
+fn monorepo_commits_that_miss_the_path_elide_and_cost_one_read_each() {
+    const CHAIN: usize = 20;
+
     let filter = Filter::prefix(PREFIX).expect("a valid prefix");
     let world = inject(&filter);
-    let head = world
+    let mut head = *world
         .map
         .get(&world.upstream.head)
         .expect("the head was injected");
 
     let mut cache = Cache::new();
-    jj_views::derive(&world.repo, head, &filter, &mut cache).expect("a derivation");
-    assert!(
-        cache.tree_entries() <= cache.commit_entries(),
-        "one tree entry per commit at most, got {} trees for {} commits",
-        cache.tree_entries(),
-        cache.commit_entries()
+    let view_before =
+        jj_views::derive(&world.repo, &head, &filter, &mut cache).expect("a derivation");
+    let trees_before = cache.tree_reads();
+    let commits_before = cache.commit_entries();
+
+    // A chain that only ever rewrites a monorepo file, so the subtree under
+    // PREFIX is untouched and its tree object is shared by every commit.
+    for step in 0..CHAIN {
+        head = append_monorepo_commit(&world.repo, &head, step);
+    }
+    let view_after =
+        jj_views::derive(&world.repo, &head, &filter, &mut cache).expect("a derivation");
+
+    assert_eq!(
+        view_after, view_before,
+        "commits that miss the filtered path must leave the view unchanged"
     );
+    let commits_added = cache.commit_entries() - commits_before;
+    assert_eq!(
+        commits_added, CHAIN,
+        "every new commit should have been mapped"
+    );
+    let reads_added = cache.tree_reads() - trees_before;
+    // One read per commit for its own root tree, which is the one tree that did
+    // change. Anything more means a deeper level was re-read per commit, which
+    // is what per-level memoization exists to prevent, and what would make
+    // incremental derivation cost the depth of the path on every commit.
+    assert_eq!(
+        reads_added, CHAIN,
+        "expected {CHAIN} tree reads for {CHAIN} commits that changed only the root, got \
+         {reads_added}"
+    );
+}
+
+/// Adds a commit on top of `parent` that rewrites one monorepo file and nothing
+/// under [`PREFIX`].
+fn append_monorepo_commit(repo: &gix::Repository, parent: &ObjectId, step: usize) -> ObjectId {
+    let parent_raw = repo.find_object(*parent).expect("a commit").detach().data;
+    let parent_tree = gix::objs::CommitRef::from_bytes(&parent_raw, repo.object_hash())
+        .expect("a well formed commit")
+        .tree();
+    let blob = repo
+        .write_blob(format!("monorepo revision {step}\n").as_bytes())
+        .expect("a blob")
+        .detach();
+
+    let base = repo.find_object(parent_tree).expect("a tree").detach().data;
+    let decoded =
+        gix::objs::TreeRef::from_bytes(&base, repo.object_hash()).expect("a well formed tree");
+    let mut entries: Vec<gix::objs::tree::Entry> = decoded
+        .entries
+        .iter()
+        .map(|entry| gix::objs::tree::Entry {
+            mode: entry.mode,
+            filename: entry.filename.to_owned(),
+            oid: entry.oid.to_owned(),
+        })
+        .collect();
+    for entry in &mut entries {
+        if entry.filename == "MONOREPO" {
+            entry.oid = blob;
+        }
+    }
+    entries.sort();
+    let tree = repo
+        .write_object(&gix::objs::Tree { entries })
+        .expect("a tree")
+        .detach();
+
+    let raw = format!(
+        "tree {tree}\nparent {parent}\nauthor Monorepo <mono@example.invalid> 100000000{step} \
+         +0000\ncommitter Monorepo <mono@example.invalid> 100000000{step} +0000\n\nmonorepo \
+         change {step}\n"
+    );
+    gix::objs::Write::write_buf(&repo.objects, gix::objs::Kind::Commit, raw.as_bytes())
+        .expect("a commit")
 }
 
 /// A path absent from the whole history has no view, rather than an empty one.

--- a/views/tests/roundtrip.rs
+++ b/views/tests/roundtrip.rs
@@ -1,0 +1,312 @@
+//! The round trip hash identity check, as a test.
+//!
+//! Round trip identity is the claim the derived-views design rests on: inject
+//! an upstream history under a prefix, filter the prefix back out, and get
+//! upstream's own commit hashes back. If it holds, a view shares real ancestry
+//! with upstream, so merge bases are correct and syncing is a plain fetch.
+//! These tests pin both the claim and the two ways it is known to fail.
+//!
+//! The history comes from `jj_views::fixture`, which builds it from raw
+//! objects. Nothing here touches the network and the object ids are the same on
+//! every run.
+
+use std::collections::HashMap;
+
+use gix::ObjectId;
+use jj_views::Cache;
+use jj_views::Filter;
+use jj_views::fixture;
+
+const PREFIX: &str = "vendor/upstream";
+
+struct Injected {
+    repo: gix::Repository,
+    upstream: fixture::Upstream,
+    /// Upstream commit to the parent-repo commit it was injected as.
+    map: HashMap<ObjectId, ObjectId>,
+    /// Kept so the repository outlives the test.
+    _dir: tempfile::TempDir,
+}
+
+/// Builds the fixture history, then injects all of it under [`PREFIX`] inside a
+/// monorepo that already has files of its own.
+fn inject(filter: &Filter) -> Injected {
+    let dir = tempfile::tempdir().expect("a temporary directory");
+    let repo = gix::init_bare(dir.path()).expect("an empty repository");
+    let upstream = fixture::write_upstream(&repo).expect("the fixture history");
+
+    let base = write_base(&repo);
+    let mut cache = Cache::new();
+    let mut map: HashMap<ObjectId, ObjectId> = HashMap::new();
+    for (_, commit) in &upstream.commits {
+        let raw = repo
+            .find_object(*commit)
+            .expect("a fixture commit")
+            .detach()
+            .data;
+        let first_parent = gix::objs::CommitRef::from_bytes(&raw, repo.object_hash())
+            .expect("a well formed commit")
+            .parents()
+            .next();
+        let onto = first_parent
+            .and_then(|parent| map.get(&parent).copied())
+            .unwrap_or(base);
+        let injected = jj_views::unfilter(&repo, commit, &onto, filter, &mut cache)
+            .expect("prefix injection cannot conflict");
+        map.insert(*commit, injected);
+    }
+    Injected {
+        repo,
+        upstream,
+        map,
+        _dir: dir,
+    }
+}
+
+/// A monorepo commit for the vendored history to sit inside, so the injected
+/// trees are not merely the prefix.
+fn write_base(repo: &gix::Repository) -> ObjectId {
+    let blob = repo.write_blob(b"the monorepo\n").expect("a blob").detach();
+    let tree = repo
+        .write_object(&gix::objs::Tree {
+            entries: vec![gix::objs::tree::Entry {
+                mode: gix::objs::tree::EntryKind::Blob.into(),
+                filename: "MONOREPO".into(),
+                oid: blob,
+            }],
+        })
+        .expect("a tree")
+        .detach();
+    let raw = format!(
+        "tree {tree}\nauthor Monorepo <mono@example.invalid> 1000000000 +0000\ncommitter Monorepo \
+         <mono@example.invalid> 1000000000 +0000\n\nthe monorepo\n"
+    );
+    gix::objs::Write::write_buf(&repo.objects, gix::objs::Kind::Commit, raw.as_bytes())
+        .expect("a commit")
+}
+
+/// The claim, in the configuration that is meant to satisfy it: every upstream
+/// commit comes back with its own hash, byte for byte.
+#[test]
+fn every_injected_commit_derives_back_to_its_own_hash() {
+    let filter = Filter::prefix(PREFIX)
+        .expect("a valid prefix")
+        .elide_empty(false);
+    let world = inject(&filter);
+
+    let mut cache = Cache::new();
+    let mut failures: Vec<String> = Vec::new();
+    for (label, commit) in &world.upstream.commits {
+        let injected = world.map.get(commit).expect("every commit was injected");
+        let derived = jj_views::derive(&world.repo, injected, &filter, &mut cache)
+            .expect("deriving a prefix cannot fail on a well formed history");
+        match derived {
+            Some(derived) if derived == *commit => {}
+            Some(derived) => {
+                let expected = world
+                    .repo
+                    .find_object(*commit)
+                    .expect("upstream")
+                    .detach()
+                    .data;
+                let actual = world
+                    .repo
+                    .find_object(derived)
+                    .expect("derived")
+                    .detach()
+                    .data;
+                failures.push(format!(
+                    "{label}: expected {commit}, got {derived}: {}",
+                    fixture::describe_difference(&expected, &actual)
+                ));
+            }
+            None => failures.push(format!("{label}: {commit} was dropped entirely")),
+        }
+    }
+    assert!(
+        failures.is_empty(),
+        "{} of {} commits did not round trip:\n{}",
+        failures.len(),
+        world.upstream.commits.len(),
+        failures.join("\n")
+    );
+}
+
+/// Elision is the documented exception, and it is transitive. The empty commit
+/// loses its counterpart, and everything after it is rebuilt on a different
+/// parent list, so its hash moves too.
+#[test]
+fn elision_costs_the_empty_commit_and_every_descendant() {
+    let filter = Filter::prefix(PREFIX).expect("a valid prefix");
+    let world = inject(&filter);
+
+    let mut cache = Cache::new();
+    let mut matched: Vec<&str> = Vec::new();
+    let mut moved: Vec<&str> = Vec::new();
+    let mut dropped: Vec<&str> = Vec::new();
+    for (label, commit) in &world.upstream.commits {
+        let injected = world.map.get(commit).expect("every commit was injected");
+        let derived = jj_views::derive(&world.repo, injected, &filter, &mut cache)
+            .expect("deriving a prefix cannot fail on a well formed history");
+        match derived {
+            Some(derived) if derived == *commit => matched.push(label),
+            Some(_) => moved.push(label),
+            None => dropped.push(label),
+        }
+    }
+
+    // Everything up to and including the commit before the empty one keeps its
+    // hash, because nothing before it was elided.
+    assert_eq!(
+        matched,
+        vec![
+            "root",
+            "non-ascii",
+            "encoding-latin1",
+            "gpgsig",
+            "gpgsig-before-encoding",
+            "negative-zero-offset",
+            "odd-timezone-offset",
+        ],
+        "commits before the first elision must be unaffected"
+    );
+    // The empty commit derives to its own parent, so it is not dropped from the
+    // view, it just stops being a distinct commit.
+    assert!(
+        dropped.is_empty(),
+        "nothing should lose its counterpart outright: {dropped:?}"
+    );
+    assert_eq!(
+        moved,
+        vec![
+            "empty",
+            "modes-symlink-gitlink",
+            "tree-order-siblings",
+            "left",
+            "right",
+            "third",
+            "merge-with-mergetag",
+            "octopus",
+            "duplicate-parents",
+        ],
+        "the elided commit and every descendant must be reported as moved"
+    );
+}
+
+/// Derivation is a pure function, so a second run over the same input has to
+/// produce the same objects, whether or not it reuses a cache.
+#[test]
+fn derivation_is_deterministic_and_cache_independent() {
+    let filter = Filter::prefix(PREFIX).expect("a valid prefix");
+    let world = inject(&filter);
+    let head = world
+        .map
+        .get(&world.upstream.head)
+        .expect("the head was injected");
+
+    let mut warm = Cache::new();
+    let first = jj_views::derive(&world.repo, head, &filter, &mut warm).expect("a derivation");
+    let second = jj_views::derive(&world.repo, head, &filter, &mut warm).expect("a derivation");
+    let mut cold = Cache::new();
+    let third = jj_views::derive(&world.repo, head, &filter, &mut cold).expect("a derivation");
+
+    assert_eq!(first, second, "a warm cache must return the same commit");
+    assert_eq!(first, third, "a cold cache must return the same commit");
+    assert!(
+        warm.tree_entries() > 0,
+        "the tree cache should have been populated"
+    );
+}
+
+/// The cache is keyed on trees, and the fixture's monorepo files are shared by
+/// every commit, so the number of distinct filtered trees stays below the
+/// number of commits. That ratio is what makes incremental derivation cheap.
+#[test]
+fn the_tree_cache_is_smaller_than_the_history() {
+    let filter = Filter::prefix(PREFIX).expect("a valid prefix");
+    let world = inject(&filter);
+    let head = world
+        .map
+        .get(&world.upstream.head)
+        .expect("the head was injected");
+
+    let mut cache = Cache::new();
+    jj_views::derive(&world.repo, head, &filter, &mut cache).expect("a derivation");
+    assert!(
+        cache.tree_entries() <= cache.commit_entries(),
+        "one tree entry per commit at most, got {} trees for {} commits",
+        cache.tree_entries(),
+        cache.commit_entries()
+    );
+}
+
+/// A path absent from the whole history has no view, rather than an empty one.
+#[test]
+fn a_path_that_never_existed_has_no_view() {
+    let filter = Filter::prefix(PREFIX).expect("a valid prefix");
+    let world = inject(&filter);
+    let head = world
+        .map
+        .get(&world.upstream.head)
+        .expect("the head was injected");
+
+    let absent = Filter::prefix("no/such/path").expect("a valid prefix");
+    let mut cache = Cache::new();
+    let derived = jj_views::derive(&world.repo, head, &absent, &mut cache).expect("a derivation");
+    assert_eq!(derived, None, "an absent path must derive to nothing");
+}
+
+/// The corner cases the fixture exists for, spelled out. Each of these commits
+/// is one a parse-and-reserialize rewrite corrupts, which is why the real
+/// rewrite works on raw bytes and why the round trip test above passes.
+#[test]
+fn the_fixture_contains_commits_a_naive_rewrite_would_corrupt() {
+    let dir = tempfile::tempdir().expect("a temporary directory");
+    let repo = gix::init_bare(dir.path()).expect("an empty repository");
+    let upstream = fixture::write_upstream(&repo).expect("the fixture history");
+
+    let mut corrupted: Vec<&str> = Vec::new();
+    for (label, commit) in &upstream.commits {
+        let raw = repo
+            .find_object(*commit)
+            .expect("a fixture commit")
+            .detach()
+            .data;
+        if !fixture::naive_rebuild_matches(&raw, repo.object_hash()) {
+            corrupted.push(label);
+        }
+    }
+    // Measured, not predicted, and both results were surprises. Header
+    // reordering was the expected failure and is not one: gix leaves `encoding`
+    // in the extra header list whenever it is not the first header, so `gpgsig`
+    // before `encoding` survives. What does not survive is either timezone
+    // offset, including `-0000`, which `git fsck` accepts without complaint. So
+    // the hazard is not confined to malformed history: an ordinary repository is
+    // enough to break a rewrite that reserializes signature lines, which is why
+    // the rewrite in `raw` copies them through as bytes.
+    assert_eq!(
+        corrupted,
+        vec!["negative-zero-offset", "odd-timezone-offset"],
+        "the fixture must keep exercising timezone offsets a normalizing serializer cannot \
+         reproduce, since that is what the byte level rewrite defends against"
+    );
+}
+
+/// Prefix filters are the only kind, and a path that is not one is refused
+/// rather than silently normalized into something else.
+#[test]
+fn unusable_filter_paths_are_refused() {
+    for path in ["a//b", "a/./b", "../escape", "."] {
+        assert!(
+            Filter::prefix(path).is_err(),
+            "{path:?} should not be accepted as a prefix"
+        );
+    }
+    assert_eq!(
+        Filter::prefix("/vendor/linux/")
+            .expect("leading and trailing slashes are trimmed")
+            .path(),
+        "vendor/linux",
+        "a josh style spelling should normalize to the same filter"
+    );
+}

--- a/views/tests/roundtrip.rs
+++ b/views/tests/roundtrip.rs
@@ -855,3 +855,178 @@ fn vendored_subtree(world: &Injected, label: &str) -> ObjectId {
         .expect("the fixture has this commit");
     tree_of(&world.repo, upstream)
 }
+
+/// Renaming a mount point destroys the view, in this implementation exactly as
+/// it does in josh. Pinned so the size of the problem is a measured number
+/// rather than a warning in a design note.
+///
+/// The mount path is part of the view's identity. Filtering `vendor/renamed`
+/// over a history where the content lived at `vendor/upstream` until a rename
+/// finds nothing before that commit, so the whole history behind it is gone and
+/// SHA continuity is broken. A fix needs a persisted rename ledger and an era
+/// splicing filter generated from it; this test is what that work has to
+/// change.
+#[test]
+fn renaming_a_mount_point_destroys_the_history_behind_it() {
+    let filter = Filter::prefix(PREFIX).expect("a valid prefix");
+    let world = inject(&filter);
+    let injected_head = *world
+        .map
+        .get(&world.upstream.head)
+        .expect("the head was injected");
+
+    // Before the rename, the full history is there.
+    let mut cache = Cache::new();
+    let before = jj_views::derive(&world.repo, &injected_head, &filter, &mut cache)
+        .expect("a derivation")
+        .expect("the head has a view");
+    assert_eq!(
+        count_ancestors(&world.repo, &before),
+        world.upstream.commits.len(),
+        "the view should have one commit per fixture commit before any rename"
+    );
+
+    // The monorepo renames the mount point, keeping the content identical.
+    let renamed_head = rename_mount_point(&world.repo, &injected_head, PREFIX, "vendor/renamed");
+
+    let after_filter = Filter::prefix("vendor/renamed").expect("a valid prefix");
+    let mut cache = Cache::new();
+    let after = jj_views::derive(&world.repo, &renamed_head, &after_filter, &mut cache)
+        .expect("a derivation")
+        .expect("the renamed path exists at the tip");
+    assert_eq!(
+        count_ancestors(&world.repo, &after),
+        1,
+        "this is the failure being pinned: everything behind the rename is gone and the view is a \
+         single orphan commit"
+    );
+
+    // And the old path's view does not simply stop: because an absent path
+    // filters to the empty tree, the rename shows up there as a commit that
+    // deletes everything. So neither filter alone describes the project. One
+    // reports the work as deleted, the other reports it as having no past.
+    let mut cache = Cache::new();
+    let old_path = jj_views::derive(&world.repo, &renamed_head, &filter, &mut cache)
+        .expect("a derivation")
+        .expect("the old path still has a view in the ancestry");
+    assert_eq!(
+        tree_of(&world.repo, &old_path),
+        gix::ObjectId::empty_tree(world.repo.object_hash()),
+        "the old path's view gains a commit that empties the tree"
+    );
+    let old_raw = world
+        .repo
+        .find_object(old_path)
+        .expect("a commit")
+        .detach()
+        .data;
+    let old_parents: Vec<ObjectId> =
+        gix::objs::CommitRef::from_bytes(&old_raw, world.repo.object_hash())
+            .expect("a well formed commit")
+            .parents()
+            .collect();
+    assert_eq!(
+        old_parents,
+        vec![before],
+        "and that deletion sits directly on the pre-rename view, so the history before the rename \
+         is intact under the old name and absent under the new one"
+    );
+}
+
+/// How many commits are reachable from `commit`, inclusive.
+fn count_ancestors(repo: &gix::Repository, commit: &ObjectId) -> usize {
+    let mut seen: HashMap<ObjectId, ()> = HashMap::new();
+    let mut stack = vec![*commit];
+    while let Some(id) = stack.pop() {
+        if seen.insert(id, ()).is_some() {
+            continue;
+        }
+        let raw = repo.find_object(id).expect("a commit").detach().data;
+        let parsed = gix::objs::CommitRef::from_bytes(&raw, repo.object_hash())
+            .expect("a well formed commit");
+        stack.extend(parsed.parents());
+    }
+    seen.len()
+}
+
+/// A commit on top of `parent_commit` that moves the subtree at `from` to `to`,
+/// leaving its content byte for byte identical.
+fn rename_mount_point(
+    repo: &gix::Repository,
+    parent_commit: &ObjectId,
+    from: &str,
+    to: &str,
+) -> ObjectId {
+    let base = tree_of(repo, parent_commit);
+    let subtree = lookup_path(repo, &base, from).expect("the mount point exists");
+    let emptied = write_path(repo, &base, from, None);
+    let moved = write_path(repo, &emptied, to, Some(subtree));
+
+    let raw = format!(
+        "tree {moved}\nparent {parent_commit}\nauthor Monorepo <mono@example.invalid> 1000000200 \
+         +0000\ncommitter Monorepo <mono@example.invalid> 1000000200 +0000\n\ngit mv {from} {to}\n"
+    );
+    gix::objs::Write::write_buf(&repo.objects, gix::objs::Kind::Commit, raw.as_bytes())
+        .expect("a commit")
+}
+
+/// The tree at a slash separated path inside `tree`.
+fn lookup_path(repo: &gix::Repository, tree: &ObjectId, path: &str) -> Option<ObjectId> {
+    let mut current = *tree;
+    for component in path.split('/') {
+        current = entry_oid(repo, &current, component)?;
+    }
+    Some(current)
+}
+
+/// `tree` with the subtree at `path` set to `sub`, or removed when `sub` is
+/// `None`, creating intermediate trees as needed.
+fn write_path(
+    repo: &gix::Repository,
+    tree: &ObjectId,
+    path: &str,
+    sub: Option<ObjectId>,
+) -> ObjectId {
+    let (name, rest) = match path.split_once('/') {
+        Some((name, rest)) => (name, Some(rest)),
+        None => (path, None),
+    };
+    let mut entries = decode_tree(repo, tree);
+    let child = match rest {
+        Some(rest) => {
+            let base = entry_oid(repo, tree, name)
+                .unwrap_or_else(|| gix::ObjectId::empty_tree(repo.object_hash()));
+            Some(write_path(repo, &base, rest, sub))
+        }
+        None => sub,
+    };
+    entries.retain(|entry| entry.filename != name);
+    if let Some(child) = child {
+        entries.push(gix::objs::tree::Entry {
+            mode: gix::objs::tree::EntryKind::Tree.into(),
+            filename: name.into(),
+            oid: child,
+        });
+    }
+    entries.sort();
+    repo.write_object(&gix::objs::Tree { entries })
+        .expect("a tree")
+        .detach()
+}
+
+fn decode_tree(repo: &gix::Repository, tree: &ObjectId) -> Vec<gix::objs::tree::Entry> {
+    if *tree == gix::ObjectId::empty_tree(repo.object_hash()) {
+        return Vec::new();
+    }
+    let raw = repo.find_object(*tree).expect("a tree").detach().data;
+    gix::objs::TreeRef::from_bytes(&raw, repo.object_hash())
+        .expect("a well formed tree")
+        .entries
+        .iter()
+        .map(|entry| gix::objs::tree::Entry {
+            mode: entry.mode,
+            filename: entry.filename.to_owned(),
+            oid: entry.oid.to_owned(),
+        })
+        .collect()
+}

--- a/views/tests/roundtrip.rs
+++ b/views/tests/roundtrip.rs
@@ -11,6 +11,7 @@
 //! every run.
 
 use std::collections::HashMap;
+use std::fmt::Write as _;
 
 use gix::ObjectId;
 use jj_views::Cache;
@@ -307,6 +308,84 @@ fn append_monorepo_commit(repo: &gix::Repository, parent: &ObjectId, step: usize
         "tree {tree}\nparent {parent}\nauthor Monorepo <mono@example.invalid> 100000000{step} \
          +0000\ncommitter Monorepo <mono@example.invalid> 100000000{step} +0000\n\nmonorepo \
          change {step}\n"
+    );
+    gix::objs::Write::write_buf(&repo.objects, gix::objs::Kind::Commit, raw.as_bytes())
+        .expect("a commit")
+}
+
+/// The other half of the parent rule. When elision collapses one side of a
+/// merge onto the other, the derived commit must lose the duplicate and stop
+/// being a merge. This is the case that makes deduplication necessary at all,
+/// and it is the same rule that must *not* fire on a source commit that already
+/// listed the same parent twice.
+#[test]
+fn a_merge_whose_side_elides_stops_being_a_merge() {
+    let filter = Filter::prefix(PREFIX).expect("a valid prefix");
+    let world = inject(&filter);
+    let head = *world
+        .map
+        .get(&world.upstream.head)
+        .expect("the head was injected");
+
+    // A side branch that only touches a monorepo file, so it elides.
+    let side = append_monorepo_commit(&world.repo, &head, 0);
+    // The merge has to change the filtered path or it elides too and there is
+    // no derived merge left to inspect. Borrowing another injected commit's tree
+    // is the cheapest way to get a different subtree under PREFIX.
+    let elsewhere = world
+        .upstream
+        .commits
+        .iter()
+        .find(|(label, _)| *label == "left")
+        .map(|(_, commit)| world.map.get(commit).expect("it was injected"))
+        .expect("the fixture has a commit labelled left");
+    let merge = append_merge(&world.repo, &[head, side], &tree_of(&world.repo, elsewhere));
+
+    let mut cache = Cache::new();
+    let base = jj_views::derive(&world.repo, &head, &filter, &mut cache)
+        .expect("a derivation")
+        .expect("the injected head has a view");
+    let derived = jj_views::derive(&world.repo, &merge, &filter, &mut cache)
+        .expect("a derivation")
+        .expect("the merge has a view");
+
+    assert_ne!(
+        derived, base,
+        "the merge changes the filtered path, so it must survive as its own commit"
+    );
+    let raw = world
+        .repo
+        .find_object(derived)
+        .expect("the derived merge")
+        .detach()
+        .data;
+    let parents: Vec<ObjectId> = gix::objs::CommitRef::from_bytes(&raw, world.repo.object_hash())
+        .expect("a well formed commit")
+        .parents()
+        .collect();
+    assert_eq!(
+        parents,
+        vec![base],
+        "both sides derive to the same view commit, so the merge must keep one parent"
+    );
+}
+
+fn tree_of(repo: &gix::Repository, commit: &ObjectId) -> ObjectId {
+    let raw = repo.find_object(*commit).expect("a commit").detach().data;
+    gix::objs::CommitRef::from_bytes(&raw, repo.object_hash())
+        .expect("a well formed commit")
+        .tree()
+}
+
+/// A merge commit over `parents` with the given `tree`.
+fn append_merge(repo: &gix::Repository, parents: &[ObjectId], tree: &ObjectId) -> ObjectId {
+    let mut raw = format!("tree {tree}\n");
+    for parent in parents {
+        writeln!(raw, "parent {parent}").expect("writing to a String cannot fail");
+    }
+    raw.push_str(
+        "author Monorepo <mono@example.invalid> 1000000100 +0000\ncommitter Monorepo \
+         <mono@example.invalid> 1000000100 +0000\n\na merge\n",
     );
     gix::objs::Write::write_buf(&repo.objects, gix::objs::Kind::Commit, raw.as_bytes())
         .expect("a commit")


### PR DESCRIPTION
## What this is

A new workspace member, `jj-views`, over gix with no dependency on `jj-lib`. It
derives a child repository as a pure function of a parent monorepo's history:

    derive(commit, filter, cache)      // parent commit -> view commit
    unfilter(commit, onto, cache)      // the inverse, lifting a view commit back

Prefix filters only. The point is **round trip hash identity**: inject an
upstream history under `vendor/<name>/`, filter the prefix back out, and get
upstream's own commit hashes back. That is what makes a view share real ancestry
with upstream, so merge bases are correct and syncing is a plain `git fetch` and
rebase rather than a translation layer.

## The claim, measured

All 85,050 commits of `git.git` (21,409 merges, 37 octopus merges, 132
`mergetag`, 83 `gpgsig`, 1 `encoding`, 1 jj `change-id`, non-ASCII metadata, a
Latin-1 message body), injected under a two component prefix and filtered back
out, with elision at its default setting:

```
  matched byte for byte:            85050
  no counterpart at all:            0
  elided onto one of their parents: 0
  moved, inherited a parent:        0
  moved, merge arity collapsed:     0
  moved in their own bytes:         0
```

Incremental cost, which is what a fetch actually pays: ten new commits
re-derived in 0.0007s with exactly ten tree reads, one per commit for the one
tree that changed.

## Three rules that are easy to get wrong in the same direction

Each of these was found by measuring, not by review, and each has a test that
was watched to fail before being trusted.

**Elision must ask whether the commit was empty *before* filtering.** Checking
only the filtered tree drops deliberately empty upstream commits, and because a
moved hash changes every descendant's parent line, that takes the rest of
history with it: 7 commits dropped and 78,500 moved, on `git.git`. Conditioning
on the unfiltered commit keeps both the clean view and the hashes. This is
josh's rule; see `Elide`.

**Derived parents must not be blindly deduplicated.** The linux kernel has four
commits that list the same parent twice, and the earliest, from 2005, has
1,458,483 of 1,464,098 commits as descendants. A blind dedupe moves 99.6% of
that history. Only duplicates the filter itself introduced may be removed.

**Only the `tree` and `parent` lines may be rewritten.** Every other byte is
copied through, so `author`, `committer`, `encoding`, `gpgsig`, `mergetag`, any
unknown extra header, their relative order, and the message survive by
construction. gix's owned `Commit` decodes the signature time and so rewrites
offsets git stores verbatim, including `-0000`, which `git fsck` accepts.
Neither corpus contains such a commit, so this is a hazard avoided rather than a
break observed, but copying bytes also means nothing has to track which fields a
future gix version normalizes.

## Dependency budget: one net slot

`grep -c '^\[\[package\]\]' Cargo.lock` goes from 545 to 546 against this
branch's base. The single new entry is `jj-views` itself; `bstr`, `gix`,
`tempfile` and `thiserror` were already in the lock.

**This was deliberate and please do not undo it.** `unfilter` needs to build a
tree with one subtree replaced, which is what gix's `tree-editor` feature is
for. Enabling it would have added the feature to the whole workspace's gix. The
entry sort is hand written against `gix_object::tree::Entry`'s `Ord`, which
already implements git's rule of comparing a directory name as though it ended
in a slash. See `graft_tree`.

## Semantics are versioned, because this is the part that cannot be undone later

Every decision that can move a hash sits behind `Semantics`, and `Filter::spec`
renders the whole rule set as one string:

    semantics=1;prefix=vendor/linux;elide=unchanged;trivial-merges=drop

`Filter::parse` refuses an unknown version, an unknown field, an unknown value,
or a **missing** field, since filling a missing field with a default is how a
spec written by a newer version gets read as though its rules did not apply.
`semantics_v1_output_hashes_are_pinned` pins the exact derived object id per
policy and tells a future reader to add a variant rather than edit the constants.

josh has broken its own output hashes at least twice and its compatibility flags
are the fossils. rust-lang force pushed the entire history of `rustc-dev-guide`
after generating commits with a josh that stripped signatures.

## Tests

`cargo nextest run -p jj-views`: 17 tests, all passing. No network at test time.
The fixture is built from raw objects, so it is byte stable across runs and
platforms, and it carries the corners: merges, an octopus, duplicate parents,
non-ASCII metadata, a Latin-1 body with an `encoding` header, `gpgsig`, `gpgsig`
before `encoding`, `mergetag`, an empty commit, a mode change, a symlink, a
dangling gitlink, a message with no trailing newline, and sibling names whose
git tree order differs from byte order.

`git fsck --strict` accepts every fixture commit except one, which deliberately
carries an offset git reports as `badTimezone`. The `fixture_repo` example writes
the history into a real repository, which is how the hand folded headers and the
tree ordering were checked against git rather than only against gix.

Two of the tests exist to check the checks. A comparison loop that matched
nothing prints the same "0 mismatches" as one that passed, so corrupting the tip
must report exactly one mismatch and name it, and corrupting a middle commit must
report the victim plus exactly its descendants.

One test pins a **known failure** on purpose: renaming a mount point reduces the
view to a single orphan commit. That is the measured size of a problem a rename
ledger has to solve, and the test will fail when it is fixed.

## Not in this PR

- The rename ledger and era splicing filter. Only the failing test exists.
- Any merge-forward operation. `unfilter` refuses to fabricate content, which is
  the enforcement, but composing lift-then-merge is not implemented.
- SHA-256. All measurement was SHA-1; the code takes the hash kind from the
  repository but is untested there.
- Hash compatibility with josh. We match *upstream*, and diverge from josh
  deliberately on parent deduplication.
