### PR TITLE
repo: make `MutableRepo.consume()` public

### DIFF
--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -1041,7 +1041,7 @@ impl MutableRepo {
     }
 
     #[expect(clippy::type_complexity)]
-    pub(crate) fn consume(
+    pub fn consume(
         mut self,
     ) -> IndexResult<(
         Box<dyn MutableIndex>,


### PR DESCRIPTION
We were working on a jj native remote server storage engine, and we do interception of writes to enable us to do custom `commit()` code. We need this to get an owned copy of the mutablerepo results

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
