### PR TITLE
repo: move `StoreFactories::default()` etc. to separate module

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -68,6 +68,8 @@ use jj_lib::config::ConfigSource;
 use jj_lib::config::ConfigValue;
 use jj_lib::config::StackedConfig;
 use jj_lib::conflicts::ConflictMarkerStyle;
+use jj_lib::default_backend_factories::default_backend_factories;
+use jj_lib::default_backend_factories::default_working_copy_factories;
 use jj_lib::fileset;
 use jj_lib::fileset::FilesetAliasesMap;
 use jj_lib::fileset::FilesetDiagnostics;
@@ -146,7 +148,6 @@ use jj_lib::workspace::Workspace;
 use jj_lib::workspace::WorkspaceLoadError;
 use jj_lib::workspace::WorkspaceLoader;
 use jj_lib::workspace::WorkspaceLoaderFactory;
-use jj_lib::workspace::default_working_copy_factories;
 use jj_lib::workspace::get_working_copy_factory;
 use pollster::FutureExt as _;
 use tracing::instrument;
@@ -4322,7 +4323,7 @@ impl<'a> CliRunner<'a> {
             app: crate::commands::default_app(),
             config_layers: crate::config::default_config_layers(),
             config_migrations: crate::config::default_config_migrations(),
-            store_factories: StoreFactories::default(),
+            store_factories: default_backend_factories(),
             working_copy_factories: default_working_copy_factories(),
             workspace_loader_factory: Box::new(DefaultWorkspaceLoaderFactory),
             revset_extensions: Default::default(),

--- a/lib/src/default_backend_factories.rs
+++ b/lib/src/default_backend_factories.rs
@@ -1,0 +1,99 @@
+// Copyright 2026 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Provides the default backend factories, i.e. `GitBackend` (if the `git`
+//! feature is enabled), `SimpleOpStore`, `LocalWorkingCopy`, etc.
+
+use crate::default_index::DefaultIndexStore;
+use crate::default_submodule_store::DefaultSubmoduleStore;
+use crate::local_working_copy::LocalWorkingCopy;
+use crate::local_working_copy::LocalWorkingCopyFactory;
+use crate::repo::StoreFactories;
+use crate::simple_backend::SimpleBackend;
+use crate::simple_op_heads_store::SimpleOpHeadsStore;
+use crate::simple_op_store::SimpleOpStore;
+use crate::working_copy::WorkingCopyFactory;
+use crate::workspace::WorkingCopyFactories;
+
+/// Returns default store factories.
+pub fn default_backend_factories() -> StoreFactories {
+    let mut factories = StoreFactories::empty();
+
+    // Backends
+    factories.add_backend(
+        SimpleBackend::name(),
+        Box::new(|_settings, store_path| Ok(Box::new(SimpleBackend::load(store_path)))),
+    );
+    #[cfg(feature = "git")]
+    factories.add_backend(
+        crate::git_backend::GitBackend::name(),
+        Box::new(|settings, store_path| {
+            Ok(Box::new(crate::git_backend::GitBackend::load(
+                settings, store_path,
+            )?))
+        }),
+    );
+    #[cfg(feature = "testing")]
+    factories.add_backend(
+        crate::secret_backend::SecretBackend::name(),
+        Box::new(|settings, store_path| {
+            Ok(Box::new(crate::secret_backend::SecretBackend::load(
+                settings, store_path,
+            )?))
+        }),
+    );
+
+    // OpStores
+    factories.add_op_store(
+        SimpleOpStore::name(),
+        Box::new(|_settings, store_path, root_data| {
+            Ok(Box::new(SimpleOpStore::load(store_path, root_data)))
+        }),
+    );
+
+    // OpHeadsStores
+    factories.add_op_heads_store(
+        SimpleOpHeadsStore::name(),
+        Box::new(|_settings, store_path| Ok(Box::new(SimpleOpHeadsStore::load(store_path)))),
+    );
+
+    // Index
+    factories.add_index_store(
+        DefaultIndexStore::name(),
+        Box::new(|_settings, store_path| Ok(Box::new(DefaultIndexStore::load(store_path)))),
+    );
+
+    // SubmoduleStores
+    factories.add_submodule_store(
+        DefaultSubmoduleStore::name(),
+        Box::new(|_settings, store_path| Ok(Box::new(DefaultSubmoduleStore::load(store_path)))),
+    );
+
+    factories
+}
+
+/// Returns default working copy factories.
+pub fn default_working_copy_factories() -> WorkingCopyFactories {
+    let mut factories = WorkingCopyFactories::new();
+    factories.insert(
+        LocalWorkingCopy::name().to_owned(),
+        Box::new(LocalWorkingCopyFactory {}),
+    );
+    factories
+}
+
+/// Returns the default (local-disk) working copy factory.
+pub fn default_working_copy_factory() -> Box<dyn WorkingCopyFactory> {
+    Box::new(LocalWorkingCopyFactory {})
+}

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -42,6 +42,7 @@ pub mod converge;
 pub mod copies;
 pub mod dag_walk;
 pub mod dag_walk_async;
+pub mod default_backend_factories;
 pub mod default_index;
 pub mod default_submodule_store;
 pub mod diff;

--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -106,7 +106,6 @@ use crate::rewrite::rebase_commit_with_options;
 use crate::settings::UserSettings;
 use crate::signing::SignInitError;
 use crate::signing::Signer;
-use crate::simple_backend::SimpleBackend;
 use crate::simple_op_heads_store::SimpleOpHeadsStore;
 use crate::simple_op_store::SimpleOpStore;
 use crate::store::Store;
@@ -430,64 +429,6 @@ pub struct StoreFactories {
     op_heads_store_factories: HashMap<String, OpHeadsStoreFactory>,
     index_store_factories: HashMap<String, IndexStoreFactory>,
     submodule_store_factories: HashMap<String, SubmoduleStoreFactory>,
-}
-
-impl Default for StoreFactories {
-    fn default() -> Self {
-        let mut factories = Self::empty();
-
-        // Backends
-        factories.add_backend(
-            SimpleBackend::name(),
-            Box::new(|_settings, store_path| Ok(Box::new(SimpleBackend::load(store_path)))),
-        );
-        #[cfg(feature = "git")]
-        factories.add_backend(
-            crate::git_backend::GitBackend::name(),
-            Box::new(|settings, store_path| {
-                Ok(Box::new(crate::git_backend::GitBackend::load(
-                    settings, store_path,
-                )?))
-            }),
-        );
-        #[cfg(feature = "testing")]
-        factories.add_backend(
-            crate::secret_backend::SecretBackend::name(),
-            Box::new(|settings, store_path| {
-                Ok(Box::new(crate::secret_backend::SecretBackend::load(
-                    settings, store_path,
-                )?))
-            }),
-        );
-
-        // OpStores
-        factories.add_op_store(
-            SimpleOpStore::name(),
-            Box::new(|_settings, store_path, root_data| {
-                Ok(Box::new(SimpleOpStore::load(store_path, root_data)))
-            }),
-        );
-
-        // OpHeadsStores
-        factories.add_op_heads_store(
-            SimpleOpHeadsStore::name(),
-            Box::new(|_settings, store_path| Ok(Box::new(SimpleOpHeadsStore::load(store_path)))),
-        );
-
-        // Index
-        factories.add_index_store(
-            DefaultIndexStore::name(),
-            Box::new(|_settings, store_path| Ok(Box::new(DefaultIndexStore::load(store_path)))),
-        );
-
-        // SubmoduleStores
-        factories.add_submodule_store(
-            DefaultSubmoduleStore::name(),
-            Box::new(|_settings, store_path| Ok(Box::new(DefaultSubmoduleStore::load(store_path)))),
-        );
-
-        factories
-    }
 }
 
 #[derive(Debug, Error)]

--- a/lib/src/workspace.rs
+++ b/lib/src/workspace.rs
@@ -25,12 +25,11 @@ use thiserror::Error;
 
 use crate::backend::BackendInitError;
 use crate::commit::Commit;
+use crate::default_backend_factories::default_working_copy_factory;
 use crate::file_util;
 use crate::file_util::BadPathEncoding;
 use crate::file_util::IoResultExt as _;
 use crate::file_util::PathError;
-use crate::local_working_copy::LocalWorkingCopy;
-use crate::local_working_copy::LocalWorkingCopyFactory;
 use crate::merged_tree::MergedTree;
 use crate::op_heads_store::OpHeadsStoreError;
 use crate::op_store::OperationId;
@@ -630,17 +629,4 @@ impl WorkspaceLoader for DefaultWorkspaceLoader {
     fn get_working_copy_type(&self) -> Result<String, StoreLoadError> {
         read_store_type("working copy", self.working_copy_state_path.join("type"))
     }
-}
-
-pub fn default_working_copy_factories() -> WorkingCopyFactories {
-    let mut factories = WorkingCopyFactories::new();
-    factories.insert(
-        LocalWorkingCopy::name().to_owned(),
-        Box::new(LocalWorkingCopyFactory {}),
-    );
-    factories
-}
-
-pub fn default_working_copy_factory() -> Box<dyn WorkingCopyFactory> {
-    Box::new(LocalWorkingCopyFactory {})
 }

--- a/lib/tests/test_bad_locking.rs
+++ b/lib/tests/test_bad_locking.rs
@@ -15,10 +15,10 @@
 use std::path::Path;
 
 use itertools::Itertools as _;
+use jj_lib::default_backend_factories::default_backend_factories;
+use jj_lib::default_backend_factories::default_working_copy_factories;
 use jj_lib::repo::Repo as _;
-use jj_lib::repo::StoreFactories;
 use jj_lib::workspace::Workspace;
-use jj_lib::workspace::default_working_copy_factories;
 use pollster::FutureExt as _;
 use test_case::test_case;
 use testutils::TestRepoBackend;
@@ -122,7 +122,7 @@ fn test_bad_locking_children(backend: TestRepoBackend) -> TestResult {
     let machine1_workspace = Workspace::load(
         &settings,
         &machine1_root,
-        &StoreFactories::default(),
+        &default_backend_factories(),
         &default_working_copy_factories(),
     )?;
     let machine1_repo = machine1_workspace.repo_loader().load_at_head().block_on()?;
@@ -136,7 +136,7 @@ fn test_bad_locking_children(backend: TestRepoBackend) -> TestResult {
     let machine2_workspace = Workspace::load(
         &settings,
         &machine2_root,
-        &StoreFactories::default(),
+        &default_backend_factories(),
         &default_working_copy_factories(),
     )?;
     let machine2_repo = machine2_workspace.repo_loader().load_at_head().block_on()?;
@@ -151,7 +151,7 @@ fn test_bad_locking_children(backend: TestRepoBackend) -> TestResult {
     let merged_workspace = Workspace::load(
         &settings,
         &merged_path,
-        &StoreFactories::default(),
+        &default_backend_factories(),
         &default_working_copy_factories(),
     )?;
     let merged_repo = merged_workspace.repo_loader().load_at_head().block_on()?;

--- a/lib/tests/test_eol.rs
+++ b/lib/tests/test_eol.rs
@@ -18,12 +18,12 @@ use std::io::Write as _;
 use bstr::ByteSlice as _;
 use jj_lib::config::ConfigLayer;
 use jj_lib::config::ConfigSource;
+use jj_lib::default_backend_factories::default_backend_factories;
+use jj_lib::default_backend_factories::default_working_copy_factories;
 use jj_lib::repo::Repo as _;
-use jj_lib::repo::StoreFactories;
 use jj_lib::rewrite::merge_commit_trees;
 use jj_lib::settings::UserSettings;
 use jj_lib::workspace::Workspace;
-use jj_lib::workspace::default_working_copy_factories;
 use pollster::FutureExt as _;
 use test_case::test_case;
 use testutils::CommitBuilderExt as _;
@@ -156,7 +156,7 @@ fn test_eol_conversion_snapshot(
     let mut workspace = Workspace::load(
         &user_settings,
         test_workspace.workspace.workspace_root(),
-        &StoreFactories::default(),
+        &default_backend_factories(),
         &default_working_copy_factories(),
     )
     .expect("Failed to reload the workspace");
@@ -266,7 +266,7 @@ fn create_conflict_snapshot_and_read(extra_setting: &str) -> Vec<u8> {
     test_workspace.workspace = Workspace::load(
         &user_settings,
         test_workspace.workspace.workspace_root(),
-        &StoreFactories::default(),
+        &default_backend_factories(),
         &default_working_copy_factories(),
     )
     .expect("Failed to reload the workspace");
@@ -281,7 +281,7 @@ fn create_conflict_snapshot_and_read(extra_setting: &str) -> Vec<u8> {
     test_workspace.workspace = Workspace::load(
         &no_eol_conversion_settings,
         test_workspace.workspace.workspace_root(),
-        &StoreFactories::default(),
+        &default_backend_factories(),
         &default_working_copy_factories(),
     )
     .expect("Failed to reload the workspace");
@@ -561,7 +561,7 @@ fn test_eol_conversion_checkout(
     test_workspace.workspace = Workspace::load(
         &user_settings,
         test_workspace.workspace.workspace_root(),
-        &StoreFactories::default(),
+        &default_backend_factories(),
         &default_working_copy_factories(),
     )
     .expect("Failed to reload the workspace");

--- a/lib/tests/test_init.rs
+++ b/lib/tests/test_init.rs
@@ -189,7 +189,7 @@ fn test_init_load_non_utf8_path() -> TestResult {
     use std::ffi::OsStr;
     use std::os::unix::ffi::OsStrExt as _;
 
-    use jj_lib::workspace::default_working_copy_factories;
+    use jj_lib::default_backend_factories::default_working_copy_factories;
     use pollster::FutureExt as _;
     use testutils::TestEnvironment;
 
@@ -219,7 +219,7 @@ fn test_init_load_non_utf8_path() -> TestResult {
     let workspace = Workspace::load(
         &settings,
         &workspace_root,
-        &test_env.default_store_factories(),
+        &test_env.default_backend_factories(),
         &default_working_copy_factories(),
     )?;
 

--- a/lib/tests/test_load_repo.rs
+++ b/lib/tests/test_load_repo.rs
@@ -37,7 +37,7 @@ fn test_load_at_operation() -> TestResult {
     let loader = RepoLoader::init_from_file_system(
         &settings,
         test_repo.repo_path(),
-        &test_repo.env.default_store_factories(),
+        &test_repo.env.default_backend_factories(),
     )?;
     let head_repo = loader.load_at_head().block_on()?;
     assert!(!head_repo.view().heads().contains(commit.id()));
@@ -47,7 +47,7 @@ fn test_load_at_operation() -> TestResult {
     let loader = RepoLoader::init_from_file_system(
         &settings,
         test_repo.repo_path(),
-        &test_repo.env.default_store_factories(),
+        &test_repo.env.default_backend_factories(),
     )?;
     let old_repo = loader.load_at(repo.operation()).block_on()?;
     assert!(old_repo.view().heads().contains(commit.id()));

--- a/lib/tests/test_local_working_copy.rs
+++ b/lib/tests/test_local_working_copy.rs
@@ -35,6 +35,7 @@ use jj_lib::backend::TreeId;
 use jj_lib::backend::TreeValue;
 use jj_lib::conflict_labels::ConflictLabels;
 use jj_lib::conflicts::ConflictMaterializeOptions;
+use jj_lib::default_backend_factories::default_working_copy_factories;
 use jj_lib::file_util;
 use jj_lib::file_util::check_symlink_support;
 use jj_lib::file_util::symlink_dir;
@@ -67,7 +68,6 @@ use jj_lib::working_copy::SnapshotOptions;
 use jj_lib::working_copy::UntrackedReason;
 use jj_lib::working_copy::WorkingCopy as _;
 use jj_lib::workspace::Workspace;
-use jj_lib::workspace::default_working_copy_factories;
 use pollster::FutureExt as _;
 use test_case::test_case;
 use testutils::CommitBuilderExt as _;
@@ -492,7 +492,7 @@ fn test_acl() -> TestResult {
     let mut ws = Workspace::load(
         &settings,
         &workspace_root,
-        &test_workspace.env.default_store_factories(),
+        &test_workspace.env.default_backend_factories(),
         &default_working_copy_factories(),
     )?;
     // Reload commits from the store associated with the workspace

--- a/lib/tests/test_local_working_copy_concurrent.rs
+++ b/lib/tests/test_local_working_copy_concurrent.rs
@@ -16,10 +16,10 @@ use std::cmp::max;
 use std::thread;
 
 use assert_matches::assert_matches;
+use jj_lib::default_backend_factories::default_working_copy_factories;
 use jj_lib::repo::Repo as _;
 use jj_lib::working_copy::CheckoutError;
 use jj_lib::workspace::Workspace;
-use jj_lib::workspace::default_working_copy_factories;
 use pollster::FutureExt as _;
 use testutils::TestResult;
 use testutils::TestWorkspace;
@@ -59,7 +59,7 @@ fn test_concurrent_checkout() -> TestResult {
         let mut ws2 = Workspace::load(
             &settings,
             &workspace1_root,
-            &test_workspace1.env.default_store_factories(),
+            &test_workspace1.env.default_backend_factories(),
             &default_working_copy_factories(),
         )?;
         // Reload commit from the store associated with the workspace
@@ -80,7 +80,7 @@ fn test_concurrent_checkout() -> TestResult {
     let ws3 = Workspace::load(
         &settings,
         &workspace1_root,
-        &test_workspace1.env.default_store_factories(),
+        &test_workspace1.env.default_backend_factories(),
         &default_working_copy_factories(),
     )?;
     assert_tree_eq!(*ws3.working_copy().tree()?, tree2);
@@ -125,7 +125,7 @@ fn test_checkout_parallel() -> TestResult {
                 let mut workspace = Workspace::load(
                     &settings,
                     &workspace_root,
-                    &test_env.default_store_factories(),
+                    &test_env.default_backend_factories(),
                     &default_working_copy_factories(),
                 )
                 .unwrap();

--- a/lib/tests/test_workspace.rs
+++ b/lib/tests/test_workspace.rs
@@ -15,12 +15,12 @@
 use std::thread;
 
 use assert_matches::assert_matches;
+use jj_lib::default_backend_factories::default_working_copy_factories;
+use jj_lib::default_backend_factories::default_working_copy_factory;
 use jj_lib::ref_name::WorkspaceNameBuf;
 use jj_lib::repo::Repo as _;
 use jj_lib::workspace::Workspace;
 use jj_lib::workspace::WorkspaceLoadError;
-use jj_lib::workspace::default_working_copy_factories;
-use jj_lib::workspace::default_working_copy_factory;
 use pollster::FutureExt as _;
 use testutils::TestEnvironment;
 use testutils::TestResult;
@@ -35,7 +35,7 @@ fn test_load_bad_path() {
     let result = Workspace::load(
         &settings,
         &workspace_root,
-        &test_env.default_store_factories(),
+        &test_env.default_backend_factories(),
         &default_working_copy_factories(),
     );
     assert_matches!(
@@ -84,7 +84,7 @@ fn test_init_additional_workspace() -> TestResult {
     let same_workspace = Workspace::load(
         &settings,
         &ws2_root,
-        &test_workspace.env.default_store_factories(),
+        &test_workspace.env.default_backend_factories(),
         &default_working_copy_factories(),
     );
     assert!(same_workspace.is_ok());
@@ -126,7 +126,7 @@ fn test_init_additional_workspace_absolute_path_compat() -> TestResult {
     let same_workspace = Workspace::load(
         &settings,
         &ws2_root,
-        &test_workspace.env.default_store_factories(),
+        &test_workspace.env.default_backend_factories(),
         &default_working_copy_factories(),
     );
     assert!(same_workspace.is_ok());
@@ -176,7 +176,7 @@ fn test_init_additional_workspace_non_utf8_path() -> TestResult {
     let same_workspace = Workspace::load(
         &settings,
         &ws2_root,
-        &test_env.default_store_factories(),
+        &test_env.default_backend_factories(),
         &default_working_copy_factories(),
     );
     let same_workspace = same_workspace?;

--- a/lib/testutils/src/lib.rs
+++ b/lib/testutils/src/lib.rs
@@ -45,6 +45,7 @@ use jj_lib::config::ConfigLayer;
 use jj_lib::config::ConfigSource;
 use jj_lib::config::StackedConfig;
 use jj_lib::conflict_labels::ConflictLabels;
+use jj_lib::default_backend_factories::default_backend_factories;
 use jj_lib::git_backend::GitBackend;
 use jj_lib::gitignore::GitIgnoreFile;
 use jj_lib::matchers::EverythingMatcher;
@@ -198,8 +199,8 @@ impl TestEnvironment {
         self.temp_dir.path()
     }
 
-    pub fn default_store_factories(&self) -> StoreFactories {
-        let mut factories = StoreFactories::default();
+    pub fn default_backend_factories(&self) -> StoreFactories {
+        let mut factories = default_backend_factories();
         factories.add_backend("test", {
             let factory = self.test_backend_factory.clone();
             Box::new(move |_settings, store_path| Ok(Box::new(factory.load(store_path))))
@@ -218,7 +219,7 @@ impl TestEnvironment {
         settings: &UserSettings,
         repo_path: &Path,
     ) -> Arc<ReadonlyRepo> {
-        RepoLoader::init_from_file_system(settings, repo_path, &self.default_store_factories())
+        RepoLoader::init_from_file_system(settings, repo_path, &self.default_backend_factories())
             .unwrap()
             .load_at_head()
             .block_on()


### PR DESCRIPTION
This is high-level glue code that we want to remove from the `repo` module, so that module can be moved into a lower-level `jj-core` crate.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [ ] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
