### PR TITLE
index: make common_ancestors() async

### DIFF
--- a/cli/src/commands/bench/common_ancestors.rs
+++ b/cli/src/commands/bench/common_ancestors.rs
@@ -15,6 +15,7 @@
 use std::slice;
 
 use jj_lib::repo::Repo as _;
+use pollster::FutureExt as _;
 
 use super::CriterionArgs;
 use super::run_bench;
@@ -47,8 +48,11 @@ pub async fn cmd_bench_common_ancestors(
         .resolve_single_rev(ui, &args.revision2)
         .await?;
     let index = workspace_command.repo().index();
-    let routine =
-        || index.common_ancestors(slice::from_ref(commit1.id()), slice::from_ref(commit2.id()));
+    let routine = || {
+        index
+            .common_ancestors(slice::from_ref(commit1.id()), slice::from_ref(commit2.id()))
+            .block_on()
+    };
     run_bench(
         ui,
         &format!("common-ancestors-{}-{}", args.revision1, args.revision2),

--- a/lib/src/default_index/composite.rs
+++ b/lib/src/default_index/composite.rs
@@ -622,7 +622,11 @@ impl Index for CompositeIndex {
         Ok(self.commits().is_ancestor(ancestor_id, descendant_id))
     }
 
-    fn common_ancestors(&self, set1: &[CommitId], set2: &[CommitId]) -> IndexResult<Vec<CommitId>> {
+    async fn common_ancestors(
+        &self,
+        set1: &[CommitId],
+        set2: &[CommitId],
+    ) -> IndexResult<Vec<CommitId>> {
         Ok(self.commits().common_ancestors(set1, set2))
     }
 

--- a/lib/src/default_index/mod.rs
+++ b/lib/src/default_index/mod.rs
@@ -110,7 +110,7 @@ mod tests {
         set1: &[CommitId],
         set2: &[CommitId],
     ) -> Vec<CommitId> {
-        index.common_ancestors(set1, set2).unwrap()
+        index.common_ancestors(set1, set2).block_on().unwrap()
     }
 
     fn is_ancestor(

--- a/lib/src/default_index/mutable.rs
+++ b/lib/src/default_index/mutable.rs
@@ -574,8 +574,12 @@ impl Index for DefaultMutableIndex {
         self.0.is_ancestor(ancestor_id, descendant_id).await
     }
 
-    fn common_ancestors(&self, set1: &[CommitId], set2: &[CommitId]) -> IndexResult<Vec<CommitId>> {
-        self.0.common_ancestors(set1, set2)
+    async fn common_ancestors(
+        &self,
+        set1: &[CommitId],
+        set2: &[CommitId],
+    ) -> IndexResult<Vec<CommitId>> {
+        self.0.common_ancestors(set1, set2).await
     }
 
     fn all_heads_for_gc(&self) -> IndexResult<Box<dyn Iterator<Item = CommitId> + '_>> {

--- a/lib/src/default_index/readonly.rs
+++ b/lib/src/default_index/readonly.rs
@@ -741,8 +741,12 @@ impl Index for DefaultReadonlyIndex {
         self.0.is_ancestor(ancestor_id, descendant_id).await
     }
 
-    fn common_ancestors(&self, set1: &[CommitId], set2: &[CommitId]) -> IndexResult<Vec<CommitId>> {
-        self.0.common_ancestors(set1, set2)
+    async fn common_ancestors(
+        &self,
+        set1: &[CommitId],
+        set2: &[CommitId],
+    ) -> IndexResult<Vec<CommitId>> {
+        self.0.common_ancestors(set1, set2).await
     }
 
     fn all_heads_for_gc(&self) -> IndexResult<Box<dyn Iterator<Item = CommitId> + '_>> {

--- a/lib/src/index.rs
+++ b/lib/src/index.rs
@@ -129,7 +129,11 @@ pub trait Index: Send + Sync {
     /// Returns the best common ancestor or ancestors of the commits in `set1`
     /// and `set2`. A "best common ancestor" has no descendants that are also
     /// common ancestors.
-    fn common_ancestors(&self, set1: &[CommitId], set2: &[CommitId]) -> IndexResult<Vec<CommitId>>;
+    async fn common_ancestors(
+        &self,
+        set1: &[CommitId],
+        set2: &[CommitId],
+    ) -> IndexResult<Vec<CommitId>>;
 
     /// Heads among all indexed commits at the associated operation.
     ///

--- a/lib/src/rewrite.rs
+++ b/lib/src/rewrite.rs
@@ -91,7 +91,7 @@ pub async fn merge_commit_trees_no_resolve_without_repo(
         .iter()
         .map(|commit| commit.id().clone())
         .collect_vec();
-    let commit_id_merge = find_recursive_merge_commits(store, index, commit_ids)?;
+    let commit_id_merge = find_recursive_merge_commits(store, index, commit_ids).await?;
     let tree_merge: Merge<(MergedTree, String)> = commit_id_merge
         .try_map_async(async |commit_id| {
             let commit = store.get_commit_async(commit_id).await?;
@@ -102,7 +102,7 @@ pub async fn merge_commit_trees_no_resolve_without_repo(
 }
 
 /// Find the commits to use as input to the recursive merge algorithm.
-pub fn find_recursive_merge_commits(
+pub async fn find_recursive_merge_commits(
     store: &Arc<Store>,
     index: &dyn Index,
     commit_ids: Vec<CommitId>,
@@ -159,6 +159,7 @@ pub fn find_recursive_merge_commits(
         if top.pos < top.commit_ids.len() {
             let ancestor_ids = index
                 .common_ancestors(&top.commit_ids[0..top.pos], &top.commit_ids[top.pos..][..1])
+                .await
                 // TODO: indexing error shouldn't be a "BackendError"
                 .map_err(|err| BackendError::Other(err.into()))?;
             match maybe_resolved(ancestor_ids) {

--- a/lib/tests/test_rewrite.rs
+++ b/lib/tests/test_rewrite.rs
@@ -160,7 +160,8 @@ fn test_find_recursive_merge_commits() -> TestResult {
         tx.repo().store(),
         tx.repo().index(),
         vec![commit_d.id().clone(), commit_e.id().clone()],
-    )?;
+    )
+    .block_on()?;
     assert_eq!(
         commit_id_merge,
         Merge::from_vec(vec![
@@ -180,7 +181,8 @@ fn test_find_recursive_merge_commits() -> TestResult {
             commit_h.id().clone(),
             commit_i.id().clone(),
         ],
-    )?;
+    )
+    .block_on()?;
     assert_eq!(
         commit_id_merge,
         Merge::from_vec(vec![


### PR DESCRIPTION
This part of the push to make index traits async.
Previous changes #9877.
May be impacted by #9888 

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
