### PR TITLE
bisect: distinguish Found from (new) FoundDespiteSkips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   splitting it. Any hunks that are not selected or cannot be absorbed remain in
   the source commit.
 
+* `jj bisect` will now mention when it cannot unambiguously find the first bad revision
+  due to skips in evaluation.
+
 ### Fixed bugs
 
 * Recursive alias definitions are detected more precisely. jj can now expand

--- a/cli/src/commands/bisect/run.rs
+++ b/cli/src/commands/bisect/run.rs
@@ -232,6 +232,25 @@ pub(crate) async fn cmd_bisect_run(
                 }
             }
         }
+        BisectionResult::FoundDespiteSkips {
+            bad_commits,
+            possibly_bad,
+        } => {
+            let commit_template = workspace_command.commit_summary_template();
+            writeln!(formatter, "The first {target} revisions are:")?;
+            for commit in bad_commits {
+                commit_template.format(&commit, formatter.as_mut())?;
+                writeln!(formatter)?;
+            }
+            writeln!(
+                formatter,
+                "These revisions may also be {target}, but couldn't be evaluated:"
+            )?;
+            for commit in possibly_bad {
+                commit_template.format(&commit, formatter.as_mut())?;
+                writeln!(formatter)?;
+            }
+        }
     }
 
     Ok(())

--- a/cli/tests/test_bisect_command.rs
+++ b/cli/tests/test_bisect_command.rs
@@ -394,7 +394,10 @@ fn test_bisect_run_skip() -> TestResult {
 
     Search complete. To discard any revisions created during search, run:
       jj op restore 07d6c9360663
-    The first bad revision is: zsuskuln 123b4d91 b | b
+    The first bad revisions are:
+    zsuskuln 123b4d91 b | b
+    These revisions may also be bad, but couldn't be evaluated:
+    rlvkpnrz 7d980be7 a | a
     [EOF]
     ------- stderr -------
     Working copy  (@) now at: royxmykx 2144134b (empty) (no description set)

--- a/lib/src/bisect.rs
+++ b/lib/src/bisect.rs
@@ -15,6 +15,7 @@
 //! Bisect a range of commits.
 
 use std::collections::HashSet;
+use std::collections::VecDeque;
 use std::pin::pin;
 use std::sync::Arc;
 
@@ -87,6 +88,14 @@ pub enum BisectionResult {
     /// Found the first bad commit(s). It should be exactly one unless the input
     /// range had multiple disjoint heads.
     Found(Vec<Commit>),
+    /// The bisection frontier is blurred by the presence of skipped commits
+    FoundDespiteSkips {
+        /// The first commit(s) that did evaluate as bad
+        bad_commits: Vec<Commit>,
+        /// Skipped commits sandwiched between good and bad commits
+        /// Are they good or bad? We couldn't tell.
+        possibly_bad: Vec<Commit>,
+    },
     /// Could not determine the first bad commit because it was in a
     /// skipped range.
     Indeterminate,
@@ -233,7 +242,25 @@ impl<'repo> Bisector<'repo> {
             if bad_commits.is_empty() {
                 Ok(NextStep::Done(BisectionResult::Indeterminate))
             } else {
-                Ok(NextStep::Done(BisectionResult::Found(bad_commits)))
+                // were any commits skipped that could also be bad?
+                let mut todo: VecDeque<Commit> = VecDeque::from(bad_commits.clone());
+                let mut possibly_bad: Vec<Commit> = Vec::new();
+                while let Some(commit) = todo.pop_front() {
+                    for parent in commit.parents().await? {
+                        if self.skipped_commits.contains(parent.id()) {
+                            possibly_bad.push(parent.clone());
+                            todo.push_back(parent);
+                        }
+                    }
+                }
+                if possibly_bad.is_empty() {
+                    Ok(NextStep::Done(BisectionResult::Found(bad_commits)))
+                } else {
+                    Ok(NextStep::Done(BisectionResult::FoundDespiteSkips {
+                        bad_commits,
+                        possibly_bad,
+                    }))
+                }
             }
         }
     }

--- a/lib/tests/test_bisect.rs
+++ b/lib/tests/test_bisect.rs
@@ -145,9 +145,31 @@ fn test_bisect_linear() {
         (commit4.id(), Evaluation::Bad),
     ];
     let result = test_bisection(tx.repo(), &input_range, expected_tests);
-    // TODO: Indicate in the result that we're unsure if commit4 was the first bad
-    // commit because the commit before it in the set was skipped.
-    assert_eq!(result, BisectionResult::Found(vec![commit4.clone()]));
+    assert_eq!(
+        result,
+        BisectionResult::FoundDespiteSkips {
+            bad_commits: vec![commit4.clone()],
+            possibly_bad: vec![commit3.clone()]
+        }
+    );
+
+    // commit2 is the first bad commit; its parent and child commits were skipped
+    // * commit1 is a possibly_bad commit: it's between a bad and a good commit
+    // * commit3 is NOT a possibly_bad commit: it's implicitly bad due to commit2
+    let expected_tests = [
+        (commit3.id(), Evaluation::Skip),
+        (commit2.id(), Evaluation::Bad),
+        (root_commit.id(), Evaluation::Good),
+        (commit1.id(), Evaluation::Skip),
+    ];
+    let result = test_bisection(tx.repo(), &input_range, expected_tests);
+    assert_eq!(
+        result,
+        BisectionResult::FoundDespiteSkips {
+            bad_commits: vec![commit2.clone()],
+            possibly_bad: vec![commit1.clone()]
+        }
+    );
 
     // Commit 7 is the first bad commit but commits before 6 were skipped
     // TODO: Avoid testing every commit near first skipped commit. Test e.g. commit


### PR DESCRIPTION
test_bisect has a few TODO comments about distinguishing between the  result of a `jj bisect` run where all commits could be evaluated and the  culprit was identified exhaustively; and the result of a bisection where  an edge between bad and good revisions was found, but this edge is  blurred by skipped commits, so strictly speaking we can't actually know  whodunnit.

In English, this commit makes it so that:
* if the commit tree goes A (good) → B (good) → C (bad) → D (bad) we'll get Found([C]), as before;
* if the commit tree goes A (good) → B (good) → C (skip) → D (bad) we'll now get FoundDespiteSkips([D], [C]) instead of Found([D]).

I thought about representing this situation as FoundDespiteSkips([C,D])  instead, but though that there might be some kind of backwards  compatible value in returning the output jj previously did, and then  also this new bit of output. This choice is kind of validated by the  changes to cli/tests/test_bisect_command.rs

I found this situation while poking around the jj source code looking  for a tiny task I could make babby's very first rust commit, and I  spotted this todo midway through writing test_bisect_multimerge; a test  that otherwise doesn't really add much to the codebase. and may in fact  be harmful: there's not really a reason why commits should be evaluated  in this exact precise order...

(I found writing these tests a little annoying, since the error messages only quote random commit hashes and all I know is that the expectation was different from actuality. I had added the commit description to the  error message while blindly writing the tests, but that's an addition  that would only make a difference for the one probably-harmful test I  added, so that change is not part of this commit.)

As for the actual implementation in bisect.rs: uhhhhhhh it clears the  todo? but it's not using the revset expression system at all. In most  practical cases, I suspect this loop will only look back through a very  small number of commits; very often this number will be zero. Still, I  think a much more seasoned jj user would've been able to determine  maybe_bad_commits through the expression system, and a much more  seasoned jj developer would've been able to evaluate that expression  from the intermediate values that have already been computed. Me? I  can't even find the code that actually calculates the bisection  points... oh well.

Finally comes run.rs: there's more copy pasting than I'd like between  Found and FoundDespiteSkips? For simplicity, I skipped the  singular/plural branching that Found uses. The code I found already  could use a little deduplication maybe, but that should likely happen  in its own commit.

Disclosure: I downloaded rustrover for this. By default it comes enabled  with a simple line autocomplete LLM model, and some funny legalese on  how the learning/FOSS license requires enabling telemetry and maybe  LLMs. I might have accepted a completion or two. The contribution is  otherwise entirely hand-crafted, and it probably shows 😭

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
