### PR TITLE
rewrite: implement find_recursive_merge_commits() without using machine stack

### DIFF
--- a/lib/src/rewrite.rs
+++ b/lib/src/rewrite.rs
@@ -16,6 +16,7 @@
 
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::mem;
 use std::slice;
 use std::sync::Arc;
 
@@ -106,22 +107,71 @@ pub fn find_recursive_merge_commits(
     index: &dyn Index,
     commit_ids: Vec<CommitId>,
 ) -> BackendResult<Merge<CommitId>> {
-    if commit_ids.is_empty() {
-        Ok(Merge::resolved(store.root_commit_id().clone()))
-    } else if commit_ids.len() == 1 {
-        Ok(Merge::resolved(commit_ids.into_iter().next().unwrap()))
-    } else {
-        let mut result = Merge::resolved(commit_ids[0].clone());
-        for i in 1..commit_ids.len() {
+    #[derive(Debug)]
+    struct WorkItem {
+        commit_ids: Vec<CommitId>,
+        result: Merge<CommitId>,
+        pos: usize,
+    }
+
+    impl WorkItem {
+        fn new(commit_ids: Vec<CommitId>) -> Self {
+            let result = Merge::resolved(commit_ids[0].clone());
+            Self {
+                commit_ids,
+                result,
+                pos: 1,
+            }
+        }
+
+        fn merge_next(&mut self, ancestor: Merge<CommitId>) {
+            let dummy = Merge::resolved(CommitId::new(vec![]));
+            let result = mem::replace(&mut self.result, dummy);
+            let other = Merge::resolved(self.commit_ids[self.pos].clone());
+            self.result = Merge::from_vec(vec![result, ancestor, other]).flatten();
+            self.pos += 1;
+        }
+    }
+
+    let maybe_resolved = |commit_ids: Vec<CommitId>| match commit_ids.len() {
+        0 => Ok(Merge::resolved(store.root_commit_id().clone())),
+        1 => Ok(Merge::resolved(commit_ids.into_iter().next().unwrap())),
+        _ => Err(commit_ids),
+    };
+
+    // Execute recursion without using the call stack:
+    // ```
+    // let mut result = Merge::resolved(commit_ids[0].clone());
+    // for pos in 1..commit_ids.len() {
+    //     let ancestor_ids = index.common_ancestors(&commit_ids[0..pos], &commit_ids[pos..][..1])?;
+    //     let ancestor = find_recursive_merge_commits(store, index, ancestor_ids)?;
+    //     let other = Merge::resolved(commit_ids[pos].clone());
+    //     result = Merge::from_vec(vec![result, ancestor, other]).flatten();
+    // }
+    // ```
+    let mut stack = Vec::new();
+    match maybe_resolved(commit_ids) {
+        Ok(result) => return Ok(result),
+        Err(commit_ids) => stack.push(WorkItem::new(commit_ids)),
+    }
+    loop {
+        let top = stack.last_mut().unwrap();
+        if top.pos < top.commit_ids.len() {
             let ancestor_ids = index
-                .common_ancestors(&commit_ids[0..i], &commit_ids[i..][..1])
+                .common_ancestors(&top.commit_ids[0..top.pos], &top.commit_ids[top.pos..][..1])
                 // TODO: indexing error shouldn't be a "BackendError"
                 .map_err(|err| BackendError::Other(err.into()))?;
-            let ancestor = find_recursive_merge_commits(store, index, ancestor_ids)?;
-            let other = Merge::resolved(commit_ids[i].clone());
-            result = Merge::from_vec(vec![result, ancestor, other]).flatten();
+            match maybe_resolved(ancestor_ids) {
+                Ok(ancestor) => top.merge_next(ancestor),
+                Err(ancestor_ids) => stack.push(WorkItem::new(ancestor_ids)),
+            }
+        } else {
+            let ancestor = stack.pop().unwrap();
+            let Some(top) = stack.last_mut() else {
+                return Ok(ancestor.result);
+            };
+            top.merge_next(ancestor.result);
         }
-        Ok(result)
     }
 }
 

--- a/lib/src/rewrite.rs
+++ b/lib/src/rewrite.rs
@@ -104,26 +104,22 @@ pub async fn merge_commit_trees_no_resolve_without_repo(
 pub fn find_recursive_merge_commits(
     store: &Arc<Store>,
     index: &dyn Index,
-    mut commit_ids: Vec<CommitId>,
+    commit_ids: Vec<CommitId>,
 ) -> BackendResult<Merge<CommitId>> {
     if commit_ids.is_empty() {
         Ok(Merge::resolved(store.root_commit_id().clone()))
     } else if commit_ids.len() == 1 {
-        Ok(Merge::resolved(commit_ids.pop().unwrap()))
+        Ok(Merge::resolved(commit_ids.into_iter().next().unwrap()))
     } else {
         let mut result = Merge::resolved(commit_ids[0].clone());
-        for (i, other_commit_id) in commit_ids.iter().enumerate().skip(1) {
+        for i in 1..commit_ids.len() {
             let ancestor_ids = index
                 .common_ancestors(&commit_ids[0..i], &commit_ids[i..][..1])
                 // TODO: indexing error shouldn't be a "BackendError"
                 .map_err(|err| BackendError::Other(err.into()))?;
-            let ancestor_merge = find_recursive_merge_commits(store, index, ancestor_ids)?;
-            result = Merge::from_vec(vec![
-                result,
-                ancestor_merge,
-                Merge::resolved(other_commit_id.clone()),
-            ])
-            .flatten();
+            let ancestor = find_recursive_merge_commits(store, index, ancestor_ids)?;
+            let other = Merge::resolved(commit_ids[i].clone());
+            result = Merge::from_vec(vec![result, ancestor, other]).flatten();
         }
         Ok(result)
     }

--- a/lib/tests/test_rewrite.rs
+++ b/lib/tests/test_rewrite.rs
@@ -137,19 +137,30 @@ fn test_find_recursive_merge_commits() -> TestResult {
     let test_repo = TestRepo::init();
     let repo = &test_repo.repo;
 
+    // G H I
+    // |X|X|
+    // D E F
+    // |X|/
+    // B C
+    // |/
+    // A
     let mut tx = repo.start_transaction();
     let commit_a = write_random_commit(tx.repo_mut());
     let commit_b = write_random_commit_with_parents(tx.repo_mut(), &[&commit_a]);
     let commit_c = write_random_commit_with_parents(tx.repo_mut(), &[&commit_a]);
     let commit_d = write_random_commit_with_parents(tx.repo_mut(), &[&commit_b, &commit_c]);
     let commit_e = write_random_commit_with_parents(tx.repo_mut(), &[&commit_b, &commit_c]);
+    let commit_f = write_random_commit_with_parents(tx.repo_mut(), &[&commit_c]);
+    let commit_g = write_random_commit_with_parents(tx.repo_mut(), &[&commit_d, &commit_e]);
+    let commit_h =
+        write_random_commit_with_parents(tx.repo_mut(), &[&commit_d, &commit_e, &commit_f]);
+    let commit_i = write_random_commit_with_parents(tx.repo_mut(), &[&commit_e, &commit_f]);
 
     let commit_id_merge = find_recursive_merge_commits(
         tx.repo().store(),
         tx.repo().index(),
         vec![commit_d.id().clone(), commit_e.id().clone()],
     )?;
-
     assert_eq!(
         commit_id_merge,
         Merge::from_vec(vec![
@@ -160,6 +171,33 @@ fn test_find_recursive_merge_commits() -> TestResult {
             commit_e.id().clone(),
         ])
     );
+
+    let commit_id_merge = find_recursive_merge_commits(
+        tx.repo().store(),
+        tx.repo().index(),
+        vec![
+            commit_g.id().clone(),
+            commit_h.id().clone(),
+            commit_i.id().clone(),
+        ],
+    )?;
+    assert_eq!(
+        commit_id_merge,
+        Merge::from_vec(vec![
+            commit_g.id().clone(),
+            commit_a.id().clone(),
+            commit_b.id().clone(),
+            commit_d.id().clone(),
+            commit_c.id().clone(),
+            commit_e.id().clone(),
+            commit_h.id().clone(),
+            commit_e.id().clone(),
+            commit_c.id().clone(),
+            commit_f.id().clone(),
+            commit_i.id().clone(),
+        ])
+    );
+
     Ok(())
 }
 


### PR DESCRIPTION
# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [ ] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
