### PR TITLE
diff: preserve shared suffixes for prefixed lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed bugs
 
+* Color-words diffs now keep shared line suffixes unstyled when only a prefix
+  was added or removed.
+  [#9914](https://github.com/jj-vcs/jj/issues/9914)
+
 * Recursive alias definitions are detected more precisely. jj can now expand
   aliases that are simply repeated. For example, with the alias `jj = []`, the
   command `jj jj jj` will resolve to `jj`. Aliases can also fall back to the

--- a/cli/src/diff_util.rs
+++ b/cli/src/diff_util.rs
@@ -1198,6 +1198,43 @@ fn show_color_words_inline_hunks(
     line_hunks: &[(DiffLineHunkSide, &BStr)],
     labels: Diff<&str>,
 ) -> io::Result<()> {
+    // A multi-line word diff can fail to find an anchor for a line that
+    // differs only by a prefix. Refine that pair so the suffix stays unstyled.
+    if let &[
+        (DiffLineHunkSide::Left, left),
+        (DiffLineHunkSide::Right, right),
+    ] = line_hunks
+    {
+        let left_content = strip_line_ending(left);
+        let right_content = strip_line_ending(right);
+        if let Some(prefix) = right_content.strip_suffix(left_content)
+            && !prefix.is_empty()
+        {
+            formatter
+                .labeled(labels.after)
+                .labeled("token")
+                .write_all(prefix)?;
+            formatter.write_all(&right[prefix.len()..])?;
+            if !right.ends_with(b"\n") {
+                writeln!(formatter)?;
+            }
+            return Ok(());
+        }
+        if let Some(prefix) = left_content.strip_suffix(right_content)
+            && !prefix.is_empty()
+        {
+            formatter
+                .labeled(labels.before)
+                .labeled("token")
+                .write_all(prefix)?;
+            formatter.write_all(&left[prefix.len()..])?;
+            if !left.ends_with(b"\n") {
+                writeln!(formatter)?;
+            }
+            return Ok(());
+        }
+    }
+
     for (side, data) in line_hunks {
         let label = match side {
             DiffLineHunkSide::Both => None,
@@ -1215,6 +1252,14 @@ fn show_color_words_inline_hunks(
         writeln!(formatter)?;
     }
     Ok(())
+}
+
+fn strip_line_ending(data: &BStr) -> &[u8] {
+    if let Some(data) = data.strip_suffix(b"\n") {
+        data.strip_suffix(b"\r").unwrap_or(data)
+    } else {
+        data
+    }
 }
 
 /// Prints left/right-only line tokens with the given label.

--- a/cli/tests/test_diff_command.rs
+++ b/cli/tests/test_diff_command.rs
@@ -2493,6 +2493,59 @@ fn test_diff_leading_trailing_context() {
 }
 
 #[test]
+fn test_diff_color_words_materialized_conflict_repeated_lines() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    work_dir.write_file("file", "start\nend\n");
+    work_dir.run_jj(["commit", "-m", "A"]).success();
+    work_dir.write_file(
+        "file",
+        indoc! {"
+            start
+              {
+                one,
+              },
+              {
+                two,
+              },
+            end
+        "},
+    );
+    work_dir.run_jj(["commit", "-m", "L"]).success();
+    work_dir.run_jj(["new", r#"subject("A")"#]).success();
+    work_dir.write_file(
+        "file",
+        indoc! {"
+            start
+              {
+                three,
+              },
+              {
+                four,
+              },
+              {
+                five,
+              },
+            end
+        "},
+    );
+    work_dir.run_jj(["commit", "-m", "M"]).success();
+    work_dir
+        .run_jj(["rebase", "-s", r#"subject("M")"#, "-d", r#"subject("L")"#])
+        .success();
+
+    let output = work_dir.run_jj(["diff", "--color=debug", "-r", r#"subject("M")"#]);
+    let output = strip_ansi_escape_codes(output.stdout.into_raw());
+    let repeated_line = output
+        .lines()
+        .find(|line| line.contains("removed line_number::   7"))
+        .unwrap();
+    insta::assert_snapshot!(repeated_line, @"<<diff color_words removed line_number::   7>><<diff color_words:: >><<diff color_words added line_number::  10>><<diff color_words::: >><<diff color_words added token::+>><<diff color_words::  },>>");
+}
+
+#[test]
 fn test_diff_conflict_sides_differ() {
     let test_env = TestEnvironment::default();
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();


### PR DESCRIPTION
Alternative to #9915. This takes a narrower approach by keeping the correction in the color-words renderer instead of changing the general diff matching algorithm.

  When an inline diff line consists of one removed and one added hunk, and one side differs only by a prefix, only that prefix is styled as changed. The shared suffix remains unstyled.

  Fixes #9914.

  # Checklist

  - [x] I have updated `CHANGELOG.md`
  - [x] I have added/updated tests to cover my changes
  - [x] I fully understand the code that I am submitting (what it does,
        how it works, how it's organized), including any code drafted by an LLM.
  - [ ] For any prose generated by an LLM, I have proof-read and copy-edited it.