### PR TITLE
docs: Clarify that `JJ_CONFIG` only overrides user configs

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -2239,21 +2239,27 @@ with the `JJ_CONFIG` environment variable. If the environment variable is set
 the default locations. It can be a path to a TOML file or a directory of TOML
 files, which will be loaded in lexicographic order and merged. Multiple paths
 can be specified by separating them with a platform-specific path separator (`:`
-on Unix-like systems, `;` on Windows).
+on Unix-like systems, `;` on Windows). Note that this variable only affects
+user-level and system-level config files; repo and workspace configs are
+unaffected and will continue to be loaded from their respective locations.
+(There is no environment variable to disable repo or workspace configs.)
 
-For example, the following could be used to run `jj` without loading any user
-configs:
+For example, the following could be used to run `jj` without loading any user or
+system configs:
 
 ```bash
-JJ_CONFIG= jj log       # Ignores any settings specified in any config files.
+# Ignores any settings specified in `{PLATFORM,/etc}/jj/{config.toml,conf.d/*.toml}`,
+# but still loads repo and workspace configs.
+JJ_CONFIG= jj log
 ```
 
 There are also the `--config-file <PATH>` and `--config <NAME=VALUE>`
-[global options](./cli-reference.md#options) which work with any `jj` command.
+[global options](#specifying-config-on-the-command-line) which work with any
+`jj` command.
 
 ### System config files
 
-On unix-like platforms, system-wide `jj` configurations are by default loaded in
+On Unix-like platforms, system-wide `jj` configurations are by default loaded in
 the following precedence order (with later configs overriding earlier ones).
 
 - `/etc/jj/config.toml`
@@ -2308,12 +2314,12 @@ config files or environment variables. For example,
 jj --config ui.color=always --config ui.diff-editor=meld split
 ```
 
-Config value should be specified as a TOML expression. If string value isn't
-enclosed by any TOML constructs (such as array notation), quotes can be omitted.
-Here is an example with more advanced TOML constructs:
+The config value should be specified as a TOML expression. If it is a string
+value and isn't enclosed by any TOML constructs (such as array notation), quotes
+can be omitted. Here is an example with more advanced TOML constructs:
 
 ```shell
-# Single quotes and the '\' are interpreted by the shell and assume a Unix shell
+# Single quotes and the '\' are interpreted by the shell (assuming a POSIX shell)
 # Double quotes are passed to jj and are parsed as TOML syntax
 jj log --config \
   'template-aliases."format_timestamp(timestamp)"="""timestamp.format("%Y-%m-%d %H:%M %:::z")"""'


### PR DESCRIPTION
This environment variable does not override repo or workspace configs, so cannot be used as a "clean slate for `jj`". This change updates the documentation to be clearer regarding the current implementation.

This specifically changes the comment in the `JJ_CONFIG= jj log` example from 8ccd0e91ab4a1f50ee5bd0b4c508baaac5be52b3, which was inaccurate.

Addresses #9458.

cc @jordandews in case you have any wording suggestions.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [ ] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
