### PR TITLE
working_copy: Add `LockedWorkingCopy::set_workspace_annotations` hook

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -141,6 +141,7 @@ use jj_lib::working_copy::SnapshotStats;
 use jj_lib::working_copy::UntrackedReason;
 use jj_lib::working_copy::WorkingCopy;
 use jj_lib::working_copy::WorkingCopyFactory;
+use jj_lib::working_copy::WorkspaceAnnotations;
 use jj_lib::working_copy::WorkingCopyFreshness;
 use jj_lib::workspace::DefaultWorkspaceLoaderFactory;
 use jj_lib::workspace::LockedWorkspace;
@@ -2136,6 +2137,14 @@ to the current parents may contain changes from multiple commits.
             }
             mut_repo
                 .set_wc_commit(workspace_name, new_wc_commit.id().clone())
+                .map_err(snapshot_command_error)?;
+            let annotations = WorkspaceAnnotations {
+                commit_id: Some(new_wc_commit.id()),
+            };
+            locked_ws
+                .locked_wc()
+                .set_workspace_annotations(annotations)
+                .await
                 .map_err(snapshot_command_error)?;
 
             // Rebase descendants

--- a/lib/src/working_copy.rs
+++ b/lib/src/working_copy.rs
@@ -27,6 +27,7 @@ use thiserror::Error;
 use tracing::instrument;
 
 use crate::backend::BackendError;
+use crate::backend::CommitId;
 use crate::commit::Commit;
 use crate::gitignore::GitIgnoreError;
 use crate::gitignore::GitIgnoreFile;
@@ -105,6 +106,14 @@ pub trait WorkingCopyFactory {
     ) -> Result<Box<dyn WorkingCopy>, WorkingCopyStateError>;
 }
 
+/// Annotations and metadata associated with a working-copy checkout.
+#[derive(Debug, Clone, Default)]
+pub struct WorkspaceAnnotations<'a> {
+    /// The working-copy commit ID associated with this checkout, if one was
+    /// created or updated.
+    pub commit_id: Option<&'a CommitId>,
+}
+
 /// A working copy that's being modified.
 #[async_trait]
 pub trait LockedWorkingCopy: Any + Send {
@@ -128,6 +137,16 @@ pub trait LockedWorkingCopy: Any + Send {
 
     /// Update to another commit without touching the files in the working copy.
     async fn reset(&mut self, commit: &Commit) -> Result<(), ResetError>;
+
+    /// Notify the locked working copy of updated workspace annotations.
+    async fn set_workspace_annotations(
+        &mut self,
+        _annotations: WorkspaceAnnotations<'_>,
+    ) -> Result<(), ResetError> {
+        // Default no-op for backends that don't track annotations in their checkout
+        // state.
+        Ok(())
+    }
 
     /// Update to another commit without touching the files in the working copy,
     /// without assuming that the previous tree exists.


### PR DESCRIPTION
This introduces a mechanism to pass metadata and annotations to a working-copy backend when its checkout is updated.

Specifically:
- Adds a `WorkspaceAnnotations` struct to hold the checkout metadata (currently the associated `CommitId`).
- Adds a `set_workspace_annotations` method to the `LockedWorkingCopy` trait, allowing backends to be notified of these updates. It defaults to a no-op for backends that do not track this state (like `LocalWorkingCopy`).
- Invokes this new hook during `snapshot_working_copy` in the CLI after the working-copy commit is updated.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [ ] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
