### PR TITLE
docs: Clarify git.sign-on-push documented behavior

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -1727,12 +1727,8 @@ to do with signing commits on modification of a change (e.g., rebasing or edits)
 - `force`: sign all commits after modification, always, even if you are not the
   author.
 
-Instead of signing all commits during creation when `signing.behavior` is
-set to `own`, the `git.sign-on-push` configuration can be used to sign
-commits only upon running `jj git push`. All mutable unsigned commits
-being pushed will be signed prior to pushing. This might be preferred if the
-signing backend requires user interaction or is slow, so that signing is
-performed in a single batch operation.
+To sign commits only when pushing, set `signing.behavior = "drop"` and
+`git.sign-on-push = true`:
 
 ```toml
 # Configure signing backend as before, but lazily signing only on push.
@@ -1744,6 +1740,16 @@ key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGj+J6N6SO+4P8dOZqfR1oiay2yxhhHnagH52
 [git]
 sign-on-push = true
 ```
+
+With this setup, commits are not signed when they are created or rewritten. At
+push time, jj signs unsigned mutable commits authored by you. Push-time signing
+behaves like `own` even though write-time signing uses `drop`.
+
+This is useful when the signing backend requires user interaction or is slow,
+because the signing work is deferred to push time. If `signing.behavior` is set
+to `own` or `force`, commits may already be signed when written, and
+`git.sign-on-push` would have little or nothing left to sign. Existing signed
+commits are not re-signed on push.
 
 ## Commit Signature Verification
 


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# What?

This is a very short documentation rewrite for clarifying the behavior of push-time signing, and explaining that for being effective it requires the `drop` signing behavior.

# Why?

The current documentation doesn't make it clear that for git.sign-on-push to be really effective, the `drop` behavior has to be selected, even though the example shows it. 

# Checklist

If applicable:

- ~~[ ] I have updated `CHANGELOG.md`~~
- [X] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- ~~[ ] I have updated the config schema (`cli/src/config-schema.json`)~~
- ~~[ ] I have added/updated tests to cover my changes~~
- ~~[ ] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.~~
- [X] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
