### PR TITLE
changelog: Move entry to unreleased section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### New features
 
+* `jj bisect` will now mention when it cannot unambiguously find the first bad
+  revision due to skips in evaluation.
+
 ### Fixed bugs
 
 ## [0.44.0] - 2026-08-05
@@ -110,9 +113,6 @@ None
   This is useful when you only want to absorb *part* of a commit without first
   splitting it. Any hunks that are not selected or cannot be absorbed remain in
   the source commit.
-
-* `jj bisect` will now mention when it cannot unambiguously find the first bad revision
-  due to skips in evaluation.
 
 ### Fixed bugs
 


### PR DESCRIPTION
f3b6c3bf2f30aa34b99dec0ec6e7319b0d6b1850 was merged after the new release in af45d57de7163cc5f17f3df178a31577e4951ea3, but the changelog entry remained in the previous section.