### PR TITLE
git_backend: Avoid double-computing the `gix::Hash::Oid`

### DIFF
--- a/lib/src/git_backend.rs
+++ b/lib/src/git_backend.rs
@@ -538,10 +538,10 @@ impl GitBackend {
 
         let locked_repo = self.lock_git_repo();
         if !locked_repo.objects.exists(&oid) {
-            // write_buf recomputes the hash; gix does the same in write_blob.
+            // re-use the precomputed hash, to avoid that Gix recomputes it.
             let write_oid = locked_repo
                 .objects
-                .write_buf(gix::objs::Kind::Blob, bytes)
+                .write_buf_with_known_id(gix::objs::Kind::Blob, bytes, oid)
                 .map_err(|err| BackendError::WriteObject {
                     object_type,
                     source: err,

--- a/lib/src/git_backend.rs
+++ b/lib/src/git_backend.rs
@@ -538,10 +538,11 @@ impl GitBackend {
 
         let locked_repo = self.lock_git_repo();
         if !locked_repo.objects.exists(&oid) {
-            // write_buf recomputes the hash; gix does the same in write_blob.
+            // reuse the precomputed hash, since Gitoxide provides an API for it (otherwise
+            // Gitoxide recomputes it).
             let write_oid = locked_repo
                 .objects
-                .write_buf(gix::objs::Kind::Blob, bytes)
+                .write_buf_with_known_id(gix::objs::Kind::Blob, bytes, oid)
                 .map_err(|err| BackendError::WriteObject {
                     object_type,
                     source: err,


### PR DESCRIPTION
This should be a small improvement in larger repos such as firefox/firefox or llvm-project/llvm. See 713a0d0898448392 and its PR where we discussed having this API in Gitoxide.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [ ] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
