### PR TITLE
object_id: back id types by `Box<[u8]>` instead of `Vec<u8>`

### DIFF
--- a/cli/src/commit_ref_list.rs
+++ b/cli/src/commit_ref_list.rs
@@ -313,9 +313,9 @@ mod tests {
         Arc::new(backend::Commit {
             parents: vec![],
             predecessors: vec![],
-            root_tree: Merge::resolved(TreeId::new(vec![])),
+            root_tree: Merge::resolved(TreeId::from_vec(vec![])),
             conflict_labels: Merge::resolved(String::new()),
-            change_id: ChangeId::new(vec![]),
+            change_id: ChangeId::from_vec(vec![]),
             description: String::new(),
             author,
             committer,
@@ -335,7 +335,7 @@ mod tests {
     }
 
     fn commit_id_generator() -> impl FnMut() -> CommitId {
-        let mut iter = (1_u128..).map(|n| CommitId::new(n.to_le_bytes().into()));
+        let mut iter = (1_u128..).map(|n| CommitId::from_vec(n.to_le_bytes().into()));
         move || iter.next().unwrap()
     }
 

--- a/lib/src/backend.rs
+++ b/lib/src/backend.rs
@@ -74,7 +74,7 @@ id_type!(
 impl ChangeId {
     /// Parses the given "reverse" hex string into a `ChangeId`.
     pub fn try_from_reverse_hex(hex: impl AsRef<[u8]>) -> Option<Self> {
-        hex_util::decode_reverse_hex(hex).map(Self)
+        hex_util::decode_reverse_hex(hex).map(Self::from_vec)
     }
 
     /// Returns the hex string representation of this ID, which uses `z-k`
@@ -89,7 +89,7 @@ impl CopyId {
     /// id yet.
     // TODO: Delete this
     pub fn placeholder() -> Self {
-        Self::new(vec![])
+        Self::from_vec(vec![])
     }
 }
 

--- a/lib/src/content_hash.rs
+++ b/lib/src/content_hash.rs
@@ -104,6 +104,12 @@ impl<T: ContentHash> ContentHash for Vec<T> {
     }
 }
 
+impl<T: ContentHash + ?Sized> ContentHash for Box<T> {
+    fn hash(&self, state: &mut impl DigestUpdate) {
+        (**self).hash(state);
+    }
+}
+
 impl ContentHash for str {
     fn hash(&self, state: &mut impl DigestUpdate) {
         self.as_bytes().hash(state);

--- a/lib/src/default_index/bit_set.rs
+++ b/lib/src/default_index/bit_set.rs
@@ -211,13 +211,13 @@ mod tests {
 
     /// Generator of unique 16-byte CommitId excluding root id
     fn commit_id_generator() -> impl FnMut() -> CommitId {
-        let mut iter = (1_u128..).map(|n| CommitId::new(n.to_le_bytes().into()));
+        let mut iter = (1_u128..).map(|n| CommitId::from_vec(n.to_le_bytes().into()));
         move || iter.next().unwrap()
     }
 
     /// Generator of unique 16-byte ChangeId excluding root id
     fn change_id_generator() -> impl FnMut() -> ChangeId {
-        let mut iter = (1_u128..).map(|n| ChangeId::new(n.to_le_bytes().into()));
+        let mut iter = (1_u128..).map(|n| ChangeId::from_vec(n.to_le_bytes().into()));
         move || iter.next().unwrap()
     }
 

--- a/lib/src/default_index/mod.rs
+++ b/lib/src/default_index/mod.rs
@@ -89,13 +89,13 @@ mod tests {
 
     /// Generator of unique 16-byte CommitId excluding root id
     fn commit_id_generator() -> impl FnMut() -> CommitId {
-        let mut iter = (1_u128..).map(|n| CommitId::new(n.to_le_bytes().into()));
+        let mut iter = (1_u128..).map(|n| CommitId::from_vec(n.to_le_bytes().into()));
         move || iter.next().unwrap()
     }
 
     /// Generator of unique 16-byte ChangeId excluding root id
     fn change_id_generator() -> impl FnMut() -> ChangeId {
-        let mut iter = (1_u128..).map(|n| ChangeId::new(n.to_le_bytes().into()));
+        let mut iter = (1_u128..).map(|n| ChangeId::from_vec(n.to_le_bytes().into()));
         move || iter.next().unwrap()
     }
 

--- a/lib/src/default_index/rev_walk.rs
+++ b/lib/src/default_index/rev_walk.rs
@@ -704,7 +704,7 @@ mod tests {
 
     /// Generator of unique 16-byte ChangeId excluding root id
     fn change_id_generator() -> impl FnMut() -> ChangeId {
-        let mut iter = (1_u128..).map(|n| ChangeId::new(n.to_le_bytes().into()));
+        let mut iter = (1_u128..).map(|n| ChangeId::from_vec(n.to_le_bytes().into()));
         move || iter.next().unwrap()
     }
 

--- a/lib/src/default_index/revset_engine.rs
+++ b/lib/src/default_index/revset_engine.rs
@@ -1593,7 +1593,7 @@ mod tests {
 
     /// Generator of unique 16-byte ChangeId excluding root id
     fn change_id_generator() -> impl FnMut() -> ChangeId {
-        let mut iter = (1_u128..).map(|n| ChangeId::new(n.to_le_bytes().into()));
+        let mut iter = (1_u128..).map(|n| ChangeId::from_vec(n.to_le_bytes().into()));
         move || iter.next().unwrap()
     }
 

--- a/lib/src/default_index/store.rs
+++ b/lib/src/default_index/store.rs
@@ -192,14 +192,14 @@ impl DefaultIndexStore {
             .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))
             .context(&op_link_file)
             .map_err(DefaultIndexStoreError::LoadAssociation)?;
-        let commit_segment_id = CommitIndexSegmentId::new(proto.commit_segment_id);
+        let commit_segment_id = CommitIndexSegmentId::from_vec(proto.commit_segment_id);
         let changed_path_start_commit_pos = proto
             .changed_path_start_commit_pos
             .map(GlobalCommitPosition);
         let changed_path_segment_ids = proto
             .changed_path_segment_ids
             .into_iter()
-            .map(ChangedPathIndexSegmentId::new)
+            .map(ChangedPathIndexSegmentId::from_vec)
             .collect_vec();
 
         let commits = ReadonlyCommitIndexSegment::load(

--- a/lib/src/git_backend.rs
+++ b/lib/src/git_backend.rs
@@ -729,7 +729,7 @@ pub fn synthetic_change_id_from_git_commit_id(id: &CommitId) -> ChangeId {
         .rev()
         .map(|b| b.reverse_bits())
         .collect();
-    ChangeId::new(bytes)
+    ChangeId::from_vec(bytes)
 }
 
 const EMPTY_STRING_PLACEHOLDER: &str = "JJ_EMPTY_STRING";
@@ -798,7 +798,7 @@ fn serialize_extras(commit: &Commit) -> Vec<u8> {
 fn deserialize_extras(commit: &mut Commit, bytes: &[u8]) {
     let proto = crate::protos::git_store::Commit::decode(bytes).unwrap();
     if !proto.change_id.is_empty() {
-        commit.change_id = ChangeId::new(proto.change_id);
+        commit.change_id = ChangeId::from_vec(proto.change_id);
     }
     if commit.root_tree.is_resolved()
         && proto.uses_tree_conflict_format
@@ -1074,7 +1074,7 @@ impl Backend for GitBackend {
         contents.read_to_end(&mut bytes).await.unwrap();
 
         let oid = self.write_blob(&bytes, "file")?;
-        Ok(FileId::new(oid.as_bytes().to_vec()))
+        Ok(FileId::from_vec(oid.as_bytes().to_vec()))
     }
 
     async fn read_symlink(&self, _path: &RepoPath, id: &SymlinkId) -> BackendResult<String> {
@@ -1092,7 +1092,7 @@ impl Backend for GitBackend {
 
     async fn write_symlink(&self, _path: &RepoPath, target: &str) -> BackendResult<SymlinkId> {
         let oid = self.write_blob(target.as_bytes(), "symlink")?;
-        Ok(SymlinkId::new(oid.as_bytes().to_vec()))
+        Ok(SymlinkId::from_vec(oid.as_bytes().to_vec()))
     }
 
     async fn read_copy(&self, _id: &CopyId) -> BackendResult<CopyHistory> {
@@ -2296,7 +2296,7 @@ mod tests {
             predecessors: vec![],
             root_tree: Merge::resolved(backend.empty_tree_id().clone()),
             conflict_labels: Merge::resolved(String::new()),
-            change_id: ChangeId::new(vec![42; 16]),
+            change_id: ChangeId::from_vec(vec![42; 16]),
             description: "initial".to_string(),
             author: signature.clone(),
             committer: signature,
@@ -2469,7 +2469,7 @@ mod tests {
             predecessors: vec![],
             root_tree: Merge::resolved(backend.empty_tree_id().clone()),
             conflict_labels: Merge::resolved(String::new()),
-            change_id: ChangeId::new(vec![42; 16]),
+            change_id: ChangeId::from_vec(vec![42; 16]),
             description: "initial".to_string(),
             author: create_signature(),
             committer: create_signature(),

--- a/lib/src/local_working_copy.rs
+++ b/lib/src/local_working_copy.rs
@@ -1154,13 +1154,13 @@ impl TreeState {
         if proto.tree_ids.is_empty() {
             self.tree = MergedTree::resolved(
                 self.store.clone(),
-                TreeId::new(proto.legacy_tree_id.clone()),
+                TreeId::from_vec(proto.legacy_tree_id.clone()),
             );
         } else {
             let tree_ids_builder: MergeBuilder<TreeId> = proto
                 .tree_ids
                 .iter()
-                .map(|id| TreeId::new(id.clone()))
+                .map(|id| TreeId::from_vec(id.clone()))
                 .collect();
             self.tree = MergedTree::new(
                 self.store.clone(),
@@ -2575,7 +2575,7 @@ impl CheckoutState {
         let proto = crate::protos::local_working_copy::Checkout::decode(&*buf)
             .map_err(|err| wrap_err(err.into()))?;
         Ok(Self {
-            operation_id: OperationId::new(proto.operation_id),
+            operation_id: OperationId::from_vec(proto.operation_id),
             workspace_name: if proto.workspace_name.is_empty() {
                 // For compatibility with old working copies.
                 // TODO: Delete in mid 2022 or so

--- a/lib/src/object_id.rs
+++ b/lib/src/object_id.rs
@@ -27,9 +27,9 @@ pub trait ObjectId {
 }
 
 // Defines a new struct type with visibility `vis` and name `ident` containing
-// a single Vec<u8> used to store an identifier (typically the output of a hash
-// function) as bytes. Types defined using this macro automatically implement
-// the `ObjectId` and `ContentHash` traits.
+// a single Box<[u8]> used to store an identifier (typically the output of a
+// hash function) as bytes. Types defined using this macro automatically
+// implement the `ObjectId` and `ContentHash` traits.
 // Documentation comments written inside the macro definition will be captured
 // and associated with the type defined by the macro.
 //
@@ -46,7 +46,7 @@ macro_rules! id_type {
     ) => {
         $(#[$attr])*
         #[derive($crate::content_hash::ContentHash, PartialEq, Eq, PartialOrd, Ord, Clone, Hash)]
-        $vis struct $name(Vec<u8>);
+        $vis struct $name(Box<[u8]>);
         $crate::object_id::impl_id_type!($name, $hex_method);
     };
 }
@@ -56,13 +56,13 @@ macro_rules! impl_id_type {
         #[allow(dead_code)]
         impl $name {
             /// Creates a new instance of this id type from the given bytes.
-            pub fn new(value: Vec<u8>) -> Self {
-                Self(value)
+            pub fn from_vec(value: Vec<u8>) -> Self {
+                Self(value.into())
             }
 
             /// Creates a new instance of this id type from the given byte slice.
             pub fn from_bytes(bytes: &[u8]) -> Self {
-                Self(bytes.to_vec())
+                Self(bytes.into())
             }
 
             /// Parses the given hex string into an ObjectId.
@@ -75,7 +75,7 @@ macro_rules! impl_id_type {
 
             /// Parses the given hex string into an ObjectId.
             pub fn try_from_hex(hex: impl AsRef<[u8]>) -> Option<Self> {
-                $crate::hex_util::decode_hex(hex).map(Self)
+                $crate::hex_util::decode_hex(hex).map(Self::from_vec)
             }
         }
 
@@ -119,7 +119,7 @@ macro_rules! impl_id_type {
             }
 
             fn to_bytes(&self) -> Vec<u8> {
-                self.0.clone()
+                self.0.to_vec()
             }
 
             fn hex(&self) -> String {

--- a/lib/src/rewrite.rs
+++ b/lib/src/rewrite.rs
@@ -125,7 +125,7 @@ pub fn find_recursive_merge_commits(
         }
 
         fn merge_next(&mut self, ancestor: Merge<CommitId>) {
-            let dummy = Merge::resolved(CommitId::new(vec![]));
+            let dummy = Merge::resolved(CommitId::from_vec(vec![]));
             let result = mem::replace(&mut self.result, dummy);
             let other = Merge::resolved(self.commit_ids[self.pos].clone());
             self.result = Merge::from_vec(vec![result, ancestor, other]).flatten();

--- a/lib/src/settings.rs
+++ b/lib/src/settings.rs
@@ -301,7 +301,7 @@ impl JJRng {
     pub fn new_change_id(&self, length: usize) -> ChangeId {
         let mut rng = self.0.lock().unwrap();
         let random_bytes = (0..length).map(|_| rng.random::<u8>()).collect();
-        ChangeId::new(random_bytes)
+        ChangeId::from_vec(random_bytes)
     }
 
     /// Creates a new RNGs. Could be made public, but we'd like to encourage all

--- a/lib/src/simple_backend.rs
+++ b/lib/src/simple_backend.rs
@@ -217,7 +217,7 @@ impl Backend for SimpleBackend {
             hasher.update(bytes);
         }
         file.flush().map_err(to_other_err)?;
-        let id = FileId::new(hasher.finalize().to_vec());
+        let id = FileId::from_vec(hasher.finalize().to_vec());
 
         persist_content_addressed_temp_file(temp_file, self.file_path(&id))
             .map_err(to_other_err)?;
@@ -238,7 +238,7 @@ impl Backend for SimpleBackend {
             .map_err(to_other_err)?;
         let mut hasher = Blake2b512::new();
         hasher.update(target.as_bytes());
-        let id = SymlinkId::new(hasher.finalize().to_vec());
+        let id = SymlinkId::from_vec(hasher.finalize().to_vec());
 
         persist_content_addressed_temp_file(temp_file, self.symlink_path(&id))
             .map_err(to_other_err)?;
@@ -281,7 +281,7 @@ impl Backend for SimpleBackend {
             .write_all(&proto.encode_to_vec())
             .map_err(to_other_err)?;
 
-        let id = TreeId::new(blake2b_hash(tree).to_vec());
+        let id = TreeId::from_vec(blake2b_hash(tree).to_vec());
 
         persist_content_addressed_temp_file(temp_file, self.tree_path(&id))
             .map_err(to_other_err)?;
@@ -331,7 +331,7 @@ impl Backend for SimpleBackend {
             .write_all(&proto.encode_to_vec())
             .map_err(to_other_err)?;
 
-        let id = CommitId::new(blake2b_hash(&commit).to_vec());
+        let id = CommitId::from_vec(blake2b_hash(&commit).to_vec());
 
         persist_content_addressed_temp_file(temp_file, self.commit_path(&id))
             .map_err(to_other_err)?;
@@ -380,12 +380,17 @@ fn commit_from_proto(mut proto: crate::protos::simple_store::Commit) -> Commit {
         sig,
     });
 
-    let parents = proto.parents.into_iter().map(CommitId::new).collect();
-    let predecessors = proto.predecessors.into_iter().map(CommitId::new).collect();
-    let merge_builder: MergeBuilder<_> = proto.root_tree.into_iter().map(TreeId::new).collect();
+    let parents = proto.parents.into_iter().map(CommitId::from_vec).collect();
+    let predecessors = proto
+        .predecessors
+        .into_iter()
+        .map(CommitId::from_vec)
+        .collect();
+    let merge_builder: MergeBuilder<_> =
+        proto.root_tree.into_iter().map(TreeId::from_vec).collect();
     let root_tree = merge_builder.build();
     let conflict_labels = ConflictLabels::from_vec(proto.conflict_labels);
-    let change_id = ChangeId::new(proto.change_id);
+    let change_id = ChangeId::from_vec(proto.change_id);
     Commit {
         parents,
         predecessors,
@@ -461,7 +466,7 @@ fn tree_value_to_proto(value: &TreeValue) -> crate::protos::simple_store::TreeVa
 fn tree_value_from_proto(proto: crate::protos::simple_store::TreeValue) -> TreeValue {
     match proto.value.unwrap() {
         crate::protos::simple_store::tree_value::Value::TreeId(id) => {
-            TreeValue::Tree(TreeId::new(id))
+            TreeValue::Tree(TreeId::from_vec(id))
         }
         crate::protos::simple_store::tree_value::Value::File(
             crate::protos::simple_store::tree_value::File {
@@ -470,12 +475,12 @@ fn tree_value_from_proto(proto: crate::protos::simple_store::TreeValue) -> TreeV
                 copy_id,
             },
         ) => TreeValue::File {
-            id: FileId::new(id),
+            id: FileId::from_vec(id),
             executable,
-            copy_id: CopyId::new(copy_id),
+            copy_id: CopyId::from_vec(copy_id),
         },
         crate::protos::simple_store::tree_value::Value::SymlinkId(id) => {
-            TreeValue::Symlink(SymlinkId::new(id))
+            TreeValue::Symlink(SymlinkId::from_vec(id))
         }
     }
 }

--- a/lib/src/simple_op_heads_store.rs
+++ b/lib/src/simple_op_heads_store.rs
@@ -148,7 +148,7 @@ impl OpHeadsStore for SimpleOpHeadsStore {
                 )
             })?;
             if let Some(op_head) = hex_util::decode_hex(op_head_file_name) {
-                op_heads.push(OperationId::new(op_head));
+                op_heads.push(OperationId::from_vec(op_head));
             }
         }
         op_heads.sort();

--- a/lib/src/simple_op_store.rs
+++ b/lib/src/simple_op_store.rs
@@ -174,7 +174,7 @@ impl OpStore for SimpleOpStore {
             .context(temp_file.path())
             .map_err(|err| io_to_write_error(err, "view"))?;
 
-        let id = ViewId::new(blake2b_hash(view).to_vec());
+        let id = ViewId::from_vec(blake2b_hash(view).to_vec());
 
         let new_path = dir.join(id.hex());
         persist_content_addressed_temp_file(temp_file, &new_path)
@@ -219,7 +219,7 @@ impl OpStore for SimpleOpStore {
             .context(temp_file.path())
             .map_err(|err| io_to_write_error(err, "operation"))?;
 
-        let id = OperationId::new(blake2b_hash(operation).to_vec());
+        let id = OperationId::from_vec(blake2b_hash(operation).to_vec());
 
         let new_path = dir.join(id.hex());
         persist_content_addressed_temp_file(temp_file, &new_path)
@@ -408,7 +408,7 @@ fn operation_id_from_proto(bytes: Vec<u8>) -> Result<OperationId, PostDecodeErro
             actual: bytes.len(),
         })
     } else {
-        Ok(OperationId::new(bytes))
+        Ok(OperationId::from_vec(bytes))
     }
 }
 
@@ -419,7 +419,7 @@ fn view_id_from_proto(bytes: Vec<u8>) -> Result<ViewId, PostDecodeError> {
             actual: bytes.len(),
         })
     } else {
-        Ok(ViewId::new(bytes))
+        Ok(ViewId::from_vec(bytes))
     }
 }
 
@@ -494,11 +494,11 @@ fn commit_predecessors_map_from_proto(
     proto
         .into_iter()
         .map(|entry| {
-            let commit_id = CommitId::new(entry.commit_id);
+            let commit_id = CommitId::from_vec(entry.commit_id);
             let predecessor_ids = entry
                 .predecessor_ids
                 .into_iter()
-                .map(CommitId::new)
+                .map(CommitId::from_vec)
                 .collect();
             (commit_id, predecessor_ids)
         })
@@ -602,13 +602,13 @@ fn view_from_proto(proto: crate::protos::simple_op_store::View) -> Result<View, 
     if !proto.wc_commit_id.is_empty() {
         wc_commit_ids.insert(
             WorkspaceName::DEFAULT.to_owned(),
-            CommitId::new(proto.wc_commit_id),
+            CommitId::from_vec(proto.wc_commit_id),
         );
     }
     for (name, commit_id) in proto.wc_commit_ids {
-        wc_commit_ids.insert(WorkspaceNameBuf::from(name), CommitId::new(commit_id));
+        wc_commit_ids.insert(WorkspaceNameBuf::from(name), CommitId::from_vec(commit_id));
     }
-    let head_ids = proto.head_ids.into_iter().map(CommitId::new).collect();
+    let head_ids = proto.head_ids.into_iter().map(CommitId::from_vec).collect();
 
     let (local_bookmarks, mut remote_views) = bookmark_views_from_proto_legacy(proto.bookmarks)?;
 
@@ -631,7 +631,7 @@ fn view_from_proto(proto: crate::protos::simple_op_store::View) -> Result<View, 
             } else {
                 // Legacy format
                 #[expect(deprecated)]
-                RefTarget::normal(CommitId::new(git_ref.commit_id))
+                RefTarget::normal(CommitId::from_vec(git_ref.commit_id))
             };
             (name, target)
         })
@@ -671,7 +671,7 @@ fn view_from_proto(proto: crate::protos::simple_op_store::View) -> Result<View, 
     let git_head = if proto.git_head.is_some() {
         ref_target_from_proto(proto.git_head)
     } else if !proto.git_head_legacy.is_empty() {
-        RefTarget::normal(CommitId::new(proto.git_head_legacy))
+        RefTarget::normal(CommitId::from_vec(proto.git_head_legacy))
     } else {
         RefTarget::absent()
     };
@@ -832,7 +832,9 @@ fn ref_target_from_terms_proto(
 ) -> Result<RefTarget, PostDecodeError> {
     let terms: SmallVec<[_; 1]> = proto
         .into_iter()
-        .map(|crate::protos::simple_op_store::RefTargetTerm { value }| value.map(CommitId::new))
+        .map(|crate::protos::simple_op_store::RefTargetTerm { value }| {
+            value.map(CommitId::from_vec)
+        })
         .collect();
     if terms.len().is_multiple_of(2) {
         Err(PostDecodeError::EvenNumberOfRefTargetTerms(terms.len()))
@@ -903,18 +905,18 @@ fn ref_target_from_proto(
         #[expect(deprecated)]
         crate::protos::simple_op_store::ref_target::Value::CommitId(id) => {
             // Legacy non-conflicting id
-            RefTarget::normal(CommitId::new(id))
+            RefTarget::normal(CommitId::from_vec(id))
         }
         #[expect(deprecated)]
         crate::protos::simple_op_store::ref_target::Value::ConflictLegacy(conflict) => {
             // Legacy conflicting ids
-            let removes = conflict.removes.into_iter().map(CommitId::new);
-            let adds = conflict.adds.into_iter().map(CommitId::new);
+            let removes = conflict.removes.into_iter().map(CommitId::from_vec);
+            let adds = conflict.adds.into_iter().map(CommitId::from_vec);
             RefTarget::from_legacy_form(removes, adds)
         }
         crate::protos::simple_op_store::ref_target::Value::Conflict(conflict) => {
             let term_from_proto = |term: crate::protos::simple_op_store::ref_conflict::Term| {
-                term.value.map(CommitId::new)
+                term.value.map(CommitId::from_vec)
             };
             let removes = conflict.removes.into_iter().map(term_from_proto);
             let adds = conflict.adds.into_iter().map(term_from_proto);
@@ -1017,10 +1019,10 @@ mod tests {
             bytes
         };
         Operation {
-            view_id: ViewId::new(pad_id_bytes("aaa111", VIEW_ID_LENGTH)),
+            view_id: ViewId::from_vec(pad_id_bytes("aaa111", VIEW_ID_LENGTH)),
             parents: vec![
-                OperationId::new(pad_id_bytes("bbb111", OPERATION_ID_LENGTH)),
-                OperationId::new(pad_id_bytes("bbb222", OPERATION_ID_LENGTH)),
+                OperationId::from_vec(pad_id_bytes("bbb111", OPERATION_ID_LENGTH)),
+                OperationId::from_vec(pad_id_bytes("bbb222", OPERATION_ID_LENGTH)),
             ],
             metadata: OperationMetadata {
                 time: TimestampRange {
@@ -1057,7 +1059,7 @@ mod tests {
     fn test_hash_view() {
         // Test exact output so we detect regressions in compatibility
         assert_snapshot!(
-            ViewId::new(blake2b_hash(&create_view()).to_vec()).hex(),
+            ViewId::from_vec(blake2b_hash(&create_view()).to_vec()).hex(),
             @"2c0b174d117ca85e7faa96f6d997362403105e8eb31e7f82ac9abd3dc48ae62683e9a76ef5d117ebc8a743d17e1945236df9ccefd7574f7e4b5336a63796b967"
         );
     }
@@ -1066,7 +1068,7 @@ mod tests {
     fn test_hash_operation() {
         // Test exact output so we detect regressions in compatibility
         assert_snapshot!(
-            OperationId::new(blake2b_hash(&create_operation()).to_vec()).hex(),
+            OperationId::from_vec(blake2b_hash(&create_operation()).to_vec()).hex(),
             @"f5963c593a63bb852061a86ad919c12c6ba1940eeef30a832524c39ccea6a9f768aa2aa53becec34d379eb291ec6726837c4113857849cb9dcc62dbe0a517176"
         );
     }

--- a/lib/tests/test_commit_builder.rs
+++ b/lib/tests/test_commit_builder.rs
@@ -103,7 +103,7 @@ fn test_initial(backend: TestRepoBackend) -> TestResult {
             tz_offset: -60,
         },
     };
-    let change_id = ChangeId::new(vec![100u8; 16]);
+    let change_id = ChangeId::from_vec(vec![100u8; 16]);
     let builder = tx
         .repo_mut()
         .new_commit(vec![store.root_commit_id().clone()], tree.clone())

--- a/lib/tests/test_converge.rs
+++ b/lib/tests/test_converge.rs
@@ -60,7 +60,7 @@ use testutils::write_random_commit;
 use testutils::write_random_commit_with_parents;
 
 fn make_change_id(repo: &TestRepo, byte: u8) -> ChangeId {
-    ChangeId::new(vec![byte; repo.repo.store().change_id_length()])
+    ChangeId::from_vec(vec![byte; repo.repo.store().change_id_length()])
 }
 
 fn get_merged_tree_value(tree: &MergedTree, path: &str) -> TestResult<Option<TreeValue>> {

--- a/lib/tests/test_local_working_copy.rs
+++ b/lib/tests/test_local_working_copy.rs
@@ -1875,7 +1875,7 @@ fn test_git_submodule(gitignore_content: &str) -> TestResult {
         Merge::normal(TreeValue::File {
             id: testutils::write_file(repo.store(), added_path, "added\n"),
             executable: false,
-            copy_id: CopyId::new(vec![]),
+            copy_id: CopyId::from_vec(vec![]),
         }),
     );
 
@@ -1909,7 +1909,7 @@ fn test_git_submodule(gitignore_content: &str) -> TestResult {
                 "file with same path as submodule\n",
             ),
             executable: false,
-            copy_id: CopyId::new(vec![]),
+            copy_id: CopyId::from_vec(vec![]),
         }),
     );
     let tree_id3 = tree_builder.write_tree().block_on()?;

--- a/lib/tests/test_merged_tree.rs
+++ b/lib/tests/test_merged_tree.rs
@@ -739,9 +739,9 @@ fn create_copy_records(paths: &[(&RepoPath, &RepoPath)]) -> CopyRecords {
     copy_records.add_records(paths.iter().map(|&(source, target)| CopyRecord {
         source: source.to_owned(),
         target: target.to_owned(),
-        target_commit: CommitId::new(vec![]),
-        source_commit: CommitId::new(vec![]),
-        source_file: FileId::new(vec![]),
+        target_commit: CommitId::from_vec(vec![]),
+        source_commit: CommitId::from_vec(vec![]),
+        source_file: FileId::from_vec(vec![]),
     }));
     copy_records
 }

--- a/lib/tests/test_rewrite.rs
+++ b/lib/tests/test_rewrite.rs
@@ -2427,7 +2427,7 @@ fn test_find_duplicate_divergent_commits() -> TestResult {
     let mut make_commit = |change_id_byte, tree, parents| {
         tx.repo_mut()
             .new_commit(parents, tree)
-            .set_change_id(ChangeId::new(vec![
+            .set_change_id(ChangeId::from_vec(vec![
                 change_id_byte;
                 store.change_id_length()
             ]))

--- a/lib/testutils/src/test_backend.rs
+++ b/lib/testutils/src/test_backend.rs
@@ -131,7 +131,7 @@ impl TestBackend {
     pub fn with_data(data: Arc<Mutex<TestBackendData>>) -> Self {
         let root_commit_id = CommitId::from_bytes(&[0; HASH_LENGTH]);
         let root_change_id = ChangeId::from_bytes(&[0; CHANGE_ID_LENGTH]);
-        let empty_tree_id = TreeId::new(get_hash(&Tree::default()));
+        let empty_tree_id = TreeId::from_vec(get_hash(&Tree::default()));
         let runtime = Runtime::new().unwrap();
 
         Self {
@@ -237,7 +237,7 @@ impl Backend for TestBackend {
         let mut bytes = Vec::new();
         contents.read_to_end(&mut bytes).await.unwrap();
         self.run_async(move |mut data| {
-            let id = FileId::new(get_hash(&bytes));
+            let id = FileId::from_vec(get_hash(&bytes));
             data.files
                 .entry(path.clone())
                 .or_default()
@@ -269,7 +269,7 @@ impl Backend for TestBackend {
     }
 
     async fn write_symlink(&self, path: &RepoPath, target: &str) -> BackendResult<SymlinkId> {
-        let id = SymlinkId::new(get_hash(target.as_bytes()));
+        let id = SymlinkId::from_vec(get_hash(target.as_bytes()));
         let path = path.to_owned();
         let target = target.to_owned();
         self.run_async(move |mut data| {
@@ -302,7 +302,7 @@ impl Backend for TestBackend {
     async fn write_copy(&self, contents: &CopyHistory) -> BackendResult<CopyId> {
         let contents = contents.clone();
         self.run_async(move |mut data| {
-            let id = CopyId::new(get_hash(&contents));
+            let id = CopyId::from_vec(get_hash(&contents));
             data.copies.insert(id.clone(), contents);
             Ok(id)
         })
@@ -369,7 +369,7 @@ impl Backend for TestBackend {
         let path = path.to_owned();
         let contents = contents.clone();
         self.run_async(move |mut data| {
-            let id = TreeId::new(get_hash(&contents));
+            let id = TreeId::from_vec(get_hash(&contents));
             data.trees
                 .entry(path.clone())
                 .or_default()
@@ -412,7 +412,7 @@ impl Backend for TestBackend {
         }
 
         self.run_async(move |mut data| {
-            let id = CommitId::new(get_hash(&contents));
+            let id = CommitId::from_vec(get_hash(&contents));
             data.commits.insert(id.clone(), contents.clone());
             Ok((id, contents))
         })


### PR DESCRIPTION
The ids are immutable, so there is no need to track spare capacity. This makes each id type one `usize` smaller.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [ ] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
