### PR TITLE
cli: reset Git HEAD when updating a stale working copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   conflicted file is snapshotted from the working copy.
   [#9868](https://github.com/jj-vcs/jj/issues/9868)
 
+* In colocated workspaces, `jj workspace update-stale` now correctly resets the
+  Git HEAD to the parent of the fresh working-copy commit.
+  [#9936](https://github.com/jj-vcs/jj/issues/9936)
+
 ## [0.44.0] - 2026-08-05
 
 ### Release highlights

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   conflicted file is snapshotted from the working copy.
   [#9868](https://github.com/jj-vcs/jj/issues/9868)
 
+* In colocated workspaces, `jj workspace update-stale` now correctly resets the
+  Git HEAD to the parent of the fresh working-copy commit.
+  [#9936](https://github.com/jj-vcs/jj/issues/9936)
+
 ## [0.44.0] - 2026-08-05
 
 ### Release highlights

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -660,10 +660,17 @@ impl CommandHelper {
                 let WorkspaceCommandHelper { workspace, env, .. } = workspace_command;
                 let mut workspace_command = self.load_from_workspace(ui, workspace, env).await?;
 
-                let repo = workspace_command.repo().clone();
+                #[cfg_attr(not(feature = "git"), expect(unused_mut))]
+                let mut repo = workspace_command.repo().clone();
+                #[cfg(feature = "git")]
+                let colocated = workspace_command.working_copy_shared_with_git();
+                #[cfg(feature = "git")]
+                let workspace_name = workspace_command.workspace_name().to_owned();
+
                 let (mut locked_ws, desired_wc_commit) = workspace_command
                     .unchecked_start_working_copy_mutation()
                     .await?;
+
                 match WorkingCopyFreshness::check_stale(
                     locked_ws.locked_wc(),
                     &desired_wc_commit,
@@ -680,6 +687,23 @@ impl CommandHelper {
                     }
                     WorkingCopyFreshness::WorkingCopyStale
                     | WorkingCopyFreshness::SiblingOperation => {
+                        // Reset Git HEAD first if the repo is colocated
+                        #[cfg(feature = "git")]
+                        if colocated && self.should_commit_transaction() {
+                            let mut tx =
+                                start_repo_transaction(&repo, &workspace_name, self.string_args());
+                            try_reset_git_head(
+                                ui,
+                                tx.repo_mut(),
+                                &desired_wc_commit,
+                                git_import_export_lock,
+                            )
+                            .await?;
+                            if tx.repo().has_changes() {
+                                repo = self.maybe_commit_transaction(tx, "reset git head").await?;
+                            }
+                        }
+
                         let stats = update_stale_working_copy(
                             locked_ws,
                             repo.op_id().clone(),
@@ -687,6 +711,7 @@ impl CommandHelper {
                             &desired_wc_commit,
                         )
                         .await?;
+                        workspace_command.user_repo = ReadonlyUserRepo::new(repo);
                         workspace_command.print_updated_working_copy_stats(
                             ui,
                             Some(&stale_wc_commit),

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -660,7 +660,13 @@ impl CommandHelper {
                 let WorkspaceCommandHelper { workspace, env, .. } = workspace_command;
                 let mut workspace_command = self.load_from_workspace(ui, workspace, env).await?;
 
-                let repo = workspace_command.repo().clone();
+                #[cfg_attr(not(feature = "git"), expect(unused_mut))]
+                let mut repo = workspace_command.repo().clone();
+                #[cfg(feature = "git")]
+                let colocated = workspace_command.working_copy_shared_with_git();
+                #[cfg(feature = "git")]
+                let workspace_name = workspace_command.workspace_name().to_owned();
+
                 let (mut locked_ws, desired_wc_commit) = workspace_command
                     .unchecked_start_working_copy_mutation()
                     .await?;
@@ -680,6 +686,24 @@ impl CommandHelper {
                     }
                     WorkingCopyFreshness::WorkingCopyStale
                     | WorkingCopyFreshness::SiblingOperation => {
+                        // Reset Git HEAD first if the repo is colocated
+                        #[cfg(feature = "git")]
+                        if colocated && self.should_commit_transaction() {
+                            let mut tx =
+                                start_repo_transaction(&repo, &workspace_name, self.string_args());
+                            try_reset_git_head(
+                                ui,
+                                tx.repo_mut(),
+                                &workspace_name,
+                                &desired_wc_commit,
+                                git_import_export_lock,
+                            )
+                            .await?;
+                            if tx.repo().has_changes() {
+                                repo = self.maybe_commit_transaction(tx, "reset git head").await?;
+                            }
+                        }
+
                         let stats = update_stale_working_copy(
                             locked_ws,
                             repo.op_id().clone(),
@@ -687,6 +711,7 @@ impl CommandHelper {
                             &desired_wc_commit,
                         )
                         .await?;
+                        workspace_command.user_repo = ReadonlyUserRepo::new(repo);
                         workspace_command.print_updated_working_copy_stats(
                             ui,
                             Some(&stale_wc_commit),

--- a/cli/tests/test_git_colocated.rs
+++ b/cli/tests/test_git_colocated.rs
@@ -244,6 +244,60 @@ fn test_git_colocated_new_wc_commit_when_wc_immutable() {
 }
 
 #[test]
+fn test_git_colocated_update_stale_resets_git_head() {
+    let test_env = TestEnvironment::default();
+    test_env
+        .run_jj_in(".", ["git", "init", "--colocate", "repo"])
+        .success();
+    let work_dir = test_env.work_dir("repo");
+
+    // A "parent" commit and a "child" working-copy commit on top
+    work_dir.write_file("file1", "a\n");
+    work_dir.run_jj(["describe", "-m", "parent"]).success();
+    work_dir.run_jj(["new", "-m", "child"]).success();
+    work_dir.write_file("file2", "b\n");
+    work_dir.run_jj(["status"]).success();
+    insta::assert_snapshot!(get_colocation_status(&work_dir), @"
+    Workspace is currently colocated with Git.
+    Last imported/exported Git HEAD: df69548750502d54d6f207b500d25da43ed6fe1e
+    [EOF]
+    ");
+
+    // From another workspace, amend "parent" directly: this rebases "child"
+    // and makes the default (colocated) workspace stale
+    work_dir
+        .run_jj(["workspace", "add", "--name", "second", "../secondary"])
+        .success();
+    let secondary_dir = test_env.work_dir("secondary");
+    secondary_dir
+        .run_jj(["edit", r#"subject(exact:"parent")"#])
+        .success();
+    secondary_dir.write_file("file1", "a\nmodified\n");
+    secondary_dir.run_jj(["status"]).success();
+
+    let output = work_dir.run_jj(["workspace", "update-stale"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    Working copy  (@) now at: kkmpptxz 422aac81 child
+    Parent commit (@-)      : qpvuntsm 239acdab parent
+    Added 0 files, modified 1 files, removed 0 files
+    Updated working copy to fresh commit 422aac811963
+    [EOF]
+    ");
+
+    // Git HEAD should point to the amended "parent", not the stale one
+    insta::assert_snapshot!(get_colocation_status(&work_dir), @"
+    Workspace is currently colocated with Git.
+    Last imported/exported Git HEAD: 239acdab88e2b438ed43a99471a385d3832190ec
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_index_state(work_dir.root()), @"
+    Unconflicted Mode(FILE) 76b5eb87f1cb ctime=0:0 mtime=0:0 size=0 flags=0 file1
+    Unconflicted Mode(FILE) e69de29bb2d1 ctime=0:0 mtime=0:0 size=0 flags=20004000 file2
+    ");
+}
+
+#[test]
 fn test_git_colocated_unborn_bookmark() -> TestResult {
     let test_env = TestEnvironment::default();
     let work_dir = test_env.work_dir("repo");

--- a/cli/tests/test_git_colocated.rs
+++ b/cli/tests/test_git_colocated.rs
@@ -244,6 +244,60 @@ fn test_git_colocated_new_wc_commit_when_wc_immutable() {
 }
 
 #[test]
+fn test_git_colocated_update_stale_resets_git_head() {
+    let test_env = TestEnvironment::default();
+    test_env
+        .run_jj_in(".", ["git", "init", "--colocate", "repo"])
+        .success();
+    let work_dir = test_env.work_dir("repo");
+
+    // A "parent" commit and a "child" working-copy commit on top
+    work_dir.write_file("file1", "a\n");
+    work_dir.run_jj(["describe", "-m", "parent"]).success();
+    work_dir.run_jj(["new", "-m", "child"]).success();
+    work_dir.write_file("file2", "b\n");
+    work_dir.run_jj(["status"]).success();
+    insta::assert_snapshot!(get_colocation_status(&work_dir), @"
+    Workspace is currently colocated with Git.
+    Last imported/exported Git HEAD: df69548750502d54d6f207b500d25da43ed6fe1e
+    [EOF]
+    ");
+
+    // From another workspace, amend "parent" directly: this rebases "child"
+    // and makes the default (colocated) workspace stale
+    work_dir
+        .run_jj(["workspace", "add", "--name", "second", "../secondary"])
+        .success();
+    let secondary_dir = test_env.work_dir("secondary");
+    secondary_dir
+        .run_jj(["edit", r#"subject(parent)"#])
+        .success();
+    secondary_dir.write_file("file1", "a\nmodified\n");
+    secondary_dir.run_jj(["status"]).success();
+
+    let output = work_dir.run_jj(["workspace", "update-stale"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    Working copy  (@) now at: kkmpptxz 422aac81 child
+    Parent commit (@-)      : qpvuntsm 239acdab parent
+    Added 0 files, modified 1 files, removed 0 files
+    Updated working copy to fresh commit 422aac811963
+    [EOF]
+    ");
+
+    // Git HEAD should point to the amended "parent", not the stale one
+    insta::assert_snapshot!(get_colocation_status(&work_dir), @"
+    Workspace is currently colocated with Git.
+    Last imported/exported Git HEAD: 239acdab88e2b438ed43a99471a385d3832190ec
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_index_state(work_dir.root()), @"
+    Unconflicted Mode(FILE) 76b5eb87f1cb ctime=0:0 mtime=0:0 size=0 flags=0 file1
+    Unconflicted Mode(FILE) e69de29bb2d1 ctime=0:0 mtime=0:0 size=0 flags=20004000 file2
+    ");
+}
+
+#[test]
 fn test_git_colocated_unborn_bookmark() -> TestResult {
     let test_env = TestEnvironment::default();
     let work_dir = test_env.work_dir("repo");


### PR DESCRIPTION
When a colocated working copy was stale (e.g. because the working-copy commit was rewritten from another workspace), update-stale checked out the fresh commit but left Git HEAD pointing at the obsolete parent.

Reset Git HEAD to the parent of the fresh working-copy commit, like it's already done in `finish_transaction`.

Fixes #9936

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
