### PR TITLE
git: track HEAD per worktree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * `jj bisect` will now mention when it cannot unambiguously find the first bad
   revision due to skips in evaluation.
 
+* Git HEAD state is now tracked per worktree internally. This prepares
+  colocated repositories for support of multiple Git worktrees, where each
+  jj workspace can have its own Git HEAD. Existing repositories are migrated
+  automatically.
+
 ### Fixed bugs
 
 * A side of a conflict whose contents end with a carriage return no longer loses

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -1355,17 +1355,17 @@ impl WorkspaceCommandHelper {
         git_import_export_lock: &GitImportExportLock,
     ) -> Result<(), CommandError> {
         assert!(self.may_snapshot_working_copy);
+        let workspace_name = self.workspace_name().to_owned();
         let mut tx = self.start_transaction();
-        jj_lib::git::import_head(tx.repo_mut()).await?;
+        jj_lib::git::import_head(tx.repo_mut(), &workspace_name).await?;
         if !tx.repo().has_changes() {
             return Ok(());
         }
 
         let mut tx = tx.into_inner();
-        let old_git_head = self.repo().view().git_head().clone();
-        let new_git_head = tx.repo().view().git_head().clone();
-        if let Some(new_git_head_id) = new_git_head.as_normal() {
-            let workspace_name = self.workspace_name().to_owned();
+        let old_git_head = self.repo().view().git_head(&workspace_name).cloned();
+        let new_git_head = tx.repo().view().git_head(&workspace_name).cloned();
+        if let Some(new_git_head_id) = new_git_head.as_ref().and_then(|t| t.as_normal()) {
             let new_git_head_commit = tx.repo().store().get_commit_async(new_git_head_id).await?;
             let wc_commit = tx
                 .repo_mut()
@@ -1388,7 +1388,7 @@ impl WorkspaceCommandHelper {
                     .finish(self.user_repo.repo.op_id().clone())
                     .await?;
             }
-            if old_git_head.is_present() {
+            if old_git_head.is_some() {
                 writeln!(
                     ui.status(),
                     "Reset the working copy parent to the new Git HEAD."
@@ -2135,7 +2135,7 @@ to the current parents may contain changes from multiple commits.
                     .map_err(snapshot_command_error)?;
             }
             mut_repo
-                .set_wc_commit(workspace_name, new_wc_commit.id().clone())
+                .set_wc_commit(workspace_name.clone(), new_wc_commit.id().clone())
                 .map_err(snapshot_command_error)?;
 
             // Rebase descendants
@@ -2156,9 +2156,15 @@ to the current parents may contain changes from multiple commits.
             {
                 if wc_immutable {
                     // New working-copy commit is created on top. Reset Git HEAD and index.
-                    try_reset_git_head(ui, mut_repo, &new_wc_commit, git_import_export_lock)
-                        .await
-                        .map_err(snapshot_command_error)?;
+                    try_reset_git_head(
+                        ui,
+                        mut_repo,
+                        &new_wc_commit,
+                        &workspace_name,
+                        git_import_export_lock,
+                    )
+                    .await
+                    .map_err(snapshot_command_error)?;
                     // export_refs() is probably unnecessary because there should be no
                     // rewritten descendants, but it's harmless.
                     let stats =
@@ -2348,7 +2354,14 @@ to the current parents may contain changes from multiple commits.
         #[cfg(feature = "git")]
         if self.env.working_copy_shared_with_git && self.env.command.should_commit_transaction() {
             if let Some(wc_commit) = &maybe_new_wc_commit {
-                try_reset_git_head(ui, tx.repo_mut(), wc_commit, git_import_export_lock).await?;
+                try_reset_git_head(
+                    ui,
+                    tx.repo_mut(),
+                    wc_commit,
+                    self.workspace_name(),
+                    git_import_export_lock,
+                )
+                .await?;
             }
             let stats = jj_lib::git::export_refs(tx.repo_mut())?;
             crate::git_util::print_git_export_stats(ui, &stats)?;
@@ -2674,6 +2687,7 @@ async fn try_reset_git_head(
     ui: &Ui,
     mut_repo: &mut MutableRepo,
     wc_commit: &Commit,
+    workspace_name: &WorkspaceName,
     _git_import_export_lock: &GitImportExportLock,
 ) -> Result<(), CommandError> {
     use std::error::Error as _;
@@ -2683,7 +2697,7 @@ async fn try_reset_git_head(
     // This can still fail if HEAD was updated concurrently by another JJ process
     // (overlapping transaction) or a non-JJ process (e.g., git checkout). In that
     // case, the actual state will be imported on the next snapshot.
-    match jj_lib::git::reset_head(mut_repo, wc_commit).await {
+    match jj_lib::git::reset_head(mut_repo, wc_commit, workspace_name).await {
         Ok(()) => Ok(()),
         Err(err @ jj_lib::git::GitResetHeadError::UpdateHeadRef(_)) => {
             writeln!(ui.warning_default(), "{err}")?;

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -1355,17 +1355,17 @@ impl WorkspaceCommandHelper {
         git_import_export_lock: &GitImportExportLock,
     ) -> Result<(), CommandError> {
         assert!(self.may_snapshot_working_copy);
+        let workspace_name = self.workspace_name().to_owned();
         let mut tx = self.start_transaction();
-        jj_lib::git::import_head(tx.repo_mut()).await?;
+        jj_lib::git::import_head(tx.repo_mut(), &workspace_name).await?;
         if !tx.repo().has_changes() {
             return Ok(());
         }
 
         let mut tx = tx.into_inner();
-        let old_git_head = self.repo().view().git_head().clone();
-        let new_git_head = tx.repo().view().git_head().clone();
+        let old_git_head = self.repo().view().git_head(&workspace_name).clone();
+        let new_git_head = tx.repo().view().git_head(&workspace_name);
         if let Some(new_git_head_id) = new_git_head.as_normal() {
-            let workspace_name = self.workspace_name().to_owned();
             let new_git_head_commit = tx.repo().store().get_commit_async(new_git_head_id).await?;
             let wc_commit = tx
                 .repo_mut()
@@ -2135,7 +2135,7 @@ to the current parents may contain changes from multiple commits.
                     .map_err(snapshot_command_error)?;
             }
             mut_repo
-                .set_wc_commit(workspace_name, new_wc_commit.id().clone())
+                .set_wc_commit(workspace_name.clone(), new_wc_commit.id().clone())
                 .map_err(snapshot_command_error)?;
 
             // Rebase descendants
@@ -2156,9 +2156,15 @@ to the current parents may contain changes from multiple commits.
             {
                 if wc_immutable {
                     // New working-copy commit is created on top. Reset Git HEAD and index.
-                    try_reset_git_head(ui, mut_repo, &new_wc_commit, git_import_export_lock)
-                        .await
-                        .map_err(snapshot_command_error)?;
+                    try_reset_git_head(
+                        ui,
+                        mut_repo,
+                        &workspace_name,
+                        &new_wc_commit,
+                        git_import_export_lock,
+                    )
+                    .await
+                    .map_err(snapshot_command_error)?;
                     // export_refs() is probably unnecessary because there should be no
                     // rewritten descendants, but it's harmless.
                     let stats =
@@ -2348,7 +2354,14 @@ to the current parents may contain changes from multiple commits.
         #[cfg(feature = "git")]
         if self.env.working_copy_shared_with_git && self.env.command.should_commit_transaction() {
             if let Some(wc_commit) = &maybe_new_wc_commit {
-                try_reset_git_head(ui, tx.repo_mut(), wc_commit, git_import_export_lock).await?;
+                try_reset_git_head(
+                    ui,
+                    tx.repo_mut(),
+                    self.workspace_name(),
+                    wc_commit,
+                    git_import_export_lock,
+                )
+                .await?;
             }
             let stats = jj_lib::git::export_refs(tx.repo_mut())?;
             crate::git_util::print_git_export_stats(ui, &stats)?;
@@ -2673,6 +2686,7 @@ pub async fn export_working_copy_changes_to_git(
 async fn try_reset_git_head(
     ui: &Ui,
     mut_repo: &mut MutableRepo,
+    workspace_name: &WorkspaceName,
     wc_commit: &Commit,
     _git_import_export_lock: &GitImportExportLock,
 ) -> Result<(), CommandError> {
@@ -2683,7 +2697,7 @@ async fn try_reset_git_head(
     // This can still fail if HEAD was updated concurrently by another JJ process
     // (overlapping transaction) or a non-JJ process (e.g., git checkout). In that
     // case, the actual state will be imported on the next snapshot.
-    match jj_lib::git::reset_head(mut_repo, wc_commit).await {
+    match jj_lib::git::reset_head(mut_repo, workspace_name, wc_commit).await {
         Ok(()) => Ok(()),
         Err(err @ jj_lib::git::GitResetHeadError::UpdateHeadRef(_)) => {
             writeln!(ui.warning_default(), "{err}")?;

--- a/cli/src/commands/git/colocation.rs
+++ b/cli/src/commands/git/colocation.rs
@@ -100,7 +100,8 @@ async fn cmd_git_colocation_status(
     workspace_supports_git_colocation_commands(&workspace_command)?;
 
     let is_colocated = is_colocated_git_workspace(workspace_command.workspace());
-    let git_head = workspace_command.repo().view().git_head();
+    let workspace_name = workspace_command.workspace_name();
+    let git_head = workspace_command.repo().view().git_head(workspace_name);
 
     if is_colocated {
         writeln!(ui.stdout(), "Workspace is currently colocated with Git.")?;
@@ -323,8 +324,9 @@ async fn set_git_head_to_wc_parent(
     workspace_command: &mut WorkspaceCommandHelper,
     wc_commit: &Commit,
 ) -> Result<(), CommandError> {
+    let workspace_name = workspace_command.workspace_name().to_owned();
     let mut tx = workspace_command.start_transaction();
-    git::reset_head(tx.repo_mut(), wc_commit).await?;
+    git::reset_head(tx.repo_mut(), &workspace_name, wc_commit).await?;
     if tx.repo().has_changes() {
         tx.finish(ui, "set git head to working copy parent").await?;
     }
@@ -336,8 +338,10 @@ async fn remove_git_head(
     ui: &mut Ui,
     workspace_command: &mut WorkspaceCommandHelper,
 ) -> Result<(), CommandError> {
+    let workspace_name = workspace_command.workspace_name().to_owned();
     let mut tx = workspace_command.start_transaction();
-    tx.repo_mut().set_git_head_target(RefTarget::absent());
+    tx.repo_mut()
+        .set_git_head_target(&workspace_name, RefTarget::absent());
     if tx.repo().has_changes() {
         tx.finish(ui, "remove git head reference").await?;
     }

--- a/cli/src/commands/git/colocation.rs
+++ b/cli/src/commands/git/colocation.rs
@@ -100,7 +100,8 @@ async fn cmd_git_colocation_status(
     workspace_supports_git_colocation_commands(&workspace_command)?;
 
     let is_colocated = is_colocated_git_workspace(workspace_command.workspace());
-    let git_head = workspace_command.repo().view().git_head();
+    let workspace_name = workspace_command.workspace_name();
+    let git_head = workspace_command.repo().view().git_head(workspace_name);
 
     if is_colocated {
         writeln!(ui.stdout(), "Workspace is currently colocated with Git.")?;
@@ -116,14 +117,18 @@ async fn cmd_git_colocation_status(
     writeln!(
         ui.stdout(),
         "Last imported/exported Git HEAD: {}",
-        git_head
-            .as_merge()
-            .iter()
-            .map(|maybe_id| match maybe_id {
-                Some(id) => id.to_string(),
-                None => "(none)".to_owned(),
-            })
-            .join(", ")
+        if let Some(target) = git_head {
+            target
+                .as_merge()
+                .iter()
+                .map(|maybe_id| match maybe_id {
+                    Some(id) => id.to_string(),
+                    None => "(none)".to_owned(),
+                })
+                .join(", ")
+        } else {
+            "(absent)".to_owned()
+        }
     )?;
 
     if is_colocated {
@@ -323,8 +328,9 @@ async fn set_git_head_to_wc_parent(
     workspace_command: &mut WorkspaceCommandHelper,
     wc_commit: &Commit,
 ) -> Result<(), CommandError> {
+    let workspace_name = workspace_command.workspace_name().to_owned();
     let mut tx = workspace_command.start_transaction();
-    git::reset_head(tx.repo_mut(), wc_commit).await?;
+    git::reset_head(tx.repo_mut(), wc_commit, &workspace_name).await?;
     if tx.repo().has_changes() {
         tx.finish(ui, "set git head to working copy parent").await?;
     }
@@ -336,8 +342,10 @@ async fn remove_git_head(
     ui: &mut Ui,
     workspace_command: &mut WorkspaceCommandHelper,
 ) -> Result<(), CommandError> {
+    let workspace_name = workspace_command.workspace_name().to_owned();
     let mut tx = workspace_command.start_transaction();
-    tx.repo_mut().set_git_head_target(RefTarget::absent());
+    tx.repo_mut()
+        .set_git_head_target(&workspace_name, RefTarget::absent());
     if tx.repo().has_changes() {
         tx.finish(ui, "remove git head reference").await?;
     }

--- a/cli/src/commands/git/import.rs
+++ b/cli/src/commands/git/import.rs
@@ -52,10 +52,11 @@ pub async fn cmd_git_import(
     let git_settings = GitSettings::from_settings(workspace_command.settings())?;
     let remote_settings = workspace_command.settings().remote_settings()?;
     let import_options = load_git_import_options(ui, &git_settings, &remote_settings)?;
+    let workspace_name = workspace_command.workspace_name().to_owned();
     let mut tx = workspace_command.start_transaction();
     // In non-colocated workspace, Git HEAD will never be moved internally by jj.
     // That's why cmd_git_export() doesn't export the HEAD ref.
-    git::import_head(tx.repo_mut()).await?;
+    git::import_head(tx.repo_mut(), &workspace_name).await?;
     let stats = git::import_refs(tx.repo_mut(), &import_options).await?;
     print_git_import_stats(ui, &tx, &stats)?;
     tx.finish(ui, "import git refs").await?;

--- a/cli/src/commands/git/init.rs
+++ b/cli/src/commands/git/init.rs
@@ -258,9 +258,16 @@ async fn do_init(
                 &config_env,
             )?;
             if !workspace_command.working_copy_shared_with_git() {
+                let workspace_name = workspace_command.workspace_name().to_owned();
                 let mut tx = workspace_command.start_transaction();
-                jj_lib::git::import_head(tx.repo_mut()).await?;
-                if let Some(git_head_id) = tx.repo().view().git_head().as_normal().cloned() {
+                jj_lib::git::import_head(tx.repo_mut(), &workspace_name).await?;
+                if let Some(git_head_id) = tx
+                    .repo()
+                    .view()
+                    .git_head(&workspace_name)
+                    .and_then(|t| t.as_normal())
+                    .cloned()
+                {
                     let git_head_commit = tx.repo().store().get_commit_async(&git_head_id).await?;
                     tx.check_out(&git_head_commit)?;
                 }

--- a/cli/src/commands/git/init.rs
+++ b/cli/src/commands/git/init.rs
@@ -258,9 +258,16 @@ async fn do_init(
                 &config_env,
             )?;
             if !workspace_command.working_copy_shared_with_git() {
+                let workspace_name = workspace_command.workspace_name().to_owned();
                 let mut tx = workspace_command.start_transaction();
-                jj_lib::git::import_head(tx.repo_mut()).await?;
-                if let Some(git_head_id) = tx.repo().view().git_head().as_normal().cloned() {
+                jj_lib::git::import_head(tx.repo_mut(), &workspace_name).await?;
+                if let Some(git_head_id) = tx
+                    .repo()
+                    .view()
+                    .git_head(&workspace_name)
+                    .as_normal()
+                    .cloned()
+                {
                     let git_head_commit = tx.repo().store().get_commit_async(&git_head_id).await?;
                     tx.check_out(&git_head_commit)?;
                 }

--- a/cli/src/commands/operation/mod.rs
+++ b/cli/src/commands/operation/mod.rs
@@ -111,7 +111,7 @@ pub(crate) fn view_with_desired_portions_restored(
         local_tags: repo_source.local_tags.clone(),
         remote_views: remote_source.remote_views.clone(),
         git_refs: current_view.git_refs.clone(),
-        git_head: current_view.git_head.clone(),
+        git_heads: current_view.git_heads.clone(),
         wc_commit_ids: repo_source.wc_commit_ids.clone(),
     }
 }

--- a/cli/src/commands/workspace/forget.rs
+++ b/cli/src/commands/workspace/forget.rs
@@ -79,7 +79,7 @@ pub async fn cmd_workspace_forget(
     let mut tx = workspace_command.start_transaction();
 
     for ws in &forget_ws {
-        tx.repo_mut().remove_wc_commit(ws).await?;
+        tx.repo_mut().remove_workspace(ws).await?;
     }
 
     workspace_store.forget(&forget_ws.iter().map(|x| x.as_ref()).collect::<Vec<_>>())?;

--- a/cli/tests/test_bisect_command.rs
+++ b/cli/tests/test_bisect_command.rs
@@ -45,7 +45,7 @@ fn test_bisect_run_empty_revset() -> TestResult {
     std::fs::write(&bisection_script, ["fail"].join("\0"))?;
     insta::assert_snapshot!(work_dir.run_jj(["bisect", "run", "--range=none()", &bisector_path]), @"
     Search complete. To discard any revisions created during search, run:
-      jj op restore 90267f31f904
+      jj op restore f63ee16f9553
     [EOF]
     ------- stderr -------
     Error: Could not find the first bad revision. Was the input range empty?
@@ -83,7 +83,7 @@ fn test_bisect_run() -> TestResult {
     The revision is bad.
 
     Search complete. To discard any revisions created during search, run:
-      jj op restore 6f4b9c7057b1
+      jj op restore e953363a3d33
     The first bad revision is: rlvkpnrz 7d980be7 a | a
     [EOF]
     ------- stderr -------
@@ -163,7 +163,7 @@ fn test_bisect_run_find_first_good() {
     The revision is good.
 
     Search complete. To discard any revisions created during search, run:
-      jj op restore 6f4b9c7057b1
+      jj op restore e953363a3d33
     The first good revision is: rlvkpnrz 7d980be7 a | a
     [EOF]
     ------- stderr -------
@@ -266,7 +266,7 @@ fn test_bisect_run_with_args() {
     The revision is bad.
 
     Search complete. To discard any revisions created during search, run:
-      jj op restore 6f4b9c7057b1
+      jj op restore e953363a3d33
     The first good revision is: royxmykx dffaa0d4 c | c
     [EOF]
     ------- stderr -------
@@ -324,7 +324,7 @@ fn test_bisect_run_crash() -> TestResult {
     The revision is bad.
 
     Search complete. To discard any revisions created during search, run:
-      jj op restore 6f4b9c7057b1
+      jj op restore e953363a3d33
     The first bad revision is: rlvkpnrz 7d980be7 a | a
     [EOF]
     ------- stderr -------
@@ -360,7 +360,7 @@ fn test_bisect_run_abort() -> TestResult {
     Evaluation command returned 127 (command not found) - aborting bisection.
 
     Search complete. To discard any revisions created during search, run:
-      jj op restore e229f77ca8de
+      jj op restore 121d6ca6dd74
     [EOF]
     ------- stderr -------
     Working copy  (@) now at: vruxwmqv 538d9e7f (empty) (no description set)
@@ -393,7 +393,7 @@ fn test_bisect_run_skip() -> TestResult {
     It could not be determined if the revision is good or bad.
 
     Search complete. To discard any revisions created during search, run:
-      jj op restore 07d6c9360663
+      jj op restore d67fa84fce93
     The first bad revisions are:
     zsuskuln 123b4d91 b | b
     These revisions may also be bad, but couldn't be evaluated:
@@ -434,7 +434,7 @@ fn test_bisect_run_multiple_results() {
     The revision is good.
 
     Search complete. To discard any revisions created during search, run:
-      jj op restore 854a7d496ee7
+      jj op restore 8feef1d21060
     The first bad revisions are:
     vruxwmqv a2dbb1aa d | d
     zsuskuln 123b4d91 b | b
@@ -480,7 +480,7 @@ fn test_bisect_run_write_file() -> TestResult {
     The revision is bad.
 
     Search complete. To discard any revisions created during search, run:
-      jj op restore 621116e08872
+      jj op restore 6518dc3e2579
     The first bad revision is: rlvkpnrz 7d980be7 a | a
     [EOF]
     ------- stderr -------
@@ -546,7 +546,7 @@ fn test_bisect_run_jj_command() -> TestResult {
     The revision is bad.
 
     Search complete. To discard any revisions created during search, run:
-      jj op restore 621116e08872
+      jj op restore 6518dc3e2579
     The first bad revision is: rlvkpnrz 7d980be7 a | a
     [EOF]
     ------- stderr -------

--- a/cli/tests/test_commit_template.rs
+++ b/cli/tests/test_commit_template.rs
@@ -582,13 +582,13 @@ fn test_log_evolog_divergence() {
     insta::assert_snapshot!(output, @"
     @  qpvuntsm/1 test.user@example.com 2001-02-03 08:05:08 556daeb7 (divergent)
     │  description 1
-    │  -- operation 124aa2060982 describe commit d0c049cd993a8d3a2e69ba6df98788e264ea9fa1
+    │  -- operation 30d053d9072b describe commit d0c049cd993a8d3a2e69ba6df98788e264ea9fa1
     ○  qpvuntsm/2 test.user@example.com 2001-02-03 08:05:08 d0c049cd (hidden)
     │  (no description set)
-    │  -- operation 576e232891c0 snapshot working copy
+    │  -- operation 8003ebfc58c1 snapshot working copy
     ○  qpvuntsm/3 test.user@example.com 2001-02-03 08:05:07 e8849ae1 (hidden)
        (empty) (no description set)
-       -- operation 90267f31f904 add workspace 'default'
+       -- operation f63ee16f9553 add workspace 'default'
     [EOF]
     ");
 
@@ -597,13 +597,13 @@ fn test_log_evolog_divergence() {
     insta::assert_snapshot!(output, @"
     [1m[38;5;2m@[0m  [1m[38;5;9mq[38;5;8mpvuntsm[38;5;9m/1[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 08:05:08[39m [38;5;12m55[38;5;8m6daeb7[39m [38;5;9m(divergent)[39m[0m
     │  [1mdescription 1[0m
-    │  [38;5;8m--[39m operation [38;5;4m124aa2060982[39m describe commit d0c049cd993a8d3a2e69ba6df98788e264ea9fa1
+    │  [38;5;8m--[39m operation [38;5;4m30d053d9072b[39m describe commit d0c049cd993a8d3a2e69ba6df98788e264ea9fa1
     ○  [1m[39mq[0m[38;5;8mpvuntsm[1m[39m/2[0m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:08[39m [1m[38;5;4md[0m[38;5;8m0c049cd[39m (hidden)
     │  [38;5;3m(no description set)[39m
-    │  [38;5;8m--[39m operation [38;5;4m576e232891c0[39m snapshot working copy
+    │  [38;5;8m--[39m operation [38;5;4m8003ebfc58c1[39m snapshot working copy
     ○  [1m[39mq[0m[38;5;8mpvuntsm[1m[39m/3[0m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:07[39m [1m[38;5;4me[0m[38;5;8m8849ae1[39m (hidden)
        [38;5;2m(empty)[39m [38;5;2m(no description set)[39m
-       [38;5;8m--[39m operation [38;5;4m90267f31f904[39m add workspace 'default'
+       [38;5;8m--[39m operation [38;5;4mf63ee16f9553[39m add workspace 'default'
     [EOF]
     ");
 }

--- a/cli/tests/test_completion.rs
+++ b/cli/tests/test_completion.rs
@@ -1311,71 +1311,71 @@ fn test_operations() {
 
     let output = work_dir.complete_fish(["op", "show", ""]).success();
     insta::assert_snapshot!(output.take_stdout_n_lines(num_ops + 2), @"
-    9b559ee756d7	(2001-02-03 08:05:16) describe commit e0e6c0a964c024a49605805925672044dfae4181
-    2424cbddf672	(2001-02-03 08:05:15) describe commit 37df8a6c1874ff45621dee0f2b7a77169b65d257
-    b95dea46e909	(2001-02-03 08:05:14) describe commit c3588cff852e44b68297f51705d6e61888806ddd
-    006433125524	(2001-02-03 08:05:13) describe commit aa0b3230e3787076f232a08c8b1c7f54948a2d7a
-    4e01f7335c34	(2001-02-03 08:05:12) describe commit 96157804fd41363cb2ff8ff957ff1df1a2a1109a
-    d9412c797d9b	(2001-02-03 08:05:11) describe commit 3725536d0ae06d69e46911258cee591dbdb66478
-    6ead3248a7c8	(2001-02-03 08:05:10) describe commit dd7390802e3ca4467ffa43f2e0c0374463d056f3
-    3274622dfd8b	(2001-02-03 08:05:09) describe commit 3ae22e7f50a15d393e412cca72d09a61165d0c84
-    8501e29d2d94	(2001-02-03 08:05:08) describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
-    90267f31f904	(2001-02-03 08:05:07) add workspace 'default'
+    c5fcd0d80cb7	(2001-02-03 08:05:16) describe commit e0e6c0a964c024a49605805925672044dfae4181
+    5bdb507f19ba	(2001-02-03 08:05:15) describe commit 37df8a6c1874ff45621dee0f2b7a77169b65d257
+    8a4a92e5ecff	(2001-02-03 08:05:14) describe commit c3588cff852e44b68297f51705d6e61888806ddd
+    aac41ddc75bf	(2001-02-03 08:05:13) describe commit aa0b3230e3787076f232a08c8b1c7f54948a2d7a
+    c915cd6b4c8d	(2001-02-03 08:05:12) describe commit 96157804fd41363cb2ff8ff957ff1df1a2a1109a
+    26d5ef64718f	(2001-02-03 08:05:11) describe commit 3725536d0ae06d69e46911258cee591dbdb66478
+    1c97a622e394	(2001-02-03 08:05:10) describe commit dd7390802e3ca4467ffa43f2e0c0374463d056f3
+    3ff36c586388	(2001-02-03 08:05:09) describe commit 3ae22e7f50a15d393e412cca72d09a61165d0c84
+    7749eb4df93f	(2001-02-03 08:05:08) describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
+    f63ee16f9553	(2001-02-03 08:05:07) add workspace 'default'
     000000000000	(1970-01-01 11:00:00)
     [EOF]
     ");
 
-    let output = work_dir.complete_fish(["op", "show", "9"]);
+    let output = work_dir.complete_fish(["op", "show", "c"]);
     insta::assert_snapshot!(output, @"
-    9b559ee756d7	(2001-02-03 08:05:16) describe commit e0e6c0a964c024a49605805925672044dfae4181
-    90267f31f904	(2001-02-03 08:05:07) add workspace 'default'
+    c5fcd0d80cb7	(2001-02-03 08:05:16) describe commit e0e6c0a964c024a49605805925672044dfae4181
+    c915cd6b4c8d	(2001-02-03 08:05:12) describe commit 96157804fd41363cb2ff8ff957ff1df1a2a1109a
     [EOF]
     ");
     // make sure global --at-op flag is respected (should not include later
     // operations)
-    let output = work_dir.complete_fish(["--at-op", "90267f31f904", "op", "show", "9"]);
+    let output = work_dir.complete_fish(["--at-op", "f63ee16f9553", "op", "show", "f"]);
     insta::assert_snapshot!(output, @"
-    90267f31f904	(2001-02-03 08:05:07) add workspace 'default'
+    f63ee16f9553	(2001-02-03 08:05:07) add workspace 'default'
     [EOF]
     ");
 
-    let output = work_dir.complete_fish(["--at-op", "9b"]);
+    let output = work_dir.complete_fish(["--at-op", "c5"]);
     insta::assert_snapshot!(output, @"
-    9b559ee756d7	(2001-02-03 08:05:16) describe commit e0e6c0a964c024a49605805925672044dfae4181
+    c5fcd0d80cb7	(2001-02-03 08:05:16) describe commit e0e6c0a964c024a49605805925672044dfae4181
     [EOF]
     ");
 
-    let output = work_dir.complete_fish(["op", "abandon", "9b"]);
+    let output = work_dir.complete_fish(["op", "abandon", "c5"]);
     insta::assert_snapshot!(output, @"
-    9b559ee756d7	(2001-02-03 08:05:16) describe commit e0e6c0a964c024a49605805925672044dfae4181
+    c5fcd0d80cb7	(2001-02-03 08:05:16) describe commit e0e6c0a964c024a49605805925672044dfae4181
     [EOF]
     ");
 
-    let output = work_dir.complete_fish(["op", "diff", "--op", "9b"]);
+    let output = work_dir.complete_fish(["op", "diff", "--op", "c5"]);
     insta::assert_snapshot!(output, @"
-    9b559ee756d7	(2001-02-03 08:05:16) describe commit e0e6c0a964c024a49605805925672044dfae4181
+    c5fcd0d80cb7	(2001-02-03 08:05:16) describe commit e0e6c0a964c024a49605805925672044dfae4181
     [EOF]
     ");
-    let output = work_dir.complete_fish(["op", "diff", "--from", "9b"]);
+    let output = work_dir.complete_fish(["op", "diff", "--from", "c5"]);
     insta::assert_snapshot!(output, @"
-    9b559ee756d7	(2001-02-03 08:05:16) describe commit e0e6c0a964c024a49605805925672044dfae4181
+    c5fcd0d80cb7	(2001-02-03 08:05:16) describe commit e0e6c0a964c024a49605805925672044dfae4181
     [EOF]
     ");
-    let output = work_dir.complete_fish(["op", "diff", "--to", "9b"]);
+    let output = work_dir.complete_fish(["op", "diff", "--to", "c5"]);
     insta::assert_snapshot!(output, @"
-    9b559ee756d7	(2001-02-03 08:05:16) describe commit e0e6c0a964c024a49605805925672044dfae4181
-    [EOF]
-    ");
-
-    let output = work_dir.complete_fish(["op", "restore", "9b"]);
-    insta::assert_snapshot!(output, @"
-    9b559ee756d7	(2001-02-03 08:05:16) describe commit e0e6c0a964c024a49605805925672044dfae4181
+    c5fcd0d80cb7	(2001-02-03 08:05:16) describe commit e0e6c0a964c024a49605805925672044dfae4181
     [EOF]
     ");
 
-    let output = work_dir.complete_fish(["op", "revert", "9b"]);
+    let output = work_dir.complete_fish(["op", "restore", "c5"]);
     insta::assert_snapshot!(output, @"
-    9b559ee756d7	(2001-02-03 08:05:16) describe commit e0e6c0a964c024a49605805925672044dfae4181
+    c5fcd0d80cb7	(2001-02-03 08:05:16) describe commit e0e6c0a964c024a49605805925672044dfae4181
+    [EOF]
+    ");
+
+    let output = work_dir.complete_fish(["op", "revert", "c5"]);
+    insta::assert_snapshot!(output, @"
+    c5fcd0d80cb7	(2001-02-03 08:05:16) describe commit e0e6c0a964c024a49605805925672044dfae4181
     [EOF]
     ");
 }

--- a/cli/tests/test_concurrent_operations.rs
+++ b/cli/tests/test_concurrent_operations.rs
@@ -35,18 +35,18 @@ fn test_concurrent_operation_divergence() -> TestResult {
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Error: The "@" expression resolved to more than one operation
-    Hint: Try specifying one of the operations by ID: c8af35ffdef5, 801df1b86ae7
+    Hint: Try specifying one of the operations by ID: ea7c53a69ce3, 4633795cf208
     [EOF]
     [exit status: 1]
     "#);
 
     // "op log --at-op" should work without merging the head operations
-    let output = work_dir.run_jj(["op", "log", "--at-op=801df1b86ae7"]);
+    let output = work_dir.run_jj(["op", "log", "--at-op=4633795cf208"]);
     insta::assert_snapshot!(output, @"
-    @  801df1b86ae7 test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    @  4633795cf208 test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     │  describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     │  args: jj describe -m 'message 2' --at-op @-
-    ○  90267f31f904 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  f63ee16f9553 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
     [EOF]
@@ -172,19 +172,19 @@ fn test_concurrent_snapshot_wc_reloadable() -> TestResult {
     let template = r#"id.short() ++ "\n" ++ description ++ "\n" ++ attributes"#;
     let output = work_dir.run_jj(["op", "log", "-T", template]);
     insta::assert_snapshot!(output, @"
-    @  617b5edc8a98
+    @  19e98b8a85da
     │  commit c91a0909a9d3f3d8392ba9fab88f4b40fc0810ee
     │  args: jj commit -m 'new child1'
-    ○  1ddd0050d50d
+    ○  55121d9434d0
     │  snapshot working copy
     │  args: jj commit -m 'new child1'
-    ○  4b73d3c2a7e6
+    ○  9f9c49403b99
     │  commit 9af4c151edead0304de97ce3a0b414552921a425
     │  args: jj commit -m initial
-    ○  4e7cb80ffdaf
+    ○  42ddf0a4e4f1
     │  snapshot working copy
     │  args: jj commit -m initial
-    ○  90267f31f904
+    ○  f63ee16f9553
     │  add workspace 'default'
     ○  000000000000
 
@@ -194,8 +194,8 @@ fn test_concurrent_snapshot_wc_reloadable() -> TestResult {
     let output = work_dir.run_jj(["op", "log", "--no-graph", "-T", template]);
     let [op_id_after_snapshot, _, op_id_before_snapshot] =
         output.stdout.raw().lines().next_array().unwrap();
-    insta::assert_snapshot!(op_id_after_snapshot[..12], @"617b5edc8a98");
-    insta::assert_snapshot!(op_id_before_snapshot[..12], @"4b73d3c2a7e6");
+    insta::assert_snapshot!(op_id_after_snapshot[..12], @"19e98b8a85da");
+    insta::assert_snapshot!(op_id_before_snapshot[..12], @"9f9c49403b99");
 
     // Simulate a concurrent operation that began from the "initial" operation
     // (before the "child1" snapshot) but finished after the "child1"

--- a/cli/tests/test_duplicate_command.rs
+++ b/cli/tests/test_duplicate_command.rs
@@ -73,8 +73,8 @@ fn test_duplicate() {
     let output = work_dir.run_jj(["undo"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Undid operation: 220a81883828 (2001-02-03 08:05:17) duplicate 1 commit(s)
-    Restored to operation: 76be3a90546e (2001-02-03 08:05:13) create bookmark c pointing to commit 387b928721d9f2efff819ccce81868f32537d71f
+    Undid operation: 894889750512 (2001-02-03 08:05:17) duplicate 1 commit(s)
+    Restored to operation: 29e5b8953f22 (2001-02-03 08:05:13) create bookmark c pointing to commit 387b928721d9f2efff819ccce81868f32537d71f
     [EOF]
     ");
     let output = work_dir.run_jj(["duplicate" /* duplicates `c` */]);
@@ -2348,8 +2348,8 @@ fn test_undo_after_duplicate() {
     let output = work_dir.run_jj(["undo"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Undid operation: 9466a30ad115 (2001-02-03 08:05:11) duplicate 1 commit(s)
-    Restored to operation: 276a53f19d12 (2001-02-03 08:05:09) create bookmark a pointing to commit 7d980be7a1d499e4d316ab4c01242885032f7eaf
+    Undid operation: 034b58b0d7cb (2001-02-03 08:05:11) duplicate 1 commit(s)
+    Restored to operation: 6edf1ea72afe (2001-02-03 08:05:09) create bookmark a pointing to commit 7d980be7a1d499e4d316ab4c01242885032f7eaf
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"

--- a/cli/tests/test_edit_command.rs
+++ b/cli/tests/test_edit_command.rs
@@ -115,7 +115,7 @@ fn test_edit_current() {
     // No operation created
     let output = work_dir.run_jj(["op", "log", "--limit=1"]);
     insta::assert_snapshot!(output, @"
-    @  90267f31f904 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    @  f63ee16f9553 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     [EOF]
     ");

--- a/cli/tests/test_evolog_command.rs
+++ b/cli/tests/test_evolog_command.rs
@@ -34,16 +34,16 @@ fn test_evolog_with_or_without_diff() {
     insta::assert_snapshot!(output, @"
     @  rlvkpnrz test.user@example.com 2001-02-03 08:05:10 33c10ace
     │  my description
-    │  -- operation 2c9e19859343 snapshot working copy
+    │  -- operation b78459d9d126 snapshot working copy
     ×  rlvkpnrz/1 test.user@example.com 2001-02-03 08:05:09 cdf175ef (hidden) (conflict)
     │  my description
-    │  -- operation 449a03ec4824 rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
+    │  -- operation b2a0c4f0aa5d rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
     ○  rlvkpnrz/2 test.user@example.com 2001-02-03 08:05:09 51e08f95 (hidden)
     │  my description
-    │  -- operation fff45c7cf767 snapshot working copy
+    │  -- operation 8c72466647e6 snapshot working copy
     ○  rlvkpnrz/3 test.user@example.com 2001-02-03 08:05:08 b955b72e (hidden)
        (empty) my description
-       -- operation c5d06fd4ff51 new empty commit
+       -- operation 390d0e261e11 new empty commit
     [EOF]
     ");
 
@@ -52,16 +52,16 @@ fn test_evolog_with_or_without_diff() {
     insta::assert_snapshot!(output, @"
     [1m[38;5;2m@[0m  [1m[38;5;13mr[38;5;8mlvkpnrz[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 08:05:10[39m [38;5;12m3[38;5;8m3c10ace[39m[0m
     │  [1mmy description[0m
-    │  [38;5;8m--[39m operation [38;5;4m2c9e19859343[39m snapshot working copy
+    │  [38;5;8m--[39m operation [38;5;4mb78459d9d126[39m snapshot working copy
     [1m[38;5;1m×[0m  [1m[39mr[0m[38;5;8mlvkpnrz[1m[39m/1[0m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:09[39m [1m[38;5;4mcd[0m[38;5;8mf175ef[39m (hidden) [38;5;1m(conflict)[39m
     │  my description
-    │  [38;5;8m--[39m operation [38;5;4m449a03ec4824[39m rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
+    │  [38;5;8m--[39m operation [38;5;4mb2a0c4f0aa5d[39m rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
     ○  [1m[39mr[0m[38;5;8mlvkpnrz[1m[39m/2[0m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:09[39m [1m[38;5;4m5[0m[38;5;8m1e08f95[39m (hidden)
     │  my description
-    │  [38;5;8m--[39m operation [38;5;4mfff45c7cf767[39m snapshot working copy
+    │  [38;5;8m--[39m operation [38;5;4m8c72466647e6[39m snapshot working copy
     ○  [1m[39mr[0m[38;5;8mlvkpnrz[1m[39m/3[0m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:08[39m [1m[38;5;4mb[0m[38;5;8m955b72e[39m (hidden)
        [38;5;2m(empty)[39m my description
-       [38;5;8m--[39m operation [38;5;4mc5d06fd4ff51[39m new empty commit
+       [38;5;8m--[39m operation [38;5;4m390d0e261e11[39m new empty commit
     [EOF]
     ");
 
@@ -71,7 +71,7 @@ fn test_evolog_with_or_without_diff() {
     insta::assert_snapshot!(output, @r#"
     @  rlvkpnrz test.user@example.com 2001-02-03 08:05:10 33c10ace
     │  my description
-    │  -- operation 2c9e19859343 snapshot working copy
+    │  -- operation b78459d9d126 snapshot working copy
     │  Resolved conflict in file1:
     │     1     : <<<<<<< conflict 1 of 1
     │     2     : %%%%%%% diff from: qpvuntsm c664a51b (parents of rebased revision)
@@ -84,10 +84,10 @@ fn test_evolog_with_or_without_diff() {
     │          1: resolved
     ×  rlvkpnrz/1 test.user@example.com 2001-02-03 08:05:09 cdf175ef (hidden) (conflict)
     │  my description
-    │  -- operation 449a03ec4824 rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
+    │  -- operation b2a0c4f0aa5d rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
     ○  rlvkpnrz/2 test.user@example.com 2001-02-03 08:05:09 51e08f95 (hidden)
     │  my description
-    │  -- operation fff45c7cf767 snapshot working copy
+    │  -- operation 8c72466647e6 snapshot working copy
     │  Modified regular file file1:
     │     1    1: foo
     │          2: bar
@@ -95,7 +95,7 @@ fn test_evolog_with_or_without_diff() {
     │          1: foo
     ○  rlvkpnrz/3 test.user@example.com 2001-02-03 08:05:08 b955b72e (hidden)
        (empty) my description
-       -- operation c5d06fd4ff51 new empty commit
+       -- operation 390d0e261e11 new empty commit
        Modified commit description:
                1: my description
     [EOF]
@@ -106,22 +106,22 @@ fn test_evolog_with_or_without_diff() {
     insta::assert_snapshot!(output, @"
     @  rlvkpnrz test.user@example.com 2001-02-03 08:05:10 33c10ace
     │  my description
-    │  -- operation 2c9e19859343 snapshot working copy
+    │  -- operation b78459d9d126 snapshot working copy
     ×  rlvkpnrz/1 test.user@example.com 2001-02-03 08:05:09 cdf175ef (hidden) (conflict)
     │  my description
-    │  -- operation 449a03ec4824 rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
+    │  -- operation b2a0c4f0aa5d rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
     ○  rlvkpnrz/2 test.user@example.com 2001-02-03 08:05:09 51e08f95 (hidden)
     │  my description
-    │  -- operation fff45c7cf767 snapshot working copy
+    │  -- operation 8c72466647e6 snapshot working copy
     ○  rlvkpnrz/3 test.user@example.com 2001-02-03 08:05:08 b955b72e (hidden)
        (empty) my description
-       -- operation c5d06fd4ff51 new empty commit
+       -- operation 390d0e261e11 new empty commit
     ○  qpvuntsm test.user@example.com 2001-02-03 08:05:08 c664a51b
     │  (no description set)
-    │  -- operation b243f4039fc9 snapshot working copy
+    │  -- operation 919afc102de5 snapshot working copy
     ○  qpvuntsm/1 test.user@example.com 2001-02-03 08:05:07 e8849ae1 (hidden)
        (empty) (no description set)
-       -- operation 90267f31f904 add workspace 'default'
+       -- operation f63ee16f9553 add workspace 'default'
     [EOF]
     ");
 
@@ -130,10 +130,10 @@ fn test_evolog_with_or_without_diff() {
     insta::assert_snapshot!(output, @"
     @  rlvkpnrz test.user@example.com 2001-02-03 08:05:10 33c10ace
     │  my description
-    │  -- operation 2c9e19859343 snapshot working copy
+    │  -- operation b78459d9d126 snapshot working copy
     ×  rlvkpnrz/1 test.user@example.com 2001-02-03 08:05:09 cdf175ef (hidden) (conflict)
     │  my description
-    │  -- operation 449a03ec4824 rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
+    │  -- operation b2a0c4f0aa5d rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
     [EOF]
     ");
 
@@ -142,16 +142,16 @@ fn test_evolog_with_or_without_diff() {
     insta::assert_snapshot!(output, @"
     rlvkpnrz test.user@example.com 2001-02-03 08:05:10 33c10ace
     my description
-    -- operation 2c9e19859343 snapshot working copy
+    -- operation b78459d9d126 snapshot working copy
     rlvkpnrz/1 test.user@example.com 2001-02-03 08:05:09 cdf175ef (hidden) (conflict)
     my description
-    -- operation 449a03ec4824 rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
+    -- operation b2a0c4f0aa5d rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
     rlvkpnrz/2 test.user@example.com 2001-02-03 08:05:09 51e08f95 (hidden)
     my description
-    -- operation fff45c7cf767 snapshot working copy
+    -- operation 8c72466647e6 snapshot working copy
     rlvkpnrz/3 test.user@example.com 2001-02-03 08:05:08 b955b72e (hidden)
     (empty) my description
-    -- operation c5d06fd4ff51 new empty commit
+    -- operation 390d0e261e11 new empty commit
     [EOF]
     ");
 
@@ -160,7 +160,7 @@ fn test_evolog_with_or_without_diff() {
     insta::assert_snapshot!(output, @r#"
     rlvkpnrz test.user@example.com 2001-02-03 08:05:10 33c10ace
     my description
-    -- operation 2c9e19859343 snapshot working copy
+    -- operation b78459d9d126 snapshot working copy
     diff --git a/file1 b/file1
     index 0000000000..2ab19ae607 100644
     --- a/file1
@@ -177,10 +177,10 @@ fn test_evolog_with_or_without_diff() {
     +resolved
     rlvkpnrz/1 test.user@example.com 2001-02-03 08:05:09 cdf175ef (hidden) (conflict)
     my description
-    -- operation 449a03ec4824 rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
+    -- operation b2a0c4f0aa5d rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
     rlvkpnrz/2 test.user@example.com 2001-02-03 08:05:09 51e08f95 (hidden)
     my description
-    -- operation fff45c7cf767 snapshot working copy
+    -- operation 8c72466647e6 snapshot working copy
     diff --git a/file1 b/file1
     index 257cc5642c..3bd1f0e297 100644
     --- a/file1
@@ -197,7 +197,7 @@ fn test_evolog_with_or_without_diff() {
     +foo
     rlvkpnrz/3 test.user@example.com 2001-02-03 08:05:08 b955b72e (hidden)
     (empty) my description
-    -- operation c5d06fd4ff51 new empty commit
+    -- operation 390d0e261e11 new empty commit
     diff --git a/JJ-COMMIT-DESCRIPTION b/JJ-COMMIT-DESCRIPTION
     --- JJ-COMMIT-DESCRIPTION
     +++ JJ-COMMIT-DESCRIPTION
@@ -229,14 +229,14 @@ fn test_evolog_template() {
     insta::assert_snapshot!(output, @"
     @  kkmpptxz test.user@example.com 2001-02-03 08:05:09 2b17ac71
        (empty) (no description set)
-       -- operation 379ad03e4902 add workspace 'default'
+       -- operation 378fe523fc0a add workspace 'default'
     [EOF]
     ");
     let output = work_dir.run_jj(["evolog", "-r@", "--color=debug"]);
     insta::assert_snapshot!(output, @"
     [1m[38;5;2m<<evolog commit node working_copy mutable::@>>[0m  [1m[38;5;13m<<evolog working_copy mutable commit change_id shortest prefix::k>>[38;5;8m<<evolog working_copy mutable commit change_id shortest rest::kmpptxz>>[39m<<evolog working_copy mutable:: >>[38;5;3m<<evolog working_copy mutable commit author email local::test.user>><<evolog working_copy mutable commit author email::@>><<evolog working_copy mutable commit author email domain::example.com>>[39m<<evolog working_copy mutable:: >>[38;5;14m<<evolog working_copy mutable commit committer timestamp local format::2001-02-03 08:05:09>>[39m<<evolog working_copy mutable:: >>[38;5;12m<<evolog working_copy mutable commit commit_id shortest prefix::2>>[38;5;8m<<evolog working_copy mutable commit commit_id shortest rest::b17ac71>>[39m<<evolog working_copy mutable::>>[0m
        [1m[38;5;10m<<evolog working_copy mutable empty::(empty)>>[39m<<evolog working_copy mutable:: >>[38;5;10m<<evolog working_copy mutable empty description placeholder::(no description set)>>[39m<<evolog working_copy mutable::>>[0m
-       [38;5;8m<<evolog separator::-->>[39m<<evolog:: operation >>[38;5;4m<<evolog operation id short::379ad03e4902>>[39m<<evolog:: >><<evolog operation description first_line::add workspace 'default'>><<evolog::>>
+       [38;5;8m<<evolog separator::-->>[39m<<evolog:: operation >>[38;5;4m<<evolog operation id short::378fe523fc0a>>[39m<<evolog:: >><<evolog operation description first_line::add workspace 'default'>><<evolog::>>
     [EOF]
     ");
 
@@ -268,7 +268,7 @@ fn test_evolog_template() {
 
     // JSON output with operation
     let output = work_dir.run_jj(["evolog", "-r@", "-Tjson(self)", "--no-graph"]);
-    insta::assert_snapshot!(output, @r#"{"commit":{"commit_id":"2b17ac719c7db025e2514f5708d2b0328fc6b268","parents":["0000000000000000000000000000000000000000"],"change_id":"kkmpptxzrspxrzommnulwmwkkqwworpl","description":"","author":{"name":"Test User","email":"test.user@example.com","timestamp":"2001-02-03T04:05:09+07:00"},"committer":{"name":"Test User","email":"test.user@example.com","timestamp":"2001-02-03T04:05:09+07:00"}},"operation":{"id":"379ad03e4902abe8dddde72816a45f76a8f81e9c8800b498b4808d0e96c5f2b79866003108fd88c9664387c1a2e15d9b2bab18c33ba0d2a9803eb8b8ea1cf81f","parents":["00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"],"time":{"start":"2001-02-03T04:05:09+07:00","end":"2001-02-03T04:05:09+07:00"},"description":"add workspace 'default'","hostname":"host.example.com","username":"test-username","is_snapshot":false,"workspace_name":null,"attributes":{}}}[EOF]"#);
+    insta::assert_snapshot!(output, @r#"{"commit":{"commit_id":"2b17ac719c7db025e2514f5708d2b0328fc6b268","parents":["0000000000000000000000000000000000000000"],"change_id":"kkmpptxzrspxrzommnulwmwkkqwworpl","description":"","author":{"name":"Test User","email":"test.user@example.com","timestamp":"2001-02-03T04:05:09+07:00"},"committer":{"name":"Test User","email":"test.user@example.com","timestamp":"2001-02-03T04:05:09+07:00"}},"operation":{"id":"378fe523fc0ae9ac17af7eee7ce6a8d87f23cb97ecdb27ca0c75892948f1ccd979d48c3dbb201c360328ce0f92bcf3ca5c8d64da61d49543403086da315bd54f","parents":["00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"],"time":{"start":"2001-02-03T04:05:09+07:00","end":"2001-02-03T04:05:09+07:00"},"description":"add workspace 'default'","hostname":"host.example.com","username":"test-username","is_snapshot":false,"workspace_name":null,"attributes":{}}}[EOF]"#);
 
     // JSON output without operation
     let output = work_dir.run_jj(["evolog", "-rmain@origin", "-Tjson(self)", "--no-graph"]);
@@ -296,16 +296,16 @@ fn test_evolog_with_custom_symbols() {
     insta::assert_snapshot!(output, @"
     $  rlvkpnrz test.user@example.com 2001-02-03 08:05:10 33c10ace
     │  my description
-    │  -- operation 1684911914c1 snapshot working copy
+    │  -- operation 68c3f8867818 snapshot working copy
     ┝  rlvkpnrz/1 test.user@example.com 2001-02-03 08:05:09 cdf175ef (hidden) (conflict)
     │  my description
-    │  -- operation 449a03ec4824 rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
+    │  -- operation b2a0c4f0aa5d rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
     ┝  rlvkpnrz/2 test.user@example.com 2001-02-03 08:05:09 51e08f95 (hidden)
     │  my description
-    │  -- operation fff45c7cf767 snapshot working copy
+    │  -- operation 8c72466647e6 snapshot working copy
     ┝  rlvkpnrz/3 test.user@example.com 2001-02-03 08:05:08 b955b72e (hidden)
        (empty) my description
-       -- operation c5d06fd4ff51 new empty commit
+       -- operation 390d0e261e11 new empty commit
     [EOF]
     ");
 }
@@ -330,46 +330,46 @@ fn test_evolog_word_wrap() {
     insta::assert_snapshot!(render(&["evolog"], 40, false), @"
     @  qpvuntsm test.user@example.com 2001-02-03 08:05:08 68a50538
     │  (empty) first
-    │  -- operation e131aa88d7c9 describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
+    │  -- operation 1e1a8ca9529a describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     ○  qpvuntsm/1 test.user@example.com 2001-02-03 08:05:07 e8849ae1 (hidden)
        (empty) (no description set)
-       -- operation 90267f31f904 add workspace 'default'
+       -- operation f63ee16f9553 add workspace 'default'
     [EOF]
     ");
     insta::assert_snapshot!(render(&["evolog"], 40, true), @"
     @  qpvuntsm test.user@example.com
     │  2001-02-03 08:05:08 68a50538
     │  (empty) first
-    │  -- operation e131aa88d7c9 describe
+    │  -- operation 1e1a8ca9529a describe
     │  commit
     │  e8849ae12c709f2321908879bc724fdb2ab8a781
     ○  qpvuntsm/1 test.user@example.com
        2001-02-03 08:05:07 e8849ae1 (hidden)
        (empty) (no description set)
-       -- operation 90267f31f904 add
+       -- operation f63ee16f9553 add
        workspace 'default'
     [EOF]
     ");
     insta::assert_snapshot!(render(&["evolog", "--no-graph"], 40, false), @"
     qpvuntsm test.user@example.com 2001-02-03 08:05:08 68a50538
     (empty) first
-    -- operation e131aa88d7c9 describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
+    -- operation 1e1a8ca9529a describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     qpvuntsm/1 test.user@example.com 2001-02-03 08:05:07 e8849ae1 (hidden)
     (empty) (no description set)
-    -- operation 90267f31f904 add workspace 'default'
+    -- operation f63ee16f9553 add workspace 'default'
     [EOF]
     ");
     insta::assert_snapshot!(render(&["evolog", "--no-graph"], 40, true), @"
     qpvuntsm test.user@example.com
     2001-02-03 08:05:08 68a50538
     (empty) first
-    -- operation e131aa88d7c9 describe
+    -- operation 1e1a8ca9529a describe
     commit
     e8849ae12c709f2321908879bc724fdb2ab8a781
     qpvuntsm/1 test.user@example.com
     2001-02-03 08:05:07 e8849ae1 (hidden)
     (empty) (no description set)
-    -- operation 90267f31f904 add workspace
+    -- operation f63ee16f9553 add workspace
     'default'
     [EOF]
     ");
@@ -419,7 +419,7 @@ fn test_evolog_squash() {
     insta::assert_snapshot!(output, @r"
     ○      qpvuntsm test.user@example.com 2001-02-03 08:05:15 5f3281c6
     ├─┬─╮  squashed 3
-    │ │ │  -- operation 834dc47a2691 squash commits into 5ec0619af5cb4f7707a556a71a6f96af0bc294d2
+    │ │ │  -- operation ce2492756a0d squash commits into 5ec0619af5cb4f7707a556a71a6f96af0bc294d2
     │ │ │  Modified commit description:
     │ │ │     1     : <<<<<<< conflict 1 of 1
     │ │ │     2     : +++++++ side #1
@@ -434,27 +434,27 @@ fn test_evolog_squash() {
     │ │ │          1: squashed 3
     │ │ ○  vruxwmqv/0 test.user@example.com 2001-02-03 08:05:15 770795d0 (hidden)
     │ │ │  fifth
-    │ │ │  -- operation d727647433c1 snapshot working copy
+    │ │ │  -- operation ac8d9eefabd0 snapshot working copy
     │ │ │  Added regular file file5:
     │ │ │          1: foo5
     │ │ ○  vruxwmqv/1 test.user@example.com 2001-02-03 08:05:14 2e0123d1 (hidden)
     │ │    (empty) fifth
-    │ │    -- operation 9b66a7792e7b new empty commit
+    │ │    -- operation 3906ce22eb5a new empty commit
     │ │    Modified commit description:
     │ │            1: fifth
     │ ○  yqosqzyt/0 test.user@example.com 2001-02-03 08:05:14 ea8161b6 (hidden)
     │ │  fourth
-    │ │  -- operation e9387215360e snapshot working copy
+    │ │  -- operation 57bb636dabb8 snapshot working copy
     │ │  Added regular file file4:
     │ │          1: foo4
     │ ○  yqosqzyt/1 test.user@example.com 2001-02-03 08:05:13 1de5fdb6 (hidden)
     │    (empty) fourth
-    │    -- operation 4746e5b93ebb new empty commit
+    │    -- operation 899b98063159 new empty commit
     │    Modified commit description:
     │            1: fourth
     ○    qpvuntsm/1 test.user@example.com 2001-02-03 08:05:12 5ec0619a (hidden)
     ├─╮  squashed 2
-    │ │  -- operation 47521583d5c7 squash commits into 690858846504af0e42fde980fdacf9851559ebb8
+    │ │  -- operation 6fdaa0b09c18 squash commits into 690858846504af0e42fde980fdacf9851559ebb8
     │ │  Modified commit description:
     │ │     1     : <<<<<<< conflict 1 of 1
     │ │     2     : +++++++ side #1
@@ -470,7 +470,7 @@ fn test_evolog_squash() {
     │ │     1     : foo3
     │ ○  zsuskuln/3 test.user@example.com 2001-02-03 08:05:12 cce957f1 (hidden)
     │ │  third
-    │ │  -- operation 4406238f2235 snapshot working copy
+    │ │  -- operation d4dd3f693233 snapshot working copy
     │ │  Modified regular file file1:
     │ │     1    1: foo
     │ │     2    2: bar
@@ -481,15 +481,15 @@ fn test_evolog_squash() {
     │ │          1: foo3
     │ ○  zsuskuln/4 test.user@example.com 2001-02-03 08:05:11 3a2a4253 (hidden)
     │ │  (empty) third
-    │ │  -- operation 1ef878808235 describe commit ebec10f449ad7ab92c7293efab5e3db2d8e9fea1
+    │ │  -- operation 33e1d3ed9731 describe commit ebec10f449ad7ab92c7293efab5e3db2d8e9fea1
     │ │  Modified commit description:
     │ │          1: third
     │ ○  zsuskuln/5 test.user@example.com 2001-02-03 08:05:10 ebec10f4 (hidden)
     │    (empty) (no description set)
-    │    -- operation c6c228cfffd1 squash commits into 5878cbe03cdf599c9353e5a1a52a01f4c5e0e0fa
+    │    -- operation 5e3953f66df8 squash commits into 5878cbe03cdf599c9353e5a1a52a01f4c5e0e0fa
     ○    qpvuntsm/2 test.user@example.com 2001-02-03 08:05:10 69085884 (hidden)
     ├─╮  squashed 1
-    │ │  -- operation c6c228cfffd1 squash commits into 5878cbe03cdf599c9353e5a1a52a01f4c5e0e0fa
+    │ │  -- operation 5e3953f66df8 squash commits into 5878cbe03cdf599c9353e5a1a52a01f4c5e0e0fa
     │ │  Modified commit description:
     │ │     1     : <<<<<<< conflict 1 of 1
     │ │     2     : %%%%%%% diff from: base
@@ -501,28 +501,28 @@ fn test_evolog_squash() {
     │ │          1: squashed 1
     │ ○  kkmpptxz/0 test.user@example.com 2001-02-03 08:05:10 a3759c9d (hidden)
     │ │  second
-    │ │  -- operation d7409e8bb16e snapshot working copy
+    │ │  -- operation 41aaffdd1249 snapshot working copy
     │ │  Modified regular file file1:
     │ │     1    1: foo
     │ │          2: bar
     │ ○  kkmpptxz/1 test.user@example.com 2001-02-03 08:05:09 a5b2f625 (hidden)
     │    (empty) second
-    │    -- operation 3882a27a689e new empty commit
+    │    -- operation 624750bb3872 new empty commit
     │    Modified commit description:
     │            1: second
     ○  qpvuntsm/3 test.user@example.com 2001-02-03 08:05:09 5878cbe0 (hidden)
     │  first
-    │  -- operation 09276dd2e7a3 snapshot working copy
+    │  -- operation 6959849352e5 snapshot working copy
     │  Added regular file file1:
     │          1: foo
     ○  qpvuntsm/4 test.user@example.com 2001-02-03 08:05:08 68a50538 (hidden)
     │  (empty) first
-    │  -- operation e131aa88d7c9 describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
+    │  -- operation 1e1a8ca9529a describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     │  Modified commit description:
     │          1: first
     ○  qpvuntsm/5 test.user@example.com 2001-02-03 08:05:07 e8849ae1 (hidden)
        (empty) (no description set)
-       -- operation 90267f31f904 add workspace 'default'
+       -- operation f63ee16f9553 add workspace 'default'
     [EOF]
     ");
 }
@@ -541,21 +541,21 @@ fn test_evolog_abandoned_op() {
     insta::assert_snapshot!(work_dir.run_jj(["evolog", "--summary"]), @"
     @  qpvuntsm test.user@example.com 2001-02-03 08:05:09 e1869e5d
     │  file2
-    │  -- operation fc77633b6bae describe commit 32cabcfa05c604a36074d74ae59964e4e5eb18e9
+    │  -- operation d8b6fd24ba81 describe commit 32cabcfa05c604a36074d74ae59964e4e5eb18e9
     ○  qpvuntsm/1 test.user@example.com 2001-02-03 08:05:09 32cabcfa (hidden)
     │  file1
-    │  -- operation b53688d1ffdb snapshot working copy
+    │  -- operation 8d538c10fa39 snapshot working copy
     │  A file2
     ○  qpvuntsm/2 test.user@example.com 2001-02-03 08:05:08 cb5ebdc6 (hidden)
     │  file1
-    │  -- operation da73408c375b describe commit 093c3c9624b6cfe22b310586f5638792aa80e6d7
+    │  -- operation 7f39e29a02f6 describe commit 093c3c9624b6cfe22b310586f5638792aa80e6d7
     ○  qpvuntsm/3 test.user@example.com 2001-02-03 08:05:08 093c3c96 (hidden)
     │  (no description set)
-    │  -- operation 7957eae6f36e snapshot working copy
+    │  -- operation c2b5918d8499 snapshot working copy
     │  A file1
     ○  qpvuntsm/4 test.user@example.com 2001-02-03 08:05:07 e8849ae1 (hidden)
        (empty) (no description set)
-       -- operation 90267f31f904 add workspace 'default'
+       -- operation f63ee16f9553 add workspace 'default'
     [EOF]
     ");
 
@@ -567,7 +567,7 @@ fn test_evolog_abandoned_op() {
     insta::assert_snapshot!(work_dir.run_jj(["evolog", "--summary"]), @"
     @  qpvuntsm test.user@example.com 2001-02-03 08:05:09 e1869e5d
     │  file2
-    │  -- operation 05862c165a9d describe commit 32cabcfa05c604a36074d74ae59964e4e5eb18e9
+    │  -- operation 942cfd389e43 describe commit 32cabcfa05c604a36074d74ae59964e4e5eb18e9
     ○  qpvuntsm/1 test.user@example.com 2001-02-03 08:05:09 32cabcfa (hidden)
        file1
        A file1
@@ -634,16 +634,16 @@ fn test_evolog_reversed_no_graph() {
     insta::assert_snapshot!(output, @"
     qpvuntsm/3 test.user@example.com 2001-02-03 08:05:07 e8849ae1 (hidden)
     (empty) (no description set)
-    -- operation 90267f31f904 add workspace 'default'
+    -- operation f63ee16f9553 add workspace 'default'
     qpvuntsm/2 test.user@example.com 2001-02-03 08:05:08 b86e28cd (hidden)
     (empty) a
-    -- operation a595dd82bbc9 describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
+    -- operation d3f27026b8a8 describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     qpvuntsm/1 test.user@example.com 2001-02-03 08:05:09 9f43967b (hidden)
     (empty) b
-    -- operation 185b1ed3ff38 describe commit b86e28cd6862624ad77e1aaf31e34b2c7545bebd
+    -- operation 33dc6bc64b41 describe commit b86e28cd6862624ad77e1aaf31e34b2c7545bebd
     qpvuntsm test.user@example.com 2001-02-03 08:05:10 b28cda4b
     (empty) c
-    -- operation 63b6e96eb14e describe commit 9f43967b1cdbce4ab322cb7b4636fc0362c38373
+    -- operation a87d22b54fb2 describe commit 9f43967b1cdbce4ab322cb7b4636fc0362c38373
     [EOF]
     ");
 
@@ -651,10 +651,10 @@ fn test_evolog_reversed_no_graph() {
     insta::assert_snapshot!(output, @"
     qpvuntsm/1 test.user@example.com 2001-02-03 08:05:09 9f43967b (hidden)
     (empty) b
-    -- operation 185b1ed3ff38 describe commit b86e28cd6862624ad77e1aaf31e34b2c7545bebd
+    -- operation 33dc6bc64b41 describe commit b86e28cd6862624ad77e1aaf31e34b2c7545bebd
     qpvuntsm test.user@example.com 2001-02-03 08:05:10 b28cda4b
     (empty) c
-    -- operation 63b6e96eb14e describe commit 9f43967b1cdbce4ab322cb7b4636fc0362c38373
+    -- operation a87d22b54fb2 describe commit 9f43967b1cdbce4ab322cb7b4636fc0362c38373
     [EOF]
     ");
 }
@@ -687,25 +687,25 @@ fn test_evolog_reverse_with_graph() {
     insta::assert_snapshot!(output, @"
     ○  qpvuntsm/4 test.user@example.com 2001-02-03 08:05:07 e8849ae1 (hidden)
     │  (empty) (no description set)
-    │  -- operation 90267f31f904 add workspace 'default'
+    │  -- operation f63ee16f9553 add workspace 'default'
     ○  qpvuntsm/3 test.user@example.com 2001-02-03 08:05:08 b86e28cd (hidden)
     │  (empty) a
-    │  -- operation a595dd82bbc9 describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
+    │  -- operation d3f27026b8a8 describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     ○  qpvuntsm/2 test.user@example.com 2001-02-03 08:05:09 9f43967b (hidden)
     │  (empty) b
-    │  -- operation 185b1ed3ff38 describe commit b86e28cd6862624ad77e1aaf31e34b2c7545bebd
+    │  -- operation 33dc6bc64b41 describe commit b86e28cd6862624ad77e1aaf31e34b2c7545bebd
     ○  qpvuntsm/1 test.user@example.com 2001-02-03 08:05:10 b28cda4b (hidden)
     │  (empty) c
-    │  -- operation 63b6e96eb14e describe commit 9f43967b1cdbce4ab322cb7b4636fc0362c38373
+    │  -- operation a87d22b54fb2 describe commit 9f43967b1cdbce4ab322cb7b4636fc0362c38373
     │ ○  mzvwutvl/0 test.user@example.com 2001-02-03 08:05:11 6a4ff8aa (hidden)
     ├─╯  (empty) d
-    │    -- operation 834d3c2b578c new empty commit
+    │    -- operation 8baeb4813719 new empty commit
     │ ○  royxmykx/0 test.user@example.com 2001-02-03 08:05:12 7dea2d1d (hidden)
     ├─╯  (empty) e
-    │    -- operation 303ac509f441 new empty commit
+    │    -- operation 9bdd877c3495 new empty commit
     ○  qpvuntsm test.user@example.com 2001-02-03 08:05:13 78fdd026
        (empty) c+d+e
-       -- operation 10809bce2b20 squash commits into b28cda4b118fc50495ca34a24f030abc078d032e
+       -- operation e91587b8968e squash commits into b28cda4b118fc50495ca34a24f030abc078d032e
     [EOF]
     ");
 
@@ -713,13 +713,13 @@ fn test_evolog_reverse_with_graph() {
     insta::assert_snapshot!(output, @"
     ○  mzvwutvl/0 test.user@example.com 2001-02-03 08:05:11 6a4ff8aa (hidden)
     │  (empty) d
-    │  -- operation 834d3c2b578c new empty commit
+    │  -- operation 8baeb4813719 new empty commit
     │ ○  royxmykx/0 test.user@example.com 2001-02-03 08:05:12 7dea2d1d (hidden)
     ├─╯  (empty) e
-    │    -- operation 303ac509f441 new empty commit
+    │    -- operation 9bdd877c3495 new empty commit
     ○  qpvuntsm test.user@example.com 2001-02-03 08:05:13 78fdd026
        (empty) c+d+e
-       -- operation 10809bce2b20 squash commits into b28cda4b118fc50495ca34a24f030abc078d032e
+       -- operation e91587b8968e squash commits into b28cda4b118fc50495ca34a24f030abc078d032e
     [EOF]
     ");
 }
@@ -751,7 +751,7 @@ fn test_evolog_template_predecessors_and_inter_diff() {
     insta::assert_snapshot!(output, @"
     @  kkmpptxz test.user@example.com 2001-02-03 08:05:10 c6106cde
     │  d
-    │  -- operation d23cb3c75003 snapshot working copy
+    │  -- operation 6561c201f04a snapshot working copy
     │  diff --git a/file1 b/file1
     │  new file mode 100644
     │  index 0000000000..4bcfe98e64
@@ -761,7 +761,7 @@ fn test_evolog_template_predecessors_and_inter_diff() {
     │  +d
     ○  kkmpptxz/1 test.user@example.com 2001-02-03 08:05:09 780d27be (hidden)
        (empty) d
-       -- operation 442a733fd961 new empty commit
+       -- operation f0e828390851 new empty commit
     [EOF]
     ");
 
@@ -795,34 +795,34 @@ fn test_evolog_template_predecessors_and_inter_diff() {
     insta::assert_snapshot!(output, @"
     ○      qpvuntsm test.user@example.com 2001-02-03 08:05:12 92850c35
     ├─┬─╮  c+d+e
-    │ │ │  -- operation a0d2f98ffe2f squash commits into e3ce68f48b53d16111a1310c7f417a39c2934931
+    │ │ │  -- operation e306add442b0 squash commits into e3ce68f48b53d16111a1310c7f417a39c2934931
     │ │ │  predecessors: e3ce68f4,c6106cde,870e49d7
     │ │ ○  mzvwutvl/0 test.user@example.com 2001-02-03 08:05:12 870e49d7 (hidden)
     │ │ │  e
-    │ │ │  -- operation 3e23aa680b92 snapshot working copy
+    │ │ │  -- operation cf23ca301b6e snapshot working copy
     │ │ │  predecessors: 3345e308
     │ │ │  A file3
     │ │ ○  mzvwutvl/1 test.user@example.com 2001-02-03 08:05:11 3345e308 (hidden)
     │ │    (empty) e
-    │ │    -- operation d61bdfd0cb90 new empty commit
+    │ │    -- operation f4ef2c58934a new empty commit
     │ │    predecessors:
     │ ○  kkmpptxz/0 test.user@example.com 2001-02-03 08:05:10 c6106cde (hidden)
     │ │  d
-    │ │  -- operation d23cb3c75003 snapshot working copy
+    │ │  -- operation 6561c201f04a snapshot working copy
     │ │  predecessors: 780d27be
     │ │  A file1
     │ │  A file2
     │ ○  kkmpptxz/1 test.user@example.com 2001-02-03 08:05:09 780d27be (hidden)
     │    (empty) d
-    │    -- operation 442a733fd961 new empty commit
+    │    -- operation f0e828390851 new empty commit
     │    predecessors:
     ○  qpvuntsm/1 test.user@example.com 2001-02-03 08:05:08 e3ce68f4 (hidden)
     │  (empty) c
-    │  -- operation ca53c68e9c36 describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
+    │  -- operation 6859b8912238 describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     │  predecessors: e8849ae1
     ○  qpvuntsm/2 test.user@example.com 2001-02-03 08:05:07 e8849ae1 (hidden)
        (empty) (no description set)
-       -- operation 90267f31f904 add workspace 'default'
+       -- operation f63ee16f9553 add workspace 'default'
        predecessors:
     [EOF]
     ");

--- a/cli/tests/test_file_chmod_command.rs
+++ b/cli/tests/test_file_chmod_command.rs
@@ -323,7 +323,7 @@ fn test_chmod_exec_bit_settings() -> TestResult {
 
     let output = work_dir.run_jj(["debug", "local-working-copy"]);
     insta::assert_snapshot!(output.normalize_stdout_with(redact_timestamp), @r#"
-    Current operation: OperationId("c213f276df4f2ac12ede4d6e1b7f386311c02049195b5db39a476b1785fe052e21b816b82ad41a2833296c04e27eab5a981f1744fa511581e32d405e0f8370b2")
+    Current operation: OperationId("1e4ba9c8f03df16a2771f856a721cf86d3cc39db7be7f39e2bf1684925d22ce74ea1b18a0a6a3441a2e7e6e395cd3a58967cc8cfe98e6613996c822ed1073cd0")
     Current tree: MergedTree { tree_ids: Resolved(TreeId("6d5f482d15035cdd7733b1b551d1fead28d22592")), labels: Unlabeled, .. }
     Normal { exec_bit: ExecBit(false) }             5 <timestamp> None "file"
     [EOF]
@@ -336,7 +336,7 @@ fn test_chmod_exec_bit_settings() -> TestResult {
     set_file_executable(path, true);
     let output = work_dir.run_jj(["debug", "local-working-copy"]);
     insta::assert_snapshot!(output.normalize_stdout_with(redact_timestamp), @r#"
-    Current operation: OperationId("60ebc37d4d08925da7d4d50b21ebd4395dfd71180cd3694cc288bce2145e8d601ca38ecdf2ce1abbba7368d678f154688b0f0c855e874757bfb8ec2d54c46c18")
+    Current operation: OperationId("fa0db599588bfd6e4763aafc55f72ed562d8ff94a7b902f194743267e9163efc53b9e17b7eead28023e1d002582f0f810f4295f80ccfab629bd5fba7744cd29b")
     Current tree: MergedTree { tree_ids: Resolved(TreeId("5201dbafb66dc1b28b029a262e1b206f6f93df1e")), labels: Unlabeled, .. }
     Normal { exec_bit: ExecBit(true) }             5 <timestamp> None "file"
     [EOF]
@@ -358,7 +358,7 @@ fn test_chmod_exec_bit_settings() -> TestResult {
     assert_file_executable(path, true);
     let output = work_dir.run_jj(["debug", "local-working-copy"]);
     insta::assert_snapshot!(output.normalize_stdout_with(redact_timestamp), @r#"
-    Current operation: OperationId("2b128dc13ea9967d7a233535a8ea1f70b2f9a5e713d17097507fe9f0d986c9852377aa578fdd49959bcd60692ebd4cfd6c6f02d8e86a67ce631bf39ecf48cc2c")
+    Current operation: OperationId("ed819afb0927ba7df0ffe210d95c1cf16396ec753631a88e49e5e241b3ce06f3fd6caead28c3f8ed31dc8de0cb23725f544d61ca6c1f7d2c90924970a66586be")
     Current tree: MergedTree { tree_ids: Resolved(TreeId("6d5f482d15035cdd7733b1b551d1fead28d22592")), labels: Unlabeled, .. }
     Normal { exec_bit: ExecBit(true) }             5 <timestamp> None "file"
     [EOF]
@@ -369,7 +369,7 @@ fn test_chmod_exec_bit_settings() -> TestResult {
     assert_file_executable(path, false);
     let output = work_dir.run_jj(["debug", "local-working-copy"]);
     insta::assert_snapshot!(output.normalize_stdout_with(redact_timestamp), @r#"
-    Current operation: OperationId("73ee76ab06de88c3a43feefd313883127562f28cacd52e41408b6a1769294731d7a7fd90313e6324db6e501ea6602c5c83cd647a4d750728889688b5dc7178a2")
+    Current operation: OperationId("cbe47baa102289146cae20f704e5b76ed684d89a6d5ddef7a0765aee0e33acfe78b4213efd4777266d264cdbb41cc927eba6d45a9c3478be19cd72f6c2bc3fdc")
     Current tree: MergedTree { tree_ids: Resolved(TreeId("5201dbafb66dc1b28b029a262e1b206f6f93df1e")), labels: Unlabeled, .. }
     Normal { exec_bit: ExecBit(false) }             5 <timestamp> None "file"
     [EOF]
@@ -402,7 +402,7 @@ fn test_chmod_exec_bit_settings() -> TestResult {
     set_file_executable(path, true);
     let output = work_dir.run_jj(["debug", "local-working-copy"]);
     insta::assert_snapshot!(output.normalize_stdout_with(redact_timestamp), @r#"
-    Current operation: OperationId("8ab66b017c52976aaa389ea0a5f4f6fd6a0267525b44303a8882d6ed2d5ac507fd661fcde9f466efa51f09d82c826bbff2af236b68502cbb991877e609d4858b")
+    Current operation: OperationId("29ccfbc7d485c0638720d1343290b5f51463433f1d6dc775403ffb1f8c9bca8bd603d43e4eb10eb62996f5d2fd2592835584b7670775e636e4108b996126f017")
     Current tree: MergedTree { tree_ids: Resolved(TreeId("5201dbafb66dc1b28b029a262e1b206f6f93df1e")), labels: Unlabeled, .. }
     Normal { exec_bit: ExecBit(true) }             5 <timestamp> None "file"
     [EOF]

--- a/cli/tests/test_git_clone.rs
+++ b/cli/tests/test_git_clone.rs
@@ -812,7 +812,7 @@ fn test_git_clone_ignore_working_copy() {
     let output = clone_dir.run_jj(["status"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Error: The working copy is stale (not updated since operation 90267f31f904).
+    Error: The working copy is stale (not updated since operation f63ee16f9553).
     Hint: Run `jj workspace update-stale` to update it.
     See https://docs.jj-vcs.dev/latest/working-copy/#stale-working-copy for more information.
     [EOF]
@@ -1107,7 +1107,7 @@ fn test_git_clone_malformed() {
     let output = clone_dir.run_jj(["status"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Error: The working copy is stale (not updated since operation 95b4c4e3a6ed).
+    Error: The working copy is stale (not updated since operation 68cac63e1c80).
     Hint: Run `jj workspace update-stale` to update it.
     See https://docs.jj-vcs.dev/latest/working-copy/#stale-working-copy for more information.
     [EOF]

--- a/cli/tests/test_git_colocated.rs
+++ b/cli/tests/test_git_colocated.rs
@@ -288,7 +288,7 @@ fn test_git_colocated_unborn_bookmark() -> TestResult {
     ");
     insta::assert_snapshot!(get_colocation_status(&work_dir), @"
     Workspace is currently colocated with Git.
-    Last imported/exported Git HEAD: (none)
+    Last imported/exported Git HEAD: (absent)
     [EOF]
     ");
 
@@ -316,7 +316,7 @@ fn test_git_colocated_unborn_bookmark() -> TestResult {
     ");
     insta::assert_snapshot!(get_colocation_status(&work_dir), @"
     Workspace is currently colocated with Git.
-    Last imported/exported Git HEAD: (none)
+    Last imported/exported Git HEAD: (absent)
     [EOF]
     ");
     // Staged change shouldn't persist.
@@ -394,7 +394,7 @@ fn test_git_colocated_unborn_bookmark() -> TestResult {
     ");
     insta::assert_snapshot!(get_colocation_status(&work_dir), @"
     Workspace is currently colocated with Git.
-    Last imported/exported Git HEAD: (none)
+    Last imported/exported Git HEAD: (absent)
     [EOF]
     ");
     // Staged change shouldn't persist.
@@ -1042,7 +1042,7 @@ fn test_git_colocated_external_checkout() -> TestResult {
     [EOF]
     ------- stderr -------
     Reset the working copy parent to the new Git HEAD.
-    Operation left uncommitted because --no-integrate-operation was requested: 4dd0ee71039d
+    Operation left uncommitted because --no-integrate-operation was requested: bbe960f5b642
     [EOF]
     ");
     let output = work_dir.run_jj(["status", "--no-integrate-operation"]);
@@ -1053,7 +1053,7 @@ fn test_git_colocated_external_checkout() -> TestResult {
     [EOF]
     ------- stderr -------
     Reset the working copy parent to the new Git HEAD.
-    Operation left uncommitted because --no-integrate-operation was requested: 1c501b6939b3
+    Operation left uncommitted because --no-integrate-operation was requested: a995bf65df58
     [EOF]
     ");
 
@@ -1200,7 +1200,7 @@ fn test_git_colocated_undo_head_move() -> TestResult {
     ");
     insta::assert_snapshot!(get_colocation_status(&work_dir), @"
     Workspace is currently colocated with Git.
-    Last imported/exported Git HEAD: (none)
+    Last imported/exported Git HEAD: (absent)
     [EOF]
     ");
 
@@ -1228,8 +1228,8 @@ fn test_git_colocated_undo_head_move() -> TestResult {
     let output = work_dir.run_jj(["undo"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Undid operation: 370aaac5a54d (2001-02-03 08:05:15) new empty commit
-    Restored to operation: f4eb73ce02a5 (2001-02-03 08:05:14) new empty commit
+    Undid operation: c3aad0e25c1e (2001-02-03 08:05:15) new empty commit
+    Restored to operation: c6c88e19d828 (2001-02-03 08:05:14) new empty commit
     Working copy  (@) now at: vruxwmqv 23e6e06a (empty) (no description set)
     Parent commit (@-)      : qpvuntsm e8849ae1 (empty) (no description set)
     [EOF]

--- a/cli/tests/test_git_colocated.rs
+++ b/cli/tests/test_git_colocated.rs
@@ -1042,7 +1042,7 @@ fn test_git_colocated_external_checkout() -> TestResult {
     [EOF]
     ------- stderr -------
     Reset the working copy parent to the new Git HEAD.
-    Operation left uncommitted because --no-integrate-operation was requested: 4dd0ee71039d
+    Operation left uncommitted because --no-integrate-operation was requested: bbe960f5b642
     [EOF]
     ");
     let output = work_dir.run_jj(["status", "--no-integrate-operation"]);
@@ -1053,7 +1053,7 @@ fn test_git_colocated_external_checkout() -> TestResult {
     [EOF]
     ------- stderr -------
     Reset the working copy parent to the new Git HEAD.
-    Operation left uncommitted because --no-integrate-operation was requested: 1c501b6939b3
+    Operation left uncommitted because --no-integrate-operation was requested: a995bf65df58
     [EOF]
     ");
 
@@ -1228,8 +1228,8 @@ fn test_git_colocated_undo_head_move() -> TestResult {
     let output = work_dir.run_jj(["undo"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Undid operation: 370aaac5a54d (2001-02-03 08:05:15) new empty commit
-    Restored to operation: f4eb73ce02a5 (2001-02-03 08:05:14) new empty commit
+    Undid operation: c3aad0e25c1e (2001-02-03 08:05:15) new empty commit
+    Restored to operation: c6c88e19d828 (2001-02-03 08:05:14) new empty commit
     Working copy  (@) now at: vruxwmqv 23e6e06a (empty) (no description set)
     Parent commit (@-)      : qpvuntsm e8849ae1 (empty) (no description set)
     [EOF]

--- a/cli/tests/test_git_colocation.rs
+++ b/cli/tests/test_git_colocation.rs
@@ -60,7 +60,7 @@ fn test_git_colocation_enable_success() -> TestResult {
     // And that there is no Git HEAD yet
     insta::assert_snapshot!(get_colocation_status(&work_dir), @"
     Workspace is currently not colocated with Git.
-    Last imported/exported Git HEAD: (none)
+    Last imported/exported Git HEAD: (absent)
     [EOF]
     ");
 
@@ -129,7 +129,7 @@ fn test_git_colocation_enable_empty() {
     // Verify that Git HEAD was set correctly
     insta::assert_snapshot!(get_colocation_status(&work_dir), @"
     Workspace is currently colocated with Git.
-    Last imported/exported Git HEAD: (none)
+    Last imported/exported Git HEAD: (absent)
     [EOF]
     ");
 
@@ -210,7 +210,7 @@ fn test_git_colocation_enable_external_git_repo() {
     let output = work_dir.run_jj(["git", "colocation", "status"]);
     insta::assert_snapshot!(output, @"
     Workspace is currently not colocated with Git.
-    Last imported/exported Git HEAD: (none)
+    Last imported/exported Git HEAD: (absent)
     [EOF]
     ------- stderr -------
     Hint: Colocation cannot be enabled because the workspace is backed by an external Git repository.
@@ -276,7 +276,7 @@ fn test_git_colocation_disable_success() {
     // Verify that Git HEAD was removed correctly
     insta::assert_snapshot!(get_colocation_status(&work_dir), @"
     Workspace is currently not colocated with Git.
-    Last imported/exported Git HEAD: (none)
+    Last imported/exported Git HEAD: (absent)
     [EOF]
     ");
 
@@ -302,7 +302,7 @@ fn test_git_colocation_disable_empty() {
     // Verify that Git HEAD is unset
     insta::assert_snapshot!(get_colocation_status(&work_dir), @"
     Workspace is currently colocated with Git.
-    Last imported/exported Git HEAD: (none)
+    Last imported/exported Git HEAD: (absent)
     [EOF]
     ");
 
@@ -357,7 +357,7 @@ fn test_git_colocation_status_non_colocated() {
     let output = work_dir.run_jj(["git", "colocation", "status"]);
     insta::assert_snapshot!(output, @"
     Workspace is currently not colocated with Git.
-    Last imported/exported Git HEAD: (none)
+    Last imported/exported Git HEAD: (absent)
     [EOF]
     ------- stderr -------
     Hint: To enable colocation, run: `jj git colocation enable`
@@ -379,7 +379,7 @@ fn test_git_colocation_status_colocated() {
     let output = work_dir.run_jj(["git", "colocation", "status"]);
     insta::assert_snapshot!(output, @"
     Workspace is currently colocated with Git.
-    Last imported/exported Git HEAD: (none)
+    Last imported/exported Git HEAD: (absent)
     [EOF]
     ------- stderr -------
     Hint: To disable colocation, run: `jj git colocation disable`

--- a/cli/tests/test_git_fetch.rs
+++ b/cli/tests/test_git_fetch.rs
@@ -1495,8 +1495,8 @@ fn test_git_fetch_undo() {
     let output = target_dir.run_jj(["undo"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Undid operation: 353367639195 (2001-02-03 08:05:20) fetch from git remote(s) origin
-    Restored to operation: abd709a7b737 (2001-02-03 08:05:07) add git remote origin
+    Undid operation: 450e0713ac6d (2001-02-03 08:05:20) fetch from git remote(s) origin
+    Restored to operation: f9f128e730c0 (2001-02-03 08:05:07) add git remote origin
     [EOF]
     ");
     // The undo works as expected
@@ -1586,7 +1586,7 @@ fn test_fetch_undo_what() {
     let output = work_dir.run_jj(["op", "restore", "--what", "repo", &base_operation_id]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Restored to operation: abd709a7b737 (2001-02-03 08:05:07) add git remote origin
+    Restored to operation: f9f128e730c0 (2001-02-03 08:05:07) add git remote origin
     [EOF]
     ");
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @"
@@ -1618,7 +1618,7 @@ fn test_fetch_undo_what() {
     ]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Restored to operation: abd709a7b737 (2001-02-03 08:05:07) add git remote origin
+    Restored to operation: f9f128e730c0 (2001-02-03 08:05:07) add git remote origin
     [EOF]
     ");
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @"
@@ -2126,12 +2126,12 @@ fn test_git_fetch_remotely_rewritten() {
     insta::assert_snapshot!(output, @"
     ◆  kkmpptxz test.user@example.com 2001-02-03 08:05:14 book@origin 3ee37bc8
     │  (empty) bookmarked
-    │  -- operation 747e22d526e2 fetch from git remote(s) origin
+    │  -- operation bc9504529c2b fetch from git remote(s) origin
     ○  kkmpptxz/1 test.user@example.com 2001-02-03 08:05:09 eedc2709 (hidden)
        (empty) bookmarked
     ◆  qpvuntsm test.user@example.com 2001-02-03 08:05:14 f30445f7
     │  (empty) modified
-    │  -- operation 747e22d526e2 fetch from git remote(s) origin
+    │  -- operation bc9504529c2b fetch from git remote(s) origin
     ○  qpvuntsm/1 test.user@example.com 2001-02-03 08:05:08 97604bbe (hidden)
        (empty) original
     [EOF]
@@ -2165,12 +2165,12 @@ fn test_git_fetch_remotely_rewritten() {
     insta::assert_snapshot!(output, @"
     ◆  kkmpptxz test.user@example.com 2001-02-03 08:05:14 book@origin 3ee37bc8
     │  (empty) bookmarked
-    │  -- operation 747e22d526e2 fetch from git remote(s) origin
+    │  -- operation bc9504529c2b fetch from git remote(s) origin
     ○  kkmpptxz/1 test.user@example.com 2001-02-03 08:05:09 eedc2709 (hidden)
        (empty) bookmarked
     ◆  qpvuntsm test.user@example.com 2001-02-03 08:05:14 f30445f7
     │  (empty) modified
-    │  -- operation 747e22d526e2 fetch from git remote(s) origin
+    │  -- operation bc9504529c2b fetch from git remote(s) origin
     ○  qpvuntsm/1 test.user@example.com 2001-02-03 08:05:08 97604bbe (hidden)
        (empty) original
     [EOF]
@@ -2338,17 +2338,17 @@ fn test_git_fetch_remotely_rewritten_descendants() {
     insta::assert_snapshot!(output, @"
     ◆  mzvwutvl test.user@example.com 2001-02-03 08:05:16 book2@origin 3faff772
     │  (empty) bookmarked 2
-    │  -- operation 8285ffe9ef99 fetch from git remote(s) origin
+    │  -- operation c59a4ba1a1a9 fetch from git remote(s) origin
     ○  mzvwutvl/1 test.user@example.com 2001-02-03 08:05:11 cce448c2 (hidden)
        (empty) bookmarked 2
     ◆  kkmpptxz test.user@example.com 2001-02-03 08:05:16 book1@origin ad5c5f3c
     │  (empty) bookmarked 1
-    │  -- operation eed0c1c063f4 fetch from git remote(s) origin
+    │  -- operation 2cce05945865 fetch from git remote(s) origin
     ○  kkmpptxz/1 test.user@example.com 2001-02-03 08:05:09 2a6bbeb4 (hidden)
        (empty) bookmarked 1
     ◆  qpvuntsm test.user@example.com 2001-02-03 08:05:16 a843bfad
     │  (empty) modified
-    │  -- operation eed0c1c063f4 fetch from git remote(s) origin
+    │  -- operation 2cce05945865 fetch from git remote(s) origin
     ○  qpvuntsm/1 test.user@example.com 2001-02-03 08:05:08 97604bbe (hidden)
        (empty) original
     [EOF]

--- a/cli/tests/test_git_import_export.rs
+++ b/cli/tests/test_git_import_export.rs
@@ -149,8 +149,8 @@ fn test_git_export_undo() -> TestResult {
     let output = work_dir.run_jj(["undo"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Undid operation: 563b0274c404 (2001-02-03 08:05:10) export git refs
-    Restored to operation: a8cc177d3fa6 (2001-02-03 08:05:08) create bookmark a pointing to commit e8849ae12c709f2321908879bc724fdb2ab8a781
+    Undid operation: 29447db431a3 (2001-02-03 08:05:10) export git refs
+    Restored to operation: 5142cb3d7c38 (2001-02-03 08:05:08) create bookmark a pointing to commit e8849ae12c709f2321908879bc724fdb2ab8a781
     [EOF]
     ");
     insta::assert_debug_snapshot!(get_git_repo_refs(&git_repo), @r#"
@@ -224,7 +224,7 @@ fn test_git_import_undo() -> TestResult {
     let output = work_dir.run_jj(["op", "restore", &base_operation_id]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Restored to operation: 90267f31f904 (2001-02-03 08:05:07) add workspace 'default'
+    Restored to operation: f63ee16f9553 (2001-02-03 08:05:07) add workspace 'default'
     [EOF]
     ");
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @"");
@@ -305,7 +305,7 @@ fn test_git_import_move_export_with_default_undo() -> TestResult {
     let output = work_dir.run_jj(["op", "restore", &base_operation_id]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Restored to operation: 90267f31f904 (2001-02-03 08:05:07) add workspace 'default'
+    Restored to operation: f63ee16f9553 (2001-02-03 08:05:07) add workspace 'default'
     Working copy  (@) now at: qpvuntsm e8849ae1 (empty) (no description set)
     Parent commit (@-)      : zzzzzzzz 00000000 (empty) (no description set)
     [EOF]

--- a/cli/tests/test_git_init.rs
+++ b/cli/tests/test_git_init.rs
@@ -928,7 +928,7 @@ fn test_git_init_external_but_git_dir_exists() {
     ");
     insta::assert_snapshot!(get_colocation_status(&work_dir), @"
     Workspace is currently not colocated with Git.
-    Last imported/exported Git HEAD: (none)
+    Last imported/exported Git HEAD: (absent)
     [EOF]
     ");
 }
@@ -1104,7 +1104,7 @@ fn test_git_init_colocated_via_flag_git_dir_not_exists() {
     ");
     insta::assert_snapshot!(get_colocation_status(&work_dir), @"
     Workspace is currently colocated with Git.
-    Last imported/exported Git HEAD: (none)
+    Last imported/exported Git HEAD: (absent)
     [EOF]
     ");
 
@@ -1122,7 +1122,7 @@ fn test_git_init_colocated_via_flag_git_dir_not_exists() {
     ");
     insta::assert_snapshot!(get_colocation_status(&work_dir), @"
     Workspace is currently colocated with Git.
-    Last imported/exported Git HEAD: (none)
+    Last imported/exported Git HEAD: (absent)
     [EOF]
     ");
 }

--- a/cli/tests/test_global_opts.rs
+++ b/cli/tests/test_global_opts.rs
@@ -251,8 +251,8 @@ fn test_no_integrate_operation() {
     let output = test_env.run_jj_in(&repo_path, &["squash", "--no-integrate-operation"]);
     insta::assert_snapshot!(output.stdout, @"");
     insta::assert_snapshot!(output.stderr, @"
-    Snapshot operation left uncommitted because --no-integrate-operation was requested: 13357990b38a
-    Operation left uncommitted because --no-integrate-operation was requested: a028de7aa4f4
+    Snapshot operation left uncommitted because --no-integrate-operation was requested: 1b6e5938fe7e
+    Operation left uncommitted because --no-integrate-operation was requested: 0e885c491646
     [EOF]
     ");
     let stderr = output.stderr.into_raw();
@@ -277,19 +277,19 @@ fn test_no_integrate_operation() {
     ");
     let stdout = test_env.run_jj_in(&repo_path, &["op", "log", "--at-op", op_id_hex.as_str()]);
     insta::assert_snapshot!(stdout, @"
-    @  a028de7aa4f4 test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    @  0e885c491646 test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
     │  squash commits into e6fc2362ee5fdd5eb879befc0ae556a2f57b94a0
     │  args: jj squash --no-integrate-operation
-    ○  13357990b38a test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    ○  1b6e5938fe7e test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
     │  snapshot working copy
     │  args: jj squash --no-integrate-operation
-    ○  e167310e1125 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    ○  8d4c74253280 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  commit 289d54a4554ed0d7df9c47d566480a6b773ee431
     │  args: jj commit '-m=initial'
-    ○  55b88fdb1890 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    ○  65136c03793e test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  snapshot working copy
     │  args: jj commit '-m=initial'
-    ○  90267f31f904 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  f63ee16f9553 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
     [EOF]
@@ -320,8 +320,8 @@ fn test_no_integrate_operation_colocated() {
     let output = test_env.run_jj_in(&repo_path, &["squash", "--no-integrate-operation"]);
     insta::assert_snapshot!(output.stdout, @"");
     insta::assert_snapshot!(output.stderr, @"
-    Snapshot operation left uncommitted because --no-integrate-operation was requested: f9d2255ff5a3
-    Operation left uncommitted because --no-integrate-operation was requested: 0eccbf94f56f
+    Snapshot operation left uncommitted because --no-integrate-operation was requested: 62fa29d079c6
+    Operation left uncommitted because --no-integrate-operation was requested: ba14e2cc9e65
     [EOF]
     ");
     let stderr = output.stderr.into_raw();
@@ -346,19 +346,19 @@ fn test_no_integrate_operation_colocated() {
     ");
     let stdout = test_env.run_jj_in(&repo_path, &["op", "log", "--at-op", op_id_hex.as_str()]);
     insta::assert_snapshot!(stdout, @"
-    @  0eccbf94f56f test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    @  ba14e2cc9e65 test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
     │  squash commits into e6fc2362ee5fdd5eb879befc0ae556a2f57b94a0
     │  args: jj squash --no-integrate-operation
-    ○  f9d2255ff5a3 test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    ○  62fa29d079c6 test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
     │  snapshot working copy
     │  args: jj squash --no-integrate-operation
-    ○  30e6a62058cc test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    ○  b1b9a22805e6 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  commit 289d54a4554ed0d7df9c47d566480a6b773ee431
     │  args: jj commit '-m=initial'
-    ○  55b88fdb1890 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    ○  65136c03793e test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  snapshot working copy
     │  args: jj commit '-m=initial'
-    ○  90267f31f904 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  f63ee16f9553 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
     [EOF]

--- a/cli/tests/test_identical_commits.rs
+++ b/cli/tests/test_identical_commits.rs
@@ -92,10 +92,10 @@ fn test_identical_commits_by_cycling_rewrite() {
     insta::assert_snapshot!(work_dir.run_jj(["evolog"]), @"
     @  oxmtprsl test.user@example.com 2001-01-01 11:00:00 c5abd225
     │  (empty) test2
-    │  -- operation f0e7f7b1629b describe commit 053222c21fa06b9492e22346f8f70e732231ad4f
+    │  -- operation 0b504315f7ba describe commit 053222c21fa06b9492e22346f8f70e732231ad4f
     ○  oxmtprsl/1 test.user@example.com 2001-01-01 11:00:00 053222c2 (hidden)
        (empty) test1
-       -- operation 72d9ec4ca389 new empty commit
+       -- operation 166b2bc3dc53 new empty commit
     [EOF]
     ");
     // TODO: Test `jj op diff --from @--`
@@ -127,7 +127,7 @@ fn test_identical_commits_by_convergent_rewrite() {
     insta::assert_snapshot!(work_dir.run_jj(["evolog"]), @"
     @  oxmtprsl/1 test.user@example.com 2001-01-01 11:00:00 c5abd225 (divergent)
        (empty) test2
-       -- operation 2c0ac8f6dfb7 new empty commit
+       -- operation 4249d34636d2 new empty commit
     [EOF]
     ");
 }
@@ -163,7 +163,7 @@ fn test_identical_commits_by_convergent_rewrite_one_operation() {
     insta::assert_snapshot!(work_dir.run_jj(["evolog"]), @"
     @  oxmtprsl/0 test.user@example.com 2001-01-01 11:00:00 c5abd225 (divergent)
        (empty) test2
-       -- operation 2c0ac8f6dfb7 new empty commit
+       -- operation 4249d34636d2 new empty commit
     [EOF]
     ");
 }
@@ -204,13 +204,13 @@ fn test_identical_commits_swap_by_reordering() {
     insta::assert_snapshot!(work_dir.run_jj(["evolog", "-r=@"]), @"
     @  oxmtprsl/0 test.user@example.com 2001-01-01 11:00:00 5bae90c9 (divergent)
        (empty) test
-       -- operation 51fb079a7e7c new empty commit
+       -- operation af5cee55f7e1 new empty commit
     [EOF]
     ");
     insta::assert_snapshot!(work_dir.run_jj(["evolog", "-r=@-"]), @"
     ○  oxmtprsl/1 test.user@example.com 2001-01-01 11:00:00 e94ed463 (divergent)
        (empty) test
-       -- operation 03fecb732164 new empty commit
+       -- operation 9d92250a8782 new empty commit
     [EOF]
     ");
     // TODO: Test that `jj op show` displays something reasonable

--- a/cli/tests/test_metaedit_command.rs
+++ b/cli/tests/test_metaedit_command.rs
@@ -641,25 +641,25 @@ fn test_new_change_id() {
     insta::assert_snapshot!(work_dir.run_jj(["evolog", "-r", "yqosqzytrlswkspswpqrmlplxylrzsnz"]), @"
     ○  yqosqzyt test.user@example.com 2001-02-03 08:05:13 b 01d6741e
     │  (no description set)
-    │  -- operation 35c9be8faa47 edit commit metadata for commit 75591b1896b4990e7695701fd7cdbb32dba3ff50
+    │  -- operation ae935f447fc3 edit commit metadata for commit 75591b1896b4990e7695701fd7cdbb32dba3ff50
     ○  kkmpptxz/0 test.user@example.com 2001-02-03 08:05:11 75591b18 (hidden)
     │  (no description set)
-    │  -- operation 96903839b342 snapshot working copy
+    │  -- operation 40edb1af22f3 snapshot working copy
     ○  kkmpptxz/1 test.user@example.com 2001-02-03 08:05:09 acebf2bd (hidden)
        (empty) (no description set)
-       -- operation 35de69400054 new empty commit
+       -- operation 9cda02fa4d24 new empty commit
     [EOF]
     ");
     insta::assert_snapshot!(work_dir.run_jj(["evolog", "-r", "mzvwut"]), @"
     @  mzvwutvl test.user@example.com 2001-02-03 08:05:13 c 0c3fe2d8
     │  (no description set)
-    │  -- operation 35c9be8faa47 edit commit metadata for commit 75591b1896b4990e7695701fd7cdbb32dba3ff50
+    │  -- operation ae935f447fc3 edit commit metadata for commit 75591b1896b4990e7695701fd7cdbb32dba3ff50
     ○  mzvwutvl/1 test.user@example.com 2001-02-03 08:05:13 22be6c4e (hidden)
     │  (no description set)
-    │  -- operation 7d623f9b6867 snapshot working copy
+    │  -- operation 8eb7de08e61f snapshot working copy
     ○  mzvwutvl/2 test.user@example.com 2001-02-03 08:05:11 b9f5490a (hidden)
        (empty) (no description set)
-       -- operation 80928a366fe1 new empty commit
+       -- operation d4a1aacb95fb new empty commit
     [EOF]
     ");
 }

--- a/cli/tests/test_op_integrate_command.rs
+++ b/cli/tests/test_op_integrate_command.rs
@@ -29,7 +29,7 @@ fn test_integrate_integrated_operation() {
     insta::assert_snapshot!(output, @"");
     let output = work_dir.run_jj(["op", "log"]);
     insta::assert_snapshot!(output, @"
-    @  90267f31f904 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    @  f63ee16f9553 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
     [EOF]
@@ -64,8 +64,8 @@ fn test_integrate_sibling_operation() -> TestResult {
     let output = work_dir.run_jj(["op", "log"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Internal error: The repo was loaded at operation f0f64355037e, which seems to be a sibling of the working copy's operation 4f1ea5911f2f
-    Hint: Run `jj op integrate 4f1ea5911f2f` to add the working copy's operation to the operation log.
+    Internal error: The repo was loaded at operation 63a847e21093, which seems to be a sibling of the working copy's operation 4bffc36765bd
+    Hint: Run `jj op integrate 4bffc36765bd` to add the working copy's operation to the operation log.
     [EOF]
     [exit status: 255]
     ");
@@ -79,16 +79,16 @@ fn test_integrate_sibling_operation() -> TestResult {
     ");
     let output = work_dir.run_jj(["op", "log"]);
     insta::assert_snapshot!(output, @"
-    @    c07a58eed726 test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    @    f28c8b5750f5 test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
     ├─╮  reconcile divergent operations
-    │ │  args: jj op integrate 4f1ea5911f2f5d4e94a1620c9f762f33ab985d1635eb345027ed85c54bce3c085d0e0fa14c104743e26df5e565b47b2ca8c90dd7b548dbefed192b775ee2e3bc
-    ○ │  4f1ea5911f2f test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    │ │  args: jj op integrate 4bffc36765bd9b796cc8bd631a09e92c60b686ef98c316a9baa7164c4f6f9d0071871d5678b014fec33b920d1177776b748af2a6395fc28031f92ab75a1d31ec
+    ○ │  4bffc36765bd test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │ │  new empty commit
     │ │  args: jj new '-m=first'
-    │ ○  f0f64355037e test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    │ ○  63a847e21093 test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     ├─╯  new empty commit
     │    args: jj new '-m=second' --ignore-working-copy
-    ○  90267f31f904 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  f63ee16f9553 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
     [EOF]
@@ -132,8 +132,8 @@ fn test_integrate_rebase_descendants() -> TestResult {
     let output = work_dir.run_jj(["op", "log"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Internal error: The repo was loaded at operation dfab2903608d, which seems to be a sibling of the working copy's operation 17c93f71a912
-    Hint: Run `jj op integrate 17c93f71a912` to add the working copy's operation to the operation log.
+    Internal error: The repo was loaded at operation 02d52b605abd, which seems to be a sibling of the working copy's operation ec162faff901
+    Hint: Run `jj op integrate ec162faff901` to add the working copy's operation to the operation log.
     [EOF]
     [exit status: 255]
     ");
@@ -148,19 +148,19 @@ fn test_integrate_rebase_descendants() -> TestResult {
     ");
     let output = work_dir.run_jj(["op", "log"]);
     insta::assert_snapshot!(output, @"
-    @    e9ad6c38ebf5 test-username@host.example.com default@ 2001-02-03 04:05:12.000 +07:00 - 2001-02-03 04:05:12.000 +07:00
+    @    000180467209 test-username@host.example.com default@ 2001-02-03 04:05:12.000 +07:00 - 2001-02-03 04:05:12.000 +07:00
     ├─╮  reconcile divergent operations
-    │ │  args: jj op integrate 17c93f71a9128fbc6c2a7ea7a310efc2f6e476638b58caed13735a7b2e20a6c6dae9dcc84795dd7cca1eecf38ae2812e0216f46430250b1ce3aef4330522012c
-    ○ │  17c93f71a912 test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    │ │  args: jj op integrate ec162faff90142f42a8fe4e514c61c06c10756a11b3ee0d645500b6f4280225e20c0b21b18759c23c37f144c6643492f170b8b809ae5f932f5d73dcf651941d1
+    ○ │  ec162faff901 test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     │ │  new empty commit
     │ │  args: jj new '-m=child 2'
-    │ ○  dfab2903608d test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    │ ○  02d52b605abd test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     ├─╯  describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     │    args: jj describe '-m=parent' --ignore-working-copy
-    ○  78dcb3cf0b64 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    ○  10ad95d988d6 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  new empty commit
     │  args: jj new --no-edit '-m=child 1'
-    ○  90267f31f904 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  f63ee16f9553 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
     [EOF]
@@ -210,8 +210,8 @@ fn test_integrate_concurrent_operations() -> TestResult {
     let output = work_dir.run_jj(["op", "log"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Internal error: The repo was loaded at operation e18a1a944247, which seems to be a sibling of the working copy's operation 1bc121d24e06
-    Hint: Run `jj op integrate 1bc121d24e06` to add the working copy's operation to the operation log.
+    Internal error: The repo was loaded at operation 383be968e923, which seems to be a sibling of the working copy's operation 49428a30d110
+    Hint: Run `jj op integrate 49428a30d110` to add the working copy's operation to the operation log.
     [EOF]
     [exit status: 255]
     ");
@@ -225,16 +225,16 @@ fn test_integrate_concurrent_operations() -> TestResult {
     ");
     let output = work_dir.run_jj(["op", "log"]);
     insta::assert_snapshot!(output, @"
-    @    da91ff6e5aec test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    @    ddbaedf9ee34 test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
     ├─╮  reconcile divergent operations
-    │ │  args: jj op integrate 1bc121d24e06835c4c22e5f02b623c1deffec8b1bbf68a41e1f0b720d116c6b931e5588fcd262ea41962a4d5e746de19d23323ca08baa13cd0b5bc25402242ff
-    ○ │  1bc121d24e06 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    │ │  args: jj op integrate 49428a30d110a365178cdca38a32661982fb260d18df5c19f2b76df283c9cd2fd367dce1b124a7a75cfe9487eeee3b5031bd1b2a851261a3fc3f1d9dba41d768
+    ○ │  49428a30d110 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │ │  describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     │ │  args: jj describe '-m=left'
-    │ ○  e18a1a944247 test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    │ ○  383be968e923 test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     ├─╯  describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     │    args: jj describe '-m=right' --ignore-working-copy
-    ○  90267f31f904 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  f63ee16f9553 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
     [EOF]

--- a/cli/tests/test_op_restore_command.rs
+++ b/cli/tests/test_op_restore_command.rs
@@ -41,7 +41,7 @@ fn test_op_restore_to_valid_op_no_warning() {
     let output = work_dir.run_jj(["op", "restore", "@"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Restored to operation: 90267f31f904 (2001-02-03 08:05:07) add workspace 'default'
+    Restored to operation: f63ee16f9553 (2001-02-03 08:05:07) add workspace 'default'
     Nothing changed.
     [EOF]
     ");

--- a/cli/tests/test_operations.rs
+++ b/cli/tests/test_operations.rs
@@ -36,10 +36,10 @@ fn test_op_log() {
 
     let output = work_dir.run_jj(["op", "log"]);
     insta::assert_snapshot!(output, @"
-    @  8501e29d2d94 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    @  7749eb4df93f test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     │  args: jj describe -m 'description 0'
-    ○  90267f31f904 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  f63ee16f9553 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
     [EOF]
@@ -82,7 +82,7 @@ fn test_op_log() {
 
     let output = work_dir.run_jj(["op", "log", "--op-diff"]);
     insta::assert_snapshot!(output, @"
-    @  8501e29d2d94 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    @  7749eb4df93f test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     │  args: jj describe -m 'description 0'
     │
@@ -93,7 +93,7 @@ fn test_op_log() {
     │  Changed working copy default@:
     │  + qpvuntsm 3ae22e7f (empty) description 0
     │  - qpvuntsm/1 e8849ae1 (hidden) (empty) (no description set)
-    ○  90267f31f904 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  f63ee16f9553 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     │
     │  Changed commits:
@@ -108,7 +108,7 @@ fn test_op_log() {
 
     let output = work_dir.run_jj(["op", "log", "--op-diff", "--color=always"]);
     insta::assert_snapshot!(output, @"
-    [1m[38;5;2m@[0m  [1m[38;5;12m8501e29d2d94[39m [38;5;3mtest-username@host.example.com[39m [38;5;2mdefault@[39m [38;5;14m2001-02-03 04:05:08.000 +07:00[39m - [38;5;14m2001-02-03 04:05:08.000 +07:00[39m[0m
+    [1m[38;5;2m@[0m  [1m[38;5;12m7749eb4df93f[39m [38;5;3mtest-username@host.example.com[39m [38;5;2mdefault@[39m [38;5;14m2001-02-03 04:05:08.000 +07:00[39m - [38;5;14m2001-02-03 04:05:08.000 +07:00[39m[0m
     │  [1mdescribe commit e8849ae12c709f2321908879bc724fdb2ab8a781[0m
     │  [1m[38;5;13margs: jj describe -m 'description 0'[39m[0m
     │
@@ -119,7 +119,7 @@ fn test_op_log() {
     │  Changed working copy [38;5;2mdefault@[39m:
     │  [38;5;2m+[39m [1m[38;5;13mq[38;5;8mpvuntsm[39m [38;5;12m3[38;5;8mae22e7f[39m [38;5;10m(empty)[39m description 0[0m
     │  [38;5;1m-[39m [1m[39mq[0m[38;5;8mpvuntsm[1m[39m/1[0m [1m[38;5;4me[0m[38;5;8m8849ae1[39m (hidden) [38;5;2m(empty)[39m [38;5;2m(no description set)[39m
-    ○  [38;5;4m90267f31f904[39m [38;5;3mtest-username@host.example.com[39m [38;5;6m2001-02-03 04:05:07.000 +07:00[39m - [38;5;6m2001-02-03 04:05:07.000 +07:00[39m
+    ○  [38;5;4mf63ee16f9553[39m [38;5;3mtest-username@host.example.com[39m [38;5;6m2001-02-03 04:05:07.000 +07:00[39m - [38;5;6m2001-02-03 04:05:07.000 +07:00[39m
     │  add workspace 'default'
     │
     │  Changed commits:
@@ -147,7 +147,7 @@ fn test_op_log() {
     insta::assert_snapshot!(work_dir.run_jj(["log", "--at-op", "@-"]), @r#"
     ------- stderr -------
     Error: The "@" expression resolved to more than one operation
-    Hint: Try specifying one of the operations by ID: 7d0b0e318f0d, d58786619b23
+    Hint: Try specifying one of the operations by ID: 6fba4276d4b7, da58be7f2aaf
     [EOF]
     [exit status: 1]
     "#);
@@ -168,10 +168,10 @@ fn test_op_log_with_custom_symbols() {
         "--config=templates.op_log_node='if(current_operation, \"$\", if(root, \"┴\", \"┝\"))'",
     ]);
     insta::assert_snapshot!(output, @"
-    $  8501e29d2d94 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    $  7749eb4df93f test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     │  args: jj describe -m 'description 0'
-    ┝  90267f31f904 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ┝  f63ee16f9553 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ┴  000000000000 root()
     [EOF]
@@ -244,7 +244,7 @@ fn test_op_log_no_graph() {
 
     let output = work_dir.run_jj(["op", "log", "--no-graph", "--color=always"]);
     insta::assert_snapshot!(output, @"
-    [1m[38;5;12m90267f31f904[39m [38;5;3mtest-username@host.example.com[39m [38;5;14m2001-02-03 04:05:07.000 +07:00[39m - [38;5;14m2001-02-03 04:05:07.000 +07:00[39m[0m
+    [1m[38;5;12mf63ee16f9553[39m [38;5;3mtest-username@host.example.com[39m [38;5;14m2001-02-03 04:05:07.000 +07:00[39m - [38;5;14m2001-02-03 04:05:07.000 +07:00[39m[0m
     [1madd workspace 'default'[0m
     [38;5;4m000000000000[39m [38;5;2mroot()[39m
     [EOF]
@@ -252,7 +252,7 @@ fn test_op_log_no_graph() {
 
     let output = work_dir.run_jj(["op", "log", "--op-diff", "--no-graph"]);
     insta::assert_snapshot!(output, @"
-    90267f31f904 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    f63ee16f9553 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     add workspace 'default'
 
     Changed commits:
@@ -278,9 +278,9 @@ fn test_op_log_reversed() {
     let output = work_dir.run_jj(["op", "log", "--reversed"]);
     insta::assert_snapshot!(output, @"
     ○  000000000000 root()
-    ○  90267f31f904 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  f63ee16f9553 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
-    @  8501e29d2d94 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    @  7749eb4df93f test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
        describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
        args: jj describe -m 'description 0'
     [EOF]
@@ -294,15 +294,15 @@ fn test_op_log_reversed() {
     let output = work_dir.run_jj(["op", "log", "--reversed"]);
     insta::assert_snapshot!(output, @"
     ○  000000000000 root()
-    ○    90267f31f904 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○    f63ee16f9553 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     ├─╮  add workspace 'default'
-    │ ○  c3220ab4ab10 test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    │ ○  14a336c68678 test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     │ │  describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     │ │  args: jj describe -m 'description 1' --at-op @-
-    ○ │  8501e29d2d94 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    ○ │  7749eb4df93f test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     ├─╯  describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     │    args: jj describe -m 'description 0'
-    @  b3ce1ff6899e test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    @  684841dcf740 test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
        reconcile divergent operations
        args: jj op log --reversed
     [EOF]
@@ -315,15 +315,15 @@ fn test_op_log_reversed() {
     let output = work_dir.run_jj(["op", "log", "--reversed", "--no-graph"]);
     insta::assert_snapshot!(output, @"
     000000000000 root()
-    90267f31f904 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    f63ee16f9553 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     add workspace 'default'
-    c3220ab4ab10 test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    14a336c68678 test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     args: jj describe -m 'description 1' --at-op @-
-    8501e29d2d94 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    7749eb4df93f test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     args: jj describe -m 'description 0'
-    b3ce1ff6899e test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    684841dcf740 test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
     reconcile divergent operations
     args: jj op log --reversed
     [EOF]
@@ -332,13 +332,13 @@ fn test_op_log_reversed() {
     // Should work correctly with `--limit`
     let output = work_dir.run_jj(["op", "log", "--reversed", "--limit=3"]);
     insta::assert_snapshot!(output, @"
-    ○  c3220ab4ab10 test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    ○  14a336c68678 test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     │  describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     │  args: jj describe -m 'description 1' --at-op @-
-    │ ○  8501e29d2d94 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    │ ○  7749eb4df93f test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     ├─╯  describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     │    args: jj describe -m 'description 0'
-    @  b3ce1ff6899e test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    @  684841dcf740 test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
        reconcile divergent operations
        args: jj op log --reversed
     [EOF]
@@ -347,10 +347,10 @@ fn test_op_log_reversed() {
     // Should work correctly with `--limit` and `--no-graph`
     let output = work_dir.run_jj(["op", "log", "--reversed", "--limit=2", "--no-graph"]);
     insta::assert_snapshot!(output, @"
-    8501e29d2d94 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    7749eb4df93f test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     args: jj describe -m 'description 0'
-    b3ce1ff6899e test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    684841dcf740 test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
     reconcile divergent operations
     args: jj op log --reversed
     [EOF]
@@ -374,7 +374,7 @@ fn test_op_log_no_graph_null_terminated() {
             r#"id.short(4) ++ "\0""#,
         ])
         .success();
-    insta::assert_debug_snapshot!(output.stdout.normalized(), @r#""20fb\01ea2\09026\00000\0""#);
+    insta::assert_debug_snapshot!(output.stdout.normalized(), @r#""bdb7\0a4de\0f63e\00000\0""#);
 }
 
 #[test]
@@ -385,14 +385,14 @@ fn test_op_log_template() -> TestResult {
     let render = |template| work_dir.run_jj(["op", "log", "-T", template]);
 
     insta::assert_snapshot!(render(r#"id ++ "\n""#), @"
-    @  90267f31f90442f630dd8a2b5feaf8cf753dc64324e3d2d46bfd6d93f279a4d7630c2701a06a60ec04ca5c01a1e3f6758c0ab4f1efe6997ae82789328fb77fc9
+    @  f63ee16f95539ec5bda4a7178aa3ace2bf594719aa2cc3410cfc4d070cb31ae31225bef146eb2428baf760180976c936cd60891e7a9087e6836d3a315fe81030
     ○  00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
     [EOF]
     ");
     insta::assert_snapshot!(
         render(r#"separate(" ", id.short(5), current_operation, user,
                                 time.start(), time.end(), time.duration()) ++ "\n""#), @"
-    @  90267 true test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 2001-02-03 04:05:07.000 +07:00 less than a microsecond
+    @  f63ee true test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 2001-02-03 04:05:07.000 +07:00 less than a microsecond
     ○  00000 false @ 1970-01-01 00:00:00.000 +00:00 1970-01-01 00:00:00.000 +00:00 less than a microsecond
     [EOF]
     ");
@@ -405,7 +405,7 @@ fn test_op_log_template() -> TestResult {
     ");
 
     insta::assert_snapshot!(render(r#"json(self) ++ "\n""#), @r#"
-    @  {"id":"90267f31f90442f630dd8a2b5feaf8cf753dc64324e3d2d46bfd6d93f279a4d7630c2701a06a60ec04ca5c01a1e3f6758c0ab4f1efe6997ae82789328fb77fc9","parents":["00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"],"time":{"start":"2001-02-03T04:05:07+07:00","end":"2001-02-03T04:05:07+07:00"},"description":"add workspace 'default'","hostname":"host.example.com","username":"test-username","is_snapshot":false,"workspace_name":null,"attributes":{}}
+    @  {"id":"f63ee16f95539ec5bda4a7178aa3ace2bf594719aa2cc3410cfc4d070cb31ae31225bef146eb2428baf760180976c936cd60891e7a9087e6836d3a315fe81030","parents":["00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"],"time":{"start":"2001-02-03T04:05:07+07:00","end":"2001-02-03T04:05:07+07:00"},"description":"add workspace 'default'","hostname":"host.example.com","username":"test-username","is_snapshot":false,"workspace_name":null,"attributes":{}}
     ○  {"id":"00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","parents":[],"time":{"start":"1970-01-01T00:00:00Z","end":"1970-01-01T00:00:00Z"},"description":"","hostname":"","username":"","is_snapshot":false,"workspace_name":null,"attributes":{}}
     [EOF]
     "#);
@@ -423,7 +423,7 @@ fn test_op_log_template() -> TestResult {
     let output = work_dir.run_jj(["op", "log"]);
     insta::assert_snapshot!(
         output.normalize_stdout_with(|s| regex.replace_all(&s, "NN years").into_owned()), @"
-    @  90267f31f904 test-username@host.example.com NN years ago, lasted less than a microsecond
+    @  f63ee16f9553 test-username@host.example.com NN years ago, lasted less than a microsecond
     │  add workspace 'default'
     ○  000000000000 root()
     [EOF]
@@ -443,21 +443,21 @@ fn test_op_log_builtin_templates() {
         .success();
 
     insta::assert_snapshot!(render(r#"builtin_op_log_compact"#), @"
-    8501e29d2d94 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    7749eb4df93f test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     args: jj describe -m 'description 0'
-    90267f31f904 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    f63ee16f9553 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     add workspace 'default'
     000000000000 root()
     [EOF]
     ");
 
     insta::assert_snapshot!(render(r#"builtin_op_log_comfortable"#), @"
-    8501e29d2d94 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    7749eb4df93f test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     args: jj describe -m 'description 0'
 
-    90267f31f904 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    f63ee16f9553 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     add workspace 'default'
 
     000000000000 root()
@@ -466,8 +466,8 @@ fn test_op_log_builtin_templates() {
     ");
 
     insta::assert_snapshot!(render(r#"builtin_op_log_oneline"#), @"
-    8501e29d2d94 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00 describe commit e8849ae12c709f2321908879bc724fdb2ab8a781 args: jj describe -m 'description 0'
-    90267f31f904 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00 add workspace 'default'
+    7749eb4df93f test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00 describe commit e8849ae12c709f2321908879bc724fdb2ab8a781 args: jj describe -m 'description 0'
+    f63ee16f9553 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00 add workspace 'default'
     000000000000 root()
     [EOF]
     ");
@@ -492,23 +492,23 @@ fn test_op_log_word_wrap() {
 
     // ui.log-word-wrap option works
     insta::assert_snapshot!(render(&["op", "log"], 40, false), @"
-    @  5ea39824268b test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    @  2c5632322012 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  snapshot working copy
     │  args: jj debug snapshot
-    ○  90267f31f904 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  f63ee16f9553 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
     [EOF]
     ");
     insta::assert_snapshot!(render(&["op", "log"], 40, true), @"
-    @  5ea39824268b
+    @  2c5632322012
     │  test-username@host.example.com
     │  default@ 2001-02-03 04:05:08.000
     │  +07:00 - 2001-02-03 04:05:08.000
     │  +07:00
     │  snapshot working copy
     │  args: jj debug snapshot
-    ○  90267f31f904
+    ○  f63ee16f9553
     │  test-username@host.example.com
     │  2001-02-03 04:05:07.000 +07:00 -
     │  2001-02-03 04:05:07.000 +07:00
@@ -519,7 +519,7 @@ fn test_op_log_word_wrap() {
 
     // Nested graph should be wrapped
     insta::assert_snapshot!(render(&["op", "log", "--op-diff"], 40, true), @"
-    @  5ea39824268b
+    @  2c5632322012
     │  test-username@host.example.com
     │  default@ 2001-02-03 04:05:08.000
     │  +07:00 - 2001-02-03 04:05:08.000
@@ -538,7 +538,7 @@ fn test_op_log_word_wrap() {
     │  set)
     │  - qpvuntsm/1 e8849ae1 (hidden)
     │  (empty) (no description set)
-    ○  90267f31f904
+    ○  f63ee16f9553
     │  test-username@host.example.com
     │  2001-02-03 04:05:07.000 +07:00 -
     │  2001-02-03 04:05:07.000 +07:00
@@ -558,7 +558,7 @@ fn test_op_log_word_wrap() {
 
     // Nested diff stat shouldn't exceed the terminal width
     insta::assert_snapshot!(render(&["op", "log", "-n1", "--stat"], 40, true), @"
-    @  5ea39824268b
+    @  2c5632322012
     │  test-username@host.example.com
     │  default@ 2001-02-03 04:05:08.000
     │  +07:00 - 2001-02-03 04:05:08.000
@@ -582,7 +582,7 @@ fn test_op_log_word_wrap() {
     [EOF]
     ");
     insta::assert_snapshot!(render(&["op", "log", "-n1", "--no-graph", "--stat"], 40, true), @"
-    5ea39824268b
+    2c5632322012
     test-username@host.example.com default@
     2001-02-03 04:05:08.000 +07:00 -
     2001-02-03 04:05:08.000 +07:00
@@ -647,7 +647,7 @@ fn test_op_log_configurable() {
 
     let output = work_dir.run_jj(["op", "log"]);
     insta::assert_snapshot!(output, @"
-    @  8f6a440a18ee my-username@my-hostname 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    @  37978585dec5 my-username@my-hostname 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
     [EOF]
@@ -701,7 +701,7 @@ fn test_op_abandon_invalid() {
     let output = work_dir.run_jj(["op", "abandon", "@-.."]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Error: Cannot abandon the current operation b6272840524f
+    Error: Cannot abandon the current operation 0facabbe7f97
     Hint: Run `jj undo` to revert the current operation, then use `jj op abandon`
     [EOF]
     [exit status: 1]
@@ -730,13 +730,13 @@ fn test_op_abandon_ancestors() {
     work_dir.run_jj(["commit", "-m", "commit 1"]).success();
     work_dir.run_jj(["commit", "-m", "commit 2"]).success();
     insta::assert_snapshot!(work_dir.run_jj(["op", "log"]), @"
-    @  de79e1bf0e95 test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    @  b004de1c8d83 test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     │  commit 4e0592f3dd52e7a4998a97d9a1f354e2727a856b
     │  args: jj commit -m 'commit 2'
-    ○  0012863b8815 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    ○  5d7c2b4596e3 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  commit e8849ae12c709f2321908879bc724fdb2ab8a781
     │  args: jj commit -m 'commit 1'
-    ○  90267f31f904 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  f63ee16f9553 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
     [EOF]
@@ -750,12 +750,12 @@ fn test_op_abandon_ancestors() {
     [EOF]
     ");
     insta::assert_snapshot!(work_dir.run_jj(["debug", "local-working-copy", "--ignore-working-copy"]), @r#"
-    Current operation: OperationId("cd21620021327ba3aab6fcaa933e3437f159a6e51c27215e84b1ecf85bc87f64e729db1673eff35a690177d670c5611891d426686ac89fc4f7c573c95bce64ef")
+    Current operation: OperationId("16e498947b26cdd5e09fd250167d03254f6a9d8ce555e3838bbf432e2c5d7b90d5d80414f11aa67df1ecb8074eadf3fd79336feeb2c5e564c9dc711de5d38d96")
     Current tree: MergedTree { tree_ids: Resolved(TreeId("4b825dc642cb6eb9a060e54bf8d69288fbee4904")), labels: Unlabeled, .. }
     [EOF]
     "#);
     insta::assert_snapshot!(work_dir.run_jj(["op", "log"]), @"
-    @  cd2162002132 test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    @  16e498947b26 test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     │  commit 4e0592f3dd52e7a4998a97d9a1f354e2727a856b
     │  args: jj commit -m 'commit 2'
     ○  000000000000 root()
@@ -773,10 +773,10 @@ fn test_op_abandon_ancestors() {
     [EOF]
     ");
     insta::assert_snapshot!(work_dir.run_jj(["op", "log"]), @"
-    @  76eeec9e446d test-username@host.example.com default@ 2001-02-03 04:05:16.000 +07:00 - 2001-02-03 04:05:16.000 +07:00
+    @  563693e8149d test-username@host.example.com default@ 2001-02-03 04:05:16.000 +07:00 - 2001-02-03 04:05:16.000 +07:00
     │  commit 2f3e935ade915272ccdce9e43e5a5c82fc336aee
     │  args: jj commit -m 'commit 5'
-    ○  cd2162002132 test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    ○  16e498947b26 test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     │  commit 4e0592f3dd52e7a4998a97d9a1f354e2727a856b
     │  args: jj commit -m 'commit 2'
     ○  000000000000 root()
@@ -787,7 +787,7 @@ fn test_op_abandon_ancestors() {
     let output = work_dir.run_jj(["op", "abandon", "..@"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Error: Cannot abandon the current operation 76eeec9e446d
+    Error: Cannot abandon the current operation 563693e8149d
     Hint: Run `jj undo` to revert the current operation, then use `jj op abandon`
     [EOF]
     [exit status: 1]
@@ -811,15 +811,15 @@ fn test_op_abandon_ancestors() {
     [EOF]
     ");
     insta::assert_snapshot!(work_dir.run_jj(["debug", "local-working-copy", "--ignore-working-copy"]), @r#"
-    Current operation: OperationId("de1f5c6b8347f2c2f60db66c2e3e7819ad6ba61d8044e9c1ba7b2bb494f8607e66faf234689cb7859305a42de046d0f5b3ce17a4d15c90039b6b864ff7aa6f25")
+    Current operation: OperationId("76472b5d1bf3739c027318ab349ce8531cfedc3738f87abf78dd9e5482fdb165aa34a4edba3a281bab884d9df551a731512702fc43096a59c3569568fa9b0dba")
     Current tree: MergedTree { tree_ids: Resolved(TreeId("4b825dc642cb6eb9a060e54bf8d69288fbee4904")), labels: Unlabeled, .. }
     [EOF]
     "#);
     insta::assert_snapshot!(work_dir.run_jj(["op", "log"]), @"
-    @  de1f5c6b8347 test-username@host.example.com default@ 2001-02-03 04:05:21.000 +07:00 - 2001-02-03 04:05:21.000 +07:00
-    │  revert operation 76eeec9e446db02ec9824a21998c4ffe8527f771c32e7c28a4451348fb6e0349b53c3c2ba35ad2713fdccfc6eed3bcb32714ecd335fad2ac3fc6d87c5d6c9f01
+    @  76472b5d1bf3 test-username@host.example.com default@ 2001-02-03 04:05:21.000 +07:00 - 2001-02-03 04:05:21.000 +07:00
+    │  revert operation 563693e8149d715c5ef70b1d98df1f6d9329f4318250a65d8bebddd8b671774b71a8874e61702f704e7aef07b9f1b2210341b8d1eba163d455ad63bb65b74bfc
     │  args: jj op revert
-    ○  cd2162002132 test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    ○  16e498947b26 test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     │  commit 4e0592f3dd52e7a4998a97d9a1f354e2727a856b
     │  args: jj commit -m 'commit 2'
     ○  000000000000 root()
@@ -834,8 +834,8 @@ fn test_op_abandon_ancestors() {
     [EOF]
     ");
     insta::assert_snapshot!(work_dir.run_jj(["op", "log", "-n1"]), @"
-    @  de1f5c6b8347 test-username@host.example.com default@ 2001-02-03 04:05:21.000 +07:00 - 2001-02-03 04:05:21.000 +07:00
-    │  revert operation 76eeec9e446db02ec9824a21998c4ffe8527f771c32e7c28a4451348fb6e0349b53c3c2ba35ad2713fdccfc6eed3bcb32714ecd335fad2ac3fc6d87c5d6c9f01
+    @  76472b5d1bf3 test-username@host.example.com default@ 2001-02-03 04:05:21.000 +07:00 - 2001-02-03 04:05:21.000 +07:00
+    │  revert operation 563693e8149d715c5ef70b1d98df1f6d9329f4318250a65d8bebddd8b671774b71a8874e61702f704e7aef07b9f1b2210341b8d1eba163d455ad63bb65b74bfc
     │  args: jj op revert
     [EOF]
     ");
@@ -859,12 +859,12 @@ fn test_op_abandon_without_updating_working_copy() {
     [EOF]
     ");
     insta::assert_snapshot!(work_dir.run_jj(["debug", "local-working-copy", "--ignore-working-copy"]), @r#"
-    Current operation: OperationId("224092fe2eb598ce0a755b3b06dadb32d5d838a48868f888db83fa7afee6c721665d8c9969113b1ab969122a444302590ca1364535b0de02371d5e6e2651c7c6")
+    Current operation: OperationId("62f41230e57ec67e2181e49cbc7c2e43c42aaddd5ea7f10c401ba6e0e92c20c22815994ff9993e0e0625561c7f9e0d9b2e9817cdcedb3d19dce5609be43a0859")
     Current tree: MergedTree { tree_ids: Resolved(TreeId("4b825dc642cb6eb9a060e54bf8d69288fbee4904")), labels: Unlabeled, .. }
     [EOF]
     "#);
     insta::assert_snapshot!(work_dir.run_jj(["op", "log", "-n1", "--ignore-working-copy"]), @"
-    @  77fef40aba54 test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    @  057d224b4c7c test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     │  commit 4b087e94a5d14530c3953d617623d075a13294c8
     │  args: jj commit -m 'commit 3'
     [EOF]
@@ -877,16 +877,16 @@ fn test_op_abandon_without_updating_working_copy() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Abandoned 1 operations and reparented 1 descendant operations.
-    Warning: The working copy operation 224092fe2eb5 is not updated because it differs from the repo 77fef40aba54.
+    Warning: The working copy operation 62f41230e57e is not updated because it differs from the repo 057d224b4c7c.
     [EOF]
     ");
     insta::assert_snapshot!(work_dir.run_jj(["debug", "local-working-copy", "--ignore-working-copy"]), @r#"
-    Current operation: OperationId("224092fe2eb598ce0a755b3b06dadb32d5d838a48868f888db83fa7afee6c721665d8c9969113b1ab969122a444302590ca1364535b0de02371d5e6e2651c7c6")
+    Current operation: OperationId("62f41230e57ec67e2181e49cbc7c2e43c42aaddd5ea7f10c401ba6e0e92c20c22815994ff9993e0e0625561c7f9e0d9b2e9817cdcedb3d19dce5609be43a0859")
     Current tree: MergedTree { tree_ids: Resolved(TreeId("4b825dc642cb6eb9a060e54bf8d69288fbee4904")), labels: Unlabeled, .. }
     [EOF]
     "#);
     insta::assert_snapshot!(work_dir.run_jj(["op", "log", "-n1", "--ignore-working-copy"]), @"
-    @  900485a18500 test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    @  1ac7ef4d119c test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     │  commit 4b087e94a5d14530c3953d617623d075a13294c8
     │  args: jj commit -m 'commit 3'
     [EOF]
@@ -907,8 +907,8 @@ fn test_op_abandon_multiple_heads() {
         .run_jj(["op", "log", "--no-graph", r#"-Tid.short() ++ "\n""#])
         .success();
     let [head_op_id, prev_op_id] = output.stdout.raw().lines().next_array().unwrap();
-    insta::assert_snapshot!(head_op_id, @"224092fe2eb5");
-    insta::assert_snapshot!(prev_op_id, @"de79e1bf0e95");
+    insta::assert_snapshot!(head_op_id, @"62f41230e57e");
+    insta::assert_snapshot!(prev_op_id, @"b004de1c8d83");
 
     // Create 1 other concurrent operation.
     work_dir
@@ -920,19 +920,19 @@ fn test_op_abandon_multiple_heads() {
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Error: The "@" expression resolved to more than one operation
-    Hint: Try specifying one of the operations by ID: 224092fe2eb5, 18f48a93b6c3
+    Hint: Try specifying one of the operations by ID: 62f41230e57e, ad3c8fd39dc6
     [EOF]
     [exit status: 1]
     "#);
     let (_, other_head_op_id) = output.stderr.raw().trim_end().rsplit_once(", ").unwrap();
-    insta::assert_snapshot!(other_head_op_id, @"18f48a93b6c3");
+    insta::assert_snapshot!(other_head_op_id, @"ad3c8fd39dc6");
     assert_ne!(head_op_id, other_head_op_id);
 
     // Can't abandon one of the head operations.
     let output = work_dir.run_jj(["op", "abandon", head_op_id]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Error: Cannot abandon the current operation 224092fe2eb5
+    Error: Cannot abandon the current operation 62f41230e57e
     [EOF]
     [exit status: 1]
     ");
@@ -941,7 +941,7 @@ fn test_op_abandon_multiple_heads() {
     let output = work_dir.run_jj(["op", "abandon", other_head_op_id]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Error: Cannot abandon the current operation 18f48a93b6c3
+    Error: Cannot abandon the current operation ad3c8fd39dc6
     [EOF]
     [exit status: 1]
     ");
@@ -958,19 +958,19 @@ fn test_op_abandon_multiple_heads() {
 
     let output = work_dir.run_jj(["op", "log"]);
     insta::assert_snapshot!(output, @"
-    @    2af9d2fbd725 test-username@host.example.com default@ 2001-02-03 04:05:17.000 +07:00 - 2001-02-03 04:05:17.000 +07:00
+    @    b584562d7baf test-username@host.example.com default@ 2001-02-03 04:05:17.000 +07:00 - 2001-02-03 04:05:17.000 +07:00
     ├─╮  reconcile divergent operations
     │ │  args: jj op log
-    ○ │  77fef40aba54 test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    ○ │  057d224b4c7c test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     │ │  commit 4b087e94a5d14530c3953d617623d075a13294c8
     │ │  args: jj commit -m 'commit 3'
-    │ ○  18f48a93b6c3 test-username@host.example.com default@ 2001-02-03 04:05:12.000 +07:00 - 2001-02-03 04:05:12.000 +07:00
+    │ ○  ad3c8fd39dc6 test-username@host.example.com default@ 2001-02-03 04:05:12.000 +07:00 - 2001-02-03 04:05:12.000 +07:00
     ├─╯  commit 4e0592f3dd52e7a4998a97d9a1f354e2727a856b
     │    args: jj commit '--at-op=@--' -m 'commit 4'
-    ○  0012863b8815 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    ○  5d7c2b4596e3 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  commit e8849ae12c709f2321908879bc724fdb2ab8a781
     │  args: jj commit -m 'commit 1'
-    ○  90267f31f904 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  f63ee16f9553 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
     [EOF]
@@ -1004,8 +1004,8 @@ fn test_op_recover_from_bad_gc() -> TestResult {
         .run_jj(["op", "log", "--no-graph", r#"-Tid.short() ++ "\n""#])
         .success();
     let [head_op_id, _, _, bad_op_id] = output.stdout.raw().lines().next_array().unwrap();
-    insta::assert_snapshot!(head_op_id, @"73ddac1568ed");
-    insta::assert_snapshot!(bad_op_id, @"c433ad465d84");
+    insta::assert_snapshot!(head_op_id, @"f578e4970373");
+    insta::assert_snapshot!(bad_op_id, @"ed13d7dc6cbe");
 
     // Corrupt the repo by removing hidden but reachable commit object.
     let output = work_dir
@@ -1031,7 +1031,7 @@ fn test_op_recover_from_bad_gc() -> TestResult {
     let output = work_dir.run_jj(["--at-op", head_op_id, "debug", "reindex"]);
     insta::assert_snapshot!(output.strip_stderr_last_line(), @"
     ------- stderr -------
-    Internal error: Failed to index commits at operation c433ad465d840ccf59107d350123e6ec3a4e4f40070e666c64102cb0e028cce9709bf882568b030761b20a6961fdbd1d03ffc7ff8b5b7f87d32cd6c87bcb7be8
+    Internal error: Failed to index commits at operation ed13d7dc6cbe8904f205438fa5c7462eb06dc0b81f24d90a2d0976d1c08c72435e680e9e4aa445634b069e5641329efb97a6c73707cd8936d6129d1a0fb4da7c
     Caused by:
     1: Object 4e123bae951c3216a145dbcd56d60522739d362e of type commit not found
     [EOF]
@@ -1041,22 +1041,22 @@ fn test_op_recover_from_bad_gc() -> TestResult {
     // "op log" should still be usable.
     let output = work_dir.run_jj(["op", "log", "--ignore-working-copy", "--at-op", head_op_id]);
     insta::assert_snapshot!(output, @"
-    @  73ddac1568ed test-username@host.example.com default@ 2001-02-03 04:05:12.000 +07:00 - 2001-02-03 04:05:12.000 +07:00
+    @  f578e4970373 test-username@host.example.com default@ 2001-02-03 04:05:12.000 +07:00 - 2001-02-03 04:05:12.000 +07:00
     │  describe commit a053bc8736064a739ab73f2c775a6ac2851bf1a3
     │  args: jj describe -m4
-    ○  398ac785f287 test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    ○  de6bde308963 test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
     │  new empty commit
     │  args: jj new -m3
-    ○  55e7a799e145 test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    ○  f4ad3f1e8317 test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     │  abandon commit 4e123bae951c3216a145dbcd56d60522739d362e
     │  args: jj abandon
-    ○  c433ad465d84 test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    ○  ed13d7dc6cbe test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     │  describe commit 884fe9b9c65602d724c7c0f2a238d5549efbe5e6
     │  args: jj describe -m2
-    ○  e360308cf0c0 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    ○  e77fac23262c test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     │  args: jj describe -m1
-    ○  90267f31f904 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  f63ee16f9553 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
     [EOF]
@@ -1098,7 +1098,7 @@ fn test_op_corrupted_operation_file() -> TestResult {
         .join(PathBuf::from_iter([".jj", "repo", "op_store"]));
 
     let op_id = work_dir.current_operation_id();
-    insta::assert_snapshot!(op_id, @"90267f31f90442f630dd8a2b5feaf8cf753dc64324e3d2d46bfd6d93f279a4d7630c2701a06a60ec04ca5c01a1e3f6758c0ab4f1efe6997ae82789328fb77fc9");
+    insta::assert_snapshot!(op_id, @"f63ee16f95539ec5bda4a7178aa3ace2bf594719aa2cc3410cfc4d070cb31ae31225bef146eb2428baf760180976c936cd60891e7a9087e6836d3a315fe81030");
 
     let op_file_path = op_store_path.join("operations").join(&op_id);
     assert!(op_file_path.exists());
@@ -1110,7 +1110,7 @@ fn test_op_corrupted_operation_file() -> TestResult {
     ------- stderr -------
     Internal error: Failed to load an operation
     Caused by:
-    1: Error when reading object 90267f31f90442f630dd8a2b5feaf8cf753dc64324e3d2d46bfd6d93f279a4d7630c2701a06a60ec04ca5c01a1e3f6758c0ab4f1efe6997ae82789328fb77fc9 of type operation
+    1: Error when reading object f63ee16f95539ec5bda4a7178aa3ace2bf594719aa2cc3410cfc4d070cb31ae31225bef146eb2428baf760180976c936cd60891e7a9087e6836d3a315fe81030 of type operation
     2: Invalid hash length (expected 64 bytes, got 0 bytes)
     [EOF]
     [exit status: 255]
@@ -1123,7 +1123,7 @@ fn test_op_corrupted_operation_file() -> TestResult {
     ------- stderr -------
     Internal error: Failed to load an operation
     Caused by:
-    1: Error when reading object 90267f31f90442f630dd8a2b5feaf8cf753dc64324e3d2d46bfd6d93f279a4d7630c2701a06a60ec04ca5c01a1e3f6758c0ab4f1efe6997ae82789328fb77fc9 of type operation
+    1: Error when reading object f63ee16f95539ec5bda4a7178aa3ace2bf594719aa2cc3410cfc4d070cb31ae31225bef146eb2428baf760180976c936cd60891e7a9087e6836d3a315fe81030 of type operation
     2: failed to decode Protobuf message: invalid tag value: 0
     [EOF]
     [exit status: 255]
@@ -1144,7 +1144,7 @@ fn test_op_summary_diff_template() {
     let output = work_dir.run_jj(["op", "revert", "--color=always"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Reverted operation: [38;5;4md336cf245e9c[39m ([38;5;6m2001-02-03 08:05:08[39m) new empty commit
+    Reverted operation: [38;5;4m159a7c4ed8f0[39m ([38;5;6m2001-02-03 08:05:08[39m) new empty commit
     [EOF]
     ");
     let output = work_dir.run_jj([
@@ -1158,7 +1158,7 @@ fn test_op_summary_diff_template() {
     ]);
     insta::assert_snapshot!(output, @"
     From operation: [38;5;4m000000000000[39m [38;5;2mroot()[39m
-      To operation: [38;5;4mcbae8e2b3bfb[39m ([38;5;6m2001-02-03 08:05:09[39m) revert operation d336cf245e9cc589b053feee9e8c05d3340ab7717378a8a70ca17d9ebf7c5c0c2aa40093a826aa8df143297a4628b7ea714194b50bfedc2b5835630522af4079
+      To operation: [38;5;4m061a71fe581b[39m ([38;5;6m2001-02-03 08:05:09[39m) revert operation 159a7c4ed8f06f25ac71abe76feb50bbd09df439685eea6c0cbec19e29e54a604af0eb57487b454451177ba0851e2eb22d88f918a44412a5c38230cb2d3b86b5
 
     Changed commits:
     ○  [38;5;2m+[39m [1m[38;5;13mq[38;5;8mpvuntsm[39m [38;5;12me[38;5;8m8849ae1[39m [38;5;10m(empty)[39m [38;5;10m(no description set)[0m
@@ -1176,7 +1176,7 @@ fn test_op_summary_diff_template() {
     let output = work_dir.run_jj(["op", "revert", "--color=debug"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Reverted operation: [38;5;4m<<operation id short::20994955e4c2>>[39m<<operation:: (>>[38;5;6m<<operation time end local format::2001-02-03 08:05:11>>[39m<<operation::) >><<operation description first_line::new empty commit>>
+    Reverted operation: [38;5;4m<<operation id short::638404783baf>>[39m<<operation:: (>>[38;5;6m<<operation time end local format::2001-02-03 08:05:11>>[39m<<operation::) >><<operation description first_line::new empty commit>>
     [EOF]
     ");
     let output = work_dir.run_jj([
@@ -1190,7 +1190,7 @@ fn test_op_summary_diff_template() {
     ]);
     insta::assert_snapshot!(output, @"
     From operation: [38;5;4m<<op_diff operation id short::000000000000>>[39m<<op_diff operation:: >>[38;5;2m<<op_diff operation root::root()>>[39m
-      To operation: [38;5;4m<<op_diff operation id short::f3a2dab03704>>[39m<<op_diff operation:: (>>[38;5;6m<<op_diff operation time end local format::2001-02-03 08:05:12>>[39m<<op_diff operation::) >><<op_diff operation description first_line::revert operation 20994955e4c238d6d34c6dc6942e9111e385c06676c575cd2d5d4908c6ba5a1bea26ecaccf8d420da641f9aa250aea0a33bf677601ce66ba111ac4eaf5334a95>>
+      To operation: [38;5;4m<<op_diff operation id short::5a6f74212543>>[39m<<op_diff operation:: (>>[38;5;6m<<op_diff operation time end local format::2001-02-03 08:05:12>>[39m<<op_diff operation::) >><<op_diff operation description first_line::revert operation 638404783baf5583f13d006a7844053ddeefdf4a3ca6de80dc34a30261990a884a3e517726bac64f3d154b95c286071558279cc76bf147a94ce6685a3e78d19f>>
 
     Changed commits:
     ○  [38;5;2m<<diff added::+>>[39m [1m[38;5;13m<<op_diff commit working_copy change_id shortest prefix::q>>[38;5;8m<<op_diff commit working_copy change_id shortest rest::pvuntsm>>[39m<<op_diff commit working_copy:: >>[38;5;12m<<op_diff commit working_copy commit_id shortest prefix::e>>[38;5;8m<<op_diff commit working_copy commit_id shortest rest::8849ae1>>[39m<<op_diff commit working_copy:: >>[38;5;10m<<op_diff commit working_copy empty::(empty)>>[39m<<op_diff commit working_copy:: >>[38;5;10m<<op_diff commit working_copy empty description placeholder::(no description set)>>[0m
@@ -1220,16 +1220,16 @@ fn test_op_diff() {
     // Overview of op log.
     let output = work_dir.run_jj(["op", "log"]);
     insta::assert_snapshot!(output, @"
-    @  81bc294627f7 test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    @  c398dc66e5f4 test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     │  track remote bookmark bookmark-1@origin
     │  args: jj bookmark track bookmark-1
-    ○  80e831767589 test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    ○  47cfe27aee78 test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     │  fetch from git remote(s) origin
     │  args: jj git fetch
-    ○  ccace750b730 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    ○  0dcdecd46a3d test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  add git remote origin
     │  args: jj git remote add origin ../git-repo
-    ○  90267f31f904 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  f63ee16f9553 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
     [EOF]
@@ -1244,8 +1244,8 @@ fn test_op_diff() {
     ");
     let output = work_dir.run_jj(["op", "diff", "--from", "@", "--to", "@"]);
     insta::assert_snapshot!(output, @"
-    From operation: 81bc294627f7 (2001-02-03 08:05:10) track remote bookmark bookmark-1@origin
-      To operation: 81bc294627f7 (2001-02-03 08:05:10) track remote bookmark bookmark-1@origin
+    From operation: c398dc66e5f4 (2001-02-03 08:05:10) track remote bookmark bookmark-1@origin
+      To operation: c398dc66e5f4 (2001-02-03 08:05:10) track remote bookmark bookmark-1@origin
     [EOF]
     ");
 
@@ -1254,8 +1254,8 @@ fn test_op_diff() {
     // @- --to @` (if `@` is not a merge commit).
     let output = work_dir.run_jj(["op", "diff", "--from", "@-", "--to", "@"]);
     insta::assert_snapshot!(output, @"
-    From operation: 80e831767589 (2001-02-03 08:05:09) fetch from git remote(s) origin
-      To operation: 81bc294627f7 (2001-02-03 08:05:10) track remote bookmark bookmark-1@origin
+    From operation: 47cfe27aee78 (2001-02-03 08:05:09) fetch from git remote(s) origin
+      To operation: c398dc66e5f4 (2001-02-03 08:05:10) track remote bookmark bookmark-1@origin
 
     Changed local bookmarks:
     bookmark-1:
@@ -1275,7 +1275,7 @@ fn test_op_diff() {
     let output = work_dir.run_jj(["op", "diff", "--from", "0000000"]);
     insta::assert_snapshot!(output, @"
     From operation: 000000000000 root()
-      To operation: 81bc294627f7 (2001-02-03 08:05:10) track remote bookmark bookmark-1@origin
+      To operation: c398dc66e5f4 (2001-02-03 08:05:10) track remote bookmark bookmark-1@origin
 
     Changed commits:
     ○  + skovwzlu 854c38b8 Commit 4
@@ -1319,7 +1319,7 @@ fn test_op_diff() {
     // Diff from latest operation to root operation
     let output = work_dir.run_jj(["op", "diff", "--to", "0000000"]);
     insta::assert_snapshot!(output, @"
-    From operation: 81bc294627f7 (2001-02-03 08:05:10) track remote bookmark bookmark-1@origin
+    From operation: c398dc66e5f4 (2001-02-03 08:05:10) track remote bookmark bookmark-1@origin
       To operation: 000000000000 root()
 
     Changed commits:
@@ -1408,25 +1408,25 @@ fn test_op_diff() {
     ");
     let output = work_dir.run_jj(["op", "log"]);
     insta::assert_snapshot!(output, @"
-    @    57bcd79175d6 test-username@host.example.com default@ 2001-02-03 04:05:21.000 +07:00 - 2001-02-03 04:05:21.000 +07:00
+    @    3cf9a7f329ef test-username@host.example.com default@ 2001-02-03 04:05:21.000 +07:00 - 2001-02-03 04:05:21.000 +07:00
     ├─╮  reconcile divergent operations
     │ │  args: jj log
-    ○ │  98d597e0b9b6 test-username@host.example.com default@ 2001-02-03 04:05:19.000 +07:00 - 2001-02-03 04:05:19.000 +07:00
+    ○ │  68d99f04e273 test-username@host.example.com default@ 2001-02-03 04:05:19.000 +07:00 - 2001-02-03 04:05:19.000 +07:00
     │ │  point bookmark bookmark-1 to commit e8849ae12c709f2321908879bc724fdb2ab8a781
     │ │  args: jj bookmark move bookmark-1 --to @ --allow-backwards
-    │ ○  4f85f452f6d6 test-username@host.example.com default@ 2001-02-03 04:05:20.000 +07:00 - 2001-02-03 04:05:20.000 +07:00
+    │ ○  89bdf3a23553 test-username@host.example.com default@ 2001-02-03 04:05:20.000 +07:00 - 2001-02-03 04:05:20.000 +07:00
     ├─╯  point bookmark bookmark-1 to commit 4ff6253913375c6ebdddd8423c11df3b3f17e331
     │    args: jj bookmark set bookmark-1 -r bookmark-2@origin --allow-backwards --at-op @-
-    ○  81bc294627f7 test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    ○  c398dc66e5f4 test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     │  track remote bookmark bookmark-1@origin
     │  args: jj bookmark track bookmark-1
-    ○  80e831767589 test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    ○  47cfe27aee78 test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     │  fetch from git remote(s) origin
     │  args: jj git fetch
-    ○  ccace750b730 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    ○  0dcdecd46a3d test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  add git remote origin
     │  args: jj git remote add origin ../git-repo
-    ○  90267f31f904 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  f63ee16f9553 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
     [EOF]
@@ -1439,8 +1439,8 @@ fn test_op_diff() {
     // Diff between the first parent of the merge operation and the merge operation.
     let output = work_dir.run_jj(["op", "diff", "--from", first_parent_id, "--to", op_id]);
     insta::assert_snapshot!(output, @"
-    From operation: 98d597e0b9b6 (2001-02-03 08:05:19) point bookmark bookmark-1 to commit e8849ae12c709f2321908879bc724fdb2ab8a781
-      To operation: 57bcd79175d6 (2001-02-03 08:05:21) reconcile divergent operations
+    From operation: 68d99f04e273 (2001-02-03 08:05:19) point bookmark bookmark-1 to commit e8849ae12c709f2321908879bc724fdb2ab8a781
+      To operation: 3cf9a7f329ef (2001-02-03 08:05:21) reconcile divergent operations
 
     Changed local bookmarks:
     bookmark-1:
@@ -1455,8 +1455,8 @@ fn test_op_diff() {
     // operation.
     let output = work_dir.run_jj(["op", "diff", "--from", second_parent_id, "--to", op_id]);
     insta::assert_snapshot!(output, @"
-    From operation: 4f85f452f6d6 (2001-02-03 08:05:20) point bookmark bookmark-1 to commit 4ff6253913375c6ebdddd8423c11df3b3f17e331
-      To operation: 57bcd79175d6 (2001-02-03 08:05:21) reconcile divergent operations
+    From operation: 89bdf3a23553 (2001-02-03 08:05:20) point bookmark bookmark-1 to commit 4ff6253913375c6ebdddd8423c11df3b3f17e331
+      To operation: 3cf9a7f329ef (2001-02-03 08:05:21) reconcile divergent operations
 
     Changed local bookmarks:
     bookmark-1:
@@ -1481,8 +1481,8 @@ fn test_op_diff() {
     ");
     let output = work_dir.run_jj(["op", "diff"]);
     insta::assert_snapshot!(output, @"
-    From operation: 57bcd79175d6 (2001-02-03 08:05:21) reconcile divergent operations
-      To operation: 33bda1401457 (2001-02-03 08:05:25) fetch from git remote(s) origin
+    From operation: 3cf9a7f329ef (2001-02-03 08:05:21) reconcile divergent operations
+      To operation: b43ad427fa47 (2001-02-03 08:05:25) fetch from git remote(s) origin
 
     Changed commits:
     ○  + kulxwnxm e1a239a5 bookmark-2@origin | Commit 5
@@ -1528,8 +1528,8 @@ fn test_op_diff() {
     ");
     let output = work_dir.run_jj(["op", "diff"]);
     insta::assert_snapshot!(output, @"
-    From operation: 33bda1401457 (2001-02-03 08:05:25) fetch from git remote(s) origin
-      To operation: 48e847a6dabd (2001-02-03 08:05:27) create bookmark bookmark-2 pointing to commit e1a239a57eb15cefc5910198befbbbe2b43c47af
+    From operation: b43ad427fa47 (2001-02-03 08:05:25) fetch from git remote(s) origin
+      To operation: 3ea62256d9f4 (2001-02-03 08:05:27) create bookmark bookmark-2 pointing to commit e1a239a57eb15cefc5910198befbbbe2b43c47af
 
     Changed local bookmarks:
     bookmark-2:
@@ -1547,8 +1547,8 @@ fn test_op_diff() {
     ");
     let output = work_dir.run_jj(["op", "diff"]);
     insta::assert_snapshot!(output, @"
-    From operation: 48e847a6dabd (2001-02-03 08:05:27) create bookmark bookmark-2 pointing to commit e1a239a57eb15cefc5910198befbbbe2b43c47af
-      To operation: 73b940afa9e1 (2001-02-03 08:05:29) track remote bookmark bookmark-2@origin
+    From operation: 3ea62256d9f4 (2001-02-03 08:05:27) create bookmark bookmark-2 pointing to commit e1a239a57eb15cefc5910198befbbbe2b43c47af
+      To operation: ef77f2e3c512 (2001-02-03 08:05:29) track remote bookmark bookmark-2@origin
 
     Changed remote bookmarks:
     bookmark-2@origin:
@@ -1567,8 +1567,8 @@ fn test_op_diff() {
     ");
     let output = work_dir.run_jj(["op", "diff"]);
     insta::assert_snapshot!(output, @"
-    From operation: 48e847a6dabd (2001-02-03 08:05:27) create bookmark bookmark-2 pointing to commit e1a239a57eb15cefc5910198befbbbe2b43c47af
-      To operation: 73b940afa9e1 (2001-02-03 08:05:29) track remote bookmark bookmark-2@origin
+    From operation: 3ea62256d9f4 (2001-02-03 08:05:27) create bookmark bookmark-2 pointing to commit e1a239a57eb15cefc5910198befbbbe2b43c47af
+      To operation: ef77f2e3c512 (2001-02-03 08:05:29) track remote bookmark bookmark-2@origin
 
     Changed remote bookmarks:
     bookmark-2@origin:
@@ -1588,8 +1588,8 @@ fn test_op_diff() {
     ");
     let output = work_dir.run_jj(["op", "diff"]);
     insta::assert_snapshot!(output, @"
-    From operation: 73b940afa9e1 (2001-02-03 08:05:29) track remote bookmark bookmark-2@origin
-      To operation: b28065dd5e64 (2001-02-03 08:05:33) new empty commit
+    From operation: ef77f2e3c512 (2001-02-03 08:05:29) track remote bookmark bookmark-2@origin
+      To operation: 29f574cb7ec8 (2001-02-03 08:05:33) new empty commit
 
     Changed commits:
     ○  + qmkrwlvp 96f3a57c (empty) new commit
@@ -1609,8 +1609,8 @@ fn test_op_diff() {
     ");
     let output = work_dir.run_jj(["op", "diff"]);
     insta::assert_snapshot!(output, @"
-    From operation: b28065dd5e64 (2001-02-03 08:05:33) new empty commit
-      To operation: 6c82ddcd60a1 (2001-02-03 08:05:35) point bookmark bookmark-1 to commit 96f3a57c9a4a4ae7bb45d1eafe32fe3b6e33f458
+    From operation: 29f574cb7ec8 (2001-02-03 08:05:33) new empty commit
+      To operation: 01a4d5f22fb6 (2001-02-03 08:05:35) point bookmark bookmark-1 to commit 96f3a57c9a4a4ae7bb45d1eafe32fe3b6e33f458
 
     Changed local bookmarks:
     bookmark-1:
@@ -1632,8 +1632,8 @@ fn test_op_diff() {
     ");
     let output = work_dir.run_jj(["op", "diff"]);
     insta::assert_snapshot!(output, @"
-    From operation: 6c82ddcd60a1 (2001-02-03 08:05:35) point bookmark bookmark-1 to commit 96f3a57c9a4a4ae7bb45d1eafe32fe3b6e33f458
-      To operation: e6c85abc389d (2001-02-03 08:05:37) delete bookmark bookmark-2
+    From operation: 01a4d5f22fb6 (2001-02-03 08:05:35) point bookmark bookmark-1 to commit 96f3a57c9a4a4ae7bb45d1eafe32fe3b6e33f458
+      To operation: 127e7e5ef5ff (2001-02-03 08:05:37) delete bookmark bookmark-2
 
     Changed local bookmarks:
     bookmark-2:
@@ -1653,8 +1653,8 @@ fn test_op_diff() {
     ");
     let output = work_dir.run_jj(["op", "diff"]);
     insta::assert_snapshot!(output, @"
-    From operation: e6c85abc389d (2001-02-03 08:05:37) delete bookmark bookmark-2
-      To operation: 0e622d1164cc (2001-02-03 08:05:39) push all tracked bookmarks/tags to git remote origin
+    From operation: 127e7e5ef5ff (2001-02-03 08:05:37) delete bookmark bookmark-2
+      To operation: fa7799465b41 (2001-02-03 08:05:39) push all tracked bookmarks/tags to git remote origin
 
     Changed remote bookmarks:
     bookmark-1@origin:
@@ -1671,8 +1671,8 @@ fn test_op_diff() {
     work_dir.run_jj(["tag", "set", "-r@-", "tag1"]).success();
     let output = work_dir.run_jj(["op", "diff"]);
     insta::assert_snapshot!(output, @"
-    From operation: 291f7a97d014 (2001-02-03 08:05:41) new empty commit
-      To operation: ab4465d67d63 (2001-02-03 08:05:42) set tag tag1 to commit 96f3a57c9a4a4ae7bb45d1eafe32fe3b6e33f458
+    From operation: b2360e223641 (2001-02-03 08:05:41) new empty commit
+      To operation: b499a1375446 (2001-02-03 08:05:42) set tag tag1 to commit 96f3a57c9a4a4ae7bb45d1eafe32fe3b6e33f458
 
     Changed local tags:
     tag1:
@@ -1687,8 +1687,8 @@ fn test_op_diff() {
         .success();
     let output = work_dir.run_jj(["op", "diff"]);
     insta::assert_snapshot!(output, @"
-    From operation: ab4465d67d63 (2001-02-03 08:05:42) set tag tag1 to commit 96f3a57c9a4a4ae7bb45d1eafe32fe3b6e33f458
-      To operation: 1b3f34f50d5c (2001-02-03 08:05:44) set tag tag1 to commit 0dee631320b13c6a6542c80bced33b9dd29f6bf0
+    From operation: b499a1375446 (2001-02-03 08:05:42) set tag tag1 to commit 96f3a57c9a4a4ae7bb45d1eafe32fe3b6e33f458
+      To operation: 151ccd561835 (2001-02-03 08:05:44) set tag tag1 to commit 0dee631320b13c6a6542c80bced33b9dd29f6bf0
 
     Changed local tags:
     tag1:
@@ -1701,8 +1701,8 @@ fn test_op_diff() {
     work_dir.run_jj(["tag", "delete", "tag1"]).success();
     let output = work_dir.run_jj(["op", "diff"]);
     insta::assert_snapshot!(output, @"
-    From operation: 1b3f34f50d5c (2001-02-03 08:05:44) set tag tag1 to commit 0dee631320b13c6a6542c80bced33b9dd29f6bf0
-      To operation: ffa88ff02dca (2001-02-03 08:05:46) delete tag tag1
+    From operation: 151ccd561835 (2001-02-03 08:05:44) set tag tag1 to commit 0dee631320b13c6a6542c80bced33b9dd29f6bf0
+      To operation: a35f3152e574 (2001-02-03 08:05:46) delete tag tag1
 
     Changed local tags:
     tag1:
@@ -1729,8 +1729,8 @@ fn test_op_diff_patch() {
     ");
     let output = work_dir.run_jj(["op", "diff", "--op", "@-", "-p", "--git"]);
     insta::assert_snapshot!(output, @"
-    From operation: 90267f31f904 (2001-02-03 08:05:07) add workspace 'default'
-      To operation: 2f45e55601da (2001-02-03 08:05:08) snapshot working copy
+    From operation: f63ee16f9553 (2001-02-03 08:05:07) add workspace 'default'
+      To operation: 494872ff8b1e (2001-02-03 08:05:08) snapshot working copy
 
     Changed commits:
     ○  + qpvuntsm 6b57e33c (no description set)
@@ -1750,8 +1750,8 @@ fn test_op_diff_patch() {
     ");
     let output = work_dir.run_jj(["op", "diff", "--op", "@", "-p", "--git"]);
     insta::assert_snapshot!(output, @"
-    From operation: 2f45e55601da (2001-02-03 08:05:08) snapshot working copy
-      To operation: cf0770d7100e (2001-02-03 08:05:08) new empty commit
+    From operation: 494872ff8b1e (2001-02-03 08:05:08) snapshot working copy
+      To operation: eb50f4ba33f8 (2001-02-03 08:05:08) new empty commit
 
     Changed commits:
     ○  + rlvkpnrz c1c924b8 (empty) (no description set)
@@ -1773,8 +1773,8 @@ fn test_op_diff_patch() {
     ");
     let output = work_dir.run_jj(["op", "diff", "-p", "--git"]);
     insta::assert_snapshot!(output, @"
-    From operation: 1411dd0524ab (2001-02-03 08:05:11) snapshot working copy
-      To operation: e6ae6bef0dc4 (2001-02-03 08:05:11) squash commits into 6b57e33cc56babbeaa6bcd6e2a296236b52ad93c
+    From operation: 5a7a78e63d4a (2001-02-03 08:05:11) snapshot working copy
+      To operation: f8b489c34565 (2001-02-03 08:05:11) squash commits into 6b57e33cc56babbeaa6bcd6e2a296236b52ad93c
 
     Changed commits:
     ○  + mzvwutvl 6cbd01ae (empty) (no description set)
@@ -1807,8 +1807,8 @@ fn test_op_diff_patch() {
     ");
     let output = work_dir.run_jj(["op", "diff", "-p", "--git"]);
     insta::assert_snapshot!(output, @"
-    From operation: e6ae6bef0dc4 (2001-02-03 08:05:11) squash commits into 6b57e33cc56babbeaa6bcd6e2a296236b52ad93c
-      To operation: 0b9a2eef07b2 (2001-02-03 08:05:13) abandon commit 6cbd01aefe5ae05a015328311dbd63b7305b8ebe
+    From operation: f8b489c34565 (2001-02-03 08:05:11) squash commits into 6b57e33cc56babbeaa6bcd6e2a296236b52ad93c
+      To operation: cad7943bb3ae (2001-02-03 08:05:13) abandon commit 6cbd01aefe5ae05a015328311dbd63b7305b8ebe
 
     Changed commits:
     ○  + yqosqzyt c97a8573 (empty) (no description set)
@@ -1831,7 +1831,7 @@ fn test_op_diff_sibling() {
         .run_jj(["op", "log", "--no-graph", r#"-Tid.short() ++ "\n""#])
         .success();
     let base_op_id = output.stdout.raw().lines().next().unwrap();
-    insta::assert_snapshot!(base_op_id, @"90267f31f904");
+    insta::assert_snapshot!(base_op_id, @"f63ee16f9553");
 
     // Create merge commit at one operation side. The parent trees will have to
     // be merged when diffing, which requires the commit index of this side.
@@ -1848,28 +1848,28 @@ fn test_op_diff_sibling() {
 
     let output = work_dir.run_jj(["op", "log"]);
     insta::assert_snapshot!(output, @"
-    @    1c4db3c4a594 test-username@host.example.com default@ 2001-02-03 04:05:13.000 +07:00 - 2001-02-03 04:05:13.000 +07:00
+    @    5e539df77fe9 test-username@host.example.com default@ 2001-02-03 04:05:13.000 +07:00 - 2001-02-03 04:05:13.000 +07:00
     ├─╮  reconcile divergent operations
     │ │  args: jj op log
-    ○ │  8276f97c320d test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    ○ │  49d9da1d20b9 test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
     │ │  new empty commit
     │ │  args: jj new '@-+' -mA
-    ○ │  ff1fbea612d5 test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    ○ │  eb1736b75b47 test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
     │ │  snapshot working copy
     │ │  args: jj new '@-+' -mA
-    ○ │  bf40689e8204 test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    ○ │  7d3a3c0079f2 test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     │ │  new empty commit
     │ │  args: jj new 'root()' -mA.2
-    ○ │  0075fc491372 test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    ○ │  7891168620e2 test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     │ │  snapshot working copy
     │ │  args: jj new 'root()' -mA.2
-    ○ │  7adb656f42e2 test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    ○ │  7edadff416f8 test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     │ │  new empty commit
     │ │  args: jj new 'root()' -mA.1
-    │ ○  1220c0f6978f test-username@host.example.com default@ 2001-02-03 04:05:12.000 +07:00 - 2001-02-03 04:05:12.000 +07:00
+    │ ○  cbb094fbfea4 test-username@host.example.com default@ 2001-02-03 04:05:12.000 +07:00 - 2001-02-03 04:05:12.000 +07:00
     ├─╯  describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
-    │    args: jj describe --at-op 90267f31f904 -mB
-    ○  90267f31f904 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    │    args: jj describe --at-op f63ee16f9553 -mB
+    ○  f63ee16f9553 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
     [EOF]
@@ -1882,9 +1882,9 @@ fn test_op_diff_sibling() {
         .success();
     let [head_op_id, p1_op_id, _, _, _, _, p2_op_id] =
         output.stdout.raw().lines().next_array().unwrap();
-    insta::assert_snapshot!(head_op_id, @"1c4db3c4a594");
-    insta::assert_snapshot!(p1_op_id, @"8276f97c320d");
-    insta::assert_snapshot!(p2_op_id, @"1220c0f6978f");
+    insta::assert_snapshot!(head_op_id, @"5e539df77fe9");
+    insta::assert_snapshot!(p1_op_id, @"49d9da1d20b9");
+    insta::assert_snapshot!(p2_op_id, @"cbb094fbfea4");
 
     // Diff between p1 and p2 operations should work no matter if p2 is chosen
     // as a base operation.
@@ -1900,8 +1900,8 @@ fn test_op_diff_sibling() {
         "--summary",
     ]);
     insta::assert_snapshot!(output, @"
-    From operation: 8276f97c320d (2001-02-03 08:05:11) new empty commit
-      To operation: 1220c0f6978f (2001-02-03 08:05:12) describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
+    From operation: 49d9da1d20b9 (2001-02-03 08:05:11) new empty commit
+      To operation: cbb094fbfea4 (2001-02-03 08:05:12) describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
 
     Changed commits:
     ○    - mzvwutvl/0 08c63613 (hidden) (empty) A
@@ -1930,8 +1930,8 @@ fn test_op_diff_sibling() {
         "--summary",
     ]);
     insta::assert_snapshot!(output, @"
-    From operation: 1220c0f6978f (2001-02-03 08:05:12) describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
-      To operation: 8276f97c320d (2001-02-03 08:05:11) new empty commit
+    From operation: cbb094fbfea4 (2001-02-03 08:05:12) describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
+      To operation: 49d9da1d20b9 (2001-02-03 08:05:11) new empty commit
 
     Changed commits:
     ○  - qpvuntsm/0 b1ca67e2 (hidden) (empty) B
@@ -1962,8 +1962,8 @@ fn test_op_diff_sibling() {
         "--no-graph",
     ]);
     insta::assert_snapshot!(output, @"
-    From operation: 1220c0f6978f (2001-02-03 08:05:12) describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
-      To operation: 8276f97c320d (2001-02-03 08:05:11) new empty commit
+    From operation: cbb094fbfea4 (2001-02-03 08:05:12) describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
+      To operation: 49d9da1d20b9 (2001-02-03 08:05:11) new empty commit
 
     Changed commits:
     - qpvuntsm/0 b1ca67e2 (hidden) (empty) B
@@ -2033,8 +2033,8 @@ fn test_op_diff_divergent_change() {
         &divergent_op_id,
     ]);
     insta::assert_snapshot!(output, @"
-    From operation: 46c65d1e75d8 (2001-02-03 08:05:08) commit 5d86d4b609080a15077fcd723e537582d5ea6559
-      To operation: 43adb727799e (2001-02-03 08:05:11) describe commit 7a72a9ad7f4d8aa8b613a9840313b0ef0632842b
+    From operation: 6f308a91623b (2001-02-03 08:05:08) commit 5d86d4b609080a15077fcd723e537582d5ea6559
+      To operation: 1259e1240aef (2001-02-03 08:05:11) describe commit 7a72a9ad7f4d8aa8b613a9840313b0ef0632842b
 
     Changed commits:
     ○  + rlvkpnrz/0 c5cad9ab (divergent) 2b
@@ -2058,8 +2058,8 @@ fn test_op_diff_divergent_change() {
         &resolved_op_id,
     ]);
     insta::assert_snapshot!(output, @"
-    From operation: 43adb727799e (2001-02-03 08:05:11) describe commit 7a72a9ad7f4d8aa8b613a9840313b0ef0632842b
-      To operation: c27455b31516 (2001-02-03 08:05:13) squash commits into c5cad9ab7772714178c158a133a0243908545b48
+    From operation: 1259e1240aef (2001-02-03 08:05:11) describe commit 7a72a9ad7f4d8aa8b613a9840313b0ef0632842b
+      To operation: c570e82e2625 (2001-02-03 08:05:13) squash commits into c5cad9ab7772714178c158a133a0243908545b48
 
     Changed commits:
     ○  + rlvkpnrz 17d68d92 2ab
@@ -2083,8 +2083,8 @@ fn test_op_diff_divergent_change() {
         &divergent_op_id,
     ]);
     insta::assert_snapshot!(output, @"
-    From operation: 46c65d1e75d8 (2001-02-03 08:05:08) commit 5d86d4b609080a15077fcd723e537582d5ea6559
-      To operation: 43adb727799e (2001-02-03 08:05:11) describe commit 7a72a9ad7f4d8aa8b613a9840313b0ef0632842b
+    From operation: 6f308a91623b (2001-02-03 08:05:08) commit 5d86d4b609080a15077fcd723e537582d5ea6559
+      To operation: 1259e1240aef (2001-02-03 08:05:11) describe commit 7a72a9ad7f4d8aa8b613a9840313b0ef0632842b
 
     Changed commits:
     ○  + rlvkpnrz/0 c5cad9ab (divergent) 2b
@@ -2133,8 +2133,8 @@ fn test_op_diff_divergent_change() {
         &resolved_op_id,
     ]);
     insta::assert_snapshot!(output, @"
-    From operation: 43adb727799e (2001-02-03 08:05:11) describe commit 7a72a9ad7f4d8aa8b613a9840313b0ef0632842b
-      To operation: c27455b31516 (2001-02-03 08:05:13) squash commits into c5cad9ab7772714178c158a133a0243908545b48
+    From operation: 1259e1240aef (2001-02-03 08:05:11) describe commit 7a72a9ad7f4d8aa8b613a9840313b0ef0632842b
+      To operation: c570e82e2625 (2001-02-03 08:05:13) squash commits into c5cad9ab7772714178c158a133a0243908545b48
 
     Changed commits:
     ○  + rlvkpnrz 17d68d92 2ab
@@ -2171,8 +2171,8 @@ fn test_op_diff_divergent_change() {
         &divergent_op_id,
     ]);
     insta::assert_snapshot!(output, @"
-    From operation: c27455b31516 (2001-02-03 08:05:13) squash commits into c5cad9ab7772714178c158a133a0243908545b48
-      To operation: 43adb727799e (2001-02-03 08:05:11) describe commit 7a72a9ad7f4d8aa8b613a9840313b0ef0632842b
+    From operation: c570e82e2625 (2001-02-03 08:05:13) squash commits into c5cad9ab7772714178c158a133a0243908545b48
+      To operation: 1259e1240aef (2001-02-03 08:05:11) describe commit 7a72a9ad7f4d8aa8b613a9840313b0ef0632842b
 
     Changed commits:
     ○  + rlvkpnrz/1 c5cad9ab (divergent) 2b
@@ -2196,8 +2196,8 @@ fn test_op_diff_divergent_change() {
         &initial_op_id,
     ]);
     insta::assert_snapshot!(output, @"
-    From operation: 43adb727799e (2001-02-03 08:05:11) describe commit 7a72a9ad7f4d8aa8b613a9840313b0ef0632842b
-      To operation: 46c65d1e75d8 (2001-02-03 08:05:08) commit 5d86d4b609080a15077fcd723e537582d5ea6559
+    From operation: 1259e1240aef (2001-02-03 08:05:11) describe commit 7a72a9ad7f4d8aa8b613a9840313b0ef0632842b
+      To operation: 6f308a91623b (2001-02-03 08:05:08) commit 5d86d4b609080a15077fcd723e537582d5ea6559
 
     Changed commits:
     ○  + rlvkpnrz 4f7a567a (empty) (no description set)
@@ -2240,9 +2240,9 @@ fn test_op_diff_at_merge_op_with_rebased_commits() {
     // FIXME: the diff should be empty
     let output = work_dir.run_jj(["op", "diff"]);
     insta::assert_snapshot!(output, @"
-    From operation: aebc639c7fdb (2001-02-03 08:05:09) describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
-    From operation: f36a8c8cba9e (2001-02-03 08:05:10) describe commit ab92d1a87bebb4300165a16a753c5403bd7bc578
-      To operation: 8f0e2ab3b7cc (2001-02-03 08:05:11) reconcile divergent operations
+    From operation: e20b9b9f8704 (2001-02-03 08:05:09) describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
+    From operation: 71ec13d562f6 (2001-02-03 08:05:10) describe commit ab92d1a87bebb4300165a16a753c5403bd7bc578
+      To operation: 110aea121037 (2001-02-03 08:05:11) reconcile divergent operations
 
     Changed commits:
     ○  + rlvkpnrz/1 8f35f6a6 (divergent) (empty) 2b
@@ -2252,7 +2252,7 @@ fn test_op_diff_at_merge_op_with_rebased_commits() {
 
     let output = work_dir.run_jj(["op", "show"]);
     insta::assert_snapshot!(output, @"
-    8f0e2ab3b7cc test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    110aea121037 test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
     reconcile divergent operations
     args: jj log
     [EOF]
@@ -2260,10 +2260,10 @@ fn test_op_diff_at_merge_op_with_rebased_commits() {
 
     let output = work_dir.run_jj(["op", "log", "--op-diff", "--limit=3"]);
     insta::assert_snapshot!(output, @"
-    @    8f0e2ab3b7cc test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    @    110aea121037 test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
     ├─╮  reconcile divergent operations
     │ │  args: jj log
-    ○ │  aebc639c7fdb test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    ○ │  e20b9b9f8704 test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     │ │  describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     │ │  args: jj describe -r@- -m1
     │ │
@@ -2276,7 +2276,7 @@ fn test_op_diff_at_merge_op_with_rebased_commits() {
     │ │  Changed working copy default@:
     │ │  + rlvkpnrz 7ed5a610 (empty) 2a
     │ │  - rlvkpnrz/1 ab92d1a8 (hidden) (empty) 2a
-    │ ○  f36a8c8cba9e test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    │ ○  71ec13d562f6 test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     ├─╯  describe commit ab92d1a87bebb4300165a16a753c5403bd7bc578
     │    args: jj describe '--at-op=@-' -m2b
     │
@@ -2316,8 +2316,8 @@ fn test_op_diff_word_wrap() {
 
     // ui.log-word-wrap option works, and diff stat respects content width
     insta::assert_snapshot!(render(&["op", "diff", "--from=@---", "--stat"], 40, true), @"
-    From operation: f6dad0859f53 (2001-02-03 08:05:07) add git remote origin
-      To operation: 5991a13625d6 (2001-02-03 08:05:08) snapshot working copy
+    From operation: 267d2e28edfc (2001-02-03 08:05:07) add git remote origin
+      To operation: 668558c2bb9b (2001-02-03 08:05:08) snapshot working copy
 
     Changed commits:
     ○  + sqpuoqvx f6f32c19 (no description
@@ -2384,8 +2384,8 @@ fn test_op_diff_word_wrap() {
     let config = r#"templates.commit_summary='"0 1 2 3 4 5 6 7 8 9"'"#;
     insta::assert_snapshot!(
         render(&["op", "diff", "--from=@---", "--config", config], 10, true), @"
-    From operation: f6dad0859f53 (2001-02-03 08:05:07) add git remote origin
-      To operation: 5991a13625d6 (2001-02-03 08:05:08) snapshot working copy
+    From operation: 267d2e28edfc (2001-02-03 08:05:07) add git remote origin
+      To operation: 668558c2bb9b (2001-02-03 08:05:08) snapshot working copy
 
     Changed
     commits:
@@ -2496,16 +2496,16 @@ fn test_op_show() {
     // Overview of op log.
     let output = work_dir.run_jj(["op", "log"]);
     insta::assert_snapshot!(output, @"
-    @  81bc294627f7 test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    @  c398dc66e5f4 test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     │  track remote bookmark bookmark-1@origin
     │  args: jj bookmark track bookmark-1
-    ○  80e831767589 test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    ○  47cfe27aee78 test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     │  fetch from git remote(s) origin
     │  args: jj git fetch
-    ○  ccace750b730 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    ○  0dcdecd46a3d test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  add git remote origin
     │  args: jj git remote add origin ../git-repo
-    ○  90267f31f904 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  f63ee16f9553 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
     [EOF]
@@ -2521,7 +2521,7 @@ fn test_op_show() {
     // Showing the latest operation.
     let output = work_dir.run_jj(["op", "show", "@"]);
     insta::assert_snapshot!(output, @"
-    81bc294627f7 test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    c398dc66e5f4 test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     track remote bookmark bookmark-1@origin
     args: jj bookmark track bookmark-1
 
@@ -2543,7 +2543,7 @@ fn test_op_show() {
     // Showing a given operation.
     let output = work_dir.run_jj(["op", "show", "@-"]);
     insta::assert_snapshot!(output, @"
-    80e831767589 test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    47cfe27aee78 test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     fetch from git remote(s) origin
     args: jj git fetch
 
@@ -2603,7 +2603,7 @@ fn test_op_show() {
     // Showing a merge operation is empty.
     let output = work_dir.run_jj(["op", "show"]);
     insta::assert_snapshot!(output, @"
-    05f1e72786bd test-username@host.example.com default@ 2001-02-03 04:05:17.000 +07:00 - 2001-02-03 04:05:17.000 +07:00
+    92b44996917e test-username@host.example.com default@ 2001-02-03 04:05:17.000 +07:00 - 2001-02-03 04:05:17.000 +07:00
     reconcile divergent operations
     args: jj log
     [EOF]
@@ -2623,7 +2623,7 @@ fn test_op_show() {
     ");
     let output = work_dir.run_jj(["op", "show"]);
     insta::assert_snapshot!(output, @"
-    4d57f8c435c5 test-username@host.example.com default@ 2001-02-03 04:05:19.000 +07:00 - 2001-02-03 04:05:19.000 +07:00
+    e4311180b383 test-username@host.example.com default@ 2001-02-03 04:05:19.000 +07:00 - 2001-02-03 04:05:19.000 +07:00
     fetch from git remote(s) origin
     args: jj git fetch
 
@@ -2667,7 +2667,7 @@ fn test_op_show() {
     ");
     let output = work_dir.run_jj(["op", "show"]);
     insta::assert_snapshot!(output, @"
-    9919170b2011 test-username@host.example.com default@ 2001-02-03 04:05:21.000 +07:00 - 2001-02-03 04:05:21.000 +07:00
+    ce4b2e34b24c test-username@host.example.com default@ 2001-02-03 04:05:21.000 +07:00 - 2001-02-03 04:05:21.000 +07:00
     create bookmark bookmark-2 pointing to commit e1a239a57eb15cefc5910198befbbbe2b43c47af
     args: jj bookmark create bookmark-2 -r bookmark-2@origin
 
@@ -2687,7 +2687,7 @@ fn test_op_show() {
     ");
     let output = work_dir.run_jj(["op", "show"]);
     insta::assert_snapshot!(output, @"
-    fb6f3682d196 test-username@host.example.com default@ 2001-02-03 04:05:23.000 +07:00 - 2001-02-03 04:05:23.000 +07:00
+    07b2b85e64f5 test-username@host.example.com default@ 2001-02-03 04:05:23.000 +07:00 - 2001-02-03 04:05:23.000 +07:00
     track remote bookmark bookmark-2@origin
     args: jj bookmark track bookmark-2
 
@@ -2708,7 +2708,7 @@ fn test_op_show() {
     ");
     let output = work_dir.run_jj(["op", "show"]);
     insta::assert_snapshot!(output, @"
-    fb6f3682d196 test-username@host.example.com default@ 2001-02-03 04:05:23.000 +07:00 - 2001-02-03 04:05:23.000 +07:00
+    07b2b85e64f5 test-username@host.example.com default@ 2001-02-03 04:05:23.000 +07:00 - 2001-02-03 04:05:23.000 +07:00
     track remote bookmark bookmark-2@origin
     args: jj bookmark track bookmark-2
 
@@ -2730,7 +2730,7 @@ fn test_op_show() {
     ");
     let output = work_dir.run_jj(["op", "show"]);
     insta::assert_snapshot!(output, @"
-    0a422359fac3 test-username@host.example.com default@ 2001-02-03 04:05:27.000 +07:00 - 2001-02-03 04:05:27.000 +07:00
+    56bd9e4967d5 test-username@host.example.com default@ 2001-02-03 04:05:27.000 +07:00 - 2001-02-03 04:05:27.000 +07:00
     new empty commit
     args: jj new bookmark-1@origin -m 'new commit'
 
@@ -2753,7 +2753,7 @@ fn test_op_show() {
     ");
     let output = work_dir.run_jj(["op", "show"]);
     insta::assert_snapshot!(output, @"
-    d240a4e0bf5c test-username@host.example.com default@ 2001-02-03 04:05:29.000 +07:00 - 2001-02-03 04:05:29.000 +07:00
+    3ed3cc92cf58 test-username@host.example.com default@ 2001-02-03 04:05:29.000 +07:00 - 2001-02-03 04:05:29.000 +07:00
     point bookmark bookmark-1 to commit 8f340dd76dc637e4deac17f30056eef7d8eaf682
     args: jj bookmark set bookmark-1 -r @
 
@@ -2774,7 +2774,7 @@ fn test_op_show() {
     ");
     let output = work_dir.run_jj(["op", "show"]);
     insta::assert_snapshot!(output, @"
-    57051f5b9177 test-username@host.example.com default@ 2001-02-03 04:05:31.000 +07:00 - 2001-02-03 04:05:31.000 +07:00
+    82f0716300b2 test-username@host.example.com default@ 2001-02-03 04:05:31.000 +07:00 - 2001-02-03 04:05:31.000 +07:00
     delete bookmark bookmark-2
     args: jj bookmark delete bookmark-2
 
@@ -2796,7 +2796,7 @@ fn test_op_show() {
     ");
     let output = work_dir.run_jj(["op", "show"]);
     insta::assert_snapshot!(output, @"
-    4c467aa621a6 test-username@host.example.com default@ 2001-02-03 04:05:33.000 +07:00 - 2001-02-03 04:05:33.000 +07:00
+    ef37121543ef test-username@host.example.com default@ 2001-02-03 04:05:33.000 +07:00 - 2001-02-03 04:05:33.000 +07:00
     push all tracked bookmarks/tags to git remote origin
     args: jj git push --tracked --deleted
 
@@ -2811,9 +2811,9 @@ fn test_op_show() {
     ");
 
     // Showing a given operation, without graph
-    let output = work_dir.run_jj(["op", "show", "--no-graph", "0a422359fac3"]);
+    let output = work_dir.run_jj(["op", "show", "--no-graph", "56bd9e4967d5"]);
     insta::assert_snapshot!(output, @"
-    0a422359fac3 test-username@host.example.com default@ 2001-02-03 04:05:27.000 +07:00 - 2001-02-03 04:05:27.000 +07:00
+    56bd9e4967d5 test-username@host.example.com default@ 2001-02-03 04:05:27.000 +07:00 - 2001-02-03 04:05:27.000 +07:00
     new empty commit
     args: jj new bookmark-1@origin -m 'new commit'
 
@@ -2845,7 +2845,7 @@ fn test_op_show_patch() {
     ");
     let output = work_dir.run_jj(["op", "show", "@-", "-p", "--git"]);
     insta::assert_snapshot!(output, @"
-    2f45e55601da test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    494872ff8b1e test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     snapshot working copy
     args: jj new
 
@@ -2867,7 +2867,7 @@ fn test_op_show_patch() {
     ");
     let output = work_dir.run_jj(["op", "show", "@", "-p", "--git"]);
     insta::assert_snapshot!(output, @"
-    cf0770d7100e test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    eb50f4ba33f8 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     new empty commit
     args: jj new
 
@@ -2891,7 +2891,7 @@ fn test_op_show_patch() {
     ");
     let output = work_dir.run_jj(["op", "show", "-p", "--git"]);
     insta::assert_snapshot!(output, @"
-    e6ae6bef0dc4 test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    f8b489c34565 test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
     squash commits into 6b57e33cc56babbeaa6bcd6e2a296236b52ad93c
     args: jj squash
 
@@ -2926,7 +2926,7 @@ fn test_op_show_patch() {
     ");
     let output = work_dir.run_jj(["op", "show", "-p", "--git"]);
     insta::assert_snapshot!(output, @"
-    0b9a2eef07b2 test-username@host.example.com default@ 2001-02-03 04:05:13.000 +07:00 - 2001-02-03 04:05:13.000 +07:00
+    cad7943bb3ae test-username@host.example.com default@ 2001-02-03 04:05:13.000 +07:00 - 2001-02-03 04:05:13.000 +07:00
     abandon commit 6cbd01aefe5ae05a015328311dbd63b7305b8ebe
     args: jj abandon
 
@@ -2943,7 +2943,7 @@ fn test_op_show_patch() {
     // Try again with "op log".
     let output = work_dir.run_jj(["op", "log", "--git"]);
     insta::assert_snapshot!(output, @"
-    @  0b9a2eef07b2 test-username@host.example.com default@ 2001-02-03 04:05:13.000 +07:00 - 2001-02-03 04:05:13.000 +07:00
+    @  cad7943bb3ae test-username@host.example.com default@ 2001-02-03 04:05:13.000 +07:00 - 2001-02-03 04:05:13.000 +07:00
     │  abandon commit 6cbd01aefe5ae05a015328311dbd63b7305b8ebe
     │  args: jj abandon
     │
@@ -2954,7 +2954,7 @@ fn test_op_show_patch() {
     │  Changed working copy default@:
     │  + yqosqzyt c97a8573 (empty) (no description set)
     │  - mzvwutvl/0 6cbd01ae (hidden) (empty) (no description set)
-    ○  e6ae6bef0dc4 test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    ○  f8b489c34565 test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
     │  squash commits into 6b57e33cc56babbeaa6bcd6e2a296236b52ad93c
     │  args: jj squash
     │
@@ -2974,7 +2974,7 @@ fn test_op_show_patch() {
     │  Changed working copy default@:
     │  + mzvwutvl 6cbd01ae (empty) (no description set)
     │  - rlvkpnrz/0 05a2969e (hidden) (no description set)
-    ○  1411dd0524ab test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    ○  5a7a78e63d4a test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
     │  snapshot working copy
     │  args: jj squash
     │
@@ -2992,7 +2992,7 @@ fn test_op_show_patch() {
     │  Changed working copy default@:
     │  + rlvkpnrz 05a2969e (no description set)
     │  - rlvkpnrz/1 c1c924b8 (hidden) (empty) (no description set)
-    ○  cf0770d7100e test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    ○  eb50f4ba33f8 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  new empty commit
     │  args: jj new
     │
@@ -3002,7 +3002,7 @@ fn test_op_show_patch() {
     │  Changed working copy default@:
     │  + rlvkpnrz c1c924b8 (empty) (no description set)
     │  - qpvuntsm 6b57e33c (no description set)
-    ○  2f45e55601da test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    ○  494872ff8b1e test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  snapshot working copy
     │  args: jj new
     │
@@ -3020,7 +3020,7 @@ fn test_op_show_patch() {
     │  Changed working copy default@:
     │  + qpvuntsm 6b57e33c (no description set)
     │  - qpvuntsm/1 e8849ae1 (hidden) (empty) (no description set)
-    ○  90267f31f904 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  f63ee16f9553 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     │
     │  Changed commits:
@@ -3051,12 +3051,12 @@ fn test_op_show_template() {
         r#"separate(" ", id.short(), description)"#,
         "--no-op-diff",
     ]);
-    insta::assert_snapshot!(output, @"88b1bf13af2b commit 0883ea507656cce545dbba9f23760ff72dff5174[EOF]");
+    insta::assert_snapshot!(output, @"22e6b90c70c1 commit 0883ea507656cce545dbba9f23760ff72dff5174[EOF]");
 
     // Test --no-op-diff flag suppresses the diff
     let output = work_dir.run_jj(["op", "show", "--no-op-diff"]);
     insta::assert_snapshot!(output, @"
-    88b1bf13af2b test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    22e6b90c70c1 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     commit 0883ea507656cce545dbba9f23760ff72dff5174
     args: jj commit -m 'first commit'
     [EOF]
@@ -3070,7 +3070,7 @@ fn test_op_show_template() {
         r#"separate(" ", id.short(), description)"#,
     ]);
     insta::assert_snapshot!(output, @"
-    88b1bf13af2b commit 0883ea507656cce545dbba9f23760ff72dff5174
+    22e6b90c70c1 commit 0883ea507656cce545dbba9f23760ff72dff5174
     Changed commits:
     ○  + rlvkpnrz e4863b8c (empty) (no description set)
     ○  + qpvuntsm b52b7cb5 first commit
@@ -3098,13 +3098,13 @@ fn test_op_log_parents() {
     let template = r#"id.short() ++ "\nP: " ++ parents.len() ++ " " ++ parents.map(|o| o.id().short()) ++ "\n""#;
     let output = work_dir.run_jj(["op", "log", "-T", template]);
     insta::assert_snapshot!(output, @"
-    @    b991e0d37e4d
-    ├─╮  P: 2 8501e29d2d94 9eb037245431
-    ○ │  8501e29d2d94
-    │ │  P: 1 90267f31f904
-    │ ○  9eb037245431
-    ├─╯  P: 1 90267f31f904
-    ○  90267f31f904
+    @    7f1c9ff8575c
+    ├─╮  P: 2 7749eb4df93f 3cb69b18c151
+    ○ │  7749eb4df93f
+    │ │  P: 1 f63ee16f9553
+    │ ○  3cb69b18c151
+    ├─╯  P: 1 f63ee16f9553
+    ○  f63ee16f9553
     │  P: 1 000000000000
     ○  000000000000
        P: 0
@@ -3126,10 +3126,10 @@ fn test_op_log_anonymize() {
 
     let output = work_dir.run_jj(["op", "log", "-Tbuiltin_op_log_redacted"]);
     insta::assert_snapshot!(output, @"
-    @  8501e29d2d94 user-5910 workspace-ab88@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    @  7749eb4df93f user-5910 workspace-ab88@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     │  (redacted)
-    ○  90267f31f904 user-5910 workspace-482a@ 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  f63ee16f9553 user-5910 workspace-482a@ 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
     [EOF]
@@ -3162,7 +3162,7 @@ fn test_op_immutable_revisions() {
         .run_jj(["abandon", "--ignore-immutable", "::t1 & ~root()"])
         .success();
     insta::assert_snapshot!(work_dir.run_jj(["op", "show"]), @"
-    d86e21bb08c0 test-username@host.example.com default@ 2001-02-03 04:05:16.000 +07:00 - 2001-02-03 04:05:16.000 +07:00
+    57739a739904 test-username@host.example.com default@ 2001-02-03 04:05:16.000 +07:00 - 2001-02-03 04:05:16.000 +07:00
     abandon commit 9c86781f3fe9097ffc530e65fd2ab4aff1e654bd and 5 more
     args: jj abandon --ignore-immutable '::t1 & ~root()'
 
@@ -3175,8 +3175,8 @@ fn test_op_immutable_revisions() {
     // Undo
     work_dir.run_jj(["op", "revert"]).success();
     insta::assert_snapshot!(work_dir.run_jj(["op", "show"]), @"
-    abbb2399227e test-username@host.example.com default@ 2001-02-03 04:05:18.000 +07:00 - 2001-02-03 04:05:18.000 +07:00
-    revert operation d86e21bb08c07020add3b8624a72211b087501d2cce3e1fc90ef0e37596385b73b5470b1754dfbaf1ec28df0df5d61dadb6cf338ceb1ae2a1974a3a473ec8230
+    d5b2b3f52ef8 test-username@host.example.com default@ 2001-02-03 04:05:18.000 +07:00 - 2001-02-03 04:05:18.000 +07:00
+    revert operation 57739a7399047ab60f9bf4aedcf1c604e868abd0f33795f7e18f99b86acb5fd8549c852fb49eb18f8c85fcfb4784e95161f2d9efc24b01c603f468a52689405f
     args: jj op revert
 
     Changed commits:
@@ -3207,7 +3207,7 @@ fn test_op_immutable_revisions() {
         .success();
     let op_id_for_diff = work_dir.current_operation_id();
     insta::assert_snapshot!(work_dir.run_jj(["op", "show"]), @"
-    cf3d5f839512 test-username@host.example.com default@ 2001-02-03 04:05:31.000 +07:00 - 2001-02-03 04:05:31.000 +07:00
+    a3d69d664845 test-username@host.example.com default@ 2001-02-03 04:05:31.000 +07:00 - 2001-02-03 04:05:31.000 +07:00
     abandon commit 7c60d8fd187f77196d1def564b0d893d477b7e56 and 11 more
     args: jj abandon --ignore-immutable '(::f1 | ::f2) & ~root()'
 
@@ -3222,7 +3222,7 @@ fn test_op_immutable_revisions() {
 
     // Use `--show-changes-in none()` to see only elisions
     insta::assert_snapshot!(work_dir.run_jj(["op", "show", "--show-changes-in", "none()"]), @"
-    cf3d5f839512 test-username@host.example.com default@ 2001-02-03 04:05:31.000 +07:00 - 2001-02-03 04:05:31.000 +07:00
+    a3d69d664845 test-username@host.example.com default@ 2001-02-03 04:05:31.000 +07:00 - 2001-02-03 04:05:31.000 +07:00
     abandon commit 7c60d8fd187f77196d1def564b0d893d477b7e56 and 11 more
     args: jj abandon --ignore-immutable '(::f1 | ::f2) & ~root()'
 
@@ -3259,7 +3259,7 @@ fn test_op_immutable_revisions() {
         .run_jj(["rebase", "--ignore-immutable", "-s", "bb----", "-d", "ba"])
         .success();
     insta::assert_snapshot!(work_dir.run_jj(["op", "show"]), @"
-    5139db3ae21c test-username@host.example.com default@ 2001-02-03 04:05:48.000 +07:00 - 2001-02-03 04:05:48.000 +07:00
+    e92cd1c233e5 test-username@host.example.com default@ 2001-02-03 04:05:48.000 +07:00 - 2001-02-03 04:05:48.000 +07:00
     rebase commit 6c3a9c2476ba8a8e5bac722f9c0e2ca914b9577d and descendants
     args: jj rebase --ignore-immutable -s bb---- -d ba
 
@@ -3283,7 +3283,7 @@ fn test_op_immutable_revisions() {
 
     // Use `--show-changes-in none()` to see only elisions
     insta::assert_snapshot!(work_dir.run_jj(["op", "show", "--show-changes-in", "none()"]), @"
-    5139db3ae21c test-username@host.example.com default@ 2001-02-03 04:05:48.000 +07:00 - 2001-02-03 04:05:48.000 +07:00
+    e92cd1c233e5 test-username@host.example.com default@ 2001-02-03 04:05:48.000 +07:00 - 2001-02-03 04:05:48.000 +07:00
     rebase commit 6c3a9c2476ba8a8e5bac722f9c0e2ca914b9577d and descendants
     args: jj rebase --ignore-immutable -s bb---- -d ba
 
@@ -3315,7 +3315,7 @@ fn test_op_immutable_revisions() {
         .run_jj(["abandon", "--ignore-immutable", "::ts & ~root()"])
         .success();
     insta::assert_snapshot!(work_dir.run_jj(["op", "show"]), @"
-    e660cbda9711 test-username@host.example.com default@ 2001-02-03 04:05:55.000 +07:00 - 2001-02-03 04:05:55.000 +07:00
+    95b73748d059 test-username@host.example.com default@ 2001-02-03 04:05:55.000 +07:00 - 2001-02-03 04:05:55.000 +07:00
     abandon commit 4ebd4aa1d0bfee524ccd21882606990e3b75fc12 and 1 more
     args: jj abandon --ignore-immutable '::ts & ~root()'
 
@@ -3334,8 +3334,8 @@ fn test_op_immutable_revisions() {
     // Undo to see single addition elision
     work_dir.run_jj(["op", "revert"]).success();
     insta::assert_snapshot!(work_dir.run_jj(["op", "show"]), @"
-    d4f2cba9248e test-username@host.example.com default@ 2001-02-03 04:05:57.000 +07:00 - 2001-02-03 04:05:57.000 +07:00
-    revert operation e660cbda9711f6258fca5dffa47b356ace070baff91ee1ff29dee57432d2d44a65cc96375ef6a6e0f0c17171a3a4e209df9f8613790abb28c87acb6fbe107f8d
+    6efe5476f4ba test-username@host.example.com default@ 2001-02-03 04:05:57.000 +07:00 - 2001-02-03 04:05:57.000 +07:00
+    revert operation 95b73748d0599916938dca69ee15ca6a483ff989edc9623a4de65da4059d6b80613dbaa61c24145b621886f1e8562d2a951de817a3ea2ae46a59ec40bc67e4ec
     args: jj op revert
 
     Changed commits:
@@ -3352,8 +3352,8 @@ fn test_op_immutable_revisions() {
 
     // 5. op diff and op log tests
     insta::assert_snapshot!(work_dir.run_jj(["op", "diff", "--from", &op_id_for_diff]), @"
-    From operation: cf3d5f839512 (2001-02-03 08:05:31) abandon commit 7c60d8fd187f77196d1def564b0d893d477b7e56 and 11 more
-      To operation: d4f2cba9248e (2001-02-03 08:05:57) revert operation e660cbda9711f6258fca5dffa47b356ace070baff91ee1ff29dee57432d2d44a65cc96375ef6a6e0f0c17171a3a4e209df9f8613790abb28c87acb6fbe107f8d
+    From operation: a3d69d664845 (2001-02-03 08:05:31) abandon commit 7c60d8fd187f77196d1def564b0d893d477b7e56 and 11 more
+      To operation: 6efe5476f4ba (2001-02-03 08:05:57) revert operation 95b73748d0599916938dca69ee15ca6a483ff989edc9623a4de65da4059d6b80613dbaa61c24145b621886f1e8562d2a951de817a3ea2ae46a59ec40bc67e4ec
 
     Changed commits:
     ○  + ztnvrxlv 13887367 (empty) (no description set)
@@ -3383,8 +3383,8 @@ fn test_op_immutable_revisions() {
     ");
 
     insta::assert_snapshot!(work_dir.run_jj(["op", "log", "-p", "--limit", "1"]), @"
-    @  d4f2cba9248e test-username@host.example.com default@ 2001-02-03 04:05:57.000 +07:00 - 2001-02-03 04:05:57.000 +07:00
-    │  revert operation e660cbda9711f6258fca5dffa47b356ace070baff91ee1ff29dee57432d2d44a65cc96375ef6a6e0f0c17171a3a4e209df9f8613790abb28c87acb6fbe107f8d
+    @  6efe5476f4ba test-username@host.example.com default@ 2001-02-03 04:05:57.000 +07:00 - 2001-02-03 04:05:57.000 +07:00
+    │  revert operation 95b73748d0599916938dca69ee15ca6a483ff989edc9623a4de65da4059d6b80613dbaa61c24145b621886f1e8562d2a951de817a3ea2ae46a59ec40bc67e4ec
     │  args: jj op revert
     │
     │  Changed commits:
@@ -3472,8 +3472,8 @@ fn test_op_immutable_revisions() {
         "all()",
     ]);
     insta::assert_snapshot!(output, @"
-    From operation: 6065717c85c3 (2001-02-03 08:06:12) abandon commit 65f87c2d667d5088987ce6bed60f31f783b9e2ba
-      To operation: 15571d49e1b7 (2001-02-03 08:06:13) abandon commit 7d9fcee9d7dedaa91bee64d976a4252c74750905 and 1 more
+    From operation: 5e7f0dc78d52 (2001-02-03 08:06:12) abandon commit 65f87c2d667d5088987ce6bed60f31f783b9e2ba
+      To operation: 251152d9b321 (2001-02-03 08:06:13) abandon commit 7d9fcee9d7dedaa91bee64d976a4252c74750905 and 1 more
 
     Changed commits:
     ○  - quyylypw/0 7d9fcee9 (hidden) (empty) acc-c2
@@ -3493,8 +3493,8 @@ fn test_op_immutable_revisions() {
     // of the newly hidden set and elide c1.
     let output = work_dir.run_jj(["op", "diff", "--from", &op_a, "--to", &op_b]);
     insta::assert_snapshot!(output, @"
-    From operation: 6065717c85c3 (2001-02-03 08:06:12) abandon commit 65f87c2d667d5088987ce6bed60f31f783b9e2ba
-      To operation: 15571d49e1b7 (2001-02-03 08:06:13) abandon commit 7d9fcee9d7dedaa91bee64d976a4252c74750905 and 1 more
+    From operation: 5e7f0dc78d52 (2001-02-03 08:06:12) abandon commit 65f87c2d667d5088987ce6bed60f31f783b9e2ba
+      To operation: 251152d9b321 (2001-02-03 08:06:13) abandon commit 7d9fcee9d7dedaa91bee64d976a4252c74750905 and 1 more
 
     Changed commits:
     ○  - quyylypw/0 7d9fcee9 (hidden) (empty) acc-c2
@@ -3561,7 +3561,7 @@ commit_summary = 'commit_id.short() ++ " " ++ description.first_line()'
     // 5. Test op show for op_rebase: should show ELISION summary.
     // bookmark_x exists in both states of the rebase.
     insta::assert_snapshot!(work_dir.run_jj(["op", "show", &op_rebase]), @"
-    ce91c7903087 test-username@host.example.com default@ 2001-02-03 04:05:14.000 +07:00 - 2001-02-03 04:05:14.000 +07:00
+    f03470add4fa test-username@host.example.com default@ 2001-02-03 04:05:14.000 +07:00 - 2001-02-03 04:05:14.000 +07:00
     rebase commit 0f12cf5c679b373cb1ee0fa3e441c2f5030c4dc9 and descendants
     args: jj rebase -s bookmark_x- -d @
 
@@ -3580,7 +3580,7 @@ commit_summary = 'commit_id.short() ++ " " ++ description.first_line()'
     // 6. Test op show for op_create: should show WARNING.
     // bookmark_x did not exist in the 'from' state.
     insta::assert_snapshot!(work_dir.run_jj(["op", "show", &op_create]), @"
-    d3ffb3ae407a test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    e57fae0b2f31 test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     create bookmark bookmark_x pointing to commit 2308e5a241f7a47f186b0686ffb17aa613a727d7
     args: jj bookmark create -r@ bookmark_x
 
@@ -3597,7 +3597,7 @@ commit_summary = 'commit_id.short() ++ " " ++ description.first_line()'
     // 7. Test op show for op_create with the flag: should show all changes and NO
     //    WARNING.
     insta::assert_snapshot!(work_dir.run_jj(["op", "show", &op_create, "--show-changes-in", "all()"]), @"
-    d3ffb3ae407a test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    e57fae0b2f31 test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     create bookmark bookmark_x pointing to commit 2308e5a241f7a47f186b0686ffb17aa613a727d7
     args: jj bookmark create -r@ bookmark_x
 
@@ -3611,8 +3611,8 @@ commit_summary = 'commit_id.short() ++ " " ++ description.first_line()'
     // 8. Test op diff from BEFORE creation to op_rebase: should show WARNING.
     let op_before_create = format!("{op_create}-");
     insta::assert_snapshot!(work_dir.run_jj(["op", "diff", "--from", &op_before_create, "--to", &op_rebase]), @"
-    From operation: 2bd218a33e22 (2001-02-03 08:05:08) new empty commit
-      To operation: ce91c7903087 (2001-02-03 08:05:14) rebase commit 0f12cf5c679b373cb1ee0fa3e441c2f5030c4dc9 and descendants
+    From operation: 3c9db0573e75 (2001-02-03 08:05:08) new empty commit
+      To operation: f03470add4fa (2001-02-03 08:05:14) rebase commit 0f12cf5c679b373cb1ee0fa3e441c2f5030c4dc9 and descendants
 
     Warning: Could not resolve revset expression for elision: Revision `bookmark_x` doesn't exist
        (Use --show-changes-in=all() to see all changes)
@@ -3639,8 +3639,8 @@ commit_summary = 'commit_id.short() ++ " " ++ description.first_line()'
         "--show-changes-in",
         "all()",
     ]), @"
-    From operation: 2bd218a33e22 (2001-02-03 08:05:08) new empty commit
-      To operation: ce91c7903087 (2001-02-03 08:05:14) rebase commit 0f12cf5c679b373cb1ee0fa3e441c2f5030c4dc9 and descendants
+    From operation: 3c9db0573e75 (2001-02-03 08:05:08) new empty commit
+      To operation: f03470add4fa (2001-02-03 08:05:14) rebase commit 0f12cf5c679b373cb1ee0fa3e441c2f5030c4dc9 and descendants
 
     Changed commits:
     ○  + 3cafca23bb81 stack 2
@@ -3661,7 +3661,7 @@ commit_summary = 'commit_id.short() ++ " " ++ description.first_line()'
     // 10. Test op log -p: should show BOTH behaviors.
     test_env.add_config(r#"revsets.op-diff-changes-in = "mutable() | bookmark_x""#);
     insta::assert_snapshot!(work_dir.run_jj(["op", "log", "-p", "--limit", "6"]), @"
-    @  ce91c7903087 test-username@host.example.com default@ 2001-02-03 04:05:14.000 +07:00 - 2001-02-03 04:05:14.000 +07:00
+    @  f03470add4fa test-username@host.example.com default@ 2001-02-03 04:05:14.000 +07:00 - 2001-02-03 04:05:14.000 +07:00
     │  rebase commit 0f12cf5c679b373cb1ee0fa3e441c2f5030c4dc9 and descendants
     │  args: jj rebase -s bookmark_x- -d @
     │
@@ -3675,7 +3675,7 @@ commit_summary = 'commit_id.short() ++ " " ++ description.first_line()'
     │  bookmark_x:
     │  + 3cafca23bb81 stack 2
     │  - 5456f1af47ed stack 2
-    ○  86f2ef744e62 test-username@host.example.com default@ 2001-02-03 04:05:13.000 +07:00 - 2001-02-03 04:05:13.000 +07:00
+    ○  ecab6f492442 test-username@host.example.com default@ 2001-02-03 04:05:13.000 +07:00 - 2001-02-03 04:05:13.000 +07:00
     │  new empty commit
     │  args: jj new 'root()' -m new_base
     │
@@ -3687,7 +3687,7 @@ commit_summary = 'commit_id.short() ++ " " ++ description.first_line()'
     │  Changed working copy default@:
     │  + 6b753f7043b4 new_base
     │  - 5456f1af47ed stack 2
-    ○  460a7cedc5a7 test-username@host.example.com default@ 2001-02-03 04:05:12.000 +07:00 - 2001-02-03 04:05:12.000 +07:00
+    ○  e3d322015195 test-username@host.example.com default@ 2001-02-03 04:05:12.000 +07:00 - 2001-02-03 04:05:12.000 +07:00
     │  point bookmark bookmark_x to commit 5456f1af47edb52cfd73d582364cc4dd6ddb08cf
     │  args: jj bookmark set bookmark_x -r@
     │
@@ -3695,7 +3695,7 @@ commit_summary = 'commit_id.short() ++ " " ++ description.first_line()'
     │  bookmark_x:
     │  + 5456f1af47ed stack 2
     │  - 2308e5a241f7 base
-    ○  f64dfa7b064f test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    ○  5ae91ad4e666 test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
     │  new empty commit
     │  args: jj new @ -m 'stack 2'
     │
@@ -3707,7 +3707,7 @@ commit_summary = 'commit_id.short() ++ " " ++ description.first_line()'
     │  Changed working copy default@:
     │  + 5456f1af47ed stack 2
     │  - 0f12cf5c679b stack 1
-    ○  a6bc21ea52ed test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    ○  40eb3a0af389 test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     │  new empty commit
     │  args: jj new @ -m 'stack 1'
     │
@@ -3719,7 +3719,7 @@ commit_summary = 'commit_id.short() ++ " " ++ description.first_line()'
     │  Changed working copy default@:
     │  + 0f12cf5c679b stack 1
     │  - 2308e5a241f7 base
-    ○  d3ffb3ae407a test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    ○  e57fae0b2f31 test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     │  create bookmark bookmark_x pointing to commit 2308e5a241f7a47f186b0686ffb17aa613a727d7
     │  args: jj bookmark create -r@ bookmark_x
     │
@@ -3743,7 +3743,7 @@ commit_summary = 'commit_id.short() ++ " " ++ description.first_line()'
         "--show-changes-in",
         "all()",
     ]), @"
-    @  ce91c7903087 test-username@host.example.com default@ 2001-02-03 04:05:14.000 +07:00 - 2001-02-03 04:05:14.000 +07:00
+    @  f03470add4fa test-username@host.example.com default@ 2001-02-03 04:05:14.000 +07:00 - 2001-02-03 04:05:14.000 +07:00
     │  rebase commit 0f12cf5c679b373cb1ee0fa3e441c2f5030c4dc9 and descendants
     │  args: jj rebase -s bookmark_x- -d @
     │
@@ -3757,7 +3757,7 @@ commit_summary = 'commit_id.short() ++ " " ++ description.first_line()'
     │  bookmark_x:
     │  + 3cafca23bb81 stack 2
     │  - 5456f1af47ed stack 2
-    ○  86f2ef744e62 test-username@host.example.com default@ 2001-02-03 04:05:13.000 +07:00 - 2001-02-03 04:05:13.000 +07:00
+    ○  ecab6f492442 test-username@host.example.com default@ 2001-02-03 04:05:13.000 +07:00 - 2001-02-03 04:05:13.000 +07:00
     │  new empty commit
     │  args: jj new 'root()' -m new_base
     │
@@ -3769,7 +3769,7 @@ commit_summary = 'commit_id.short() ++ " " ++ description.first_line()'
     │  Changed working copy default@:
     │  + 6b753f7043b4 new_base
     │  - 5456f1af47ed stack 2
-    ○  460a7cedc5a7 test-username@host.example.com default@ 2001-02-03 04:05:12.000 +07:00 - 2001-02-03 04:05:12.000 +07:00
+    ○  e3d322015195 test-username@host.example.com default@ 2001-02-03 04:05:12.000 +07:00 - 2001-02-03 04:05:12.000 +07:00
     │  point bookmark bookmark_x to commit 5456f1af47edb52cfd73d582364cc4dd6ddb08cf
     │  args: jj bookmark set bookmark_x -r@
     │
@@ -3777,7 +3777,7 @@ commit_summary = 'commit_id.short() ++ " " ++ description.first_line()'
     │  bookmark_x:
     │  + 5456f1af47ed stack 2
     │  - 2308e5a241f7 base
-    ○  f64dfa7b064f test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    ○  5ae91ad4e666 test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
     │  new empty commit
     │  args: jj new @ -m 'stack 2'
     │
@@ -3789,7 +3789,7 @@ commit_summary = 'commit_id.short() ++ " " ++ description.first_line()'
     │  Changed working copy default@:
     │  + 5456f1af47ed stack 2
     │  - 0f12cf5c679b stack 1
-    ○  a6bc21ea52ed test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    ○  40eb3a0af389 test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     │  new empty commit
     │  args: jj new @ -m 'stack 1'
     │
@@ -3801,7 +3801,7 @@ commit_summary = 'commit_id.short() ++ " " ++ description.first_line()'
     │  Changed working copy default@:
     │  + 0f12cf5c679b stack 1
     │  - 2308e5a241f7 base
-    ○  d3ffb3ae407a test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    ○  e57fae0b2f31 test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     │  create bookmark bookmark_x pointing to commit 2308e5a241f7a47f186b0686ffb17aa613a727d7
     │  args: jj bookmark create -r@ bookmark_x
     │

--- a/cli/tests/test_rebase_command.rs
+++ b/cli/tests/test_rebase_command.rs
@@ -704,7 +704,7 @@ fn test_rebase_revision_onto_descendant() {
     let output = work_dir.run_jj(["op", "restore", &setup_opid]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Restored to operation: 445e5af39d91 (2001-02-03 08:05:15) create bookmark merge pointing to commit 08c0951bf69d0362708a5223a78446d664823b50
+    Restored to operation: 246c3972ba42 (2001-02-03 08:05:15) create bookmark merge pointing to commit 08c0951bf69d0362708a5223a78446d664823b50
     Working copy  (@) now at: vruxwmqv 08c0951b merge | merge
     Parent commit (@-)      : royxmykx 6a7081ef b | b
     Parent commit (@-)      : zsuskuln 68fbc443 a | a

--- a/cli/tests/test_split_command.rs
+++ b/cli/tests/test_split_command.rs
@@ -419,16 +419,16 @@ fn test_split_with_descendants() -> TestResult {
     insta::assert_snapshot!(evolog_1, @"
     ○  qpvuntsm test.user@example.com 2001-02-03 08:05:12 74306e35
     │  Add file1
-    │  -- operation ec53c39a72a8 split commit 1d2499e72cefc8a2b87ebb47569140857b96189f
+    │  -- operation 8da478b86b17 split commit 1d2499e72cefc8a2b87ebb47569140857b96189f
     ○  qpvuntsm/1 test.user@example.com 2001-02-03 08:05:08 1d2499e7 (hidden)
     │  Add file1 & file2
-    │  -- operation 8185a834cefe commit f5700f8ef89e290e4e90ae6adc0908707e0d8c85
+    │  -- operation 8f1bd50aa0bd commit f5700f8ef89e290e4e90ae6adc0908707e0d8c85
     ○  qpvuntsm/2 test.user@example.com 2001-02-03 08:05:08 f5700f8e (hidden)
     │  (no description set)
-    │  -- operation d36e968aa414 snapshot working copy
+    │  -- operation f470eed642a6 snapshot working copy
     ○  qpvuntsm/3 test.user@example.com 2001-02-03 08:05:07 e8849ae1 (hidden)
        (empty) (no description set)
-       -- operation 90267f31f904 add workspace 'default'
+       -- operation f63ee16f9553 add workspace 'default'
     [EOF]
     ");
 
@@ -438,16 +438,16 @@ fn test_split_with_descendants() -> TestResult {
     insta::assert_snapshot!(evolog_2, @"
     ○  royxmykx test.user@example.com 2001-02-03 08:05:12 0a37745e
     │  Add file2
-    │  -- operation ec53c39a72a8 split commit 1d2499e72cefc8a2b87ebb47569140857b96189f
+    │  -- operation 8da478b86b17 split commit 1d2499e72cefc8a2b87ebb47569140857b96189f
     ○  qpvuntsm/1 test.user@example.com 2001-02-03 08:05:08 1d2499e7 (hidden)
     │  Add file1 & file2
-    │  -- operation 8185a834cefe commit f5700f8ef89e290e4e90ae6adc0908707e0d8c85
+    │  -- operation 8f1bd50aa0bd commit f5700f8ef89e290e4e90ae6adc0908707e0d8c85
     ○  qpvuntsm/2 test.user@example.com 2001-02-03 08:05:08 f5700f8e (hidden)
     │  (no description set)
-    │  -- operation d36e968aa414 snapshot working copy
+    │  -- operation f470eed642a6 snapshot working copy
     ○  qpvuntsm/3 test.user@example.com 2001-02-03 08:05:07 e8849ae1 (hidden)
        (empty) (no description set)
-       -- operation 90267f31f904 add workspace 'default'
+       -- operation f63ee16f9553 add workspace 'default'
     [EOF]
     ");
     Ok(())
@@ -575,13 +575,13 @@ fn test_split_parallel_no_descendants() -> TestResult {
     insta::assert_snapshot!(evolog_1, @"
     ○  qpvuntsm test.user@example.com 2001-02-03 08:05:09 7bcd474c
     │  TESTED=TODO
-    │  -- operation 90307a87dc57 split commit f5700f8ef89e290e4e90ae6adc0908707e0d8c85
+    │  -- operation 46ec05e13358 split commit f5700f8ef89e290e4e90ae6adc0908707e0d8c85
     ○  qpvuntsm/1 test.user@example.com 2001-02-03 08:05:08 f5700f8e (hidden)
     │  (no description set)
-    │  -- operation f07456070284 snapshot working copy
+    │  -- operation 9173705f4b2a snapshot working copy
     ○  qpvuntsm/2 test.user@example.com 2001-02-03 08:05:07 e8849ae1 (hidden)
        (empty) (no description set)
-       -- operation 90267f31f904 add workspace 'default'
+       -- operation f63ee16f9553 add workspace 'default'
     [EOF]
     ");
 
@@ -591,13 +591,13 @@ fn test_split_parallel_no_descendants() -> TestResult {
     insta::assert_snapshot!(evolog_2, @"
     @  kkmpptxz test.user@example.com 2001-02-03 08:05:09 431886f6
     │  (no description set)
-    │  -- operation 90307a87dc57 split commit f5700f8ef89e290e4e90ae6adc0908707e0d8c85
+    │  -- operation 46ec05e13358 split commit f5700f8ef89e290e4e90ae6adc0908707e0d8c85
     ○  qpvuntsm/1 test.user@example.com 2001-02-03 08:05:08 f5700f8e (hidden)
     │  (no description set)
-    │  -- operation f07456070284 snapshot working copy
+    │  -- operation 9173705f4b2a snapshot working copy
     ○  qpvuntsm/2 test.user@example.com 2001-02-03 08:05:07 e8849ae1 (hidden)
        (empty) (no description set)
-       -- operation 90267f31f904 add workspace 'default'
+       -- operation f63ee16f9553 add workspace 'default'
     [EOF]
     ");
     Ok(())

--- a/cli/tests/test_squash_command.rs
+++ b/cli/tests/test_squash_command.rs
@@ -2124,31 +2124,31 @@ fn test_squash_to_new_commit() -> TestResult {
     insta::assert_snapshot!(output, @"
     ○    pkstwlsy test.user@example.com 2001-02-03 08:05:35 41510a56
     ├─╮  file 3&4
-    │ │  -- operation 3d6e647dccb7 squash commit 0d254956d33ed5bb11d93eb795c5e514aadc81b5 and 1 more
+    │ │  -- operation 5a8916858004 squash commit 0d254956d33ed5bb11d93eb795c5e514aadc81b5 and 1 more
     │ ○  zsuskuln/0 test.user@example.com 2001-02-03 08:05:35 a5bc761f (hidden)
     │ │  file4
-    │ │  -- operation 3d6e647dccb7 squash commit 0d254956d33ed5bb11d93eb795c5e514aadc81b5 and 1 more
+    │ │  -- operation 5a8916858004 squash commit 0d254956d33ed5bb11d93eb795c5e514aadc81b5 and 1 more
     │ ○  zsuskuln/4 test.user@example.com 2001-02-03 08:05:11 38778966 (hidden)
     │ │  file4
-    │ │  -- operation 9ca0f4771551 commit 89a30a7539466ed176c1ef122a020fd9cb15848e
+    │ │  -- operation bc1b588e00d0 commit 89a30a7539466ed176c1ef122a020fd9cb15848e
     │ ○  zsuskuln/5 test.user@example.com 2001-02-03 08:05:11 89a30a75 (hidden)
     │ │  (no description set)
-    │ │  -- operation 26b29f385618 snapshot working copy
+    │ │  -- operation 0b07b8894eb2 snapshot working copy
     │ ○  zsuskuln/6 test.user@example.com 2001-02-03 08:05:10 bbf04d26 (hidden)
     │    (empty) (no description set)
-    │    -- operation fc5403fc3984 commit c23c424826221bc4fdee9487926595324e50ee95
+    │    -- operation 28d93bc62a97 commit c23c424826221bc4fdee9487926595324e50ee95
     ○  kkmpptxz/0 test.user@example.com 2001-02-03 08:05:35 ce3b0a58 (hidden)
     │  file3
-    │  -- operation 3d6e647dccb7 squash commit 0d254956d33ed5bb11d93eb795c5e514aadc81b5 and 1 more
+    │  -- operation 5a8916858004 squash commit 0d254956d33ed5bb11d93eb795c5e514aadc81b5 and 1 more
     ○  kkmpptxz/3 test.user@example.com 2001-02-03 08:05:10 0d254956 (hidden)
     │  file3
-    │  -- operation fc5403fc3984 commit c23c424826221bc4fdee9487926595324e50ee95
+    │  -- operation 28d93bc62a97 commit c23c424826221bc4fdee9487926595324e50ee95
     ○  kkmpptxz/4 test.user@example.com 2001-02-03 08:05:10 c23c4248 (hidden)
     │  (no description set)
-    │  -- operation c5043d80534d snapshot working copy
+    │  -- operation d4b6d8894b8d snapshot working copy
     ○  kkmpptxz/5 test.user@example.com 2001-02-03 08:05:09 c1272e87 (hidden)
        (empty) (no description set)
-       -- operation 4eb3252f7fd7 commit cb58ff1c6f1af92f827661e7275941ceb4d910c5
+       -- operation 24e77086e358 commit cb58ff1c6f1af92f827661e7275941ceb4d910c5
     [EOF]
     ");
 
@@ -2222,7 +2222,7 @@ fn test_squash_to_new_commit() -> TestResult {
     insta::assert_snapshot!(output, @"
     ○  nsrwusvy test.user@example.com 2001-02-03 08:05:42 c2183685
        (empty) (no description set)
-       -- operation 29b5af212226 squash 0 commits
+       -- operation f492acaa90e1 squash 0 commits
     [EOF]
     ");
 
@@ -2266,7 +2266,7 @@ fn test_squash_to_new_commit() -> TestResult {
     insta::assert_snapshot!(output, @"
     ○  wtlqussy test.user@example.com 2001-02-03 08:05:46 7eff41c8
        (empty) (no description set)
-       -- operation f5c12bfd0cbc squash commit 0d254956d33ed5bb11d93eb795c5e514aadc81b5 and 1 more
+       -- operation 607e6cfefd17 squash commit 0d254956d33ed5bb11d93eb795c5e514aadc81b5 and 1 more
     [EOF]
     ");
 
@@ -2313,10 +2313,10 @@ fn test_squash_to_new_commit() -> TestResult {
     insta::assert_snapshot!(output, @"
     ○  pyoswmwk test.user@example.com 2001-02-03 08:05:50 991d0644
     │  (empty) (no description set)
-    │  -- operation 587bcc3abdef squash commit f5e47d019271a392eb7f92a6b2e9f8cf41d97049
+    │  -- operation e7931f81c66a squash commit f5e47d019271a392eb7f92a6b2e9f8cf41d97049
     ○  szrrkvty/0 test.user@example.com 2001-02-03 08:05:50 f5e47d01 (hidden)
        (empty) (no description set)
-       -- operation 4096cc584a23 new empty commit
+       -- operation cffbaf4787d4 new empty commit
     [EOF]
     ");
 

--- a/cli/tests/test_undo_redo_commands.rs
+++ b/cli/tests/test_undo_redo_commands.rs
@@ -23,7 +23,7 @@ fn test_undo_root_operation() {
     let output = work_dir.run_jj(["undo"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Undid operation: 90267f31f904 (2001-02-03 08:05:07) add workspace 'default'
+    Undid operation: f63ee16f9553 (2001-02-03 08:05:07) add workspace 'default'
     Restored to operation: 000000000000 root()
     Warning: The current workspace 'default' no longer exists after this operation. The working copy was left untouched.
     Hint: Restore to an operation that contains the workspace (e.g. `jj undo` or `jj redo`).
@@ -78,8 +78,8 @@ fn test_undo_push_operation() {
     ------- stderr -------
     Warning: Undoing a push operation often leads to conflicted bookmarks.
     Hint: To avoid this, run `jj redo` now.
-    Undid operation: 161aca25fa92 (2001-02-03 08:05:10) push bookmark push-rlvkpnrzqnoo to git remote origin
-    Restored to operation: ac6334185db7 (2001-02-03 08:05:09) commit 3850397cf31988d0657948307ad5bbe873d76a38
+    Undid operation: 841f09db81a1 (2001-02-03 08:05:10) push bookmark push-rlvkpnrzqnoo to git remote origin
+    Restored to operation: 27cf57bcf92a (2001-02-03 08:05:09) commit 3850397cf31988d0657948307ad5bbe873d76a38
     [EOF]
     ");
 }

--- a/cli/tests/test_util_command.rs
+++ b/cli/tests/test_util_command.rs
@@ -114,8 +114,8 @@ fn test_gc_operation_log() {
     ------- stderr -------
     Internal error: Failed to load an operation
     Caused by:
-    1: Object 8eda7af9cb0a21f1e2663b153d168ae65ee8508fdcff832e6ea53bd7285f5304bc6d05d3ce4096d5d0ac4c16159c02a864defafd1f2908af190e02f27d6d28ed of type operation not found
-    2: Cannot access $TEST_ENV/repo/.jj/repo/op_store/operations/8eda7af9cb0a21f1e2663b153d168ae65ee8508fdcff832e6ea53bd7285f5304bc6d05d3ce4096d5d0ac4c16159c02a864defafd1f2908af190e02f27d6d28ed
+    1: Object 2bf28acab8bf15817f17f696d4483584440e13d155280691c7dd5abfa2e7e9b67258f06022cfdd5b86295cbfcfd42e9132740b8d3a75d18c2b0718b45f69d8d9 of type operation not found
+    2: Cannot access $TEST_ENV/repo/.jj/repo/op_store/operations/2bf28acab8bf15817f17f696d4483584440e13d155280691c7dd5abfa2e7e9b67258f06022cfdd5b86295cbfcfd42e9132740b8d3a75d18c2b0718b45f69d8d9
     [EOF]
     [exit status: 255]
     ");

--- a/cli/tests/test_working_copy.rs
+++ b/cli/tests/test_working_copy.rs
@@ -417,7 +417,7 @@ fn test_conflict_marker_length_stored_in_working_copy() -> TestResult {
     // Working copy should contain conflict marker length
     let output = work_dir.run_jj(["debug", "local-working-copy"]);
     insta::assert_snapshot!(output.normalize_stdout_with(redact_output), @r#"
-    Current operation: OperationId("072342f0123bbb53824fe316de828240ec981d9d11608e8a31c12253e99cd504d5a0fae3851f6a83941863a85b68954c90b7d6ad2fd4f7da469b7d8a6482c003")
+    Current operation: OperationId("ee791f2181026a056ad383d14dbc749ba44e24fedfd39418954871b83d754929147b951bde1fbcca6a8460932e53a6d7ea739bf054ec0bf03607b9370173d6e5")
     Current tree: MergedTree { tree_ids: Conflicted([TreeId("381273b50cf73f8c81b3f1502ee89e9bbd6c1518"), TreeId("771f3d31c4588ea40a8864b2a981749888e596c2"), TreeId("f56b8223da0dab22b03b8323ced4946329aeb4e0")]), labels: Labeled(["rlvkpnrz ccf9527c \"side-a\"", "qpvuntsm 2205b3ac \"base\"", "zsuskuln d7acaf48 \"side-b\""]), .. }
     Normal { exec_bit: ExecBit(false) }           313 <timestamp> Some(MaterializedConflictData { conflict_marker_len: 11 }) "file"
     [EOF]
@@ -480,7 +480,7 @@ fn test_conflict_marker_length_stored_in_working_copy() -> TestResult {
     // Working copy should still contain conflict marker length
     let output = work_dir.run_jj(["debug", "local-working-copy"]);
     insta::assert_snapshot!(output.normalize_stdout_with(redact_output), @r#"
-    Current operation: OperationId("19bcba55afcdec47b31cf0217b2a4b20dd9d90fe7dd7b4cdf0c52b74735c5407a8fddd1d3b43f37c09223b8b8053289f49bcba58c0af68869f891f582460ad4a")
+    Current operation: OperationId("b196f038bbd8cf84508417da8e974874b52202bc98abca08725e946a7a9ea9e011aeddda805c565f49a1e07e43524161caa56fa438de662aba8a6349b5a44be1")
     Current tree: MergedTree { tree_ids: Conflicted([TreeId("381273b50cf73f8c81b3f1502ee89e9bbd6c1518"), TreeId("771f3d31c4588ea40a8864b2a981749888e596c2"), TreeId("3329c18c95f7b7a55c278c2259e9c4ce711fae59")]), labels: Labeled(["rlvkpnrz ccf9527c \"side-a\"", "qpvuntsm 2205b3ac \"base\"", "zsuskuln d7acaf48 \"side-b\""]), .. }
     Normal { exec_bit: ExecBit(false) }           274 <timestamp> Some(MaterializedConflictData { conflict_marker_len: 11 }) "file"
     [EOF]
@@ -515,7 +515,7 @@ fn test_conflict_marker_length_stored_in_working_copy() -> TestResult {
     // working copy
     let output = work_dir.run_jj(["debug", "local-working-copy"]);
     insta::assert_snapshot!(output.normalize_stdout_with(redact_output), @r#"
-    Current operation: OperationId("ed741c71397533330b01669ac13c3407ed89ba782a65ef038cefef27f95f3e2a513f0d3b04a2f96e79ac8b9e050ea080b06dd6ad2b10fc4e3f6978100b8ec8c9")
+    Current operation: OperationId("65b561ae4667b8b9db3f3d6cb2f6bccd087f17b008ba87b976266e641efdab4f12193407e4f6f8bd76b02eff767a6c173ef53e2c0217be389b05779170a257b6")
     Current tree: MergedTree { tree_ids: Resolved(TreeId("6120567b3cb2472d549753ed3e4b84183d52a650")), labels: Unlabeled, .. }
     Normal { exec_bit: ExecBit(false) }           130 <timestamp> None "file"
     [EOF]

--- a/cli/tests/test_workspaces.rs
+++ b/cli/tests/test_workspaces.rs
@@ -649,7 +649,7 @@ fn test_workspace_add_override_path_in_store() {
     let output = main_dir.run_jj(["operation", "restore", "@--"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Restored to operation: 98ef745836d5 (2001-02-03 08:05:08) commit 006bd1130b84e90ab082adeabd7409270d5a86da
+    Restored to operation: 7d5981d12f2a (2001-02-03 08:05:08) commit 006bd1130b84e90ab082adeabd7409270d5a86da
     [EOF]
     ");
 
@@ -738,7 +738,7 @@ fn test_workspaces_conflicting_edits() {
     let output = secondary_dir.run_jj(["st"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Error: The working copy is stale (not updated since operation 58f8ef773e05).
+    Error: The working copy is stale (not updated since operation 149761aea7d1).
     Hint: Run `jj workspace update-stale` to update it.
     See https://docs.jj-vcs.dev/latest/working-copy/#stale-working-copy for more information.
     [EOF]
@@ -748,7 +748,7 @@ fn test_workspaces_conflicting_edits() {
     let output = secondary_dir.run_jj(["log"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Error: The working copy is stale (not updated since operation 58f8ef773e05).
+    Error: The working copy is stale (not updated since operation 149761aea7d1).
     Hint: Run `jj workspace update-stale` to update it.
     See https://docs.jj-vcs.dev/latest/working-copy/#stale-working-copy for more information.
     [EOF]
@@ -839,7 +839,7 @@ fn test_workspaces_updated_by_other() {
     let output = secondary_dir.run_jj(["st"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Error: The working copy is stale (not updated since operation 58f8ef773e05).
+    Error: The working copy is stale (not updated since operation 149761aea7d1).
     Hint: Run `jj workspace update-stale` to update it.
     See https://docs.jj-vcs.dev/latest/working-copy/#stale-working-copy for more information.
     [EOF]
@@ -1089,14 +1089,14 @@ fn test_workspaces_current_op_discarded_by_other(automatic: bool) {
     ]);
     insta::allow_duplicates! {
         insta::assert_snapshot!(output, @"
-        @  2dea766382 abandon commit de90575a14d8b9198dc0930f9de4a69f846ded36
-        ○  0d3faebd8c create initial working-copy commit in workspace secondary
-        ○  200ba564cb add workspace 'secondary'
-        ○  b34eafb924 new empty commit
-        ○  c883929a6b snapshot working copy
-        ○  bd7b1cfa98 new empty commit
-        ○  4509e20d8c snapshot working copy
-        ○  90267f31f9 add workspace 'default'
+        @  a9b524b948 abandon commit de90575a14d8b9198dc0930f9de4a69f846ded36
+        ○  0392b7d733 create initial working-copy commit in workspace secondary
+        ○  766373d1f4 add workspace 'secondary'
+        ○  eb6701963b new empty commit
+        ○  1d937e1f1e snapshot working copy
+        ○  e22ce69861 new empty commit
+        ○  48aa617132 snapshot working copy
+        ○  f63ee16f95 add workspace 'default'
         ○  0000000000
         [EOF]
         ");
@@ -1131,7 +1131,7 @@ fn test_workspaces_current_op_discarded_by_other(automatic: bool) {
         Parent commit (@-): rzvqmyuk 891f0006 (empty) (no description set)
         [EOF]
         ------- stderr -------
-        Failed to read working copy's current operation; attempting recovery. Error message from read attempt: Object 0d3faebd8cf4f0e39ea3eab47f22c9cdbcdaa54d95e79a86a0dab4ebe3b0377f69e1d64fa4661913c8c6af01dc0ebb5ad7c8b2bfa3d229827b2ba756d729e0bf of type operation not found
+        Failed to read working copy's current operation; attempting recovery. Error message from read attempt: Object 0392b7d73383f694906abd6ffd55416c30d1775a9790553062784f5c4553c09746b388aa86fb7d27b113d1096f50845e28dc24b3de8b1a9d515cbde3b44eb346 of type operation not found
         Created and checked out recovery commit 866928d1e0fd
         [EOF]
         ");
@@ -1149,7 +1149,7 @@ fn test_workspaces_current_op_discarded_by_other(automatic: bool) {
         let output = secondary_dir.run_jj(["workspace", "update-stale"]);
         insta::assert_snapshot!(output, @"
         ------- stderr -------
-        Failed to read working copy's current operation; attempting recovery. Error message from read attempt: Object 0d3faebd8cf4f0e39ea3eab47f22c9cdbcdaa54d95e79a86a0dab4ebe3b0377f69e1d64fa4661913c8c6af01dc0ebb5ad7c8b2bfa3d229827b2ba756d729e0bf of type operation not found
+        Failed to read working copy's current operation; attempting recovery. Error message from read attempt: Object 0392b7d73383f694906abd6ffd55416c30d1775a9790553062784f5c4553c09746b388aa86fb7d27b113d1096f50845e28dc24b3de8b1a9d515cbde3b44eb346 of type operation not found
         Created and checked out recovery commit 866928d1e0fd
         [EOF]
         ");
@@ -1200,20 +1200,20 @@ fn test_workspaces_current_op_discarded_by_other(automatic: bool) {
         insta::assert_snapshot!(output, @"
         @  kmkuslsw test.user@example.com 2001-02-03 08:05:18 secondary@ 18851b39
         │  RECOVERY COMMIT FROM `jj workspace update-stale`
-        │  -- operation a35d39d101f4 snapshot working copy
+        │  -- operation 91f539374e6a snapshot working copy
         ○  kmkuslsw/1 test.user@example.com 2001-02-03 08:05:18 866928d1 (hidden)
            (empty) RECOVERY COMMIT FROM `jj workspace update-stale`
-           -- operation 754c2986ff83 recovery commit
+           -- operation 2a845e0b4514 recovery commit
         [EOF]
         ");
     } else {
         insta::assert_snapshot!(output, @"
         @  kmkuslsw test.user@example.com 2001-02-03 08:05:18 secondary@ 18851b39
         │  RECOVERY COMMIT FROM `jj workspace update-stale`
-        │  -- operation 3ae899f26750 snapshot working copy
+        │  -- operation 2d387a4a6355 snapshot working copy
         ○  kmkuslsw/1 test.user@example.com 2001-02-03 08:05:18 866928d1 (hidden)
            (empty) RECOVERY COMMIT FROM `jj workspace update-stale`
-           -- operation 754c2986ff83 recovery commit
+           -- operation 2a845e0b4514 recovery commit
         [EOF]
         ");
     }
@@ -1271,8 +1271,8 @@ fn test_workspaces_unpublished_operation_same_tree() {
     let output = main_dir.run_jj(["status"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Internal error: The repo was loaded at operation 8627c7508be4, which seems to be a sibling of the working copy's operation eceacbdafd84
-    Hint: Run `jj op integrate eceacbdafd84` to add the working copy's operation to the operation log.
+    Internal error: The repo was loaded at operation eb46e46959f1, which seems to be a sibling of the working copy's operation 2a68fa5a5771
+    Hint: Run `jj op integrate 2a68fa5a5771` to add the working copy's operation to the operation log.
     [EOF]
     [exit status: 255]
     ");
@@ -1399,7 +1399,7 @@ fn test_colocated_workspace_update_stale() {
     let output = main_dir.run_jj(["st"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Error: The working copy is stale (not updated since operation 8ab980a3d398).
+    Error: The working copy is stale (not updated since operation 572e45b3fba3).
     Hint: Run `jj workspace update-stale` to update it.
     See https://docs.jj-vcs.dev/latest/working-copy/#stale-working-copy for more information.
     [EOF]
@@ -1606,7 +1606,7 @@ fn test_workspaces_forget_multi_transaction() {
     // the op log should have the multiple valid workspaces forgotten in a single tx
     let output = main_dir.run_jj(["op", "log", "--limit", "1"]);
     insta::assert_snapshot!(output, @"
-    @  90493ae75198 test-username@host.example.com default@ 2001-02-03 04:05:12.000 +07:00 - 2001-02-03 04:05:12.000 +07:00
+    @  da3075edb24f test-username@host.example.com default@ 2001-02-03 04:05:12.000 +07:00 - 2001-02-03 04:05:12.000 +07:00
     │  forget workspaces second, third
     │  args: jj workspace forget second third fourth
     [EOF]
@@ -1935,10 +1935,10 @@ fn test_debug_snapshot() {
     work_dir.run_jj(["debug", "snapshot"]).success();
     let output = work_dir.run_jj(["op", "log"]);
     insta::assert_snapshot!(output, @"
-    @  a60628738654 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    @  d870c9898b59 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  snapshot working copy
     │  args: jj debug snapshot
-    ○  90267f31f904 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  f63ee16f9553 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
     [EOF]
@@ -1946,13 +1946,13 @@ fn test_debug_snapshot() {
     work_dir.run_jj(["describe", "-m", "initial"]).success();
     let output = work_dir.run_jj(["op", "log"]);
     insta::assert_snapshot!(output, @"
-    @  e6e34553de88 test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    @  fd7a8fca455a test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     │  describe commit 006bd1130b84e90ab082adeabd7409270d5a86da
     │  args: jj describe -m initial
-    ○  a60628738654 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    ○  d870c9898b59 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  snapshot working copy
     │  args: jj debug snapshot
-    ○  90267f31f904 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  f63ee16f9553 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
     [EOF]

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -67,6 +67,7 @@ use crate::ref_name::RemoteName;
 use crate::ref_name::RemoteNameBuf;
 use crate::ref_name::RemoteRefSymbol;
 use crate::ref_name::RemoteRefSymbolBuf;
+use crate::ref_name::WorkspaceName;
 use crate::repo::MutableRepo;
 use crate::repo::Repo;
 use crate::repo_path::RepoPath;
@@ -1166,18 +1167,22 @@ fn remotely_pinned_commit_ids(view: &View) -> Vec<CommitId> {
 ///
 /// Unlike `reset_head()`, this function doesn't move the working-copy commit to
 /// the child of the new HEAD revision.
-pub async fn import_head(mut_repo: &mut MutableRepo) -> Result<(), GitImportError> {
+pub async fn import_head(
+    mut_repo: &mut MutableRepo,
+    workspace: &WorkspaceName,
+) -> Result<(), GitImportError> {
     let store = mut_repo.store();
     let git_backend = get_git_backend(store)?;
     let git_repo = git_backend.git_repo();
 
-    let old_git_head = mut_repo.view().git_head();
+    let old_git_head = mut_repo.view().git_head(workspace);
     let new_git_head_id = if let Ok(oid) = git_repo.head_id() {
         Some(CommitId::from_bytes(oid.as_bytes()))
     } else {
         None
     };
-    if old_git_head.as_resolved() == Some(&new_git_head_id) {
+    let old_resolved = old_git_head.map(|t| t.as_resolved()).unwrap_or(Some(&None));
+    if old_resolved == Some(&new_git_head_id) {
         return Ok(());
     }
 
@@ -1198,7 +1203,7 @@ pub async fn import_head(mut_repo: &mut MutableRepo) -> Result<(), GitImportErro
         mut_repo.add_head(&commit).await?;
     }
 
-    mut_repo.set_git_head_target(RefTarget::resolved(new_git_head_id));
+    mut_repo.set_git_head_target(workspace, RefTarget::resolved(new_git_head_id));
     Ok(())
 }
 
@@ -1801,6 +1806,7 @@ impl GitResetHeadError {
 pub async fn reset_head(
     mut_repo: &mut MutableRepo,
     wc_commit: &Commit,
+    workspace: &WorkspaceName,
 ) -> Result<(), GitResetHeadError> {
     let git_repo = get_git_repo(mut_repo.store())?;
 
@@ -1812,7 +1818,7 @@ pub async fn reset_head(
     };
 
     // If the first parent of the working copy has changed, reset the Git HEAD.
-    let old_head_target = mut_repo.git_head();
+    let old_head_target = mut_repo.git_head(workspace);
     if old_head_target != new_head_target {
         let expected_ref = if let Some(id) = old_head_target.as_normal() {
             // We have to check the actual HEAD state because we don't record a
@@ -1833,7 +1839,7 @@ pub async fn reset_head(
         let new_oid = new_head_target.as_normal().map(owned_oid_from_commit_id);
         update_git_head(&git_repo, expected_ref, new_oid)
             .map_err(|err| GitResetHeadError::UpdateHeadRef(err.into()))?;
-        mut_repo.set_git_head_target(new_head_target);
+        mut_repo.set_git_head_target(workspace, new_head_target);
     }
 
     // If there is an ongoing operation (merge, rebase, etc.), we need to clean it

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -67,6 +67,7 @@ use crate::ref_name::RemoteName;
 use crate::ref_name::RemoteNameBuf;
 use crate::ref_name::RemoteRefSymbol;
 use crate::ref_name::RemoteRefSymbolBuf;
+use crate::ref_name::WorkspaceName;
 use crate::repo::MutableRepo;
 use crate::repo::Repo;
 use crate::repo_path::RepoPath;
@@ -1166,12 +1167,15 @@ fn remotely_pinned_commit_ids(view: &View) -> Vec<CommitId> {
 ///
 /// Unlike `reset_head()`, this function doesn't move the working-copy commit to
 /// the child of the new HEAD revision.
-pub async fn import_head(mut_repo: &mut MutableRepo) -> Result<(), GitImportError> {
+pub async fn import_head(
+    mut_repo: &mut MutableRepo,
+    workspace: &WorkspaceName,
+) -> Result<(), GitImportError> {
     let store = mut_repo.store();
     let git_backend = get_git_backend(store)?;
     let git_repo = git_backend.git_repo();
 
-    let old_git_head = mut_repo.view().git_head();
+    let old_git_head = mut_repo.view().git_head(workspace);
     let new_git_head_id = if let Ok(oid) = git_repo.head_id() {
         Some(CommitId::from_bytes(oid.as_bytes()))
     } else {
@@ -1198,7 +1202,7 @@ pub async fn import_head(mut_repo: &mut MutableRepo) -> Result<(), GitImportErro
         mut_repo.add_head(&commit).await?;
     }
 
-    mut_repo.set_git_head_target(RefTarget::resolved(new_git_head_id));
+    mut_repo.set_git_head_target(workspace, RefTarget::resolved(new_git_head_id));
     Ok(())
 }
 
@@ -1800,6 +1804,7 @@ impl GitResetHeadError {
 /// the Git index.
 pub async fn reset_head(
     mut_repo: &mut MutableRepo,
+    workspace: &WorkspaceName,
     wc_commit: &Commit,
 ) -> Result<(), GitResetHeadError> {
     let git_repo = get_git_repo(mut_repo.store())?;
@@ -1812,7 +1817,7 @@ pub async fn reset_head(
     };
 
     // If the first parent of the working copy has changed, reset the Git HEAD.
-    let old_head_target = mut_repo.git_head();
+    let old_head_target = mut_repo.git_head(workspace);
     if old_head_target != new_head_target {
         let expected_ref = if let Some(id) = old_head_target.as_normal() {
             // We have to check the actual HEAD state because we don't record a
@@ -1833,7 +1838,7 @@ pub async fn reset_head(
         let new_oid = new_head_target.as_normal().map(owned_oid_from_commit_id);
         update_git_head(&git_repo, expected_ref, new_oid)
             .map_err(|err| GitResetHeadError::UpdateHeadRef(err.into()))?;
-        mut_repo.set_git_head_target(new_head_target);
+        mut_repo.set_git_head_target(workspace, new_head_target);
     }
 
     // If there is an ongoing operation (merge, rebase, etc.), we need to clean it

--- a/lib/src/op_store.rs
+++ b/lib/src/op_store.rs
@@ -253,10 +253,9 @@ pub struct View {
     pub local_tags: BTreeMap<RefNameBuf, RefTarget>,
     pub remote_views: BTreeMap<RemoteNameBuf, RemoteView>,
     pub git_refs: BTreeMap<GitRefNameBuf, RefTarget>,
-    /// The commit the Git HEAD points to.
-    // TODO: Support multiple Git worktrees?
+    /// The commit each workspace's Git HEAD points to, keyed by workspace name.
     // TODO: Do we want to store the current bookmark name too?
-    pub git_head: RefTarget,
+    pub git_heads: BTreeMap<WorkspaceNameBuf, RefTarget>,
     // The commit that *should be* checked out in the workspace. Note that the working copy
     // (.jj/working_copy/) has the source of truth about which commit *is* checked out (to be
     // precise: the commit to which we most recently completed an update to).
@@ -272,7 +271,7 @@ impl View {
             local_tags: BTreeMap::new(),
             remote_views: BTreeMap::new(),
             git_refs: BTreeMap::new(),
-            git_head: RefTarget::absent(),
+            git_heads: BTreeMap::new(),
             wc_commit_ids: BTreeMap::new(),
         }
     }

--- a/lib/src/protos/simple_op_store.proto
+++ b/lib/src/protos/simple_op_store.proto
@@ -103,9 +103,11 @@ message View {
   // type). New Views have (only) the target field.
   // TODO: Delete support for the old format.
   bytes git_head_legacy = 7 [deprecated = true];
-  RefTarget git_head = 9;
+  RefTarget git_head = 9 [deprecated = true];
   // Whether "@git" tags have been migrated to remote_views.
   bool has_git_refs_migrated_to_remote_tags = 12;
+  // Per-workspace Git HEAD targets, keyed by workspace name.
+  map<string, RefTarget> git_heads = 13;
   reserved 10;
 }
 

--- a/lib/src/protos/simple_op_store.proto
+++ b/lib/src/protos/simple_op_store.proto
@@ -76,6 +76,11 @@ message GitRef {
   RefTarget target = 3;
 }
 
+message GitHead {
+  string name = 1;
+  RefTarget target = 2;
+}
+
 message RemoteRef {
   string name = 1;
   repeated RefTargetTerm target_terms = 2;
@@ -103,9 +108,11 @@ message View {
   // type). New Views have (only) the target field.
   // TODO: Delete support for the old format.
   bytes git_head_legacy = 7 [deprecated = true];
-  RefTarget git_head = 9;
+  RefTarget git_head = 9 [deprecated = true];
   // Whether "@git" tags have been migrated to remote_views.
   bool has_git_refs_migrated_to_remote_tags = 12;
+  // Per-workspace Git HEAD targets, keyed by workspace name.
+  repeated GitHead git_heads = 13;
   reserved 10;
 }
 

--- a/lib/src/protos/simple_op_store.rs
+++ b/lib/src/protos/simple_op_store.rs
@@ -90,6 +90,13 @@ pub struct GitRef {
     pub target: ::core::option::Option<RefTarget>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GitHead {
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+    #[prost(message, optional, tag = "2")]
+    pub target: ::core::option::Option<RefTarget>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RemoteRef {
     #[prost(string, tag = "1")]
     pub name: ::prost::alloc::string::String,
@@ -134,11 +141,15 @@ pub struct View {
     #[deprecated]
     #[prost(bytes = "vec", tag = "7")]
     pub git_head_legacy: ::prost::alloc::vec::Vec<u8>,
+    #[deprecated]
     #[prost(message, optional, tag = "9")]
     pub git_head: ::core::option::Option<RefTarget>,
     /// Whether "@git" tags have been migrated to remote_views.
     #[prost(bool, tag = "12")]
     pub has_git_refs_migrated_to_remote_tags: bool,
+    /// Per-workspace Git HEAD targets, keyed by workspace name.
+    #[prost(message, repeated, tag = "13")]
+    pub git_heads: ::prost::alloc::vec::Vec<GitHead>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RemoteView {

--- a/lib/src/protos/simple_op_store.rs
+++ b/lib/src/protos/simple_op_store.rs
@@ -134,11 +134,18 @@ pub struct View {
     #[deprecated]
     #[prost(bytes = "vec", tag = "7")]
     pub git_head_legacy: ::prost::alloc::vec::Vec<u8>,
+    #[deprecated]
     #[prost(message, optional, tag = "9")]
     pub git_head: ::core::option::Option<RefTarget>,
     /// Whether "@git" tags have been migrated to remote_views.
     #[prost(bool, tag = "12")]
     pub has_git_refs_migrated_to_remote_tags: bool,
+    /// Per-workspace Git HEAD targets, keyed by workspace name.
+    #[prost(map = "string, message", tag = "13")]
+    pub git_heads: ::std::collections::HashMap<
+        ::prost::alloc::string::String,
+        RefTarget,
+    >,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RemoteView {

--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -1924,12 +1924,15 @@ impl MutableRepo {
         Ok(())
     }
 
-    pub fn git_head(&self) -> RefTarget {
-        self.view.git_head().clone()
+    pub fn git_head(&self, workspace: &WorkspaceName) -> RefTarget {
+        self.view
+            .git_head(workspace)
+            .cloned()
+            .unwrap_or_else(RefTarget::absent)
     }
 
-    pub fn set_git_head_target(&mut self, target: RefTarget) {
-        self.view.set_git_head_target(target);
+    pub fn set_git_head_target(&mut self, workspace: &WorkspaceName, target: RefTarget) {
+        self.view.set_git_head_target(workspace, target);
     }
 
     pub fn set_view(&mut self, data: op_store::View) {
@@ -2020,14 +2023,16 @@ impl MutableRepo {
             self.merge_remote_tag(symbol, base_ref, other_ref).await?;
         }
 
-        let new_git_head_target = merge_ref_targets(
-            self.index(),
-            self.view().git_head(),
-            base.git_head(),
-            other.git_head(),
-        )
-        .await?;
-        self.set_git_head_target(new_git_head_target);
+        let changed_git_heads = diff_named_ref_targets(base.all_git_heads(), other.all_git_heads());
+        for (workspace, (base_target, other_target)) in changed_git_heads {
+            let self_target = self
+                .view()
+                .git_head(workspace)
+                .unwrap_or(RefTarget::absent_ref());
+            let new_target =
+                merge_ref_targets(self.index(), self_target, base_target, other_target).await?;
+            self.set_git_head_target(workspace, new_target);
+        }
 
         Ok(())
     }

--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -1924,12 +1924,12 @@ impl MutableRepo {
         Ok(())
     }
 
-    pub fn git_head(&self) -> RefTarget {
-        self.view.git_head().clone()
+    pub fn git_head(&self, workspace: &WorkspaceName) -> RefTarget {
+        self.view.git_head(workspace).clone()
     }
 
-    pub fn set_git_head_target(&mut self, target: RefTarget) {
-        self.view.set_git_head_target(target);
+    pub fn set_git_head_target(&mut self, workspace: &WorkspaceName, target: RefTarget) {
+        self.view.set_git_head_target(workspace, target);
     }
 
     pub fn set_view(&mut self, data: op_store::View) {
@@ -2020,14 +2020,13 @@ impl MutableRepo {
             self.merge_remote_tag(symbol, base_ref, other_ref).await?;
         }
 
-        let new_git_head_target = merge_ref_targets(
-            self.index(),
-            self.view().git_head(),
-            base.git_head(),
-            other.git_head(),
-        )
-        .await?;
-        self.set_git_head_target(new_git_head_target);
+        let changed_git_heads = diff_named_ref_targets(base.all_git_heads(), other.all_git_heads());
+        for (workspace, (base_target, other_target)) in changed_git_heads {
+            let self_target = self.view().git_head(workspace);
+            let new_target =
+                merge_ref_targets(self.index(), self_target, base_target, other_target).await?;
+            self.set_git_head_target(workspace, new_target);
+        }
 
         Ok(())
     }

--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -1567,9 +1567,9 @@ impl MutableRepo {
         Ok(())
     }
 
-    pub async fn remove_wc_commit(&mut self, name: &WorkspaceName) -> Result<(), EditCommitError> {
+    pub async fn remove_workspace(&mut self, name: &WorkspaceName) -> Result<(), EditCommitError> {
         self.maybe_abandon_wc_commit(name).await?;
-        self.view.remove_wc_commit(name);
+        self.view.remove_workspace(name);
         Ok(())
     }
 
@@ -1598,7 +1598,7 @@ impl MutableRepo {
         };
         match new_id {
             Some(id) => self.view.set_wc_commit(name.to_owned(), id),
-            None => self.view.remove_wc_commit(name),
+            None => self.view.remove_workspace(name),
         }
     }
 

--- a/lib/src/simple_op_store.rs
+++ b/lib/src/simple_op_store.rs
@@ -575,7 +575,14 @@ fn view_to_proto(view: &View) -> crate::protos::simple_op_store::View {
         })
         .collect();
 
-    let git_head = ref_target_to_proto(&view.git_head);
+    let git_heads = view
+        .git_heads
+        .iter()
+        .map(|(name, target)| crate::protos::simple_op_store::GitHead {
+            name: name.as_str().to_owned(),
+            target: ref_target_to_proto(target),
+        })
+        .collect();
 
     #[expect(deprecated)]
     crate::protos::simple_op_store::View {
@@ -587,9 +594,14 @@ fn view_to_proto(view: &View) -> crate::protos::simple_op_store::View {
         remote_views,
         git_refs,
         git_head_legacy: Default::default(),
-        git_head,
+        // TODO: Remove in jj 0.51+
+        git_head: view
+            .git_heads
+            .get(WorkspaceName::DEFAULT)
+            .and_then(ref_target_to_proto),
         // New/loaded view should have been migrated to the latest format
         has_git_refs_migrated_to_remote_tags: true,
+        git_heads,
     }
 }
 
@@ -667,14 +679,29 @@ fn view_from_proto(proto: crate::protos::simple_op_store::View) -> Result<View, 
         }
     }
 
+    let mut git_heads: BTreeMap<WorkspaceNameBuf, RefTarget> = proto
+        .git_heads
+        .into_iter()
+        .map(|entry| {
+            (
+                WorkspaceNameBuf::from(entry.name),
+                ref_target_from_proto(entry.target),
+            )
+        })
+        .collect();
     #[expect(deprecated)]
-    let git_head = if proto.git_head.is_some() {
-        ref_target_from_proto(proto.git_head)
-    } else if !proto.git_head_legacy.is_empty() {
-        RefTarget::normal(CommitId::new(proto.git_head_legacy))
-    } else {
-        RefTarget::absent()
-    };
+    if git_heads.is_empty() {
+        let git_head = if proto.git_head.is_some() {
+            ref_target_from_proto(proto.git_head)
+        } else if !proto.git_head_legacy.is_empty() {
+            RefTarget::normal(CommitId::new(proto.git_head_legacy))
+        } else {
+            RefTarget::absent()
+        };
+        if git_head.is_present() {
+            git_heads.insert(WorkspaceName::DEFAULT.to_owned(), git_head);
+        }
+    }
 
     Ok(View {
         head_ids,
@@ -682,7 +709,7 @@ fn view_from_proto(proto: crate::protos::simple_op_store::View) -> Result<View, 
         local_tags,
         remote_views,
         git_refs,
-        git_head,
+        git_heads,
         wc_commit_ids,
     })
 }
@@ -1001,7 +1028,9 @@ mod tests {
                 "refs/heads/main".into() => git_refs_main_target,
                 "refs/heads/feature".into() => git_refs_feature_target,
             },
-            git_head: RefTarget::normal(CommitId::from_hex("fff111")),
+            git_heads: btreemap! {
+                WorkspaceName::DEFAULT.to_owned() => RefTarget::normal(CommitId::from_hex("fff111")),
+            },
             wc_commit_ids: btreemap! {
                 WorkspaceName::DEFAULT.to_owned() => default_wc_commit_id,
                 "test".into() => test_wc_commit_id,
@@ -1057,7 +1086,7 @@ mod tests {
         // Test exact output so we detect regressions in compatibility
         assert_snapshot!(
             ViewId::new(blake2b_hash(&create_view()).to_vec()).hex(),
-            @"2c0b174d117ca85e7faa96f6d997362403105e8eb31e7f82ac9abd3dc48ae62683e9a76ef5d117ebc8a743d17e1945236df9ccefd7574f7e4b5336a63796b967"
+            @"b37a61a743f394241cd44e9016cc6f9b68321d7ae0e21e432d9124d08a1b5f98f08f6a1d04534ea0652ea4be74e9c4fb2075bdf00343165b5d380aa196790a14"
         );
     }
 

--- a/lib/src/simple_op_store.rs
+++ b/lib/src/simple_op_store.rs
@@ -575,7 +575,14 @@ fn view_to_proto(view: &View) -> crate::protos::simple_op_store::View {
         })
         .collect();
 
-    let git_head = ref_target_to_proto(&view.git_head);
+    let git_heads = view
+        .git_heads
+        .iter()
+        .filter_map(|(name, target)| {
+            let proto_target = ref_target_to_proto(target)?;
+            Some((name.as_str().to_owned(), proto_target))
+        })
+        .collect();
 
     #[expect(deprecated)]
     crate::protos::simple_op_store::View {
@@ -587,9 +594,10 @@ fn view_to_proto(view: &View) -> crate::protos::simple_op_store::View {
         remote_views,
         git_refs,
         git_head_legacy: Default::default(),
-        git_head,
+        git_head: Default::default(),
         // New/loaded view should have been migrated to the latest format
         has_git_refs_migrated_to_remote_tags: true,
+        git_heads,
     }
 }
 
@@ -667,14 +675,29 @@ fn view_from_proto(proto: crate::protos::simple_op_store::View) -> Result<View, 
         }
     }
 
+    let mut git_heads: BTreeMap<WorkspaceNameBuf, RefTarget> = proto
+        .git_heads
+        .into_iter()
+        .map(|(name, target)| {
+            (
+                WorkspaceNameBuf::from(name),
+                ref_target_from_proto(Some(target)),
+            )
+        })
+        .collect();
     #[expect(deprecated)]
-    let git_head = if proto.git_head.is_some() {
-        ref_target_from_proto(proto.git_head)
-    } else if !proto.git_head_legacy.is_empty() {
-        RefTarget::normal(CommitId::new(proto.git_head_legacy))
-    } else {
-        RefTarget::absent()
-    };
+    if git_heads.is_empty() {
+        let git_head = if proto.git_head.is_some() {
+            ref_target_from_proto(proto.git_head)
+        } else if !proto.git_head_legacy.is_empty() {
+            RefTarget::normal(CommitId::new(proto.git_head_legacy))
+        } else {
+            RefTarget::absent()
+        };
+        if git_head.is_present() {
+            git_heads.insert(WorkspaceName::DEFAULT.to_owned(), git_head);
+        }
+    }
 
     Ok(View {
         head_ids,
@@ -682,7 +705,7 @@ fn view_from_proto(proto: crate::protos::simple_op_store::View) -> Result<View, 
         local_tags,
         remote_views,
         git_refs,
-        git_head,
+        git_heads,
         wc_commit_ids,
     })
 }
@@ -1002,7 +1025,9 @@ mod tests {
                 "refs/heads/main".into() => git_refs_main_target,
                 "refs/heads/feature".into() => git_refs_feature_target,
             },
-            git_head: RefTarget::normal(CommitId::from_hex("fff111")),
+            git_heads: btreemap! {
+                WorkspaceName::DEFAULT.to_owned() => RefTarget::normal(CommitId::from_hex("fff111")),
+            },
             wc_commit_ids: btreemap! {
                 WorkspaceName::DEFAULT.to_owned() => default_wc_commit_id,
                 "test".into() => test_wc_commit_id,
@@ -1058,7 +1083,7 @@ mod tests {
         // Test exact output so we detect regressions in compatibility
         assert_snapshot!(
             ViewId::new(blake2b_hash(&create_view()).to_vec()).hex(),
-            @"2c0b174d117ca85e7faa96f6d997362403105e8eb31e7f82ac9abd3dc48ae62683e9a76ef5d117ebc8a743d17e1945236df9ccefd7574f7e4b5336a63796b967"
+            @"b37a61a743f394241cd44e9016cc6f9b68321d7ae0e21e432d9124d08a1b5f98f08f6a1d04534ea0652ea4be74e9c4fb2075bdf00343165b5d380aa196790a14"
         );
     }
 

--- a/lib/src/view.rs
+++ b/lib/src/view.rs
@@ -119,7 +119,7 @@ impl View {
         self.data.wc_commit_ids.insert(name, commit_id);
     }
 
-    pub fn remove_wc_commit(&mut self, name: &WorkspaceName) {
+    pub fn remove_workspace(&mut self, name: &WorkspaceName) {
         self.data.wc_commit_ids.remove(name);
         self.data.git_heads.remove(name);
     }

--- a/lib/src/view.rs
+++ b/lib/src/view.rs
@@ -107,8 +107,12 @@ impl View {
         &self.data.git_refs
     }
 
-    pub fn git_head(&self) -> &RefTarget {
-        &self.data.git_head
+    pub fn git_head(&self, workspace: &WorkspaceName) -> &RefTarget {
+        self.data.git_heads.get(workspace).flatten()
+    }
+
+    pub fn all_git_heads(&self) -> &BTreeMap<WorkspaceNameBuf, RefTarget> {
+        &self.data.git_heads
     }
 
     pub fn set_wc_commit(&mut self, name: WorkspaceNameBuf, commit_id: CommitId) {
@@ -117,6 +121,7 @@ impl View {
 
     pub fn remove_wc_commit(&mut self, name: &WorkspaceName) {
         self.data.wc_commit_ids.remove(name);
+        self.data.git_heads.remove(name);
     }
 
     pub fn rename_workspace(
@@ -134,7 +139,12 @@ impl View {
                 name: old_name.to_owned(),
             }
         })?;
-        self.data.wc_commit_ids.insert(new_name, wc_commit_id);
+        self.data
+            .wc_commit_ids
+            .insert(new_name.clone(), wc_commit_id);
+        if let Some(git_head) = self.data.git_heads.remove(old_name) {
+            self.data.git_heads.insert(new_name, git_head);
+        }
         Ok(())
     }
 
@@ -564,10 +574,14 @@ impl View {
         }
     }
 
-    /// Sets Git HEAD to point to the given target. If the target is absent, the
-    /// reference will be cleared.
-    pub fn set_git_head_target(&mut self, target: RefTarget) {
-        self.data.git_head = target;
+    /// Sets Git HEAD for the given workspace to point to the given target. If
+    /// the target is absent, the entry will be removed.
+    pub fn set_git_head_target(&mut self, workspace: &WorkspaceName, target: RefTarget) {
+        if target.is_present() {
+            self.data.git_heads.insert(workspace.to_owned(), target);
+        } else {
+            self.data.git_heads.remove(workspace);
+        }
     }
 
     /// Iterates all commit ids referenced by this view.
@@ -593,7 +607,7 @@ impl View {
             local_tags,
             remote_views,
             git_refs,
-            git_head,
+            git_heads,
             wc_commit_ids,
         } = &self.data;
         itertools::chain!(
@@ -606,7 +620,7 @@ impl View {
                     .flat_map(|remote_ref| ref_target_ids(&remote_ref.target))
             }),
             git_refs.values().flat_map(ref_target_ids),
-            ref_target_ids(git_head),
+            git_heads.values().flat_map(ref_target_ids),
             wc_commit_ids.values()
         )
     }

--- a/lib/src/view.rs
+++ b/lib/src/view.rs
@@ -107,8 +107,12 @@ impl View {
         &self.data.git_refs
     }
 
-    pub fn git_head(&self) -> &RefTarget {
-        &self.data.git_head
+    pub fn git_head(&self, workspace: &WorkspaceName) -> Option<&RefTarget> {
+        self.data.git_heads.get(workspace)
+    }
+
+    pub fn all_git_heads(&self) -> &BTreeMap<WorkspaceNameBuf, RefTarget> {
+        &self.data.git_heads
     }
 
     pub fn set_wc_commit(&mut self, name: WorkspaceNameBuf, commit_id: CommitId) {
@@ -117,6 +121,7 @@ impl View {
 
     pub fn remove_wc_commit(&mut self, name: &WorkspaceName) {
         self.data.wc_commit_ids.remove(name);
+        self.data.git_heads.remove(name);
     }
 
     pub fn rename_workspace(
@@ -134,7 +139,12 @@ impl View {
                 name: old_name.to_owned(),
             }
         })?;
-        self.data.wc_commit_ids.insert(new_name, wc_commit_id);
+        self.data
+            .wc_commit_ids
+            .insert(new_name.clone(), wc_commit_id);
+        if let Some(git_head) = self.data.git_heads.remove(old_name) {
+            self.data.git_heads.insert(new_name, git_head);
+        }
         Ok(())
     }
 
@@ -564,10 +574,14 @@ impl View {
         }
     }
 
-    /// Sets Git HEAD to point to the given target. If the target is absent, the
-    /// reference will be cleared.
-    pub fn set_git_head_target(&mut self, target: RefTarget) {
-        self.data.git_head = target;
+    /// Sets Git HEAD for the given workspace to point to the given target. If
+    /// the target is absent, the entry will be removed.
+    pub fn set_git_head_target(&mut self, workspace: &WorkspaceName, target: RefTarget) {
+        if target.is_present() {
+            self.data.git_heads.insert(workspace.to_owned(), target);
+        } else {
+            self.data.git_heads.remove(workspace);
+        }
     }
 
     /// Iterates all commit ids referenced by this view.
@@ -593,7 +607,7 @@ impl View {
             local_tags,
             remote_views,
             git_refs,
-            git_head,
+            git_heads,
             wc_commit_ids,
         } = &self.data;
         itertools::chain!(
@@ -606,7 +620,7 @@ impl View {
                     .flat_map(|remote_ref| ref_target_ids(&remote_ref.target))
             }),
             git_refs.values().flat_map(ref_target_ids),
-            ref_target_ids(git_head),
+            git_heads.values().flat_map(ref_target_ids),
             wc_commit_ids.values()
         )
     }

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -77,6 +77,7 @@ use jj_lib::ref_name::GitRefNameBuf;
 use jj_lib::ref_name::RefName;
 use jj_lib::ref_name::RemoteName;
 use jj_lib::ref_name::RemoteRefSymbol;
+use jj_lib::ref_name::WorkspaceName;
 use jj_lib::repo::MutableRepo;
 use jj_lib::repo::ReadonlyRepo;
 use jj_lib::repo::Repo as _;
@@ -280,7 +281,7 @@ fn test_import_refs() -> TestResult {
     testutils::git::set_symbolic_reference(&git_repo, "HEAD", "refs/heads/main");
 
     let mut tx = repo.start_transaction();
-    git::import_head(tx.repo_mut()).block_on()?;
+    git::import_head(tx.repo_mut(), WorkspaceName::DEFAULT).block_on()?;
     let stats = git::import_refs(tx.repo_mut(), &import_options).block_on()?;
     tx.repo_mut().rebase_descendants().block_on()?;
     let repo = tx.commit("test").block_on()?;
@@ -398,7 +399,10 @@ fn test_import_refs() -> TestResult {
         view.get_git_ref("refs/tags/v1.0".as_ref()),
         &RefTarget::normal(jj_id(commit5))
     );
-    assert_eq!(view.git_head(), &RefTarget::normal(jj_id(commit2)));
+    assert_eq!(
+        view.git_head(WorkspaceName::DEFAULT),
+        &RefTarget::normal(jj_id(commit2))
+    );
     Ok(())
 }
 
@@ -561,14 +565,14 @@ fn test_import_refs_reimport_git_head_does_not_count() -> TestResult {
     testutils::git::set_head_to_id(&git_repo, commit);
 
     let mut tx = repo.start_transaction();
-    git::import_head(tx.repo_mut()).block_on()?;
+    git::import_head(tx.repo_mut(), WorkspaceName::DEFAULT).block_on()?;
     git::import_refs(tx.repo_mut(), &import_options).block_on()?;
     tx.repo_mut().rebase_descendants().block_on()?;
 
     // Delete the bookmark and re-import. The commit should still be there since
     // HEAD points to it
     git_repo.find_reference("refs/heads/main")?.delete()?;
-    git::import_head(tx.repo_mut()).block_on()?;
+    git::import_head(tx.repo_mut(), WorkspaceName::DEFAULT).block_on()?;
     git::import_refs(tx.repo_mut(), &import_options).block_on()?;
     tx.repo_mut().rebase_descendants().block_on()?;
     assert!(!tx.repo().view().heads().contains(&jj_id(commit)));
@@ -591,7 +595,7 @@ fn test_import_refs_reimport_git_head_without_ref() -> TestResult {
     testutils::git::set_head_to_id(&git_repo, git_id(&commit1));
 
     // Import HEAD.
-    git::import_head(tx.repo_mut()).block_on()?;
+    git::import_head(tx.repo_mut(), WorkspaceName::DEFAULT).block_on()?;
     git::import_refs(tx.repo_mut(), &import_options).block_on()?;
     tx.repo_mut().rebase_descendants().block_on()?;
     assert!(tx.repo().view().heads().contains(commit1.id()));
@@ -604,7 +608,7 @@ fn test_import_refs_reimport_git_head_without_ref() -> TestResult {
     // would be moved by `git checkout` command. This isn't always true because the
     // detached HEAD commit could be rewritten by e.g. `git commit --amend` command,
     // but it should be safer than abandoning old checkout branch.
-    git::import_head(tx.repo_mut()).block_on()?;
+    git::import_head(tx.repo_mut(), WorkspaceName::DEFAULT).block_on()?;
     git::import_refs(tx.repo_mut(), &import_options).block_on()?;
     tx.repo_mut().rebase_descendants().block_on()?;
     assert!(tx.repo().view().heads().contains(commit1.id()));
@@ -633,7 +637,7 @@ fn test_import_refs_reimport_git_head_with_moved_ref() -> TestResult {
     testutils::git::set_head_to_id(&git_repo, git_id(&commit1));
 
     // Import HEAD and main.
-    git::import_head(tx.repo_mut()).block_on()?;
+    git::import_head(tx.repo_mut(), WorkspaceName::DEFAULT).block_on()?;
     git::import_refs(tx.repo_mut(), &import_options).block_on()?;
     tx.repo_mut().rebase_descendants().block_on()?;
     assert!(tx.repo().view().heads().contains(commit1.id()));
@@ -649,13 +653,13 @@ fn test_import_refs_reimport_git_head_with_moved_ref() -> TestResult {
     testutils::git::set_head_to_id(&git_repo, git_id(&commit2));
 
     // Reimport HEAD and main, which abandons the old main branch.
-    git::import_head(tx.repo_mut()).block_on()?;
+    git::import_head(tx.repo_mut(), WorkspaceName::DEFAULT).block_on()?;
     git::import_refs(tx.repo_mut(), &import_options).block_on()?;
     tx.repo_mut().rebase_descendants().block_on()?;
     assert!(!tx.repo().view().heads().contains(commit1.id()));
     assert!(tx.repo().view().heads().contains(commit2.id()));
     // Reimport HEAD and main, which abandons the old main bookmark.
-    git::import_head(tx.repo_mut()).block_on()?;
+    git::import_head(tx.repo_mut(), WorkspaceName::DEFAULT).block_on()?;
     git::import_refs(tx.repo_mut(), &import_options).block_on()?;
     tx.repo_mut().rebase_descendants().block_on()?;
     assert!(!tx.repo().view().heads().contains(commit1.id()));
@@ -1340,7 +1344,7 @@ fn test_import_refs_reimport_git_head_with_fixed_ref() -> TestResult {
     testutils::git::set_head_to_id(&git_repo, git_id(&commit1));
 
     // Import HEAD and main.
-    git::import_head(tx.repo_mut()).block_on()?;
+    git::import_head(tx.repo_mut(), WorkspaceName::DEFAULT).block_on()?;
     git::import_refs(tx.repo_mut(), &import_options).block_on()?;
     tx.repo_mut().rebase_descendants().block_on()?;
     assert!(tx.repo().view().heads().contains(commit1.id()));
@@ -1350,7 +1354,7 @@ fn test_import_refs_reimport_git_head_with_fixed_ref() -> TestResult {
     testutils::git::set_head_to_id(&git_repo, git_id(&commit2));
 
     // Reimport HEAD, which shouldn't abandon the old HEAD branch.
-    git::import_head(tx.repo_mut()).block_on()?;
+    git::import_head(tx.repo_mut(), WorkspaceName::DEFAULT).block_on()?;
     git::import_refs(tx.repo_mut(), &import_options).block_on()?;
     tx.repo_mut().rebase_descendants().block_on()?;
     assert!(tx.repo().view().heads().contains(commit1.id()));
@@ -2436,7 +2440,7 @@ fn test_import_refs_empty_git_repo() -> TestResult {
     assert_eq!(repo.view().bookmarks().count(), 0);
     assert_eq!(repo.view().local_tags().count(), 0);
     assert_eq!(repo.view().git_refs().len(), 0);
-    assert_eq!(repo.view().git_head(), RefTarget::absent_ref());
+    assert!(repo.view().git_head(WorkspaceName::DEFAULT).is_absent());
     Ok(())
 }
 
@@ -2473,7 +2477,7 @@ fn test_import_refs_missing_git_commit() -> TestResult {
     git_repo.find_reference("refs/heads/main")?.delete()?;
     testutils::git::set_head_to_id(&git_repo, commit2);
     let mut tx = repo.start_transaction();
-    let result = git::import_head(tx.repo_mut()).block_on();
+    let result = git::import_head(tx.repo_mut(), WorkspaceName::DEFAULT).block_on();
     assert_matches!(
         result,
         Err(GitImportError::MissingHeadTarget {
@@ -2504,7 +2508,7 @@ fn test_import_refs_missing_git_commit() -> TestResult {
     testutils::git::set_head_to_id(&git_repo, commit1);
     fs::rename(&object_file, &backup_object_file)?;
     let mut tx = repo.start_transaction();
-    let result = git::import_head(tx.repo_mut()).block_on();
+    let result = git::import_head(tx.repo_mut(), WorkspaceName::DEFAULT).block_on();
     assert!(result.is_ok());
     Ok(())
 }
@@ -2523,7 +2527,7 @@ fn test_import_refs_detached_head() -> TestResult {
     testutils::git::set_head_to_id(&test_data.git_repo, commit1);
 
     let mut tx = test_data.repo.start_transaction();
-    git::import_head(tx.repo_mut()).block_on()?;
+    git::import_head(tx.repo_mut(), WorkspaceName::DEFAULT).block_on()?;
     git::import_refs(tx.repo_mut(), &import_options).block_on()?;
     tx.repo_mut().rebase_descendants().block_on()?;
     let repo = tx.commit("test").block_on()?;
@@ -2531,7 +2535,10 @@ fn test_import_refs_detached_head() -> TestResult {
     let expected_heads = hashset! { jj_id(commit1) };
     assert_eq!(*repo.view().heads(), expected_heads);
     assert_eq!(repo.view().git_refs().len(), 0);
-    assert_eq!(repo.view().git_head(), &RefTarget::normal(jj_id(commit1)));
+    assert_eq!(
+        repo.view().git_head(WorkspaceName::DEFAULT),
+        &RefTarget::normal(jj_id(commit1))
+    );
     Ok(())
 }
 
@@ -2546,7 +2553,7 @@ fn test_export_refs_no_detach() -> TestResult {
     testutils::git::set_symbolic_reference(&git_repo, "HEAD", "refs/heads/main");
     let mut tx = test_data.repo.start_transaction();
     let mut_repo = tx.repo_mut();
-    git::import_head(mut_repo).block_on()?;
+    git::import_head(mut_repo, WorkspaceName::DEFAULT).block_on()?;
     git::import_refs(mut_repo, &import_options).block_on()?;
     mut_repo.rebase_descendants().block_on()?;
 
@@ -2583,7 +2590,7 @@ fn test_export_refs_bookmark_changed() -> TestResult {
 
     let mut tx = test_data.repo.start_transaction();
     let mut_repo = tx.repo_mut();
-    git::import_head(mut_repo).block_on()?;
+    git::import_head(mut_repo, WorkspaceName::DEFAULT).block_on()?;
     git::import_refs(mut_repo, &import_options).block_on()?;
     mut_repo.rebase_descendants().block_on()?;
     let stats = git::export_refs(mut_repo)?;
@@ -2636,7 +2643,7 @@ fn test_export_refs_tag_changed() -> TestResult {
 
     let mut tx = test_data.repo.start_transaction();
     let mut_repo = tx.repo_mut();
-    git::import_head(mut_repo).block_on()?;
+    git::import_head(mut_repo, WorkspaceName::DEFAULT).block_on()?;
     let stats = git::import_refs(mut_repo, &import_options).block_on()?;
     assert_eq!(stats.changed_remote_tags.len(), 4);
     mut_repo.rebase_descendants().block_on()?;
@@ -2718,7 +2725,7 @@ fn test_export_refs_current_bookmark_changed() -> TestResult {
     testutils::git::set_symbolic_reference(&git_repo, "HEAD", "refs/heads/main");
     let mut tx = test_data.repo.start_transaction();
     let mut_repo = tx.repo_mut();
-    git::import_head(mut_repo).block_on()?;
+    git::import_head(mut_repo, WorkspaceName::DEFAULT).block_on()?;
     git::import_refs(mut_repo, &import_options).block_on()?;
     mut_repo.rebase_descendants().block_on()?;
     let stats = git::export_refs(mut_repo)?;
@@ -2771,7 +2778,7 @@ fn test_export_refs_worktree_head_changed() -> TestResult {
 
     let mut tx = test_data.repo.start_transaction();
     let mut_repo = tx.repo_mut();
-    git::import_head(mut_repo).block_on()?;
+    git::import_head(mut_repo, WorkspaceName::DEFAULT).block_on()?;
     git::import_refs(mut_repo, &import_options).block_on()?;
     mut_repo.rebase_descendants().block_on()?;
 
@@ -2814,7 +2821,7 @@ fn test_export_refs_worktree_no_detach() -> TestResult {
 
     let mut tx = test_data.repo.start_transaction();
     let mut_repo = tx.repo_mut();
-    git::import_head(mut_repo).block_on()?;
+    git::import_head(mut_repo, WorkspaceName::DEFAULT).block_on()?;
     git::import_refs(mut_repo, &import_options).block_on()?;
     mut_repo.rebase_descendants().block_on()?;
 
@@ -2849,7 +2856,7 @@ fn test_export_refs_current_tag_changed() -> TestResult {
     testutils::git::set_symbolic_reference(&git_repo, "HEAD", "refs/tags/v1.0");
     let mut tx = test_data.repo.start_transaction();
     let mut_repo = tx.repo_mut();
-    git::import_head(mut_repo).block_on()?;
+    git::import_head(mut_repo, WorkspaceName::DEFAULT).block_on()?;
     git::import_refs(mut_repo, &import_options).block_on()?;
     mut_repo.rebase_descendants().block_on()?;
     let stats = git::export_refs(mut_repo)?;
@@ -2889,7 +2896,7 @@ fn test_export_refs_unborn_git_bookmark(move_placeholder_ref: bool) -> TestResul
     testutils::git::set_symbolic_reference(&git_repo, "HEAD", "refs/heads/main");
     let mut tx = test_data.repo.start_transaction();
     let mut_repo = tx.repo_mut();
-    git::import_head(mut_repo).block_on()?;
+    git::import_head(mut_repo, WorkspaceName::DEFAULT).block_on()?;
     git::import_refs(mut_repo, &import_options).block_on()?;
     mut_repo.rebase_descendants().block_on()?;
     let stats = git::export_refs(mut_repo)?;
@@ -3595,17 +3602,17 @@ fn test_reset_head_to_root() -> TestResult {
         .write_unwrap();
 
     // Set Git HEAD to commit2's parent (i.e. commit1)
-    git::reset_head(tx.repo_mut(), &commit2).block_on()?;
+    git::reset_head(tx.repo_mut(), WorkspaceName::DEFAULT, &commit2).block_on()?;
     assert!(git_repo.head()?.is_detached(), "HEAD is detached");
     assert_eq!(
-        tx.repo().git_head(),
+        tx.repo().git_head(WorkspaceName::DEFAULT),
         RefTarget::normal(commit1.id().clone())
     );
 
     // Set Git HEAD back to root
-    git::reset_head(tx.repo_mut(), &commit1).block_on()?;
+    git::reset_head(tx.repo_mut(), WorkspaceName::DEFAULT, &commit1).block_on()?;
     assert!(git_repo.head()?.is_unborn(), "HEAD is unborn");
-    assert!(tx.repo().git_head().is_absent());
+    assert!(tx.repo().git_head(WorkspaceName::DEFAULT).is_absent());
 
     // Move placeholder ref as if new commit were created by git
     git_repo.reference(
@@ -3614,18 +3621,18 @@ fn test_reset_head_to_root() -> TestResult {
         gix::refs::transaction::PreviousValue::MustNotExist,
         "",
     )?;
-    git::reset_head(tx.repo_mut(), &commit2).block_on()?;
+    git::reset_head(tx.repo_mut(), WorkspaceName::DEFAULT, &commit2).block_on()?;
     assert!(git_repo.head_id().is_ok());
     assert_eq!(
-        tx.repo().git_head(),
+        tx.repo().git_head(WorkspaceName::DEFAULT),
         RefTarget::normal(commit1.id().clone())
     );
     assert!(git_repo.find_reference("refs/jj/root").is_ok());
 
     // Set Git HEAD back to root
-    git::reset_head(tx.repo_mut(), &commit1).block_on()?;
+    git::reset_head(tx.repo_mut(), WorkspaceName::DEFAULT, &commit1).block_on()?;
     assert!(git_repo.head()?.is_unborn(), "HEAD is unborn");
-    assert!(tx.repo().git_head().is_absent());
+    assert!(tx.repo().git_head(WorkspaceName::DEFAULT).is_absent());
     // The placeholder ref should be deleted
     assert!(git_repo.find_reference("refs/jj/root").is_err());
     Ok(())
@@ -3658,9 +3665,9 @@ fn test_reset_head_detached_out_of_sync() -> TestResult {
     let commit5 = write_random_commit(tx.repo_mut());
 
     // unborn -> commit1 (= commit2's parent)
-    git::reset_head(tx.repo_mut(), &commit2).block_on()?;
+    git::reset_head(tx.repo_mut(), WorkspaceName::DEFAULT, &commit2).block_on()?;
     assert_eq!(
-        tx.repo().git_head(),
+        tx.repo().git_head(WorkspaceName::DEFAULT),
         RefTarget::normal(commit1.id().clone())
     );
 
@@ -3669,34 +3676,34 @@ fn test_reset_head_detached_out_of_sync() -> TestResult {
 
     // {expected: commit1, actual: commit5} -> commit1 (= commit3's parent):
     // works because the expected HEAD is unchanged.
-    git::reset_head(tx.repo_mut(), &commit3).block_on()?;
+    git::reset_head(tx.repo_mut(), WorkspaceName::DEFAULT, &commit3).block_on()?;
     assert_eq!(
-        tx.repo().git_head(),
+        tx.repo().git_head(WorkspaceName::DEFAULT),
         RefTarget::normal(commit1.id().clone())
     );
 
     // {expected: commit1, actual: commit5} -> commit3 (= commit4's parent)
     assert_matches!(
-        git::reset_head(tx.repo_mut(), &commit4).block_on(),
+        git::reset_head(tx.repo_mut(), WorkspaceName::DEFAULT, &commit4).block_on(),
         Err(GitResetHeadError::UpdateHeadRef(_))
     );
     assert_eq!(
-        tx.repo().git_head(),
+        tx.repo().git_head(WorkspaceName::DEFAULT),
         RefTarget::normal(commit1.id().clone()),
         "view shouldn't be updated on failed export"
     );
 
     // Import the HEAD moved by external process
-    git::import_head(tx.repo_mut()).block_on()?;
+    git::import_head(tx.repo_mut(), WorkspaceName::DEFAULT).block_on()?;
     assert_eq!(
-        tx.repo().git_head(),
+        tx.repo().git_head(WorkspaceName::DEFAULT),
         RefTarget::normal(commit5.id().clone())
     );
 
     // commit5 -> commit3 (= commit4's parent)
-    git::reset_head(tx.repo_mut(), &commit4).block_on()?;
+    git::reset_head(tx.repo_mut(), WorkspaceName::DEFAULT, &commit4).block_on()?;
     assert_eq!(
-        tx.repo().git_head(),
+        tx.repo().git_head(WorkspaceName::DEFAULT),
         RefTarget::normal(commit3.id().clone())
     );
     Ok(())
@@ -3743,7 +3750,7 @@ fn test_reset_head_with_index() -> TestResult {
         .write_unwrap();
 
     // Set Git HEAD to commit2's parent (i.e. commit1)
-    git::reset_head(tx.repo_mut(), &commit2).block_on()?;
+    git::reset_head(tx.repo_mut(), WorkspaceName::DEFAULT, &commit2).block_on()?;
     insta::assert_snapshot!(get_index_state(&workspace_root), @"");
 
     // Add "staged changes" to the Git index
@@ -3755,7 +3762,7 @@ fn test_reset_head_with_index() -> TestResult {
     insta::assert_snapshot!(get_index_state(&workspace_root), @"Unconflicted file.txt Mode(FILE)");
 
     // Reset head and the Git index
-    git::reset_head(tx.repo_mut(), &commit2).block_on()?;
+    git::reset_head(tx.repo_mut(), WorkspaceName::DEFAULT, &commit2).block_on()?;
     insta::assert_snapshot!(get_index_state(&workspace_root), @"");
     Ok(())
 }
@@ -3798,7 +3805,7 @@ fn test_reset_head_with_index_no_conflict() -> TestResult {
         .write_unwrap();
 
     // Reset head to working copy commit
-    git::reset_head(mut_repo, &wc_commit).block_on()?;
+    git::reset_head(mut_repo, WorkspaceName::DEFAULT, &wc_commit).block_on()?;
 
     // Git index should contain all files from the tree.
     // `Mode(DIR | SYMLINK)` actually means `MODE(COMMIT)`, as in a git submodule.
@@ -3892,7 +3899,7 @@ fn test_reset_head_with_index_merge_conflict() -> TestResult {
         .write_unwrap();
 
     // Reset head to working copy commit with merge conflict
-    git::reset_head(mut_repo, &wc_commit).block_on()?;
+    git::reset_head(mut_repo, WorkspaceName::DEFAULT, &wc_commit).block_on()?;
 
     // Index should contain conflicted files from merge of parent commits.
     // `Mode(DIR | SYMLINK)` actually means `MODE(COMMIT)`, as in a git submodule.
@@ -3956,7 +3963,7 @@ fn test_reset_head_with_index_file_directory_conflict() -> TestResult {
         .write_unwrap();
 
     // Reset head to working copy commit with file-directory conflict
-    git::reset_head(mut_repo, &wc_commit).block_on()?;
+    git::reset_head(mut_repo, WorkspaceName::DEFAULT, &wc_commit).block_on()?;
 
     // Only the file should be added to the index (the tree should be skipped).
     insta::assert_snapshot!(get_index_state(&workspace_root), @"Theirs test Mode(FILE)");

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -77,6 +77,7 @@ use jj_lib::ref_name::GitRefNameBuf;
 use jj_lib::ref_name::RefName;
 use jj_lib::ref_name::RemoteName;
 use jj_lib::ref_name::RemoteRefSymbol;
+use jj_lib::ref_name::WorkspaceName;
 use jj_lib::repo::MutableRepo;
 use jj_lib::repo::ReadonlyRepo;
 use jj_lib::repo::Repo as _;
@@ -280,7 +281,7 @@ fn test_import_refs() -> TestResult {
     testutils::git::set_symbolic_reference(&git_repo, "HEAD", "refs/heads/main");
 
     let mut tx = repo.start_transaction();
-    git::import_head(tx.repo_mut()).block_on()?;
+    git::import_head(tx.repo_mut(), WorkspaceName::DEFAULT).block_on()?;
     let stats = git::import_refs(tx.repo_mut(), &import_options).block_on()?;
     tx.repo_mut().rebase_descendants().block_on()?;
     let repo = tx.commit("test").block_on()?;
@@ -398,7 +399,10 @@ fn test_import_refs() -> TestResult {
         view.get_git_ref("refs/tags/v1.0".as_ref()),
         &RefTarget::normal(jj_id(commit5))
     );
-    assert_eq!(view.git_head(), &RefTarget::normal(jj_id(commit2)));
+    assert_eq!(
+        view.git_head(WorkspaceName::DEFAULT),
+        Some(&RefTarget::normal(jj_id(commit2)))
+    );
     Ok(())
 }
 
@@ -561,14 +565,14 @@ fn test_import_refs_reimport_git_head_does_not_count() -> TestResult {
     testutils::git::set_head_to_id(&git_repo, commit);
 
     let mut tx = repo.start_transaction();
-    git::import_head(tx.repo_mut()).block_on()?;
+    git::import_head(tx.repo_mut(), WorkspaceName::DEFAULT).block_on()?;
     git::import_refs(tx.repo_mut(), &import_options).block_on()?;
     tx.repo_mut().rebase_descendants().block_on()?;
 
     // Delete the bookmark and re-import. The commit should still be there since
     // HEAD points to it
     git_repo.find_reference("refs/heads/main")?.delete()?;
-    git::import_head(tx.repo_mut()).block_on()?;
+    git::import_head(tx.repo_mut(), WorkspaceName::DEFAULT).block_on()?;
     git::import_refs(tx.repo_mut(), &import_options).block_on()?;
     tx.repo_mut().rebase_descendants().block_on()?;
     assert!(!tx.repo().view().heads().contains(&jj_id(commit)));
@@ -591,7 +595,7 @@ fn test_import_refs_reimport_git_head_without_ref() -> TestResult {
     testutils::git::set_head_to_id(&git_repo, git_id(&commit1));
 
     // Import HEAD.
-    git::import_head(tx.repo_mut()).block_on()?;
+    git::import_head(tx.repo_mut(), WorkspaceName::DEFAULT).block_on()?;
     git::import_refs(tx.repo_mut(), &import_options).block_on()?;
     tx.repo_mut().rebase_descendants().block_on()?;
     assert!(tx.repo().view().heads().contains(commit1.id()));
@@ -604,7 +608,7 @@ fn test_import_refs_reimport_git_head_without_ref() -> TestResult {
     // would be moved by `git checkout` command. This isn't always true because the
     // detached HEAD commit could be rewritten by e.g. `git commit --amend` command,
     // but it should be safer than abandoning old checkout branch.
-    git::import_head(tx.repo_mut()).block_on()?;
+    git::import_head(tx.repo_mut(), WorkspaceName::DEFAULT).block_on()?;
     git::import_refs(tx.repo_mut(), &import_options).block_on()?;
     tx.repo_mut().rebase_descendants().block_on()?;
     assert!(tx.repo().view().heads().contains(commit1.id()));
@@ -633,7 +637,7 @@ fn test_import_refs_reimport_git_head_with_moved_ref() -> TestResult {
     testutils::git::set_head_to_id(&git_repo, git_id(&commit1));
 
     // Import HEAD and main.
-    git::import_head(tx.repo_mut()).block_on()?;
+    git::import_head(tx.repo_mut(), WorkspaceName::DEFAULT).block_on()?;
     git::import_refs(tx.repo_mut(), &import_options).block_on()?;
     tx.repo_mut().rebase_descendants().block_on()?;
     assert!(tx.repo().view().heads().contains(commit1.id()));
@@ -649,13 +653,13 @@ fn test_import_refs_reimport_git_head_with_moved_ref() -> TestResult {
     testutils::git::set_head_to_id(&git_repo, git_id(&commit2));
 
     // Reimport HEAD and main, which abandons the old main branch.
-    git::import_head(tx.repo_mut()).block_on()?;
+    git::import_head(tx.repo_mut(), WorkspaceName::DEFAULT).block_on()?;
     git::import_refs(tx.repo_mut(), &import_options).block_on()?;
     tx.repo_mut().rebase_descendants().block_on()?;
     assert!(!tx.repo().view().heads().contains(commit1.id()));
     assert!(tx.repo().view().heads().contains(commit2.id()));
     // Reimport HEAD and main, which abandons the old main bookmark.
-    git::import_head(tx.repo_mut()).block_on()?;
+    git::import_head(tx.repo_mut(), WorkspaceName::DEFAULT).block_on()?;
     git::import_refs(tx.repo_mut(), &import_options).block_on()?;
     tx.repo_mut().rebase_descendants().block_on()?;
     assert!(!tx.repo().view().heads().contains(commit1.id()));
@@ -1340,7 +1344,7 @@ fn test_import_refs_reimport_git_head_with_fixed_ref() -> TestResult {
     testutils::git::set_head_to_id(&git_repo, git_id(&commit1));
 
     // Import HEAD and main.
-    git::import_head(tx.repo_mut()).block_on()?;
+    git::import_head(tx.repo_mut(), WorkspaceName::DEFAULT).block_on()?;
     git::import_refs(tx.repo_mut(), &import_options).block_on()?;
     tx.repo_mut().rebase_descendants().block_on()?;
     assert!(tx.repo().view().heads().contains(commit1.id()));
@@ -1350,7 +1354,7 @@ fn test_import_refs_reimport_git_head_with_fixed_ref() -> TestResult {
     testutils::git::set_head_to_id(&git_repo, git_id(&commit2));
 
     // Reimport HEAD, which shouldn't abandon the old HEAD branch.
-    git::import_head(tx.repo_mut()).block_on()?;
+    git::import_head(tx.repo_mut(), WorkspaceName::DEFAULT).block_on()?;
     git::import_refs(tx.repo_mut(), &import_options).block_on()?;
     tx.repo_mut().rebase_descendants().block_on()?;
     assert!(tx.repo().view().heads().contains(commit1.id()));
@@ -2436,7 +2440,7 @@ fn test_import_refs_empty_git_repo() -> TestResult {
     assert_eq!(repo.view().bookmarks().count(), 0);
     assert_eq!(repo.view().local_tags().count(), 0);
     assert_eq!(repo.view().git_refs().len(), 0);
-    assert_eq!(repo.view().git_head(), RefTarget::absent_ref());
+    assert_eq!(repo.view().git_head(WorkspaceName::DEFAULT), None);
     Ok(())
 }
 
@@ -2473,7 +2477,7 @@ fn test_import_refs_missing_git_commit() -> TestResult {
     git_repo.find_reference("refs/heads/main")?.delete()?;
     testutils::git::set_head_to_id(&git_repo, commit2);
     let mut tx = repo.start_transaction();
-    let result = git::import_head(tx.repo_mut()).block_on();
+    let result = git::import_head(tx.repo_mut(), WorkspaceName::DEFAULT).block_on();
     assert_matches!(
         result,
         Err(GitImportError::MissingHeadTarget {
@@ -2504,7 +2508,7 @@ fn test_import_refs_missing_git_commit() -> TestResult {
     testutils::git::set_head_to_id(&git_repo, commit1);
     fs::rename(&object_file, &backup_object_file)?;
     let mut tx = repo.start_transaction();
-    let result = git::import_head(tx.repo_mut()).block_on();
+    let result = git::import_head(tx.repo_mut(), WorkspaceName::DEFAULT).block_on();
     assert!(result.is_ok());
     Ok(())
 }
@@ -2523,7 +2527,7 @@ fn test_import_refs_detached_head() -> TestResult {
     testutils::git::set_head_to_id(&test_data.git_repo, commit1);
 
     let mut tx = test_data.repo.start_transaction();
-    git::import_head(tx.repo_mut()).block_on()?;
+    git::import_head(tx.repo_mut(), WorkspaceName::DEFAULT).block_on()?;
     git::import_refs(tx.repo_mut(), &import_options).block_on()?;
     tx.repo_mut().rebase_descendants().block_on()?;
     let repo = tx.commit("test").block_on()?;
@@ -2531,7 +2535,10 @@ fn test_import_refs_detached_head() -> TestResult {
     let expected_heads = hashset! { jj_id(commit1) };
     assert_eq!(*repo.view().heads(), expected_heads);
     assert_eq!(repo.view().git_refs().len(), 0);
-    assert_eq!(repo.view().git_head(), &RefTarget::normal(jj_id(commit1)));
+    assert_eq!(
+        repo.view().git_head(WorkspaceName::DEFAULT),
+        Some(&RefTarget::normal(jj_id(commit1)))
+    );
     Ok(())
 }
 
@@ -2546,7 +2553,7 @@ fn test_export_refs_no_detach() -> TestResult {
     testutils::git::set_symbolic_reference(&git_repo, "HEAD", "refs/heads/main");
     let mut tx = test_data.repo.start_transaction();
     let mut_repo = tx.repo_mut();
-    git::import_head(mut_repo).block_on()?;
+    git::import_head(mut_repo, WorkspaceName::DEFAULT).block_on()?;
     git::import_refs(mut_repo, &import_options).block_on()?;
     mut_repo.rebase_descendants().block_on()?;
 
@@ -2583,7 +2590,7 @@ fn test_export_refs_bookmark_changed() -> TestResult {
 
     let mut tx = test_data.repo.start_transaction();
     let mut_repo = tx.repo_mut();
-    git::import_head(mut_repo).block_on()?;
+    git::import_head(mut_repo, WorkspaceName::DEFAULT).block_on()?;
     git::import_refs(mut_repo, &import_options).block_on()?;
     mut_repo.rebase_descendants().block_on()?;
     let stats = git::export_refs(mut_repo)?;
@@ -2636,7 +2643,7 @@ fn test_export_refs_tag_changed() -> TestResult {
 
     let mut tx = test_data.repo.start_transaction();
     let mut_repo = tx.repo_mut();
-    git::import_head(mut_repo).block_on()?;
+    git::import_head(mut_repo, WorkspaceName::DEFAULT).block_on()?;
     let stats = git::import_refs(mut_repo, &import_options).block_on()?;
     assert_eq!(stats.changed_remote_tags.len(), 4);
     mut_repo.rebase_descendants().block_on()?;
@@ -2718,7 +2725,7 @@ fn test_export_refs_current_bookmark_changed() -> TestResult {
     testutils::git::set_symbolic_reference(&git_repo, "HEAD", "refs/heads/main");
     let mut tx = test_data.repo.start_transaction();
     let mut_repo = tx.repo_mut();
-    git::import_head(mut_repo).block_on()?;
+    git::import_head(mut_repo, WorkspaceName::DEFAULT).block_on()?;
     git::import_refs(mut_repo, &import_options).block_on()?;
     mut_repo.rebase_descendants().block_on()?;
     let stats = git::export_refs(mut_repo)?;
@@ -2771,7 +2778,7 @@ fn test_export_refs_worktree_head_changed() -> TestResult {
 
     let mut tx = test_data.repo.start_transaction();
     let mut_repo = tx.repo_mut();
-    git::import_head(mut_repo).block_on()?;
+    git::import_head(mut_repo, WorkspaceName::DEFAULT).block_on()?;
     git::import_refs(mut_repo, &import_options).block_on()?;
     mut_repo.rebase_descendants().block_on()?;
 
@@ -2814,7 +2821,7 @@ fn test_export_refs_worktree_no_detach() -> TestResult {
 
     let mut tx = test_data.repo.start_transaction();
     let mut_repo = tx.repo_mut();
-    git::import_head(mut_repo).block_on()?;
+    git::import_head(mut_repo, WorkspaceName::DEFAULT).block_on()?;
     git::import_refs(mut_repo, &import_options).block_on()?;
     mut_repo.rebase_descendants().block_on()?;
 
@@ -2849,7 +2856,7 @@ fn test_export_refs_current_tag_changed() -> TestResult {
     testutils::git::set_symbolic_reference(&git_repo, "HEAD", "refs/tags/v1.0");
     let mut tx = test_data.repo.start_transaction();
     let mut_repo = tx.repo_mut();
-    git::import_head(mut_repo).block_on()?;
+    git::import_head(mut_repo, WorkspaceName::DEFAULT).block_on()?;
     git::import_refs(mut_repo, &import_options).block_on()?;
     mut_repo.rebase_descendants().block_on()?;
     let stats = git::export_refs(mut_repo)?;
@@ -2889,7 +2896,7 @@ fn test_export_refs_unborn_git_bookmark(move_placeholder_ref: bool) -> TestResul
     testutils::git::set_symbolic_reference(&git_repo, "HEAD", "refs/heads/main");
     let mut tx = test_data.repo.start_transaction();
     let mut_repo = tx.repo_mut();
-    git::import_head(mut_repo).block_on()?;
+    git::import_head(mut_repo, WorkspaceName::DEFAULT).block_on()?;
     git::import_refs(mut_repo, &import_options).block_on()?;
     mut_repo.rebase_descendants().block_on()?;
     let stats = git::export_refs(mut_repo)?;
@@ -3595,17 +3602,17 @@ fn test_reset_head_to_root() -> TestResult {
         .write_unwrap();
 
     // Set Git HEAD to commit2's parent (i.e. commit1)
-    git::reset_head(tx.repo_mut(), &commit2).block_on()?;
+    git::reset_head(tx.repo_mut(), &commit2, WorkspaceName::DEFAULT).block_on()?;
     assert!(git_repo.head()?.is_detached(), "HEAD is detached");
     assert_eq!(
-        tx.repo().git_head(),
+        tx.repo().git_head(WorkspaceName::DEFAULT),
         RefTarget::normal(commit1.id().clone())
     );
 
     // Set Git HEAD back to root
-    git::reset_head(tx.repo_mut(), &commit1).block_on()?;
+    git::reset_head(tx.repo_mut(), &commit1, WorkspaceName::DEFAULT).block_on()?;
     assert!(git_repo.head()?.is_unborn(), "HEAD is unborn");
-    assert!(tx.repo().git_head().is_absent());
+    assert!(tx.repo().git_head(WorkspaceName::DEFAULT).is_absent());
 
     // Move placeholder ref as if new commit were created by git
     git_repo.reference(
@@ -3614,18 +3621,18 @@ fn test_reset_head_to_root() -> TestResult {
         gix::refs::transaction::PreviousValue::MustNotExist,
         "",
     )?;
-    git::reset_head(tx.repo_mut(), &commit2).block_on()?;
+    git::reset_head(tx.repo_mut(), &commit2, WorkspaceName::DEFAULT).block_on()?;
     assert!(git_repo.head_id().is_ok());
     assert_eq!(
-        tx.repo().git_head(),
+        tx.repo().git_head(WorkspaceName::DEFAULT),
         RefTarget::normal(commit1.id().clone())
     );
     assert!(git_repo.find_reference("refs/jj/root").is_ok());
 
     // Set Git HEAD back to root
-    git::reset_head(tx.repo_mut(), &commit1).block_on()?;
+    git::reset_head(tx.repo_mut(), &commit1, WorkspaceName::DEFAULT).block_on()?;
     assert!(git_repo.head()?.is_unborn(), "HEAD is unborn");
-    assert!(tx.repo().git_head().is_absent());
+    assert!(tx.repo().git_head(WorkspaceName::DEFAULT).is_absent());
     // The placeholder ref should be deleted
     assert!(git_repo.find_reference("refs/jj/root").is_err());
     Ok(())
@@ -3658,9 +3665,9 @@ fn test_reset_head_detached_out_of_sync() -> TestResult {
     let commit5 = write_random_commit(tx.repo_mut());
 
     // unborn -> commit1 (= commit2's parent)
-    git::reset_head(tx.repo_mut(), &commit2).block_on()?;
+    git::reset_head(tx.repo_mut(), &commit2, WorkspaceName::DEFAULT).block_on()?;
     assert_eq!(
-        tx.repo().git_head(),
+        tx.repo().git_head(WorkspaceName::DEFAULT),
         RefTarget::normal(commit1.id().clone())
     );
 
@@ -3669,34 +3676,34 @@ fn test_reset_head_detached_out_of_sync() -> TestResult {
 
     // {expected: commit1, actual: commit5} -> commit1 (= commit3's parent):
     // works because the expected HEAD is unchanged.
-    git::reset_head(tx.repo_mut(), &commit3).block_on()?;
+    git::reset_head(tx.repo_mut(), &commit3, WorkspaceName::DEFAULT).block_on()?;
     assert_eq!(
-        tx.repo().git_head(),
+        tx.repo().git_head(WorkspaceName::DEFAULT),
         RefTarget::normal(commit1.id().clone())
     );
 
     // {expected: commit1, actual: commit5} -> commit3 (= commit4's parent)
     assert_matches!(
-        git::reset_head(tx.repo_mut(), &commit4).block_on(),
+        git::reset_head(tx.repo_mut(), &commit4, WorkspaceName::DEFAULT).block_on(),
         Err(GitResetHeadError::UpdateHeadRef(_))
     );
     assert_eq!(
-        tx.repo().git_head(),
+        tx.repo().git_head(WorkspaceName::DEFAULT),
         RefTarget::normal(commit1.id().clone()),
         "view shouldn't be updated on failed export"
     );
 
     // Import the HEAD moved by external process
-    git::import_head(tx.repo_mut()).block_on()?;
+    git::import_head(tx.repo_mut(), WorkspaceName::DEFAULT).block_on()?;
     assert_eq!(
-        tx.repo().git_head(),
+        tx.repo().git_head(WorkspaceName::DEFAULT),
         RefTarget::normal(commit5.id().clone())
     );
 
     // commit5 -> commit3 (= commit4's parent)
-    git::reset_head(tx.repo_mut(), &commit4).block_on()?;
+    git::reset_head(tx.repo_mut(), &commit4, WorkspaceName::DEFAULT).block_on()?;
     assert_eq!(
-        tx.repo().git_head(),
+        tx.repo().git_head(WorkspaceName::DEFAULT),
         RefTarget::normal(commit3.id().clone())
     );
     Ok(())
@@ -3743,7 +3750,7 @@ fn test_reset_head_with_index() -> TestResult {
         .write_unwrap();
 
     // Set Git HEAD to commit2's parent (i.e. commit1)
-    git::reset_head(tx.repo_mut(), &commit2).block_on()?;
+    git::reset_head(tx.repo_mut(), &commit2, WorkspaceName::DEFAULT).block_on()?;
     insta::assert_snapshot!(get_index_state(&workspace_root), @"");
 
     // Add "staged changes" to the Git index
@@ -3755,7 +3762,7 @@ fn test_reset_head_with_index() -> TestResult {
     insta::assert_snapshot!(get_index_state(&workspace_root), @"Unconflicted file.txt Mode(FILE)");
 
     // Reset head and the Git index
-    git::reset_head(tx.repo_mut(), &commit2).block_on()?;
+    git::reset_head(tx.repo_mut(), &commit2, WorkspaceName::DEFAULT).block_on()?;
     insta::assert_snapshot!(get_index_state(&workspace_root), @"");
     Ok(())
 }
@@ -3798,7 +3805,7 @@ fn test_reset_head_with_index_no_conflict() -> TestResult {
         .write_unwrap();
 
     // Reset head to working copy commit
-    git::reset_head(mut_repo, &wc_commit).block_on()?;
+    git::reset_head(mut_repo, &wc_commit, WorkspaceName::DEFAULT).block_on()?;
 
     // Git index should contain all files from the tree.
     // `Mode(DIR | SYMLINK)` actually means `MODE(COMMIT)`, as in a git submodule.
@@ -3892,7 +3899,7 @@ fn test_reset_head_with_index_merge_conflict() -> TestResult {
         .write_unwrap();
 
     // Reset head to working copy commit with merge conflict
-    git::reset_head(mut_repo, &wc_commit).block_on()?;
+    git::reset_head(mut_repo, &wc_commit, WorkspaceName::DEFAULT).block_on()?;
 
     // Index should contain conflicted files from merge of parent commits.
     // `Mode(DIR | SYMLINK)` actually means `MODE(COMMIT)`, as in a git submodule.
@@ -3956,7 +3963,7 @@ fn test_reset_head_with_index_file_directory_conflict() -> TestResult {
         .write_unwrap();
 
     // Reset head to working copy commit with file-directory conflict
-    git::reset_head(mut_repo, &wc_commit).block_on()?;
+    git::reset_head(mut_repo, &wc_commit, WorkspaceName::DEFAULT).block_on()?;
 
     // Only the file should be added to the index (the tree should be skipped).
     insta::assert_snapshot!(get_index_state(&workspace_root), @"Theirs test Mode(FILE)");

--- a/lib/tests/test_mut_repo.rs
+++ b/lib/tests/test_mut_repo.rs
@@ -670,6 +670,7 @@ fn test_remove_wc_commit_previous_not_discardable() -> TestResult {
     let old_wc_commit = write_random_commit(mut_repo);
     let ws_name = WorkspaceName::DEFAULT.to_owned();
     mut_repo.edit(ws_name.clone(), &old_wc_commit).block_on()?;
+    mut_repo.set_git_head_target(&ws_name, RefTarget::normal(old_wc_commit.id().clone()));
     let repo = tx.commit("test").block_on()?;
 
     let mut tx = repo.start_transaction();
@@ -677,6 +678,7 @@ fn test_remove_wc_commit_previous_not_discardable() -> TestResult {
     mut_repo.remove_wc_commit(&ws_name).block_on()?;
     mut_repo.rebase_descendants().block_on()?;
     assert!(mut_repo.view().heads().contains(old_wc_commit.id()));
+    assert!(mut_repo.view().git_head(&ws_name).is_absent());
     Ok(())
 }
 

--- a/lib/tests/test_mut_repo.rs
+++ b/lib/tests/test_mut_repo.rs
@@ -660,7 +660,7 @@ fn test_rename_remote() {
 
 #[test]
 fn test_remove_wc_commit_previous_not_discardable() -> TestResult {
-    // Test that MutableRepo::remove_wc_commit() does not usually abandon the
+    // Test that MutableRepo::remove_workspace() does not usually abandon the
     // previous commit.
     let test_repo = TestRepo::init();
     let repo = &test_repo.repo;
@@ -675,7 +675,7 @@ fn test_remove_wc_commit_previous_not_discardable() -> TestResult {
 
     let mut tx = repo.start_transaction();
     let mut_repo = tx.repo_mut();
-    mut_repo.remove_wc_commit(&ws_name).block_on()?;
+    mut_repo.remove_workspace(&ws_name).block_on()?;
     mut_repo.rebase_descendants().block_on()?;
     assert!(mut_repo.view().heads().contains(old_wc_commit.id()));
     assert!(mut_repo.view().git_head(&ws_name).is_absent());
@@ -684,7 +684,7 @@ fn test_remove_wc_commit_previous_not_discardable() -> TestResult {
 
 #[test]
 fn test_remove_wc_commit_previous_discardable() -> TestResult {
-    // Test that MutableRepo::remove_wc_commit() abandons the previous commit
+    // Test that MutableRepo::remove_workspace() abandons the previous commit
     // if it was discardable.
     let test_repo = TestRepo::init();
     let repo = &test_repo.repo;
@@ -703,7 +703,7 @@ fn test_remove_wc_commit_previous_discardable() -> TestResult {
 
     let mut tx = repo.start_transaction();
     let mut_repo = tx.repo_mut();
-    mut_repo.remove_wc_commit(&ws_name).block_on()?;
+    mut_repo.remove_workspace(&ws_name).block_on()?;
     mut_repo.rebase_descendants().block_on()?;
     assert!(!mut_repo.view().heads().contains(old_wc_commit.id()));
     Ok(())

--- a/lib/tests/test_mut_repo.rs
+++ b/lib/tests/test_mut_repo.rs
@@ -670,6 +670,7 @@ fn test_remove_wc_commit_previous_not_discardable() -> TestResult {
     let old_wc_commit = write_random_commit(mut_repo);
     let ws_name = WorkspaceName::DEFAULT.to_owned();
     mut_repo.edit(ws_name.clone(), &old_wc_commit).block_on()?;
+    mut_repo.set_git_head_target(&ws_name, RefTarget::normal(old_wc_commit.id().clone()));
     let repo = tx.commit("test").block_on()?;
 
     let mut tx = repo.start_transaction();
@@ -677,6 +678,7 @@ fn test_remove_wc_commit_previous_not_discardable() -> TestResult {
     mut_repo.remove_wc_commit(&ws_name).block_on()?;
     mut_repo.rebase_descendants().block_on()?;
     assert!(mut_repo.view().heads().contains(old_wc_commit.id()));
+    assert_eq!(mut_repo.view().git_head(&ws_name), None);
     Ok(())
 }
 

--- a/lib/tests/test_operations.rs
+++ b/lib/tests/test_operations.rs
@@ -646,15 +646,15 @@ fn test_resolve_op_id() -> TestResult {
         let repo = tx.commit(format!("transaction {i}")).block_on()?;
         operations.push(repo.operation().clone());
     }
-    // "3" and "0" are ambiguous
+    // "b" is ambiguous (operations[2] and operations[5])
     insta::assert_debug_snapshot!(operations.iter().map(|op| op.id().hex()).collect_vec(), @r#"
     [
-        "3fb99188ad57448697795ade6d59a7fc36c4ba9daa5ce5501ec2e2bb23a027e7358ededd902994b7e9fc319d262c7679af7f079cdf5403ec2784a33f79f17c21",
-        "75f94ddb7d65b220acca16ff4d5a1851945051803d809b66aeb1cd12b77ad8a1cf8973cb531a4524c1948812bf3ccd650bf8988e692d7bd7fa47f08f4c506abd",
-        "de94b57efe85cd747450956e5f8221a277db649e91e643d9ccd524ab0574630abc04dd4fe81108090bfc4e183c62b3ba1b1a3ee077020ea6587a59703990ddc2",
-        "9874219f414e4bba6564c54782ed1016a5ae63d695d6b0e1165983365d527bf10af3016a0e20020c24d2208bf20ef284e2a628c8c99d9742475d51eb6417c867",
-        "380b1e3403ee19d0696441eb38eb9aeac36ac82769012a1bc370825705b745a8dab42f3bbdb1223e0adf860d15290134340842ba2d3e3ec7462a0c8cce54d54c",
-        "08b1bc4a1537ea549fa001dbc29b474f8fd3469facbab331ee2b5e3807eaaf95d04d967e270499ffb7a38098eec0dff97cdb5c7b44ba755f9b71c9924f80c16e",
+        "33d54aefeb762fec7d849fba6cdb19e4f571f9b0a14445c9ab764d800d52c7abbe9d6bb8a152a6e2b02514de2ca769038c8e3ec0093d254369d1c138eaf5b02a",
+        "13f64f9b2c7a8a882f3e5e03885cdc0cb64c8bc40e6f2b6f188c84a4ac49f9e6f1e49e5b3a1c627ef8c077184ea870e532a06554c9e9783bf78338a5e4c0b781",
+        "b1e7aa2b8e7d6015d7f281baadb1f34bdbb8841a762a7e164f7849973ace8d0b8f87309416ccc81c0459373846022c24a93486f8a4ed2ff0ec4221b587ca28f2",
+        "c9cc85d1bf80aa756583a1ba708961f94643277ae716d913b17152e80b42f1886afd1127ec8e34fc15507040ec5a643e32d4b727ea70417ba2fbb29e2e225f88",
+        "94cfe4b05e25e4329dcd2494e0e4a4e4a6608c65ccc9d0a186c81d3bf8f5606ec7b31cd9333dcacbc658ebe0df5e51f91d2d52b58a5806e1273d31c083e4acd6",
+        "b527c15f0261c2520ffe84056f8eb3a216a9994b7117fe17b996f7203bb3cebeace369461f481c412f9969a91490dc5af629efe109c3433afa0c6d0b26fdbc17",
     ]
     "#);
 
@@ -669,7 +669,7 @@ fn test_resolve_op_id() -> TestResult {
     assert_eq!(resolve(&operations[1].id().hex()[..2])?, operations[1]);
     // Ambiguous id
     assert_matches!(
-        resolve("3"),
+        resolve("b"),
         Err(OpsetEvaluationError::OpsetResolution(
             OpsetResolutionError::AmbiguousIdPrefix(_)
         ))
@@ -692,13 +692,8 @@ fn test_resolve_op_id() -> TestResult {
     let root_operation = loader.root_operation().block_on();
     assert_eq!(resolve(&root_operation.id().hex())?, root_operation);
     assert_eq!(resolve("00")?, root_operation);
-    assert_eq!(resolve("08")?, operations[5]);
-    assert_matches!(
-        resolve("0"),
-        Err(OpsetEvaluationError::OpsetResolution(
-            OpsetResolutionError::AmbiguousIdPrefix(_)
-        ))
-    );
+    assert_eq!(resolve("b5")?, operations[5]);
+    assert_eq!(resolve("0")?, root_operation);
     Ok(())
 }
 

--- a/lib/tests/test_operations.rs
+++ b/lib/tests/test_operations.rs
@@ -641,20 +641,22 @@ fn test_resolve_op_id() -> TestResult {
     let mut operations = Vec::new();
     // The actual value of `i` doesn't matter, we just need to make sure we end
     // up with hashes with ambiguous prefixes.
-    for i in (1..5).chain([10, 24]) {
+    for i in (1..5).chain([10, 24, 9]) {
         let tx = repo.start_transaction();
         let repo = tx.commit(format!("transaction {i}")).block_on()?;
         operations.push(repo.operation().clone());
     }
-    // "3" and "0" are ambiguous
+    // "b" is ambiguous (operations[2] and operations[5])
+    // "0" is ambiguous with the root operation (operations[6])
     insta::assert_debug_snapshot!(operations.iter().map(|op| op.id().hex()).collect_vec(), @r#"
     [
-        "3fb99188ad57448697795ade6d59a7fc36c4ba9daa5ce5501ec2e2bb23a027e7358ededd902994b7e9fc319d262c7679af7f079cdf5403ec2784a33f79f17c21",
-        "75f94ddb7d65b220acca16ff4d5a1851945051803d809b66aeb1cd12b77ad8a1cf8973cb531a4524c1948812bf3ccd650bf8988e692d7bd7fa47f08f4c506abd",
-        "de94b57efe85cd747450956e5f8221a277db649e91e643d9ccd524ab0574630abc04dd4fe81108090bfc4e183c62b3ba1b1a3ee077020ea6587a59703990ddc2",
-        "9874219f414e4bba6564c54782ed1016a5ae63d695d6b0e1165983365d527bf10af3016a0e20020c24d2208bf20ef284e2a628c8c99d9742475d51eb6417c867",
-        "380b1e3403ee19d0696441eb38eb9aeac36ac82769012a1bc370825705b745a8dab42f3bbdb1223e0adf860d15290134340842ba2d3e3ec7462a0c8cce54d54c",
-        "08b1bc4a1537ea549fa001dbc29b474f8fd3469facbab331ee2b5e3807eaaf95d04d967e270499ffb7a38098eec0dff97cdb5c7b44ba755f9b71c9924f80c16e",
+        "33d54aefeb762fec7d849fba6cdb19e4f571f9b0a14445c9ab764d800d52c7abbe9d6bb8a152a6e2b02514de2ca769038c8e3ec0093d254369d1c138eaf5b02a",
+        "13f64f9b2c7a8a882f3e5e03885cdc0cb64c8bc40e6f2b6f188c84a4ac49f9e6f1e49e5b3a1c627ef8c077184ea870e532a06554c9e9783bf78338a5e4c0b781",
+        "b1e7aa2b8e7d6015d7f281baadb1f34bdbb8841a762a7e164f7849973ace8d0b8f87309416ccc81c0459373846022c24a93486f8a4ed2ff0ec4221b587ca28f2",
+        "c9cc85d1bf80aa756583a1ba708961f94643277ae716d913b17152e80b42f1886afd1127ec8e34fc15507040ec5a643e32d4b727ea70417ba2fbb29e2e225f88",
+        "94cfe4b05e25e4329dcd2494e0e4a4e4a6608c65ccc9d0a186c81d3bf8f5606ec7b31cd9333dcacbc658ebe0df5e51f91d2d52b58a5806e1273d31c083e4acd6",
+        "b527c15f0261c2520ffe84056f8eb3a216a9994b7117fe17b996f7203bb3cebeace369461f481c412f9969a91490dc5af629efe109c3433afa0c6d0b26fdbc17",
+        "007480c57328c8532149d66fb2a44b6e4ff79e44362e0c9578f82c4147c8cbebf84ad08d9a1f661814902cef89bc76d90628cb606f2431e45f74493d5e1e0cbd",
     ]
     "#);
 
@@ -669,7 +671,7 @@ fn test_resolve_op_id() -> TestResult {
     assert_eq!(resolve(&operations[1].id().hex()[..2])?, operations[1]);
     // Ambiguous id
     assert_matches!(
-        resolve("3"),
+        resolve("b"),
         Err(OpsetEvaluationError::OpsetResolution(
             OpsetResolutionError::AmbiguousIdPrefix(_)
         ))
@@ -691,14 +693,22 @@ fn test_resolve_op_id() -> TestResult {
     // Virtual root id
     let root_operation = loader.root_operation().block_on();
     assert_eq!(resolve(&root_operation.id().hex())?, root_operation);
-    assert_eq!(resolve("00")?, root_operation);
-    assert_eq!(resolve("08")?, operations[5]);
+    assert_eq!(resolve("b5")?, operations[5]);
+    // "0" is ambiguous with the root operation and operations[6]
     assert_matches!(
         resolve("0"),
         Err(OpsetEvaluationError::OpsetResolution(
             OpsetResolutionError::AmbiguousIdPrefix(_)
         ))
     );
+    assert_matches!(
+        resolve("00"),
+        Err(OpsetEvaluationError::OpsetResolution(
+            OpsetResolutionError::AmbiguousIdPrefix(_)
+        ))
+    );
+    assert_eq!(resolve("000")?, root_operation);
+    assert_eq!(resolve("007")?, operations[6]);
     Ok(())
 }
 

--- a/lib/tests/test_view.rs
+++ b/lib/tests/test_view.rs
@@ -520,26 +520,35 @@ fn test_merge_views_git_heads() -> TestResult {
 
     let mut tx0 = repo.start_transaction();
     let tx0_head = write_random_commit(tx0.repo_mut());
-    tx0.repo_mut()
-        .set_git_head_target(RefTarget::normal(tx0_head.id().clone()));
+    tx0.repo_mut().set_git_head_target(
+        WorkspaceName::DEFAULT,
+        RefTarget::normal(tx0_head.id().clone()),
+    );
     let repo = tx0.commit("test").block_on()?;
 
     let mut tx1 = repo.start_transaction();
     let tx1_head = write_random_commit(tx1.repo_mut());
-    tx1.repo_mut()
-        .set_git_head_target(RefTarget::normal(tx1_head.id().clone()));
+    tx1.repo_mut().set_git_head_target(
+        WorkspaceName::DEFAULT,
+        RefTarget::normal(tx1_head.id().clone()),
+    );
 
     let mut tx2 = repo.start_transaction();
     let tx2_head = write_random_commit(tx2.repo_mut());
-    tx2.repo_mut()
-        .set_git_head_target(RefTarget::normal(tx2_head.id().clone()));
+    tx2.repo_mut().set_git_head_target(
+        WorkspaceName::DEFAULT,
+        RefTarget::normal(tx2_head.id().clone()),
+    );
 
     let repo = commit_transactions(vec![tx1, tx2]);
     let expected_git_head = RefTarget::from_legacy_form(
         [tx0_head.id().clone()],
         [tx1_head.id().clone(), tx2_head.id().clone()],
     );
-    assert_eq!(repo.view().git_head(), &expected_git_head);
+    assert_eq!(
+        repo.view().git_head(WorkspaceName::DEFAULT),
+        &expected_git_head
+    );
     Ok(())
 }
 

--- a/lib/tests/test_view.rs
+++ b/lib/tests/test_view.rs
@@ -520,26 +520,35 @@ fn test_merge_views_git_heads() -> TestResult {
 
     let mut tx0 = repo.start_transaction();
     let tx0_head = write_random_commit(tx0.repo_mut());
-    tx0.repo_mut()
-        .set_git_head_target(RefTarget::normal(tx0_head.id().clone()));
+    tx0.repo_mut().set_git_head_target(
+        WorkspaceName::DEFAULT,
+        RefTarget::normal(tx0_head.id().clone()),
+    );
     let repo = tx0.commit("test").block_on()?;
 
     let mut tx1 = repo.start_transaction();
     let tx1_head = write_random_commit(tx1.repo_mut());
-    tx1.repo_mut()
-        .set_git_head_target(RefTarget::normal(tx1_head.id().clone()));
+    tx1.repo_mut().set_git_head_target(
+        WorkspaceName::DEFAULT,
+        RefTarget::normal(tx1_head.id().clone()),
+    );
 
     let mut tx2 = repo.start_transaction();
     let tx2_head = write_random_commit(tx2.repo_mut());
-    tx2.repo_mut()
-        .set_git_head_target(RefTarget::normal(tx2_head.id().clone()));
+    tx2.repo_mut().set_git_head_target(
+        WorkspaceName::DEFAULT,
+        RefTarget::normal(tx2_head.id().clone()),
+    );
 
     let repo = commit_transactions(vec![tx1, tx2]);
     let expected_git_head = RefTarget::from_legacy_form(
         [tx0_head.id().clone()],
         [tx1_head.id().clone(), tx2_head.id().clone()],
     );
-    assert_eq!(repo.view().git_head(), &expected_git_head);
+    assert_eq!(
+        repo.view().git_head(WorkspaceName::DEFAULT),
+        Some(&expected_git_head)
+    );
     Ok(())
 }
 

--- a/lib/tests/test_view.rs
+++ b/lib/tests/test_view.rs
@@ -176,7 +176,7 @@ fn test_merge_views_checkout() -> TestResult {
         .set_wc_commit(ws1_name.clone(), commit2.id().clone())?;
     tx1.repo_mut()
         .set_wc_commit(ws2_name.clone(), commit2.id().clone())?;
-    tx1.repo_mut().remove_wc_commit(&ws4_name).block_on()?;
+    tx1.repo_mut().remove_workspace(&ws4_name).block_on()?;
     tx1.repo_mut()
         .set_wc_commit(ws5_name.clone(), commit2.id().clone())?;
     tx1.repo_mut()
@@ -189,7 +189,7 @@ fn test_merge_views_checkout() -> TestResult {
         .set_wc_commit(ws3_name.clone(), commit3.id().clone())?;
     tx2.repo_mut()
         .set_wc_commit(ws4_name.clone(), commit3.id().clone())?;
-    tx2.repo_mut().remove_wc_commit(&ws5_name).block_on()?;
+    tx2.repo_mut().remove_workspace(&ws5_name).block_on()?;
     tx2.repo_mut()
         .set_wc_commit(ws7_name.clone(), commit3.id().clone())?;
 


### PR DESCRIPTION
Store Git HEAD targets in the view keyed by worktree name instead of
keeping a single repository-wide target. This prepares colocated
repositories for linked Git worktrees, where each jj workspace can
have its own HEAD.

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
