### PR TITLE
workspace add/forget: bridge jj workspaces with git worktrees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,19 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Breaking changes
 
+* The minimum supported `git` command version is now 2.42.0, up from 2.41.0.
+  `jj workspace add` uses `git worktree add --orphan`, which was added in
+  2.42.0.
+
 ### Deprecations
 
 ### New features
+
+* `jj workspace add` supports `--colocate`/`--no-colocate` flags to control
+  whether a Git worktree is created alongside the workspace. The default
+  colocates when the current workspace is colocated and the `git.colocate`
+  config is `true`. `jj workspace forget` removes the corresponding Git
+  worktree when one exists.
 
 ### Fixed bugs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   jj workspace can have its own Git HEAD. Existing repositories are migrated
   automatically.
 
+* `jj workspace add` now automatically creates a corresponding Git worktree
+  when working in a colocated Git repository. This means Git-based tools
+  (LSPs, editors, etc) work in the new workspace out of the box.
+  `jj workspace forget` automatically removes the corresponding Git worktree.
+
 ### Fixed bugs
 
 * A side of a conflict whose contents end with a carriage return no longer loses

--- a/cli/src/command_error.rs
+++ b/cli/src/command_error.rs
@@ -535,6 +535,7 @@ impl From<TrailerParseError> for CommandError {
 
 #[cfg(feature = "git")]
 mod git {
+    use jj_lib::git::GitCreateWorktreeError;
     use jj_lib::git::GitDefaultRefspecError;
     use jj_lib::git::GitExportError;
     use jj_lib::git::GitFetchError;
@@ -623,6 +624,12 @@ jj currently does not support partial clones. To use jj with this repository, tr
 
     impl From<GitRemoteManagementError> for CommandError {
         fn from(err: GitRemoteManagementError) -> Self {
+            user_error(err)
+        }
+    }
+
+    impl From<GitCreateWorktreeError> for CommandError {
+        fn from(err: GitCreateWorktreeError) -> Self {
             user_error(err)
         }
     }

--- a/cli/src/commands/workspace/add.rs
+++ b/cli/src/commands/workspace/add.rs
@@ -19,6 +19,10 @@ use itertools::Itertools as _;
 use jj_lib::commit::CommitIteratorExt as _;
 use jj_lib::file_util;
 use jj_lib::file_util::IoResultExt as _;
+#[cfg(feature = "git")]
+use jj_lib::git::GitSubprocessOptions;
+#[cfg(feature = "git")]
+use jj_lib::git::create_worktree;
 use jj_lib::ref_name::WorkspaceNameBuf;
 use jj_lib::repo::Repo as _;
 use jj_lib::rewrite::merge_commit_trees;
@@ -30,6 +34,8 @@ use crate::cli_util::RevisionArg;
 use crate::command_error::CommandError;
 use crate::command_error::internal_error_with_message;
 use crate::command_error::user_error;
+#[cfg(feature = "git")]
+use crate::commands::git::maybe_add_gitignore;
 use crate::description_util::add_trailers;
 use crate::description_util::join_message_paragraphs;
 use crate::ui::Ui;
@@ -81,6 +87,22 @@ pub struct WorkspaceAddArgs {
     #[arg(long = "message", short, value_name = "MESSAGE")]
     message_paragraphs: Vec<String>,
 
+    /// Create a corresponding Git worktree for this workspace
+    ///
+    /// By default, a Git worktree is created when the current workspace is
+    /// colocated and the [git.colocate config] is `true`.
+    ///
+    /// [git.colocate config]:
+    ///     https://docs.jj-vcs.dev/latest/config/#default-colocation
+    #[cfg(feature = "git")]
+    #[arg(long, conflicts_with = "no_colocate")]
+    colocate: bool,
+
+    /// Do not create a Git worktree for this workspace
+    #[cfg(feature = "git")]
+    #[arg(long, conflicts_with = "colocate")]
+    no_colocate: bool,
+
     /// How to handle sparse patterns when creating a new workspace.
     #[arg(long, value_enum, default_value_t = SparseInheritance::Copy)]
     sparse_patterns: SparseInheritance,
@@ -122,6 +144,24 @@ pub async fn cmd_workspace_add(
         ));
     }
 
+    #[cfg(feature = "git")]
+    {
+        let should_colocate = if args.colocate {
+            true
+        } else if args.no_colocate {
+            false
+        } else {
+            old_workspace_command.working_copy_shared_with_git()
+                && old_workspace_command.settings().get_bool("git.colocate")?
+        };
+        if should_colocate {
+            let subprocess_options =
+                GitSubprocessOptions::from_settings(old_workspace_command.settings())?;
+            create_worktree(repo.store(), subprocess_options, &destination_path)?;
+            writeln!(ui.status(), "Created Git worktree for the new workspace.")?;
+        }
+    }
+
     let working_copy_factory = command.get_working_copy_factory()?;
     let repo_path = old_workspace_command.repo_path();
     // If we add per-workspace configuration, we'll need to reload settings for
@@ -151,6 +191,9 @@ pub async fn cmd_workspace_add(
     }
 
     let mut new_workspace_command = command.for_workable_repo(ui, new_workspace, repo)?;
+    // Keep the colocated Git worktree from tracking Jujutsu's own files.
+    #[cfg(feature = "git")]
+    maybe_add_gitignore(&new_workspace_command)?;
 
     let sparsity = match args.sparse_patterns {
         SparseInheritance::Full => None,

--- a/cli/src/commands/workspace/add.rs
+++ b/cli/src/commands/workspace/add.rs
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 use std::fs;
+use std::path::Path;
+use std::process::Command;
 
 use futures::future::try_join_all;
 use itertools::Itertools as _;
@@ -114,7 +116,24 @@ pub async fn cmd_workspace_add(
             name = workspace_name.as_symbol()
         )));
     }
-    if !destination_path.exists() {
+    let is_colocated = old_workspace_command.working_copy_shared_with_git();
+
+    if is_colocated {
+        let created_git_worktree = create_git_worktree(
+            ui,
+            old_workspace_command.workspace_root(),
+            &destination_path,
+        )?;
+        if !created_git_worktree {
+            if !destination_path.exists() {
+                fs::create_dir(&destination_path).context(&destination_path)?;
+            } else if !file_util::is_empty_dir(&destination_path)? {
+                return Err(user_error(
+                    "Destination path exists and is not an empty directory",
+                ));
+            }
+        }
+    } else if !destination_path.exists() {
         fs::create_dir(&destination_path).context(&destination_path)?;
     } else if !file_util::is_empty_dir(&destination_path)? {
         return Err(user_error(
@@ -124,8 +143,6 @@ pub async fn cmd_workspace_add(
 
     let working_copy_factory = command.get_working_copy_factory()?;
     let repo_path = old_workspace_command.repo_path();
-    // If we add per-workspace configuration, we'll need to reload settings for
-    // the new workspace.
     let (new_workspace, repo) = Workspace::init_workspace_with_existing_repo(
         &destination_path,
         repo_path,
@@ -233,4 +250,47 @@ pub async fn cmd_workspace_add(
     )
     .await?;
     Ok(())
+}
+
+fn create_git_worktree(
+    ui: &Ui,
+    main_workspace_root: &Path,
+    destination: &Path,
+) -> Result<bool, CommandError> {
+    let head_output = Command::new("git")
+        .args(["rev-parse", "--verify", "--quiet", "HEAD"])
+        .current_dir(main_workspace_root)
+        .output()
+        .map_err(|err| {
+            user_error(format!(
+                "Failed to run `git rev-parse`: {err}. Is `git` installed?"
+            ))
+        })?;
+    if !head_output.status.success() {
+        writeln!(
+            ui.warning_default(),
+            "Skipping Git worktree creation because Git HEAD does not point to a commit yet."
+        )?;
+        return Ok(false);
+    }
+
+    let output = Command::new("git")
+        .args(["worktree", "add", "--detach", "--no-checkout"])
+        .arg(destination)
+        .arg("HEAD")
+        .current_dir(main_workspace_root)
+        .output()
+        .map_err(|err| {
+            user_error(format!(
+                "Failed to run `git worktree add`: {err}. Is `git` installed?"
+            ))
+        })?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(user_error(format!(
+            "Failed to create Git worktree: {stderr}"
+        )));
+    }
+    writeln!(ui.status(), "Created Git worktree for the new workspace.")?;
+    Ok(true)
 }

--- a/cli/src/commands/workspace/forget.rs
+++ b/cli/src/commands/workspace/forget.rs
@@ -14,7 +14,11 @@
 
 use clap_complete::ArgValueCandidates;
 use itertools::Itertools as _;
+#[cfg(feature = "git")]
+use jj_lib::git::GitSubprocessOptions;
 use jj_lib::ref_name::WorkspaceNameBuf;
+#[cfg(feature = "git")]
+use jj_lib::repo::Repo as _;
 use jj_lib::workspace_store::SimpleWorkspaceStore;
 use jj_lib::workspace_store::WorkspaceStore as _;
 use tracing::instrument;
@@ -22,6 +26,8 @@ use tracing::instrument;
 use crate::cli_util::CommandHelper;
 use crate::command_error::CommandError;
 use crate::complete;
+#[cfg(feature = "git")]
+use crate::git_util::unlink_git_worktree;
 use crate::ui::Ui;
 
 /// Stop tracking a workspace's working-copy commit in the repo
@@ -74,6 +80,18 @@ pub async fn cmd_workspace_forget(
 
     let workspace_store = SimpleWorkspaceStore::load(workspace_command.repo_path())?;
 
+    #[cfg(feature = "git")]
+    let workspace_paths = {
+        let repo_path = workspace_command.repo_path();
+        forget_ws
+            .iter()
+            .filter_map(|ws| {
+                let rel_path = workspace_store.get_workspace_path(ws).ok().flatten()?;
+                dunce::canonicalize(repo_path.join(rel_path)).ok()
+            })
+            .collect_vec()
+    };
+
     // bundle every workspace forget into a single transaction, so that e.g.
     // undo correctly restores all of them at once.
     let mut tx = workspace_command.start_transaction();
@@ -94,5 +112,15 @@ pub async fn cmd_workspace_forget(
     };
 
     tx.finish(ui, description).await?;
+
+    #[cfg(feature = "git")]
+    {
+        let subprocess_options = GitSubprocessOptions::from_settings(workspace_command.settings())?;
+        let store = workspace_command.repo().store();
+        for path in &workspace_paths {
+            unlink_git_worktree(ui, store, subprocess_options.clone(), path)?;
+        }
+    }
+
     Ok(())
 }

--- a/cli/src/commands/workspace/forget.rs
+++ b/cli/src/commands/workspace/forget.rs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::path::Path;
+use std::process::Command;
+
 use clap_complete::ArgValueCandidates;
 use itertools::Itertools as _;
 use jj_lib::ref_name::WorkspaceNameBuf;
@@ -74,6 +77,15 @@ pub async fn cmd_workspace_forget(
 
     let workspace_store = SimpleWorkspaceStore::load(workspace_command.repo_path())?;
 
+    let repo_path = workspace_command.repo_path();
+    let workspace_paths: Vec<_> = forget_ws
+        .iter()
+        .filter_map(|ws| {
+            let rel_path = workspace_store.get_workspace_path(ws).ok().flatten()?;
+            dunce::canonicalize(repo_path.join(rel_path)).ok()
+        })
+        .collect();
+
     // bundle every workspace forget into a single transaction, so that e.g.
     // undo correctly restores all of them at once.
     let mut tx = workspace_command.start_transaction();
@@ -94,5 +106,52 @@ pub async fn cmd_workspace_forget(
     };
 
     tx.finish(ui, description).await?;
+
+    if workspace_command.working_copy_shared_with_git() {
+        for path in &workspace_paths {
+            remove_git_worktree(ui, workspace_command.workspace_root(), path)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn remove_git_worktree(
+    ui: &Ui,
+    main_workspace_root: &Path,
+    worktree_path: &Path,
+) -> Result<(), CommandError> {
+    let dot_git = worktree_path.join(".git");
+    if !dot_git.is_file() {
+        return Ok(());
+    }
+    let output = Command::new("git")
+        .args(["worktree", "remove", "--force"])
+        .arg(worktree_path)
+        .current_dir(main_workspace_root)
+        .output();
+    match output {
+        Ok(o) if o.status.success() => {
+            writeln!(
+                ui.status(),
+                "Removed Git worktree at \"{}\".",
+                worktree_path.display()
+            )?;
+        }
+        Ok(o) => {
+            let stderr = String::from_utf8_lossy(&o.stderr);
+            writeln!(
+                ui.warning_default(),
+                "Failed to remove Git worktree at \"{}\": {stderr}",
+                worktree_path.display()
+            )?;
+        }
+        Err(err) => {
+            writeln!(
+                ui.warning_default(),
+                "Failed to run `git worktree remove`: {err}"
+            )?;
+        }
+    }
     Ok(())
 }

--- a/cli/src/git_util.rs
+++ b/cli/src/git_util.rs
@@ -20,6 +20,7 @@ use std::io::Write as _;
 use std::iter;
 use std::mem;
 use std::path::Path;
+use std::sync::Arc;
 use std::time::Duration;
 use std::time::Instant;
 
@@ -40,11 +41,13 @@ use jj_lib::git::GitRefKind;
 use jj_lib::git::GitSettings;
 use jj_lib::git::GitSidebandLineTerminator;
 use jj_lib::git::GitSubprocessCallback;
+use jj_lib::git::GitSubprocessOptions;
 use jj_lib::git_backend::GitRepoAtWorkdirError;
 use jj_lib::op_store::RemoteRefState;
 use jj_lib::repo::ReadonlyRepo;
 use jj_lib::repo::Repo;
 use jj_lib::settings::RemoteSettingsMap;
+use jj_lib::store::Store;
 use jj_lib::workspace::Workspace;
 use unicode_width::UnicodeWidthStr as _;
 
@@ -53,6 +56,7 @@ use crate::cli_util::WorkspaceCommandTransaction;
 use crate::cli_util::print_updated_commits;
 use crate::command_error::CommandError;
 use crate::command_error::cli_error;
+use crate::command_error::print_error_sources;
 use crate::command_error::user_error;
 use crate::formatter::Formatter;
 use crate::formatter::FormatterExt as _;
@@ -555,6 +559,36 @@ pub fn print_push_stats(ui: &Ui, stats: &GitPushStats) -> io::Result<()> {
                 write!(formatter, ": {err}")?;
             }
             writeln!(formatter)?;
+        }
+    }
+    Ok(())
+}
+
+/// Disconnects the Git worktree backing a jj workspace, if there is one.
+///
+/// The workspace has already been forgotten by the time this runs, and a
+/// leftover gitlink or stale worktree metadata isn't worth failing the command
+/// over, so errors are reported as warnings.
+pub fn unlink_git_worktree(
+    ui: &Ui,
+    store: &Arc<Store>,
+    subprocess_options: GitSubprocessOptions,
+    worktree_path: &Path,
+) -> Result<(), CommandError> {
+    match git::unlink_worktree(store, subprocess_options, worktree_path) {
+        Ok(false) => {}
+        Ok(true) => writeln!(
+            ui.status(),
+            r#"Removed Git worktree for "{}"."#,
+            worktree_path.display()
+        )?,
+        Err(err) => {
+            writeln!(
+                ui.warning_default(),
+                r#"Failed to remove Git worktree for "{}"."#,
+                worktree_path.display()
+            )?;
+            print_error_sources(ui, Some(&err))?;
         }
     }
     Ok(())

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -3945,6 +3945,12 @@ By default, the new workspace inherits the sparse patterns of the current worksp
 
    If any revisions are specified, the new workspace will be created, and the new working-copy commit will be created with all these revisions as parents, i.e. the working-copy commit will exist as if you had run `jj new r1 r2 r3 ...`.
 * `-m`, `--message <MESSAGE>` — The change description to use
+* `--colocate` — Create a corresponding Git worktree for this workspace
+
+   By default, a Git worktree is created when the current workspace is colocated and the [git.colocate config] is `true`.
+
+   [git.colocate config]: https://docs.jj-vcs.dev/latest/config/#default-colocation
+* `--no-colocate` — Do not create a Git worktree for this workspace
 * `--sparse-patterns <SPARSE_PATTERNS>` — How to handle sparse patterns when creating a new workspace
 
   Default value: `copy`

--- a/cli/tests/test_workspaces.rs
+++ b/cli/tests/test_workspaces.rs
@@ -124,6 +124,26 @@ fn test_workspaces_add_second_and_third_workspace() {
 }
 
 #[test]
+fn test_workspaces_add_colocated_unborn_git_head() {
+    let test_env = TestEnvironment::default();
+    test_env
+        .run_jj_in(".", ["git", "init", "--colocate", "main"])
+        .success();
+    let main_dir = test_env.work_dir("main");
+
+    let output = main_dir.run_jj(["workspace", "add", "../secondary"]);
+    insta::assert_snapshot!(output, @r#"
+    ------- stderr -------
+    Warning: Skipping Git worktree creation because Git HEAD does not point to a commit yet.
+    Created workspace in "../secondary"
+    Working copy  (@) now at: uuqppmxq 94f41578 (empty) (no description set)
+    Parent commit (@-)      : zzzzzzzz 00000000 (empty) (no description set)
+    [EOF]
+    "#);
+    assert!(!test_env.env_root().join("secondary/.git").exists());
+}
+
+#[test]
 fn test_workspaces_add_with_message() {
     let test_env = TestEnvironment::default();
     test_env.run_jj_in(".", ["git", "init", "main"]).success();

--- a/cli/tests/test_workspaces.rs
+++ b/cli/tests/test_workspaces.rs
@@ -2101,6 +2101,297 @@ fn test_workspaces_rename_workspace_from_before_workspace_store() {
     ");
 }
 
+#[test]
+fn test_workspaces_add_forget_colocated() {
+    let test_env = TestEnvironment::default();
+    test_env.add_config("git.colocate = true");
+    test_env
+        .run_jj_in(".", ["git", "init", "--colocate", "main"])
+        .success();
+    let main_dir = test_env.work_dir("main");
+
+    main_dir.write_file("file", "contents");
+    main_dir.run_jj(["commit", "-m", "initial"]).success();
+
+    // `--no-colocate` overrides the colocated default.
+    let output = main_dir.run_jj(["workspace", "add", "--no-colocate", "../flag-off"]);
+    insta::assert_snapshot!(output.normalize_backslash(), @r#"
+    ------- stderr -------
+    Created workspace in "../flag-off"
+    Working copy  (@) now at: pmmvwywv 058f604d (empty) (no description set)
+    Parent commit (@-)      : qpvuntsm 7b22a8cb initial
+    Added 1 files, modified 0 files, removed 0 files
+    [EOF]
+    "#);
+    assert!(!test_env.env_root().join("flag-off/.git").exists());
+
+    // So does `git.colocate = false`, even though the main workspace is
+    // colocated.
+    let output = main_dir.run_jj([
+        "workspace",
+        "add",
+        "--config=git.colocate=false",
+        "../config-off",
+    ]);
+    insta::assert_snapshot!(output.normalize_backslash(), @r#"
+    ------- stderr -------
+    Created workspace in "../config-off"
+    Working copy  (@) now at: rzvqmyuk bcc858e1 (empty) (no description set)
+    Parent commit (@-)      : qpvuntsm 7b22a8cb initial
+    Added 1 files, modified 0 files, removed 0 files
+    [EOF]
+    "#);
+    assert!(!test_env.env_root().join("config-off/.git").exists());
+
+    // ...but `--colocate` overrides that in turn.
+    let output = main_dir.run_jj([
+        "workspace",
+        "add",
+        "--config=git.colocate=false",
+        "--colocate",
+        "../flag-on",
+    ]);
+    insta::assert_snapshot!(output.normalize_backslash(), @r#"
+    ------- stderr -------
+    Created Git worktree for the new workspace.
+    Created workspace in "../flag-on"
+    Working copy  (@) now at: zxsnswpr 1c1effec (empty) (no description set)
+    Parent commit (@-)      : qpvuntsm 7b22a8cb initial
+    Added 1 files, modified 0 files, removed 0 files
+    [EOF]
+    "#);
+    assert!(test_env.env_root().join("flag-on/.git").is_file());
+
+    // With neither flag, a colocated main workspace and `git.colocate = true`
+    // create a worktree.
+    let output = main_dir.run_jj(["workspace", "add", "../secondary"]);
+    insta::assert_snapshot!(output.normalize_backslash(), @r#"
+    ------- stderr -------
+    Created Git worktree for the new workspace.
+    Created workspace in "../secondary"
+    Working copy  (@) now at: nppvrztz 0bfa7004 (empty) (no description set)
+    Parent commit (@-)      : qpvuntsm 7b22a8cb initial
+    Added 1 files, modified 0 files, removed 0 files
+    [EOF]
+    "#);
+    assert!(test_env.env_root().join("secondary/.git").is_file());
+
+    // The new workspace's .jj directory must be excluded, or Git would report
+    // it as untracked in the worktree.
+    assert!(
+        test_env
+            .env_root()
+            .join("secondary/.jj/.gitignore")
+            .is_file()
+    );
+    let secondary_repo = git::open(test_env.env_root().join("secondary"));
+    insta::assert_debug_snapshot!(git::status(&secondary_repo), @r#"
+    [
+        GitStatus {
+            path: ".jj/.gitignore",
+            status: Worktree(
+                Ignored,
+            ),
+        },
+        GitStatus {
+            path: ".jj/repo",
+            status: Worktree(
+                Ignored,
+            ),
+        },
+        GitStatus {
+            path: ".jj/working_copy",
+            status: Worktree(
+                Ignored,
+            ),
+        },
+    ]
+    "#);
+
+    // Forgetting the workspace disconnects the worktree, but leaves the
+    // directory contents in place.
+    let output = main_dir.run_jj(["workspace", "forget", "secondary"]);
+    insta::assert_snapshot!(output.normalize_backslash(), @r#"
+    ------- stderr -------
+    Removed Git worktree for "$TEST_ENV/secondary".
+    [EOF]
+    "#);
+    assert!(!test_env.env_root().join("secondary/.git").exists());
+    assert!(test_env.env_root().join("secondary/file").is_file());
+
+    // Git no longer knows about the worktree, but the others are untouched,
+    // and no worktree left behind the branch `git worktree add --orphan`
+    // insisted on naming.
+    let main_repo = git::open(test_env.env_root().join("main"));
+    assert_eq!(git_worktree_ids(&main_repo), ["flag-on"]);
+    assert_eq!(local_branches(&main_repo), [] as [String; 0]);
+}
+
+#[test]
+fn test_workspaces_add_colocated_at_revision() {
+    let test_env = TestEnvironment::default();
+    test_env.add_config("git.colocate = true");
+    test_env
+        .run_jj_in(".", ["git", "init", "--colocate", "main"])
+        .success();
+    let main_dir = test_env.work_dir("main");
+
+    // Build a chain of commits so the target is neither the tip nor the root.
+    main_dir.write_file("file1", "one\n");
+    main_dir.run_jj(["commit", "-m", "one"]).success();
+    main_dir.write_file("file2", "two\n");
+    main_dir.run_jj(["commit", "-m", "two"]).success();
+    main_dir.write_file("file3", "three\n");
+    main_dir.run_jj(["commit", "-m", "three"]).success();
+
+    // `@---` is the commit that added file1.
+    let target = main_dir
+        .run_jj(["log", "--no-graph", "-r", "@---", "-T", "commit_id"])
+        .success()
+        .stdout
+        .raw()
+        .trim()
+        .to_owned();
+
+    let output = main_dir.run_jj(["workspace", "add", "-r", "@---", "../secondary"]);
+    insta::assert_snapshot!(output.normalize_backslash(), @r#"
+    ------- stderr -------
+    Created Git worktree for the new workspace.
+    Created workspace in "../secondary"
+    Working copy  (@) now at: nppvrztz 514d6d42 (empty) (no description set)
+    Parent commit (@-)      : qpvuntsm 44945a23 one
+    Added 1 files, modified 0 files, removed 0 files
+    [EOF]
+    "#);
+
+    // Git HEAD must be the revision that was asked for, not the main
+    // workspace's HEAD.
+    let secondary_repo = git::open(test_env.env_root().join("secondary"));
+    assert_eq!(git_head(&secondary_repo), target);
+
+    // jj, not git, is what populates the working copy, so only the files that
+    // exist at the target revision should be present.
+    assert!(test_env.env_root().join("secondary/file1").is_file());
+    assert!(!test_env.env_root().join("secondary/file2").exists());
+    assert!(!test_env.env_root().join("secondary/file3").exists());
+
+    // Git and jj must agree about the state of that working copy: Git has to
+    // read the worktree's own HEAD and index, not the main workspace's.
+    let secondary_dir = test_env.work_dir("secondary");
+    secondary_dir.write_file("file1", "modified in secondary\n");
+    insta::assert_snapshot!(secondary_dir.run_jj(["diff"]), @"
+    Modified regular file file1:
+       1     : one
+            1: modified in secondary
+    [EOF]
+    ");
+    insta::assert_debug_snapshot!(git::status(&secondary_repo), @r#"
+    [
+        GitStatus {
+            path: ".jj/.gitignore",
+            status: Worktree(
+                Ignored,
+            ),
+        },
+        GitStatus {
+            path: ".jj/repo",
+            status: Worktree(
+                Ignored,
+            ),
+        },
+        GitStatus {
+            path: ".jj/working_copy",
+            status: Worktree(
+                Ignored,
+            ),
+        },
+        GitStatus {
+            path: "file1",
+            status: Worktree(
+                Modified,
+            ),
+        },
+    ]
+    "#);
+}
+
+#[test]
+fn test_workspaces_add_colocated_unborn_head() {
+    let test_env = TestEnvironment::default();
+    test_env.add_config("git.colocate = true");
+    test_env
+        .run_jj_in(".", ["git", "init", "--colocate", "main"])
+        .success();
+    let main_dir = test_env.work_dir("main");
+
+    // A repo with no commits is fine: the worktree is created with an unborn
+    // HEAD rather than being refused.
+    let output = main_dir.run_jj(["workspace", "add", "../secondary"]);
+    insta::assert_snapshot!(output.normalize_backslash(), @r#"
+    ------- stderr -------
+    Created Git worktree for the new workspace.
+    Created workspace in "../secondary"
+    Working copy  (@) now at: uuqppmxq 94f41578 (empty) (no description set)
+    Parent commit (@-)      : zzzzzzzz 00000000 (empty) (no description set)
+    [EOF]
+    "#);
+    let secondary_repo = git::open(test_env.env_root().join("secondary"));
+    assert_eq!(git_head(&secondary_repo), "refs/jj/root");
+
+    main_dir.write_file("file", "contents");
+    main_dir.run_jj(["commit", "-m", "initial"]).success();
+
+    // Same for a workspace whose working-copy commit has the root commit as
+    // its parent: there is no Git commit to point HEAD at, so it must land on
+    // jj's unborn placeholder.
+    let output = main_dir.run_jj(["workspace", "add", "-r", "root()", "../tertiary"]);
+    insta::assert_snapshot!(output.normalize_backslash(), @r#"
+    ------- stderr -------
+    Created Git worktree for the new workspace.
+    Created workspace in "../tertiary"
+    Working copy  (@) now at: rzvqmyuk 42960ba4 (empty) (no description set)
+    Parent commit (@-)      : zzzzzzzz 00000000 (empty) (no description set)
+    [EOF]
+    "#);
+    let tertiary_repo = git::open(test_env.env_root().join("tertiary"));
+    assert_eq!(git_head(&tertiary_repo), "refs/jj/root");
+    assert!(!test_env.env_root().join("tertiary/file").exists());
+}
+
+/// Returns the repo's Git HEAD: the ref name if HEAD points at a ref, or the
+/// commit id if HEAD is detached.
+fn git_head(repo: &gix::Repository) -> String {
+    match repo.head().unwrap().kind {
+        gix::head::Kind::Unborn(name) => name.as_bstr().to_string(),
+        gix::head::Kind::Symbolic(reference) => reference.name.as_bstr().to_string(),
+        gix::head::Kind::Detached { target, .. } => target.to_string(),
+    }
+}
+
+fn local_branches(repo: &gix::Repository) -> Vec<String> {
+    let mut names = repo
+        .references()
+        .unwrap()
+        .local_branches()
+        .unwrap()
+        .map(|reference| reference.unwrap().name().as_bstr().to_string())
+        .collect::<Vec<_>>();
+    names.sort();
+    names
+}
+
+/// Returns the ids of the linked Git worktrees registered in the repo.
+fn git_worktree_ids(repo: &gix::Repository) -> Vec<String> {
+    let mut ids = repo
+        .worktrees()
+        .unwrap()
+        .iter()
+        .map(|proxy| proxy.id().to_string())
+        .collect::<Vec<_>>();
+    ids.sort();
+    ids
+}
+
 #[must_use]
 fn get_log_output(work_dir: &TestWorkDir) -> CommandOutput {
     let template = r#"

--- a/docs/install-and-setup.md
+++ b/docs/install-and-setup.md
@@ -215,7 +215,7 @@ cd /usr/ports/devel/jujutsu/ && make install clean
 
 ## Runtime Requirements
 
-You will need git 2.41.0 or above. On older systems (e.g. Debian 11, Ubuntu
+You will need git 2.42.0 or above. On older systems (e.g. Debian 11, Ubuntu
 22.04) you will need to [upgrade Git](https://git-scm.com/install/).
 
 ## Initial configuration

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -93,6 +93,10 @@ const REMOTE_BOOKMARK_REF_NAMESPACE: &str = "refs/remotes/";
 /// Git ref prefix where remote tags will be temporarily fetched.
 const REMOTE_TAG_REF_NAMESPACE: &str = "refs/jj/remote-tags/";
 /// Ref name used as a placeholder to unset HEAD without a commit.
+///
+/// This is not a normal branch ref, and is deliberately left unborn: HEAD is
+/// pointed at it symbolically while the ref itself is kept nonexistent. That
+/// is how jj represents "HEAD has no commit yet".
 const UNBORN_ROOT_REF_NAME: &str = "refs/jj/root";
 /// Dummy file to be added to the index to indicate that the user is editing a
 /// commit with a conflict that isn't represented in the Git index.
@@ -1816,6 +1820,109 @@ fn update_git_head(
     });
     git_repo.edit_references(ref_edits)?;
     Ok(())
+}
+
+#[derive(Debug, Error)]
+pub enum GitCreateWorktreeError {
+    #[error(transparent)]
+    Subprocess(#[from] GitSubprocessError),
+    #[error(transparent)]
+    Git(Box<dyn std::error::Error + Send + Sync>),
+    #[error(transparent)]
+    UnexpectedBackend(#[from] UnexpectedGitBackendError),
+}
+
+impl GitCreateWorktreeError {
+    fn from_git(source: impl Into<Box<dyn std::error::Error + Send + Sync>>) -> Self {
+        Self::Git(source.into())
+    }
+}
+
+/// Creates a Git worktree at `destination` to back a new jj workspace.
+///
+/// The worktree is created empty, with HEAD unborn. jj populates the working
+/// copy itself, and the subsequent HEAD export (see [`reset_head()`]) points
+/// HEAD at the parent of the new working-copy commit. Git is only responsible
+/// for the `.git` gitlink and the worktree bookkeeping under
+/// `.git/worktrees/`.
+pub fn create_worktree(
+    store: &Store,
+    subprocess_options: GitSubprocessOptions,
+    destination: &Path,
+) -> Result<(), GitCreateWorktreeError> {
+    let git_backend = get_git_backend(store)?;
+
+    // The unborn branch `git worktree add --orphan` insists on naming gets a
+    // random name: any name we could derive from the destination may already
+    // be taken by an exported bookmark.
+    let branch_name = format!("jj-worktree-{:016x}", rand::random::<u64>());
+    let git_ctx = GitSubprocessContext::from_git_backend(git_backend, subprocess_options);
+    git_ctx.spawn_worktree_add(destination, &branch_name)?;
+
+    // Nullifying HEAD puts the worktree in the same "HEAD has no commit yet"
+    // state jj uses everywhere else, so that a `git commit` in the new
+    // worktree can't materialize the branch nobody asked for. If the
+    // working-copy commit turns out to have a real parent, the HEAD export
+    // replaces this with a detached HEAD.
+    let git_repo = git_backend
+        .open_git_repo_at_workdir(destination)
+        .map_err(GitCreateWorktreeError::from_git)?;
+    let unborn_branch = gix::refs::Target::Symbolic(
+        format!("refs/heads/{branch_name}")
+            .try_into()
+            .expect("valid ref name"),
+    );
+    update_git_head(
+        &git_repo,
+        gix::refs::transaction::PreviousValue::MustExistAndMatch(unborn_branch),
+        None,
+    )
+    .map_err(GitCreateWorktreeError::from_git)
+}
+
+#[derive(Debug, Error)]
+pub enum GitUnlinkWorktreeError {
+    #[error("Failed to remove .git gitlink file")]
+    RemoveGitLink(#[source] PathError),
+    #[error(transparent)]
+    Subprocess(#[from] GitSubprocessError),
+    #[error(transparent)]
+    UnexpectedBackend(#[from] UnexpectedGitBackendError),
+}
+
+/// Disconnects the Git worktree at `worktree_path` from the repository.
+///
+/// Returns `false` if there was no Git worktree to disconnect.
+///
+/// The worktree directory and its contents are left in place: only the `.git`
+/// gitlink and Git's bookkeeping under `.git/worktrees/` are removed. This is
+/// the inverse of [`create_worktree()`], which likewise only sets those up.
+///
+/// The gitlink is removed before the bookkeeping is pruned, so an error means
+/// either that nothing was done, or that the worktree is already disconnected
+/// and only stale metadata remains. Neither is worth failing a command over,
+/// so callers may treat all errors as non-fatal.
+pub fn unlink_worktree(
+    store: &Store,
+    subprocess_options: GitSubprocessOptions,
+    worktree_path: &Path,
+) -> Result<bool, GitUnlinkWorktreeError> {
+    let dot_git = worktree_path.join(".git");
+    if !dot_git.is_file() {
+        return Ok(false);
+    }
+    let git_backend = get_git_backend(store)?;
+    // `git worktree remove` isn't used because it deletes the directory
+    // contents, and forgetting a workspace should preserve its files.
+    std::fs::remove_file(&dot_git)
+        .context(&dot_git)
+        .map_err(GitUnlinkWorktreeError::RemoveGitLink)?;
+    // TODO: `git worktree prune` removes metadata for all worktrees whose
+    // working directories are missing, not just the one we removed. Ideally
+    // we'd target only the specific worktree.
+    let git_ctx = GitSubprocessContext::from_git_backend(git_backend, subprocess_options);
+    git_ctx.spawn_worktree_prune()?;
+    Ok(true)
 }
 
 #[derive(Debug, Error)]

--- a/lib/src/git_subprocess.rs
+++ b/lib/src/git_subprocess.rs
@@ -16,6 +16,7 @@ use std::io;
 use std::io::BufReader;
 use std::io::Read;
 use std::num::NonZeroU32;
+use std::path::Path;
 use std::path::PathBuf;
 use std::process::Child;
 use std::process::Command;
@@ -43,8 +44,9 @@ use crate::ref_name::RemoteName;
 // * 2.29.0 introduced `git fetch --no-write-fetch-head`
 // * 2.40 still receives security patches (latest one was in Jan/2025)
 // * 2.41.0 introduced `git fetch --porcelain`
+// * 2.42.0 introduced `git worktree add --orphan`
 // If bumped, please update ../../docs/install-and-setup.md
-const MINIMUM_GIT_VERSION: &str = "2.41.0";
+const MINIMUM_GIT_VERSION: &str = "2.42.0";
 
 /// Error originating by a Git subprocess
 #[derive(Error, Debug)]
@@ -296,6 +298,44 @@ impl GitSubprocessContext {
 
         parse_git_push_output(output)
     }
+
+    /// Create a Git worktree at `destination` on the unborn branch
+    /// `branch_name`.
+    ///
+    /// `--orphan` is what lets the worktree be created without checking
+    /// anything out, and without requiring the repo to have any commits. It
+    /// insists on naming a branch (it rejects `--detach` and `--no-checkout`),
+    /// but leaves that branch unborn, so the caller can move HEAD off it
+    /// before anyone sees the worktree.
+    pub(crate) fn spawn_worktree_add(
+        &self,
+        destination: &Path,
+        branch_name: &str,
+    ) -> Result<(), GitSubprocessError> {
+        let mut command = self.create_command();
+        command.stdout(Stdio::null());
+        // Use relative paths to match jj's convention for portable
+        // repositories. Silently ignored by git versions that don't support
+        // it.
+        command.args(["-c", "worktree.useRelativePaths=true"]);
+        command.args(["worktree", "add", "--orphan", "-b", branch_name, "--"]);
+        command.arg(destination);
+
+        let output = wait_with_output(self.spawn_cmd(command)?)?;
+
+        parse_git_worktree_output(output)
+    }
+
+    /// Remove the bookkeeping of worktrees whose directories are gone.
+    pub(crate) fn spawn_worktree_prune(&self) -> Result<(), GitSubprocessError> {
+        let mut command = self.create_command();
+        command.stdout(Stdio::null());
+        command.args(["worktree", "prune"]);
+
+        let output = wait_with_output(self.spawn_cmd(command)?)?;
+
+        parse_git_worktree_output(output)
+    }
 }
 
 /// Generate a GitSubprocessError::ExternalGitError if the stderr output was not
@@ -508,6 +548,18 @@ fn parse_git_branch_prune_output(output: Output) -> Result<(), GitSubprocessErro
 
     if parse_no_remote_tracking_branch(&output.stderr).is_some() {
         return Ok(());
+    }
+
+    Err(external_git_error(&output.stderr))
+}
+
+fn parse_git_worktree_output(output: Output) -> Result<(), GitSubprocessError> {
+    if output.status.success() {
+        return Ok(());
+    }
+
+    if let Some(option) = parse_unknown_option(&output.stderr) {
+        return Err(GitSubprocessError::UnsupportedGitOption(option));
     }
 
     Err(external_git_error(&output.stderr))


### PR DESCRIPTION
`jj workspace add` gains `--colocate`/`--no-colocate` to control whether a Git
worktree is created alongside the jj workspace. With neither flag, a worktree is
created only when the current workspace is colocated **and** `git.colocate` is
`true`, so colocation is inherited from the repo rather than forced on by the
global default.

The worktree is created with `git worktree add --orphan`, which sets up the
`.git` gitlink and the bookkeeping under `.git/worktrees/` without checking
anything out. jj populates the working copy itself, and the HEAD export at the
end of the transaction points Git HEAD at the parent of the new working-copy
commit. Git is never asked to resolve a revision, so `jj workspace add -r <rev>`
yields a Git HEAD matching the requested revision rather than the main
workspace's HEAD

`--orphan` insists on naming a branch, so a random name is used: any name
derived from the destination could collide with an exported bookmark. That
branch is left unborn, and HEAD is immediately repointed at `refs/jj/root`,
jj's existing placeholder for "HEAD has no commit yet". A `git commit` in the
new worktree therefore cannot materialize a branch nobody asked for, and adding
a workspace to a repo with no commits now works instead of being refused.

`jj workspace forget` removes the corresponding Git worktree when one exists by
deleting the `.git` gitlink file and pruning the worktree metadata, preserving
the workspace directory contents.

`git worktree add --orphan` requires Git 2.42, so `MINIMUM_GIT_VERSION` goes
from 2.41.0 to 2.42.0.

For non-colocated repos, behavior is unchanged.

CC: @yuja

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
  how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
  an eye towards deleting anything that is irrelevant, clarifying anything
  that is confusing, and adding details that are relevant. This includes,
  for example, commit descriptions, PR descriptions, and code comments.
