### PR TITLE
repo: expose change_id_index()

### DIFF
--- a/cli/src/commit_templater.rs
+++ b/cli/src/commit_templater.rs
@@ -52,6 +52,7 @@ use jj_lib::fileset::FilesetExpression;
 use jj_lib::fileset::FilesetParseContext;
 use jj_lib::id_prefix::IdPrefixContext;
 use jj_lib::id_prefix::IdPrefixIndex;
+use jj_lib::id_prefix::resolve_change_id;
 use jj_lib::index::IndexResult;
 use jj_lib::matchers::Matcher;
 use jj_lib::merge::Diff;
@@ -1242,7 +1243,7 @@ fn builtin_commit_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, Comm
             let repo = language.repo;
             let out_property = self_property.and_then(|commit| {
                 // The given commit could be hidden in e.g. `jj evolog`.
-                let maybe_targets = repo.resolve_change_id(commit.change_id())?;
+                let maybe_targets = resolve_change_id(repo, commit.change_id())?;
                 let divergent = maybe_targets.is_some_and(|targets| targets.is_divergent());
                 Ok(divergent)
             });
@@ -1265,7 +1266,7 @@ fn builtin_commit_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, Comm
             let repo = language.repo;
             let out_property = self_property.and_then(|commit| {
                 // The given commit could be hidden in e.g. `jj evolog`.
-                let maybe_targets = repo.resolve_change_id(commit.change_id())?;
+                let maybe_targets = resolve_change_id(repo, commit.change_id())?;
                 let offset = maybe_targets
                     .and_then(|targets| targets.find_offset(commit.id()))
                     .map(i64::try_from)

--- a/lib/src/commit.rs
+++ b/lib/src/commit.rs
@@ -33,6 +33,7 @@ use crate::backend::CommitId;
 use crate::backend::Signature;
 use crate::backend::TreeId;
 use crate::conflict_labels::ConflictLabels;
+use crate::id_prefix::resolve_change_id;
 use crate::index::IndexResult;
 use crate::merge::Merge;
 use crate::merged_tree::MergedTree;
@@ -190,7 +191,7 @@ impl Commit {
 
     ///  A commit is hidden if its commit id is not in the change id index.
     pub fn is_hidden(&self, repo: &dyn Repo) -> IndexResult<bool> {
-        let maybe_targets = repo.resolve_change_id(self.change_id())?;
+        let maybe_targets = resolve_change_id(repo, self.change_id())?;
         Ok(maybe_targets.is_none_or(|targets| !targets.has_visible(&self.id)))
     }
 

--- a/lib/src/converge.rs
+++ b/lib/src/converge.rs
@@ -42,6 +42,7 @@ use jj_lib::evolution::walk_predecessors;
 use jj_lib::graph_dominators::FlowGraph;
 use jj_lib::graph_dominators::SimpleDirectedGraph;
 use jj_lib::graph_dominators::ValueCache;
+use jj_lib::id_prefix::resolve_change_id;
 use jj_lib::index::IndexError;
 use jj_lib::merge::Merge;
 use jj_lib::merge::MergeBuilder;
@@ -651,9 +652,10 @@ where
     // But some commits are not given as input, so we use CommitId as tertiary
     // sorting criterion.
 
-    let resolved_change_targets = truncated_evolution_graph
-        .repo()
-        .resolve_change_id(truncated_evolution_graph.change_id())?;
+    let resolved_change_targets = resolve_change_id(
+        truncated_evolution_graph.repo().as_ref(),
+        truncated_evolution_graph.change_id(),
+    )?;
     let input_position: HashMap<&CommitId, usize> = truncated_evolution_graph
         .divergent_commit_ids()
         .iter()

--- a/lib/src/id_prefix.rs
+++ b/lib/src/id_prefix.rs
@@ -146,6 +146,19 @@ impl IdPrefixContext {
     }
 }
 
+/// Resolves a complete change ID in the repository.
+pub fn resolve_change_id(
+    repo: &dyn Repo,
+    change_id: &ChangeId,
+) -> IndexResult<Option<ResolvedChangeTargets>> {
+    let prefix = HexPrefix::from_id(change_id);
+    match repo.change_id_index().resolve_prefix(&prefix)? {
+        PrefixResolution::NoMatch => Ok(None),
+        PrefixResolution::SingleMatch(entries) => Ok(Some(entries)),
+        PrefixResolution::AmbiguousMatch => panic!("complete change ID should be unambiguous"),
+    }
+}
+
 /// Loaded index to disambiguate commit/change IDs.
 pub struct IdPrefixIndex<'a> {
     indexes: Option<&'a Indexes>,
@@ -233,7 +246,7 @@ impl IdPrefixIndex<'_> {
                     // Fall back to resolving in entire repo
                 }
                 PrefixResolution::SingleMatch(change_id) => {
-                    return match repo.resolve_change_id(&change_id)? {
+                    return match resolve_change_id(repo, &change_id)? {
                         // There may be more commits with this change id outside the narrower sets.
                         Some(commit_ids) => Ok(PrefixResolution::SingleMatch(commit_ids)),
                         // The disambiguation set may contain hidden commits.
@@ -245,7 +258,7 @@ impl IdPrefixIndex<'_> {
                 }
             }
         }
-        repo.resolve_change_id_prefix(prefix)
+        repo.change_id_index().resolve_prefix(prefix)
     }
 
     /// Returns the shortest length of a prefix of `change_id` that can still be
@@ -275,7 +288,7 @@ impl IdPrefixIndex<'_> {
         {
             return Ok(lookup.shortest_unique_prefix_len());
         }
-        repo.shortest_unique_change_id_prefix_len(change_id)
+        repo.change_id_index().shortest_unique_prefix_len(change_id)
     }
 }
 

--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -60,13 +60,10 @@ use crate::index::IndexStore;
 use crate::index::IndexStoreError;
 use crate::index::MutableIndex;
 use crate::index::ReadonlyIndex;
-use crate::index::ResolvedChangeTargets;
 use crate::merge::MergeBuilder;
 use crate::merge::SameChange;
 use crate::merge::trivial_merge;
 use crate::merged_tree::MergedTree;
-use crate::object_id::HexPrefix;
-use crate::object_id::PrefixResolution;
 use crate::op_heads_store;
 use crate::op_heads_store::OpHeadsStore;
 use crate::op_heads_store::OpHeadsStoreError;
@@ -131,28 +128,7 @@ pub trait Repo {
 
     fn submodule_store(&self) -> &Arc<dyn SubmoduleStore>;
 
-    fn resolve_change_id(
-        &self,
-        change_id: &ChangeId,
-    ) -> IndexResult<Option<ResolvedChangeTargets>> {
-        // Replace this if we added more efficient lookup method.
-        let prefix = HexPrefix::from_id(change_id);
-        match self.resolve_change_id_prefix(&prefix)? {
-            PrefixResolution::NoMatch => Ok(None),
-            PrefixResolution::SingleMatch(entries) => Ok(Some(entries)),
-            PrefixResolution::AmbiguousMatch => panic!("complete change_id should be unambiguous"),
-        }
-    }
-
-    fn resolve_change_id_prefix(
-        &self,
-        prefix: &HexPrefix,
-    ) -> IndexResult<PrefixResolution<ResolvedChangeTargets>>;
-
-    fn shortest_unique_change_id_prefix_len(
-        &self,
-        target_id_bytes: &ChangeId,
-    ) -> IndexResult<usize>;
+    fn change_id_index(&self) -> Box<dyn ChangeIdIndex + '_>;
 }
 
 pub struct ReadonlyRepo {
@@ -309,15 +285,6 @@ impl ReadonlyRepo {
         self.index.as_ref()
     }
 
-    fn change_id_index(&self) -> &dyn ChangeIdIndex {
-        self.change_id_index
-            .get_or_init(|| {
-                self.readonly_index()
-                    .change_id_index(&mut self.view().heads().iter())
-            })
-            .as_ref()
-    }
-
     pub fn op_heads_store(&self) -> &Arc<dyn OpHeadsStore> {
         self.loader.op_heads_store()
     }
@@ -370,15 +337,9 @@ impl Repo for ReadonlyRepo {
         self.loader.submodule_store()
     }
 
-    fn resolve_change_id_prefix(
-        &self,
-        prefix: &HexPrefix,
-    ) -> IndexResult<PrefixResolution<ResolvedChangeTargets>> {
-        self.change_id_index().resolve_prefix(prefix)
-    }
-
-    fn shortest_unique_change_id_prefix_len(&self, target_id: &ChangeId) -> IndexResult<usize> {
-        self.change_id_index().shortest_unique_prefix_len(target_id)
+    fn change_id_index(&self) -> Box<dyn ChangeIdIndex + '_> {
+        self.readonly_index()
+            .change_id_index(&mut self.view().heads().iter())
     }
 }
 
@@ -2130,17 +2091,8 @@ impl Repo for MutableRepo {
         self.base_repo.submodule_store()
     }
 
-    fn resolve_change_id_prefix(
-        &self,
-        prefix: &HexPrefix,
-    ) -> IndexResult<PrefixResolution<ResolvedChangeTargets>> {
-        let change_id_index = self.index.change_id_index(&mut self.view().heads().iter());
-        change_id_index.resolve_prefix(prefix)
-    }
-
-    fn shortest_unique_change_id_prefix_len(&self, target_id: &ChangeId) -> IndexResult<usize> {
-        let change_id_index = self.index.change_id_index(&mut self.view().heads().iter());
-        change_id_index.shortest_unique_prefix_len(target_id)
+    fn change_id_index(&self) -> Box<dyn ChangeIdIndex + '_> {
+        self.index.change_id_index(&mut self.view().heads().iter())
     }
 }
 

--- a/lib/src/rewrite.rs
+++ b/lib/src/rewrite.rs
@@ -37,6 +37,7 @@ use crate::commit::CommitIteratorExt as _;
 use crate::commit::conflict_label_for_commits;
 use crate::commit_builder::CommitBuilder;
 use crate::conflict_labels::ConflictLabels;
+use crate::id_prefix::resolve_change_id;
 use crate::index::Index;
 use crate::index::IndexResult;
 use crate::index::ResolvedChangeTargets;
@@ -1511,8 +1512,7 @@ pub async fn find_duplicate_divergent_commits(
     let divergent_changes: Vec<(&Commit, Vec<CommitId>)> = target_commits
         .iter()
         .map(|target_commit| -> Result<_, BackendError> {
-            let mut ancestor_candidates = repo
-                .resolve_change_id(target_commit.change_id())
+            let mut ancestor_candidates = resolve_change_id(repo, target_commit.change_id())
                 // TODO: indexing error shouldn't be a "BackendError"
                 .map_err(|err| BackendError::Other(err.into()))?
                 .and_then(ResolvedChangeTargets::into_visible)

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -65,6 +65,7 @@ use jj_lib::git::expand_fetch_refspecs;
 use jj_lib::git::load_default_fetch_bookmarks;
 use jj_lib::git_backend::GitBackend;
 use jj_lib::hex_util;
+use jj_lib::id_prefix::resolve_change_id;
 use jj_lib::index::ResolvedChangeTargets;
 use jj_lib::merge::Diff;
 use jj_lib::merge::Merge;
@@ -6209,12 +6210,12 @@ fn test_rewrite_imported_commit() -> TestResult {
 
     // The index should be consistent with the store.
     assert_eq!(
-        repo.resolve_change_id(imported_commit.change_id())?
+        resolve_change_id(repo.as_ref(), imported_commit.change_id())?
             .and_then(ResolvedChangeTargets::into_visible),
         Some(vec![imported_commit.id().clone()]),
     );
     assert_eq!(
-        repo.resolve_change_id(authored_commit.change_id())?
+        resolve_change_id(repo.as_ref(), authored_commit.change_id())?
             .and_then(ResolvedChangeTargets::into_visible),
         Some(vec![authored_commit.id().clone()]),
     );
@@ -6277,7 +6278,7 @@ fn test_concurrent_write_commit() -> TestResult {
         assert!(repo.index().has_id(commit_id)?);
         let commit = repo.store().get_commit(commit_id)?;
         assert_eq!(
-            repo.resolve_change_id(commit.change_id())?
+            resolve_change_id(repo.as_ref(), commit.change_id())?
                 .and_then(ResolvedChangeTargets::into_visible),
             Some(vec![commit_id.clone()]),
         );
@@ -6404,7 +6405,7 @@ fn test_concurrent_read_write_commit() -> TestResult {
         assert!(repo.index().has_id(commit_id)?);
         let commit = repo.store().get_commit(commit_id)?;
         assert_eq!(
-            repo.resolve_change_id(commit.change_id())?
+            resolve_change_id(repo.as_ref(), commit.change_id())?
                 .and_then(ResolvedChangeTargets::into_visible),
             Some(vec![commit_id.clone()]),
         );


### PR DESCRIPTION
I was converting `ChangeIdIndex` as part of ongoing async index conversion. These methods seemed unnessasary.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
