### PR TITLE
index: turn ChangeIdIndex trait async

### DIFF
--- a/cli/src/commit_templater.rs
+++ b/cli/src/commit_templater.rs
@@ -1242,7 +1242,7 @@ fn builtin_commit_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, Comm
             let repo = language.repo;
             let out_property = self_property.and_then(|commit| {
                 // The given commit could be hidden in e.g. `jj evolog`.
-                let maybe_targets = repo.resolve_change_id(commit.change_id())?;
+                let maybe_targets = repo.resolve_change_id(commit.change_id()).block_on()?;
                 let divergent = maybe_targets.is_some_and(|targets| targets.is_divergent());
                 Ok(divergent)
             });
@@ -1254,7 +1254,8 @@ fn builtin_commit_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, Comm
         |language, _diagnostics, _build_ctx, self_property, function| {
             function.expect_no_arguments()?;
             let repo = language.repo;
-            let out_property = self_property.and_then(|commit| Ok(commit.is_hidden(repo)?));
+            let out_property =
+                self_property.and_then(|commit| Ok(commit.is_hidden(repo).block_on()?));
             Ok(out_property.into_dyn_wrapped())
         },
     );
@@ -1265,7 +1266,7 @@ fn builtin_commit_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, Comm
             let repo = language.repo;
             let out_property = self_property.and_then(|commit| {
                 // The given commit could be hidden in e.g. `jj evolog`.
-                let maybe_targets = repo.resolve_change_id(commit.change_id())?;
+                let maybe_targets = repo.resolve_change_id(commit.change_id()).block_on()?;
                 let offset = maybe_targets
                     .and_then(|targets| targets.find_offset(commit.id()))
                     .map(i64::try_from)
@@ -2114,7 +2115,7 @@ trait ShortestIdPrefixLen {
 
 impl ShortestIdPrefixLen for ChangeId {
     fn shortest_prefix_len(&self, repo: &dyn Repo, index: &IdPrefixIndex) -> IndexResult<usize> {
-        index.shortest_change_prefix_len(repo, self)
+        index.shortest_change_prefix_len(repo, self).block_on()
     }
 }
 

--- a/lib/src/commit.rs
+++ b/lib/src/commit.rs
@@ -189,8 +189,8 @@ impl Commit {
     }
 
     ///  A commit is hidden if its commit id is not in the change id index.
-    pub fn is_hidden(&self, repo: &dyn Repo) -> IndexResult<bool> {
-        let maybe_targets = repo.resolve_change_id(self.change_id())?;
+    pub async fn is_hidden(&self, repo: &dyn Repo) -> IndexResult<bool> {
+        let maybe_targets = repo.resolve_change_id(self.change_id()).await?;
         Ok(maybe_targets.is_none_or(|targets| !targets.has_visible(&self.id)))
     }
 

--- a/lib/src/converge.rs
+++ b/lib/src/converge.rs
@@ -529,7 +529,7 @@ async fn converge_trees(
         .await
         .map_err(|e| ConvergeError::Other(e.into()))?;
     let dominator_producer =
-        get_value_producer(truncated_evolution_graph, &dominator_value, &value_cache)?;
+        get_value_producer(truncated_evolution_graph, &dominator_value, &value_cache).await?;
 
     let base_commit = repo.store().get_commit_async(&dominator_producer).await?;
     let rebased_resolved_trees = Arc::try_unwrap(rebased_resolved_trees)
@@ -612,7 +612,7 @@ where
         .find_dominator_value_with_value_cache(divergent_commits.clone(), &mut value_cache)
         .await
         .map_err(|e| ConvergeError::Other(e.into()))?;
-    let dominator_producer = get_value_producer(graph, &dominator_value, &value_cache)?;
+    let dominator_producer = get_value_producer(graph, &dominator_value, &value_cache).await?;
 
     let mut merge_builder = MergeBuilder::default();
     // ADD
@@ -627,7 +627,7 @@ where
 
 /// Returns a commit that produces a given value (e.g. finds a commit that
 /// produces a given description). The value must be present in value_cache.
-fn get_value_producer<T, VF>(
+async fn get_value_producer<T, VF>(
     truncated_evolution_graph: &TruncatedEvolutionGraph,
     value: &Rc<T>,
     value_cache: &ValueCache<CommitId, T, VF>,
@@ -653,7 +653,8 @@ where
 
     let resolved_change_targets = truncated_evolution_graph
         .repo()
-        .resolve_change_id(truncated_evolution_graph.change_id())?;
+        .resolve_change_id(truncated_evolution_graph.change_id())
+        .await?;
     let input_position: HashMap<&CommitId, usize> = truncated_evolution_graph
         .divergent_commit_ids()
         .iter()

--- a/lib/src/default_index/composite.rs
+++ b/lib/src/default_index/composite.rs
@@ -684,13 +684,14 @@ impl<I: AsCompositeIndex> ChangeIdIndexImpl<I> {
     }
 }
 
+#[async_trait]
 impl<I: AsCompositeIndex + Send + Sync> ChangeIdIndex for ChangeIdIndexImpl<I> {
     // Resolves change ID prefix among all IDs.
     //
     // If `SingleMatch` is returned, there is at least one commit with the given
     // change ID (either visible or hidden). `AmbiguousMatch` may be returned even
     // if the prefix is unique within the visible entries.
-    fn resolve_prefix(
+    async fn resolve_prefix(
         &self,
         prefix: &HexPrefix,
     ) -> IndexResult<PrefixResolution<ResolvedChangeTargets>> {
@@ -709,7 +710,7 @@ impl<I: AsCompositeIndex + Send + Sync> ChangeIdIndex for ChangeIdIndexImpl<I> {
     // The returned length is usually a few digits longer than the minimum
     // length necessary to disambiguate within the visible entries since hidden
     // entries are also considered when determining the prefix length.
-    fn shortest_unique_prefix_len(&self, change_id: &ChangeId) -> IndexResult<usize> {
+    async fn shortest_unique_prefix_len(&self, change_id: &ChangeId) -> IndexResult<usize> {
         let index = self.index.as_composite().commits();
         Ok(index.shortest_unique_change_id_prefix_len(change_id))
     }

--- a/lib/src/id_prefix.rs
+++ b/lib/src/id_prefix.rs
@@ -219,7 +219,7 @@ impl IdPrefixIndex<'_> {
     }
 
     /// Resolve an unambiguous change ID prefix to the commit IDs in the revset.
-    pub fn resolve_change_prefix(
+    pub async fn resolve_change_prefix(
         &self,
         repo: &dyn Repo,
         prefix: &HexPrefix,
@@ -233,7 +233,7 @@ impl IdPrefixIndex<'_> {
                     // Fall back to resolving in entire repo
                 }
                 PrefixResolution::SingleMatch(change_id) => {
-                    return match repo.resolve_change_id(&change_id)? {
+                    return match repo.resolve_change_id(&change_id).await? {
                         // There may be more commits with this change id outside the narrower sets.
                         Some(commit_ids) => Ok(PrefixResolution::SingleMatch(commit_ids)),
                         // The disambiguation set may contain hidden commits.
@@ -245,17 +245,19 @@ impl IdPrefixIndex<'_> {
                 }
             }
         }
-        repo.resolve_change_id_prefix(prefix)
+        repo.resolve_change_id_prefix(prefix).await
     }
 
     /// Returns the shortest length of a prefix of `change_id` that can still be
     /// resolved by `resolve_change_prefix()` and [`SymbolResolver`].
-    pub fn shortest_change_prefix_len(
+    pub async fn shortest_change_prefix_len(
         &self,
         repo: &dyn Repo,
         change_id: &ChangeId,
     ) -> IndexResult<usize> {
-        let len = self.shortest_change_prefix_len_exact(repo, change_id)?;
+        let len = self
+            .shortest_change_prefix_len_exact(repo, change_id)
+            .await?;
         Ok(disambiguate_prefix_with_refs(
             repo.view(),
             &change_id.to_string(),
@@ -263,7 +265,7 @@ impl IdPrefixIndex<'_> {
         ))
     }
 
-    fn shortest_change_prefix_len_exact(
+    async fn shortest_change_prefix_len_exact(
         &self,
         repo: &dyn Repo,
         change_id: &ChangeId,
@@ -275,7 +277,7 @@ impl IdPrefixIndex<'_> {
         {
             return Ok(lookup.shortest_unique_prefix_len());
         }
-        repo.shortest_unique_change_id_prefix_len(change_id)
+        repo.shortest_unique_change_id_prefix_len(change_id).await
     }
 }
 

--- a/lib/src/index.rs
+++ b/lib/src/index.rs
@@ -287,9 +287,10 @@ impl ResolvedChangeTargets {
 
 /// Defines the interface for types that provide an index of the commits in a
 /// repository by [`ChangeId`].
+#[async_trait]
 pub trait ChangeIdIndex: Send + Sync {
     /// Resolve an unambiguous change ID prefix to the commit IDs in the index.
-    fn resolve_prefix(
+    async fn resolve_prefix(
         &self,
         prefix: &HexPrefix,
     ) -> IndexResult<PrefixResolution<ResolvedChangeTargets>>;
@@ -308,5 +309,5 @@ pub trait ChangeIdIndex: Send + Sync {
     ///   order to disambiguate, you need every letter of the key *and* the
     ///   additional fact that it's the entire key). This case is extremely
     ///   unlikely for hashes with 12+ hexadecimal characters.
-    fn shortest_unique_prefix_len(&self, change_id: &ChangeId) -> IndexResult<usize>;
+    async fn shortest_unique_prefix_len(&self, change_id: &ChangeId) -> IndexResult<usize>;
 }

--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -25,6 +25,7 @@ use std::path::Path;
 use std::slice;
 use std::sync::Arc;
 
+use async_trait::async_trait;
 use futures::StreamExt as _;
 use futures::TryStreamExt as _;
 use futures::future::try_join_all;
@@ -116,6 +117,7 @@ use crate::tree_merge::MergeOptions;
 use crate::view::RenameWorkspaceError;
 use crate::view::View;
 
+#[async_trait(?Send)]
 pub trait Repo {
     /// Base repository that contains all committed data. Returns `self` if this
     /// is a `ReadonlyRepo`,
@@ -131,25 +133,25 @@ pub trait Repo {
 
     fn submodule_store(&self) -> &Arc<dyn SubmoduleStore>;
 
-    fn resolve_change_id(
+    async fn resolve_change_id(
         &self,
         change_id: &ChangeId,
     ) -> IndexResult<Option<ResolvedChangeTargets>> {
         // Replace this if we added more efficient lookup method.
         let prefix = HexPrefix::from_id(change_id);
-        match self.resolve_change_id_prefix(&prefix)? {
+        match self.resolve_change_id_prefix(&prefix).await? {
             PrefixResolution::NoMatch => Ok(None),
             PrefixResolution::SingleMatch(entries) => Ok(Some(entries)),
             PrefixResolution::AmbiguousMatch => panic!("complete change_id should be unambiguous"),
         }
     }
 
-    fn resolve_change_id_prefix(
+    async fn resolve_change_id_prefix(
         &self,
         prefix: &HexPrefix,
     ) -> IndexResult<PrefixResolution<ResolvedChangeTargets>>;
 
-    fn shortest_unique_change_id_prefix_len(
+    async fn shortest_unique_change_id_prefix_len(
         &self,
         target_id_bytes: &ChangeId,
     ) -> IndexResult<usize>;
@@ -345,6 +347,7 @@ impl ReadonlyRepo {
     }
 }
 
+#[async_trait(?Send)]
 impl Repo for ReadonlyRepo {
     fn base_repo(&self) -> &ReadonlyRepo {
         self
@@ -370,15 +373,20 @@ impl Repo for ReadonlyRepo {
         self.loader.submodule_store()
     }
 
-    fn resolve_change_id_prefix(
+    async fn resolve_change_id_prefix(
         &self,
         prefix: &HexPrefix,
     ) -> IndexResult<PrefixResolution<ResolvedChangeTargets>> {
-        self.change_id_index().resolve_prefix(prefix)
+        self.change_id_index().resolve_prefix(prefix).await
     }
 
-    fn shortest_unique_change_id_prefix_len(&self, target_id: &ChangeId) -> IndexResult<usize> {
-        self.change_id_index().shortest_unique_prefix_len(target_id)
+    async fn shortest_unique_change_id_prefix_len(
+        &self,
+        target_id: &ChangeId,
+    ) -> IndexResult<usize> {
+        self.change_id_index()
+            .shortest_unique_prefix_len(target_id)
+            .await
     }
 }
 
@@ -2105,6 +2113,7 @@ impl MutableRepo {
     }
 }
 
+#[async_trait(?Send)]
 impl Repo for MutableRepo {
     fn base_repo(&self) -> &ReadonlyRepo {
         &self.base_repo
@@ -2130,17 +2139,20 @@ impl Repo for MutableRepo {
         self.base_repo.submodule_store()
     }
 
-    fn resolve_change_id_prefix(
+    async fn resolve_change_id_prefix(
         &self,
         prefix: &HexPrefix,
     ) -> IndexResult<PrefixResolution<ResolvedChangeTargets>> {
         let change_id_index = self.index.change_id_index(&mut self.view().heads().iter());
-        change_id_index.resolve_prefix(prefix)
+        change_id_index.resolve_prefix(prefix).await
     }
 
-    fn shortest_unique_change_id_prefix_len(&self, target_id: &ChangeId) -> IndexResult<usize> {
+    async fn shortest_unique_change_id_prefix_len(
+        &self,
+        target_id: &ChangeId,
+    ) -> IndexResult<usize> {
         let change_id_index = self.index.change_id_index(&mut self.view().heads().iter());
-        change_id_index.shortest_unique_prefix_len(target_id)
+        change_id_index.shortest_unique_prefix_len(target_id).await
     }
 }
 

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -2785,6 +2785,7 @@ impl ChangePrefixResolver<'_> {
             .unwrap_or(IdPrefixIndex::empty());
         match index
             .resolve_change_prefix(repo, prefix)
+            .block_on()
             .map_err(|err| RevsetResolutionError::Other(err.into()))?
         {
             PrefixResolution::AmbiguousMatch => Err(

--- a/lib/src/rewrite.rs
+++ b/lib/src/rewrite.rs
@@ -22,6 +22,7 @@ use std::sync::Arc;
 
 use futures::StreamExt as _;
 use futures::TryStreamExt as _;
+use futures::future::ready;
 use futures::future::try_join_all;
 use futures::try_join;
 use indexmap::IndexMap;
@@ -1508,11 +1509,11 @@ pub async fn find_duplicate_divergent_commits(
 
     // For each divergent change being rebased, we want to find all of the other
     // commits with the same change ID which are not being rebased.
-    let divergent_changes: Vec<(&Commit, Vec<CommitId>)> = target_commits
-        .iter()
-        .map(|target_commit| -> Result<_, BackendError> {
+    let divergent_changes: Vec<_> = futures::stream::iter(&target_commits)
+        .map(async |target_commit| -> BackendResult<_> {
             let mut ancestor_candidates = repo
                 .resolve_change_id(target_commit.change_id())
+                .await
                 // TODO: indexing error shouldn't be a "BackendError"
                 .map_err(|err| BackendError::Other(err.into()))?
                 .and_then(ResolvedChangeTargets::into_visible)
@@ -1520,8 +1521,10 @@ pub async fn find_duplicate_divergent_commits(
             ancestor_candidates.retain(|commit_id| !target_commit_ids.contains(commit_id));
             Ok((target_commit, ancestor_candidates))
         })
-        .filter_ok(|(_, candidates)| !candidates.is_empty())
-        .try_collect()?;
+        .buffered(repo.store().concurrency())
+        .try_filter(|(_, candidates)| ready(!candidates.is_empty()))
+        .try_collect()
+        .await?;
     if divergent_changes.is_empty() {
         return Ok(Vec::new());
     }

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -6209,12 +6209,14 @@ fn test_rewrite_imported_commit() -> TestResult {
 
     // The index should be consistent with the store.
     assert_eq!(
-        repo.resolve_change_id(imported_commit.change_id())?
+        repo.resolve_change_id(imported_commit.change_id())
+            .block_on()?
             .and_then(ResolvedChangeTargets::into_visible),
         Some(vec![imported_commit.id().clone()]),
     );
     assert_eq!(
-        repo.resolve_change_id(authored_commit.change_id())?
+        repo.resolve_change_id(authored_commit.change_id())
+            .block_on()?
             .and_then(ResolvedChangeTargets::into_visible),
         Some(vec![authored_commit.id().clone()]),
     );
@@ -6277,7 +6279,8 @@ fn test_concurrent_write_commit() -> TestResult {
         assert!(repo.index().has_id(commit_id)?);
         let commit = repo.store().get_commit(commit_id)?;
         assert_eq!(
-            repo.resolve_change_id(commit.change_id())?
+            repo.resolve_change_id(commit.change_id())
+                .block_on()?
                 .and_then(ResolvedChangeTargets::into_visible),
             Some(vec![commit_id.clone()]),
         );
@@ -6404,7 +6407,8 @@ fn test_concurrent_read_write_commit() -> TestResult {
         assert!(repo.index().has_id(commit_id)?);
         let commit = repo.store().get_commit(commit_id)?;
         assert_eq!(
-            repo.resolve_change_id(commit.change_id())?
+            repo.resolve_change_id(commit.change_id())
+                .block_on()?
                 .and_then(ResolvedChangeTargets::into_visible),
             Some(vec![commit_id.clone()]),
         );

--- a/lib/tests/test_id_prefix.rs
+++ b/lib/tests/test_id_prefix.rs
@@ -160,11 +160,13 @@ fn test_id_prefix() -> TestResult {
     let shortest_change_prefix_len = |index: &IdPrefixIndex, change_id| {
         index
             .shortest_change_prefix_len(repo.as_ref(), change_id)
+            .block_on()
             .unwrap()
     };
     let resolve_change_prefix = |index: &IdPrefixIndex, prefix: HexPrefix| {
         index
             .resolve_change_prefix(repo.as_ref(), &prefix)
+            .block_on()
             .unwrap()
             .filter_map(ResolvedChangeTargets::into_visible)
     };
@@ -320,11 +322,13 @@ fn test_id_prefix_divergent() -> TestResult {
     let shortest_change_prefix_len = |index: &IdPrefixIndex, change_id| {
         index
             .shortest_change_prefix_len(repo.as_ref(), change_id)
+            .block_on()
             .unwrap()
     };
     let resolve_change_prefix = |index: &IdPrefixIndex, prefix: HexPrefix| {
         index
             .resolve_change_prefix(repo.as_ref(), &prefix)
+            .block_on()
             .unwrap()
             .filter_map(ResolvedChangeTargets::into_visible)
     };
@@ -479,11 +483,13 @@ fn test_id_prefix_hidden() -> TestResult {
     let shortest_change_prefix_len = |index: &IdPrefixIndex, change_id| {
         index
             .shortest_change_prefix_len(repo.as_ref(), change_id)
+            .block_on()
             .unwrap()
     };
     let resolve_change_prefix = |index: &IdPrefixIndex, prefix: HexPrefix| {
         index
             .resolve_change_prefix(repo.as_ref(), &prefix)
+            .block_on()
             .unwrap()
             .filter_map(ResolvedChangeTargets::into_visible)
     };
@@ -568,8 +574,12 @@ fn test_id_prefix_shadowed_by_ref() {
     let index = context.populate(tx.repo()).unwrap();
     let shortest_commit_prefix_len =
         |repo: &MutableRepo, commit_id| index.shortest_commit_prefix_len(repo, commit_id).unwrap();
-    let shortest_change_prefix_len =
-        |repo: &MutableRepo, change_id| index.shortest_change_prefix_len(repo, change_id).unwrap();
+    let shortest_change_prefix_len = |repo: &MutableRepo, change_id| {
+        index
+            .shortest_change_prefix_len(repo, change_id)
+            .block_on()
+            .unwrap()
+    };
 
     assert_eq!(shortest_commit_prefix_len(tx.repo(), commit.id()), 1);
     assert_eq!(shortest_change_prefix_len(tx.repo(), commit.change_id()), 1);

--- a/lib/tests/test_index.rs
+++ b/lib/tests/test_index.rs
@@ -1175,6 +1175,7 @@ fn test_change_id_index() {
     let prefix_len = |commit: &Commit| {
         change_id_index
             .shortest_unique_prefix_len(commit.change_id())
+            .block_on()
             .unwrap()
     };
     assert_eq!(prefix_len(&root_commit), 1);
@@ -1186,6 +1187,7 @@ fn test_change_id_index() {
     let resolve_prefix = |prefix: &str| {
         change_id_index
             .resolve_prefix(&HexPrefix::try_from_hex(prefix).unwrap())
+            .block_on()
             .unwrap()
     };
     // Ambiguous matches
@@ -1242,6 +1244,7 @@ fn test_change_id_index() {
     let resolve_prefix = |prefix: &str| {
         change_id_index
             .resolve_prefix(&HexPrefix::try_from_hex(prefix).unwrap())
+            .block_on()
             .unwrap()
     };
     assert_eq!(


### PR DESCRIPTION
One of the last parts of conversion of index to async.
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
