### PR TITLE
repo: remove redundant .clone() from view forwarding functions

### DIFF
--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -1818,7 +1818,7 @@ pub async fn reset_head(
 
     // If the first parent of the working copy has changed, reset the Git HEAD.
     let old_head_target = mut_repo.git_head(workspace);
-    if old_head_target != new_head_target {
+    if *old_head_target != new_head_target {
         let expected_ref = if let Some(id) = old_head_target.as_normal() {
             // We have to check the actual HEAD state because we don't record a
             // symbolic ref as such.

--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -1767,8 +1767,8 @@ impl MutableRepo {
         Ok(indexed_commits)
     }
 
-    pub fn get_local_bookmark(&self, name: &RefName) -> RefTarget {
-        self.view.get_local_bookmark(name).clone()
+    pub fn get_local_bookmark(&self, name: &RefName) -> &RefTarget {
+        self.view.get_local_bookmark(name)
     }
 
     pub fn set_local_bookmark_target(&mut self, name: &RefName, target: RefTarget) {
@@ -1791,8 +1791,8 @@ impl MutableRepo {
         Ok(())
     }
 
-    pub fn get_remote_bookmark(&self, symbol: RemoteRefSymbol<'_>) -> RemoteRef {
-        self.view.get_remote_bookmark(symbol).clone()
+    pub fn get_remote_bookmark(&self, symbol: RemoteRefSymbol<'_>) -> &RemoteRef {
+        self.view.get_remote_bookmark(symbol)
     }
 
     pub fn set_remote_bookmark(&mut self, symbol: RemoteRefSymbol<'_>, remote_ref: RemoteRef) {
@@ -1815,7 +1815,7 @@ impl MutableRepo {
     /// Merges the specified remote bookmark in to local bookmark, and starts
     /// tracking it.
     pub async fn track_remote_bookmark(&mut self, symbol: RemoteRefSymbol<'_>) -> IndexResult<()> {
-        let mut remote_ref = self.get_remote_bookmark(symbol);
+        let mut remote_ref = self.get_remote_bookmark(symbol).clone();
         let base_target = remote_ref.tracked_target();
         self.merge_local_bookmark(symbol.name, base_target, &remote_ref.target)
             .await?;
@@ -1826,7 +1826,7 @@ impl MutableRepo {
 
     /// Stops tracking the specified remote bookmark.
     pub fn untrack_remote_bookmark(&mut self, symbol: RemoteRefSymbol<'_>) {
-        let mut remote_ref = self.get_remote_bookmark(symbol);
+        let mut remote_ref = self.get_remote_bookmark(symbol).clone();
         remote_ref.state = RemoteRefState::New;
         self.set_remote_bookmark(symbol, remote_ref);
     }
@@ -1843,8 +1843,8 @@ impl MutableRepo {
         self.view.rename_remote(old, new);
     }
 
-    pub fn get_local_tag(&self, name: &RefName) -> RefTarget {
-        self.view.get_local_tag(name).clone()
+    pub fn get_local_tag(&self, name: &RefName) -> &RefTarget {
+        self.view.get_local_tag(name)
     }
 
     pub fn set_local_tag_target(&mut self, name: &RefName, target: RefTarget) {
@@ -1864,8 +1864,8 @@ impl MutableRepo {
         Ok(())
     }
 
-    pub fn get_remote_tag(&self, symbol: RemoteRefSymbol<'_>) -> RemoteRef {
-        self.view.get_remote_tag(symbol).clone()
+    pub fn get_remote_tag(&self, symbol: RemoteRefSymbol<'_>) -> &RemoteRef {
+        self.view.get_remote_tag(symbol)
     }
 
     pub fn set_remote_tag(&mut self, symbol: RemoteRefSymbol<'_>, remote_ref: RemoteRef) {
@@ -1887,7 +1887,7 @@ impl MutableRepo {
 
     /// Merges the specified remote tag in to local tag, and starts tracking it.
     pub async fn track_remote_tag(&mut self, symbol: RemoteRefSymbol<'_>) -> IndexResult<()> {
-        let mut remote_ref = self.get_remote_tag(symbol);
+        let mut remote_ref = self.get_remote_tag(symbol).clone();
         let base_target = remote_ref.tracked_target();
         self.merge_local_tag(symbol.name, base_target, &remote_ref.target)
             .await?;
@@ -1898,13 +1898,13 @@ impl MutableRepo {
 
     /// Stops tracking the specified remote tag.
     pub fn untrack_remote_tag(&mut self, symbol: RemoteRefSymbol<'_>) {
-        let mut remote_ref = self.get_remote_tag(symbol);
+        let mut remote_ref = self.get_remote_tag(symbol).clone();
         remote_ref.state = RemoteRefState::New;
         self.set_remote_tag(symbol, remote_ref);
     }
 
-    pub fn get_git_ref(&self, name: &GitRefName) -> RefTarget {
-        self.view.get_git_ref(name).clone()
+    pub fn get_git_ref(&self, name: &GitRefName) -> &RefTarget {
+        self.view.get_git_ref(name)
     }
 
     pub fn set_git_ref_target(&mut self, name: &GitRefName, target: RefTarget) {
@@ -1924,8 +1924,8 @@ impl MutableRepo {
         Ok(())
     }
 
-    pub fn git_head(&self, workspace: &WorkspaceName) -> RefTarget {
-        self.view.git_head(workspace).clone()
+    pub fn git_head(&self, workspace: &WorkspaceName) -> &RefTarget {
+        self.view.git_head(workspace)
     }
 
     pub fn set_git_head_target(&mut self, workspace: &WorkspaceName, target: RefTarget) {

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -2563,7 +2563,7 @@ fn test_export_refs_no_detach() -> TestResult {
     assert!(stats.failed_tags.is_empty());
     assert_eq!(
         mut_repo.get_git_ref("refs/heads/main".as_ref()),
-        RefTarget::normal(jj_id(commit1))
+        &RefTarget::normal(jj_id(commit1))
     );
     assert_eq!(git_repo.head_name()?.unwrap().as_bstr(), b"refs/heads/main");
     assert_eq!(
@@ -2606,7 +2606,7 @@ fn test_export_refs_bookmark_changed() -> TestResult {
     assert!(stats.failed_tags.is_empty());
     assert_eq!(
         mut_repo.get_git_ref("refs/heads/main".as_ref()),
-        RefTarget::normal(new_commit.id().clone())
+        &RefTarget::normal(new_commit.id().clone())
     );
     assert_eq!(
         git_repo
@@ -2665,21 +2665,21 @@ fn test_export_refs_tag_changed() -> TestResult {
     assert!(stats.failed_tags.is_empty());
     assert_eq!(
         mut_repo.get_git_ref("refs/tags/lightweight-change".as_ref()),
-        new_target
+        &new_target
     );
     assert_eq!(
         mut_repo.get_git_ref("refs/tags/lightweight-delete".as_ref()),
-        RefTarget::absent()
+        RefTarget::absent_ref()
     );
     assert_eq!(
         mut_repo.get_git_ref("refs/tags/annotated-change".as_ref()),
-        new_target
+        &new_target
     );
     assert_eq!(
         mut_repo.get_git_ref("refs/tags/annotated-delete".as_ref()),
-        RefTarget::absent()
+        RefTarget::absent_ref()
     );
-    assert_eq!(mut_repo.get_git_ref("refs/tags/new".as_ref()), new_target);
+    assert_eq!(mut_repo.get_git_ref("refs/tags/new".as_ref()), &new_target);
     assert_eq!(
         git_repo
             .find_reference("refs/tags/lightweight-change")?
@@ -2741,7 +2741,7 @@ fn test_export_refs_current_bookmark_changed() -> TestResult {
     assert!(stats.failed_tags.is_empty());
     assert_eq!(
         mut_repo.get_git_ref("refs/heads/main".as_ref()),
-        RefTarget::normal(new_commit.id().clone())
+        &RefTarget::normal(new_commit.id().clone())
     );
     assert_eq!(
         git_repo
@@ -2872,7 +2872,7 @@ fn test_export_refs_current_tag_changed() -> TestResult {
     assert!(stats.failed_tags.is_empty());
     assert_eq!(
         mut_repo.get_git_ref("refs/tags/v1.0".as_ref()),
-        RefTarget::normal(new_commit.id().clone())
+        &RefTarget::normal(new_commit.id().clone())
     );
     assert_eq!(
         git_repo
@@ -2919,7 +2919,7 @@ fn test_export_refs_unborn_git_bookmark(move_placeholder_ref: bool) -> TestResul
     assert!(stats.failed_tags.is_empty());
     assert_eq!(
         mut_repo.get_git_ref("refs/heads/main".as_ref()),
-        RefTarget::normal(new_commit.id().clone())
+        &RefTarget::normal(new_commit.id().clone())
     );
     assert_eq!(
         git_repo
@@ -2959,7 +2959,7 @@ fn test_export_import_sequence() -> TestResult {
     git::import_refs(mut_repo, &import_options).block_on()?;
     assert_eq!(
         mut_repo.get_git_ref("refs/heads/main".as_ref()),
-        RefTarget::normal(commit_a.id().clone())
+        &RefTarget::normal(commit_a.id().clone())
     );
 
     // Modify the bookmark in jj to point to B
@@ -2971,7 +2971,7 @@ fn test_export_import_sequence() -> TestResult {
     assert!(stats.failed_tags.is_empty());
     assert_eq!(
         mut_repo.get_git_ref("refs/heads/main".as_ref()),
-        RefTarget::normal(commit_b.id().clone())
+        &RefTarget::normal(commit_b.id().clone())
     );
 
     // Modify the bookmark in git to point to C
@@ -2986,7 +2986,7 @@ fn test_export_import_sequence() -> TestResult {
     git::import_refs(mut_repo, &import_options).block_on()?;
     assert_eq!(
         mut_repo.get_git_ref("refs/heads/main".as_ref()),
-        RefTarget::normal(commit_c.id().clone())
+        &RefTarget::normal(commit_c.id().clone())
     );
     assert_eq!(
         mut_repo.view().get_local_bookmark("main".as_ref()),
@@ -3025,7 +3025,7 @@ fn test_import_export_non_tracking_bookmark() -> TestResult {
     );
     assert_eq!(
         mut_repo.get_git_ref("refs/remotes/origin/main".as_ref()),
-        RefTarget::normal(jj_id(commit_main_t0))
+        &RefTarget::normal(jj_id(commit_main_t0))
     );
 
     // Export the bookmark to git
@@ -3034,7 +3034,7 @@ fn test_import_export_non_tracking_bookmark() -> TestResult {
     assert!(stats.failed_tags.is_empty());
     assert_eq!(
         mut_repo.get_git_ref("refs/heads/main".as_ref()),
-        RefTarget::absent()
+        RefTarget::absent_ref()
     );
 
     // Reimport with auto-track-bookmarks on. Local bookmark shouldn't be created
@@ -3152,21 +3152,21 @@ fn test_export_conflicts() -> TestResult {
     // Conflicted bookmarks shouldn't be copied to the "git" remote
     assert_eq!(
         mut_repo.get_remote_bookmark(remote_symbol("feature", "git")),
-        RemoteRef {
+        &RemoteRef {
             target: RefTarget::normal(commit_a.id().clone()),
             state: RemoteRefState::Tracked,
         },
     );
     assert_eq!(
         mut_repo.get_remote_bookmark(remote_symbol("main", "git")),
-        RemoteRef {
+        &RemoteRef {
             target: RefTarget::normal(commit_b.id().clone()),
             state: RemoteRefState::Tracked,
         },
     );
     assert_eq!(
         mut_repo.get_remote_tag(remote_symbol("v1.0", "git")),
-        RemoteRef {
+        &RemoteRef {
             target: RefTarget::normal(commit_a.id().clone()),
             state: RemoteRefState::Tracked,
         },
@@ -3270,26 +3270,26 @@ fn test_export_partial_failure() -> TestResult {
     // Failed bookmarks/tags shouldn't be copied to the "git" remote
     assert_eq!(
         mut_repo.get_remote_bookmark(remote_symbol("", "git")),
-        RemoteRef::absent()
+        RemoteRef::absent_ref()
     );
     assert_eq!(
         mut_repo.get_remote_bookmark(remote_symbol("HEAD", "git")),
-        RemoteRef::absent()
+        RemoteRef::absent_ref()
     );
     assert_eq!(
         mut_repo.get_remote_bookmark(remote_symbol("main", "git")),
-        RemoteRef {
+        &RemoteRef {
             target: target.clone(),
             state: RemoteRefState::Tracked,
         },
     );
     assert_eq!(
         mut_repo.get_remote_bookmark(remote_symbol("main/sub", "git")),
-        RemoteRef::absent()
+        RemoteRef::absent_ref()
     );
     assert_eq!(
         mut_repo.get_remote_tag(remote_symbol("", "git")),
-        RemoteRef::absent()
+        RemoteRef::absent_ref()
     );
 
     // Now remove the `main` bookmark and make sure that the `main/sub` gets
@@ -3334,26 +3334,26 @@ fn test_export_partial_failure() -> TestResult {
     // Failed bookmarks/tags shouldn't be copied to the "git" remote
     assert_eq!(
         mut_repo.get_remote_bookmark(remote_symbol("", "git")),
-        RemoteRef::absent()
+        RemoteRef::absent_ref()
     );
     assert_eq!(
         mut_repo.get_remote_bookmark(remote_symbol("HEAD", "git")),
-        RemoteRef::absent()
+        RemoteRef::absent_ref()
     );
     assert_eq!(
         mut_repo.get_remote_bookmark(remote_symbol("main", "git")),
-        RemoteRef::absent()
+        RemoteRef::absent_ref()
     );
     assert_eq!(
         mut_repo.get_remote_bookmark(remote_symbol("main/sub", "git")),
-        RemoteRef {
+        &RemoteRef {
             target: target.clone(),
             state: RemoteRefState::Tracked,
         },
     );
     assert_eq!(
         mut_repo.get_remote_tag(remote_symbol("", "git")),
-        RemoteRef::absent()
+        RemoteRef::absent_ref()
     );
     Ok(())
 }
@@ -3538,15 +3538,15 @@ fn test_export_undo_reexport() -> TestResult {
         git_repo.find_reference("refs/tags/v1.0")?.target().id(),
         git_id(&commit_a)
     );
-    assert_eq!(mut_repo.get_git_ref("refs/heads/main".as_ref()), target_a);
-    assert_eq!(mut_repo.get_git_ref("refs/tags/v1.0".as_ref()), target_a);
+    assert_eq!(mut_repo.get_git_ref("refs/heads/main".as_ref()), &target_a);
+    assert_eq!(mut_repo.get_git_ref("refs/tags/v1.0".as_ref()), &target_a);
     assert_eq!(
         mut_repo.get_remote_bookmark(remote_symbol("main", "git")),
-        remote_ref_a
+        &remote_ref_a
     );
     assert_eq!(
         mut_repo.get_remote_tag(remote_symbol("v1.0", "git")),
-        remote_ref_a
+        &remote_ref_a
     );
 
     // Undo remote changes only
@@ -3565,15 +3565,15 @@ fn test_export_undo_reexport() -> TestResult {
         git_repo.find_reference("refs/tags/v1.0")?.target().id(),
         git_id(&commit_a)
     );
-    assert_eq!(mut_repo.get_git_ref("refs/heads/main".as_ref()), target_a);
-    assert_eq!(mut_repo.get_git_ref("refs/tags/v1.0".as_ref()), target_a);
+    assert_eq!(mut_repo.get_git_ref("refs/heads/main".as_ref()), &target_a);
+    assert_eq!(mut_repo.get_git_ref("refs/tags/v1.0".as_ref()), &target_a);
     assert_eq!(
         mut_repo.get_remote_bookmark(remote_symbol("main", "git")),
-        remote_ref_a
+        &remote_ref_a
     );
     assert_eq!(
         mut_repo.get_remote_tag(remote_symbol("v1.0", "git")),
-        remote_ref_a
+        &remote_ref_a
     );
     Ok(())
 }
@@ -3606,7 +3606,7 @@ fn test_reset_head_to_root() -> TestResult {
     assert!(git_repo.head()?.is_detached(), "HEAD is detached");
     assert_eq!(
         tx.repo().git_head(WorkspaceName::DEFAULT),
-        RefTarget::normal(commit1.id().clone())
+        &RefTarget::normal(commit1.id().clone())
     );
 
     // Set Git HEAD back to root
@@ -3625,7 +3625,7 @@ fn test_reset_head_to_root() -> TestResult {
     assert!(git_repo.head_id().is_ok());
     assert_eq!(
         tx.repo().git_head(WorkspaceName::DEFAULT),
-        RefTarget::normal(commit1.id().clone())
+        &RefTarget::normal(commit1.id().clone())
     );
     assert!(git_repo.find_reference("refs/jj/root").is_ok());
 
@@ -3668,7 +3668,7 @@ fn test_reset_head_detached_out_of_sync() -> TestResult {
     git::reset_head(tx.repo_mut(), WorkspaceName::DEFAULT, &commit2).block_on()?;
     assert_eq!(
         tx.repo().git_head(WorkspaceName::DEFAULT),
-        RefTarget::normal(commit1.id().clone())
+        &RefTarget::normal(commit1.id().clone())
     );
 
     // External process updates HEAD to point to commit5
@@ -3679,7 +3679,7 @@ fn test_reset_head_detached_out_of_sync() -> TestResult {
     git::reset_head(tx.repo_mut(), WorkspaceName::DEFAULT, &commit3).block_on()?;
     assert_eq!(
         tx.repo().git_head(WorkspaceName::DEFAULT),
-        RefTarget::normal(commit1.id().clone())
+        &RefTarget::normal(commit1.id().clone())
     );
 
     // {expected: commit1, actual: commit5} -> commit3 (= commit4's parent)
@@ -3689,7 +3689,7 @@ fn test_reset_head_detached_out_of_sync() -> TestResult {
     );
     assert_eq!(
         tx.repo().git_head(WorkspaceName::DEFAULT),
-        RefTarget::normal(commit1.id().clone()),
+        &RefTarget::normal(commit1.id().clone()),
         "view shouldn't be updated on failed export"
     );
 
@@ -3697,14 +3697,14 @@ fn test_reset_head_detached_out_of_sync() -> TestResult {
     git::import_head(tx.repo_mut(), WorkspaceName::DEFAULT).block_on()?;
     assert_eq!(
         tx.repo().git_head(WorkspaceName::DEFAULT),
-        RefTarget::normal(commit5.id().clone())
+        &RefTarget::normal(commit5.id().clone())
     );
 
     // commit5 -> commit3 (= commit4's parent)
     git::reset_head(tx.repo_mut(), WorkspaceName::DEFAULT, &commit4).block_on()?;
     assert_eq!(
         tx.repo().git_head(WorkspaceName::DEFAULT),
-        RefTarget::normal(commit3.id().clone())
+        &RefTarget::normal(commit3.id().clone())
     );
     Ok(())
 }
@@ -4204,7 +4204,7 @@ fn test_fetch_prune_deleted_ref() -> TestResult {
     assert_eq!(
         tx.repo_mut()
             .get_remote_bookmark(remote_symbol("main", "origin")),
-        RemoteRef::absent()
+        RemoteRef::absent_ref()
     );
     Ok(())
 }
@@ -4259,14 +4259,14 @@ fn test_fetch_empty_refspecs() -> TestResult {
     assert_eq!(
         tx.repo_mut()
             .get_remote_bookmark(remote_symbol("main", "origin")),
-        RemoteRef::absent()
+        RemoteRef::absent_ref()
     );
     // No remote refs should have been fetched
     git::import_refs(tx.repo_mut(), &import_options).block_on()?;
     assert_eq!(
         tx.repo_mut()
             .get_remote_bookmark(remote_symbol("main", "origin")),
-        RemoteRef::absent()
+        RemoteRef::absent_ref()
     );
     Ok(())
 }

--- a/lib/tests/test_mut_repo.rs
+++ b/lib/tests/test_mut_repo.rs
@@ -650,11 +650,11 @@ fn test_rename_remote() {
     mut_repo.rename_remote("origin".as_ref(), "upstream".as_ref());
     assert_eq!(
         mut_repo.get_remote_bookmark(remote_symbol("main", "upstream")),
-        remote_ref
+        &remote_ref
     );
     assert_eq!(
         mut_repo.get_remote_bookmark(remote_symbol("main", "origin")),
-        RemoteRef::absent()
+        RemoteRef::absent_ref()
     );
 }
 

--- a/lib/tests/test_revset.rs
+++ b/lib/tests/test_revset.rs
@@ -704,15 +704,15 @@ fn test_resolve_symbol_bookmarks_only() -> TestResult {
     );
     mut_repo.set_remote_bookmark(
         remote_symbol("local-remote", "mirror"),
-        tracked_remote_ref(mut_repo.get_local_bookmark("local-remote".as_ref())),
+        tracked_remote_ref(mut_repo.get_local_bookmark("local-remote".as_ref()).clone()),
     );
     mut_repo.set_remote_bookmark(
         remote_symbol("local-remote", "untracked"),
-        new_remote_ref(mut_repo.get_local_bookmark("local-remote".as_ref())),
+        new_remote_ref(mut_repo.get_local_bookmark("local-remote".as_ref()).clone()),
     );
     mut_repo.set_remote_bookmark(
         remote_symbol("local-remote", git::REMOTE_NAME_FOR_LOCAL_GIT_REPO),
-        tracked_remote_ref(mut_repo.get_local_bookmark("local-remote".as_ref())),
+        tracked_remote_ref(mut_repo.get_local_bookmark("local-remote".as_ref()).clone()),
     );
 
     mut_repo.set_local_bookmark_target(
@@ -1012,11 +1012,11 @@ fn test_resolve_symbol_remote_tags_or_bookmarks() -> TestResult {
     );
     mut_repo.set_remote_tag(
         remote_symbol("local-remote-tag", "untracked"),
-        new_remote_ref(mut_repo.get_local_tag("local-remote-tag".as_ref())),
+        new_remote_ref(mut_repo.get_local_tag("local-remote-tag".as_ref()).clone()),
     );
     mut_repo.set_remote_tag(
         remote_symbol("local-remote-tag", "tracked"),
-        tracked_remote_ref(mut_repo.get_local_tag("local-remote-tag".as_ref())),
+        tracked_remote_ref(mut_repo.get_local_tag("local-remote-tag".as_ref()).clone()),
     );
 
     // Tag precedes bookmark

--- a/lib/tests/test_rewrite.rs
+++ b/lib/tests/test_rewrite.rs
@@ -1464,7 +1464,7 @@ fn test_rebase_descendants_basic_bookmark_update() -> TestResult {
     tx.repo_mut().rebase_descendants().block_on()?;
     assert_eq!(
         tx.repo().get_local_bookmark("main".as_ref()),
-        RefTarget::normal(commit_b2.id().clone())
+        &RefTarget::normal(commit_b2.id().clone())
     );
 
     assert_eq!(*tx.repo().view().heads(), hashset! {commit_b2.id().clone()});
@@ -1514,7 +1514,7 @@ fn test_rebase_descendants_bookmark_move_two_steps() -> TestResult {
     assert_eq!(commit_c3.parent_ids(), vec![commit_b2.id().clone()]);
     assert_eq!(
         tx.repo().get_local_bookmark("main".as_ref()),
-        RefTarget::normal(commit_c3.id().clone())
+        &RefTarget::normal(commit_c3.id().clone())
     );
     Ok(())
 }
@@ -1552,17 +1552,17 @@ fn test_rebase_descendants_basic_bookmark_update_with_non_local_bookmark() -> Te
     tx.repo_mut().rebase_descendants().block_on()?;
     assert_eq!(
         tx.repo().get_local_bookmark("main".as_ref()),
-        RefTarget::normal(commit_b2.id().clone())
+        &RefTarget::normal(commit_b2.id().clone())
     );
     // The remote bookmark and tag should not get updated
     assert_eq!(
         tx.repo()
             .get_remote_bookmark(remote_symbol("main", "origin")),
-        commit_b_remote_ref
+        &commit_b_remote_ref
     );
     assert_eq!(
         tx.repo().get_local_tag("v1".as_ref()),
-        RefTarget::normal(commit_b.id().clone())
+        &RefTarget::normal(commit_b.id().clone())
     );
 
     // Commit B is no longer visible even though the remote bookmark points to it.
@@ -1613,7 +1613,7 @@ fn test_rebase_descendants_update_bookmark_after_abandon(
     };
     let rebase_map = rebase_descendants_with_options_return_map(tx.repo_mut(), &options);
     assert_eq!(
-        tx.repo().get_local_bookmark("main".as_ref()),
+        *tx.repo().get_local_bookmark("main".as_ref()),
         if delete_abandoned_bookmarks {
             RefTarget::absent()
         } else {
@@ -1628,7 +1628,7 @@ fn test_rebase_descendants_update_bookmark_after_abandon(
     );
     assert_eq!(
         tx.repo().get_local_bookmark("other".as_ref()),
-        RefTarget::normal(rebase_map[commit_c.id()].clone())
+        &RefTarget::normal(rebase_map[commit_c.id()].clone())
     );
 
     assert_eq!(
@@ -1841,7 +1841,7 @@ fn test_rebase_descendants_rewrite_resolves_bookmark_conflict() -> TestResult {
     tx.repo_mut().rebase_descendants().block_on()?;
     assert_eq!(
         tx.repo().get_local_bookmark("main".as_ref()),
-        RefTarget::normal(commit_b2.id().clone())
+        &RefTarget::normal(commit_b2.id().clone())
     );
 
     assert_eq!(
@@ -1889,7 +1889,7 @@ fn test_rebase_descendants_bookmark_delete_modify_abandon(
     let _rebase_map = rebase_descendants_with_options_return_map(tx.repo_mut(), &options);
     assert_eq!(
         tx.repo().get_local_bookmark("main".as_ref()),
-        RefTarget::absent()
+        RefTarget::absent_ref()
     );
     Ok(())
 }
@@ -1934,7 +1934,7 @@ fn test_rebase_descendants_bookmark_move_forward_abandon(
     };
     let _rebase_map = rebase_descendants_with_options_return_map(tx.repo_mut(), &options);
     assert_eq!(
-        tx.repo().get_local_bookmark("main".as_ref()),
+        *tx.repo().get_local_bookmark("main".as_ref()),
         if delete_abandoned_bookmarks {
             RefTarget::from_merge(Merge::from_vec(vec![
                 None,
@@ -1988,7 +1988,7 @@ fn test_rebase_descendants_bookmark_move_sideways_abandon(
     };
     let _rebase_map = rebase_descendants_with_options_return_map(tx.repo_mut(), &options);
     assert_eq!(
-        tx.repo().get_local_bookmark("main".as_ref()),
+        *tx.repo().get_local_bookmark("main".as_ref()),
         if delete_abandoned_bookmarks {
             RefTarget::from_merge(Merge::from_vec(vec![
                 None,


### PR DESCRIPTION
# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [ ] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
