### PR TITLE
cli: warn when sign-on-push skips immutable commits

### DIFF
--- a/cli/src/commands/git/push.rs
+++ b/cli/src/commands/git/push.rs
@@ -66,6 +66,7 @@ use crate::cli_util::WorkspaceCommandHelper;
 use crate::cli_util::WorkspaceCommandTransaction;
 use crate::cli_util::has_tracked_remote_bookmarks;
 use crate::cli_util::has_tracked_remote_tags;
+use crate::cli_util::print_updated_commits;
 use crate::cli_util::short_change_hash;
 use crate::cli_util::short_commit_hash;
 use crate::command_error::CommandError;
@@ -798,12 +799,12 @@ fn ready_to_push_revset_expression(
         .flat_map(|(_, old_head)| old_head.target.added_ids())
         .cloned()
         .collect_vec();
-    RevsetExpression::commits(old_heads)
-        .union(workspace_helper.env().immutable_heads_expression())
-        .range(&RevsetExpression::commits(new_heads))
+    RevsetExpression::commits(old_heads).range(&RevsetExpression::commits(new_heads))
 }
 
 /// Signs commits before pushing.
+///
+/// Warns about commits that need a signature but are immutable.
 ///
 /// Returns the updated list of bookmark names and corresponding
 /// [`BookmarkPushUpdate`]s.
@@ -815,14 +816,42 @@ async fn sign_commits_before_push(
 ) -> Result<GitPushRefTargets, CommandError> {
     let mut sign_settings = tx.settings().sign_settings();
     sign_settings.behavior = SignBehavior::Own;
-    let commit_ids: IndexSet<CommitId> = tx
-        .base_workspace_helper()
-        .attach_revset_evaluator(commits_to_push)
+    // TODO: make filter condition configurable by revset?
+    let needs_signing = |commit: &Commit| {
+        future::ready(!commit.is_signed() && sign_settings.should_sign(commit.store_commit()))
+    };
+
+    let workspace_helper = tx.base_workspace_helper();
+    let immutable = workspace_helper.env().immutable_expression();
+    let skipped: Vec<Commit> = workspace_helper
+        .attach_revset_evaluator(commits_to_push.intersection(&immutable))
         .evaluate_to_commits()?
-        // TODO: make filter condition configurable by revset?
-        .try_filter(|commit| {
-            future::ready(!commit.is_signed() && sign_settings.should_sign(commit.store_commit()))
-        })
+        .try_filter(needs_signing)
+        .take(11)
+        .try_collect()
+        .await?;
+    if !skipped.is_empty() {
+        let count = if skipped.len() > 10 {
+            "10+".to_owned()
+        } else {
+            skipped.len().to_string()
+        };
+        writeln!(
+            ui.warning_default(),
+            "Skipped signing {count} immutable commits:"
+        )?;
+        let mut formatter = ui.stderr_formatter();
+        print_updated_commits(
+            formatter.as_mut(),
+            &workspace_helper.commit_summary_template(),
+            &skipped,
+        )?;
+    }
+
+    let commit_ids: IndexSet<CommitId> = workspace_helper
+        .attach_revset_evaluator(commits_to_push.minus(&immutable))
+        .evaluate_to_commits()?
+        .try_filter(needs_signing)
         .map_ok(|commit| commit.id().clone())
         .try_collect()
         .await?;

--- a/cli/tests/test_git_push.rs
+++ b/cli/tests/test_git_push.rs
@@ -2728,6 +2728,8 @@ fn test_git_push_sign_on_push() {
     let output = work_dir.run_jj(["git", "push"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
+    Warning: Skipped signing 1 immutable commits:
+      kpqxywon 48ea83e9 bookmark2* | (empty) commit which should not be signed 1
     Changes to push to origin:
       bookmark: bookmark2 [move forward from d45e2adce0ad to 48ea83e9499c]
     [EOF]


### PR DESCRIPTION
Small QoL improvement to warn when a commit that *should* have been signed is skipped during `jj git push` (when using `sign-on-push`). This can easily happen when tagging a commit while it is unsigned, then pushing it (since the tag makes the commit immutable).

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
