### PR TITLE
workspace add: support --adopt flag for git worktrees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   follows the repository's colocation state. `jj workspace forget` removes
   the corresponding Git worktree when one exists.
 
+* `jj workspace sync` synchronizes jj workspaces with Git worktrees in
+  colocated repositories: adopting external worktrees, forgetting removed
+  ones, and repairing moved paths. This also runs automatically when
+  `git.auto-sync-worktrees` is enabled (the default).
+
 ### Fixed bugs
 
 * A side of a conflict whose contents end with a carriage return no longer loses

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -576,6 +576,18 @@ impl CommandHelper {
         Ok(factory)
     }
 
+    pub fn get_working_copy_factory_at(
+        &self,
+        workspace_root: &Path,
+    ) -> Result<&dyn WorkingCopyFactory, CommandError> {
+        let loader = self.new_workspace_loader_at(workspace_root)?;
+        let factory: Result<_, WorkspaceLoadError> =
+            get_working_copy_factory(loader.as_ref(), &self.data.working_copy_factories)
+                .map_err(|e| e.into());
+        let factory = factory.map_err(|err| map_workspace_load_error(err, None))?;
+        Ok(factory)
+    }
+
     /// Loads workspace for the current command.
     #[instrument(skip_all)]
     pub fn load_workspace(&self) -> Result<Workspace, CommandError> {

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -150,6 +150,10 @@ use jj_lib::workspace::WorkspaceLoadError;
 use jj_lib::workspace::WorkspaceLoader;
 use jj_lib::workspace::WorkspaceLoaderFactory;
 use jj_lib::workspace::get_working_copy_factory;
+#[cfg(feature = "git")]
+use jj_lib::workspace_store::SimpleWorkspaceStore;
+#[cfg(feature = "git")]
+use jj_lib::workspace_store::WorkspaceStore as _;
 use pollster::FutureExt as _;
 use tracing::instrument;
 use tracing_chrome::ChromeLayerBuilder;
@@ -182,6 +186,22 @@ use crate::diff_util::DiffRenderer;
 use crate::formatter::FormatRecorder;
 use crate::formatter::Formatter;
 use crate::formatter::FormatterExt as _;
+#[cfg(feature = "git")]
+use crate::git_util::GitWorktreeRepoContext;
+#[cfg(feature = "git")]
+use crate::git_util::create_git_worktree_in_existing_workspace;
+#[cfg(feature = "git")]
+use crate::git_util::discover_git_worktree_paths;
+#[cfg(feature = "git")]
+use crate::git_util::git_head_resolves;
+#[cfg(feature = "git")]
+use crate::git_util::git_rev_parse_path;
+#[cfg(feature = "git")]
+use crate::git_util::git_worktree_paths;
+#[cfg(feature = "git")]
+use crate::git_util::repair_jj_repo_link;
+#[cfg(feature = "git")]
+use crate::git_util::workspace_abs_path;
 use crate::merge_tools::DiffEditor;
 use crate::merge_tools::MergeEditor;
 use crate::merge_tools::MergeToolConfigError;
@@ -473,22 +493,38 @@ impl CommandHelper {
         &self,
         ui: &Ui,
     ) -> Result<(WorkspaceCommandHelper, SnapshotStats, bool), CommandError> {
-        let workspace = self.load_workspace()?;
-        let env = self.workspace_environment(ui, &workspace)?;
-        // Acquire the lock to ensure that the loaded repo points to the head
-        // operation whose refs should be synchronized with the Git repo. This
-        // prevents races with other processes during Git HEAD and refs
-        // import/export.
-        let git_import_export_lock = self
-            .is_working_copy_writable()
-            .then(|| env.lock_git_import_export(&workspace))
-            .transpose()?;
-        let mut workspace_command = self.load_from_workspace(ui, workspace, env).await?;
+        let auto_sync = self.settings().get_bool("git.auto-sync-worktrees")?;
+        let (workspace_command, git_import_export_lock) = loop {
+            let workspace = if auto_sync {
+                self.load_workspace_or_auto_init_git_worktree(ui).await?
+            } else {
+                self.load_workspace()?
+            };
+            let env = self.workspace_environment(ui, &workspace)?;
+            // Acquire the lock to ensure that the loaded repo points to the head
+            // operation whose refs should be synchronized with the Git repo. This
+            // prevents races with other processes during Git HEAD and refs
+            // import/export.
+            let git_import_export_lock = self
+                .is_working_copy_writable()
+                .then(|| env.lock_git_import_export(&workspace))
+                .transpose()?;
+            let workspace_command = self.load_from_workspace(ui, workspace, env).await?;
+            if auto_sync && workspace_command.ensure_current_workspace_git_worktree(ui)? {
+                continue;
+            }
+            break (workspace_command, git_import_export_lock);
+        };
+        let mut workspace_command = workspace_command;
+        let old_repo = workspace_command.repo().clone();
+        if auto_sync && self.is_working_copy_writable() {
+            workspace_command.forget_removed_git_worktrees(ui).await?;
+        }
         let Some(git_import_export_lock) = git_import_export_lock else {
-            return Ok((workspace_command, SnapshotStats::default(), false));
+            let changed = old_repo.op_id() != workspace_command.repo().op_id();
+            return Ok((workspace_command, SnapshotStats::default(), changed));
         };
 
-        let old_repo = workspace_command.repo().clone();
         let (workspace_command, stats) = match workspace_command
             .snapshot_impl(ui, &git_import_export_lock)
             .await
@@ -522,12 +558,96 @@ impl CommandHelper {
         &self,
         ui: &Ui,
     ) -> Result<WorkspaceCommandHelper, CommandError> {
-        let workspace = self.load_workspace()?;
-        let env = self.workspace_environment(ui, &workspace)?;
-        self.load_from_workspace(ui, workspace, env).await
+        let auto_sync = self.settings().get_bool("git.auto-sync-worktrees")?;
+        let mut workspace_command = loop {
+            let workspace = if auto_sync {
+                self.load_workspace_or_auto_init_git_worktree(ui).await?
+            } else {
+                self.load_workspace()?
+            };
+            let env = self.workspace_environment(ui, &workspace)?;
+            let workspace_command = self.load_from_workspace(ui, workspace, env).await?;
+            if auto_sync && workspace_command.ensure_current_workspace_git_worktree(ui)? {
+                continue;
+            }
+            break workspace_command;
+        };
+        if auto_sync && self.is_working_copy_writable() {
+            workspace_command.forget_removed_git_worktrees(ui).await?;
+        }
+        Ok(workspace_command)
     }
 
-    async fn load_from_workspace(
+    pub async fn load_workspace_or_auto_init_git_worktree(
+        &self,
+        ui: &Ui,
+    ) -> Result<Workspace, CommandError> {
+        match self.load_workspace() {
+            Ok(workspace) => Ok(workspace),
+            Err(err) => {
+                if self.data.global_args.repository.is_none()
+                    && let Some(workspace) = self.auto_init_git_worktree_workspace(ui).await?
+                {
+                    return Ok(workspace);
+                }
+                Err(err)
+            }
+        }
+    }
+
+    #[cfg(feature = "git")]
+    async fn auto_init_git_worktree_workspace(
+        &self,
+        ui: &Ui,
+    ) -> Result<Option<Workspace>, CommandError> {
+        let git_settings = jj_lib::git::GitSettings::from_settings(self.settings())?;
+        let Some(git_paths) = discover_git_worktree_paths(&git_settings, self.cwd())? else {
+            return Ok(None);
+        };
+        let main_workspace_root = match git_paths.common_git_dir.parent() {
+            Some(path) if path.join(".jj").is_dir() => path,
+            _ => return Ok(None),
+        };
+        let main_workspace = self.load_workspace_at(main_workspace_root, self.settings())?;
+        let main_loader = self.new_workspace_loader_at(main_workspace_root)?;
+        let working_copy_factory =
+            get_working_copy_factory(main_loader.as_ref(), &self.data.working_copy_factories)
+                .map_err(|err| {
+                    map_workspace_load_error(WorkspaceLoadError::StoreLoadError(err), None)
+                })?;
+        let repo = main_workspace.repo_loader().load_at_head().await?;
+        if repo
+            .view()
+            .get_wc_commit_id(&git_paths.workspace_name)
+            .is_some()
+        {
+            return Ok(None);
+        }
+        let (workspace, _repo) = Workspace::init_workspace_with_existing_repo(
+            &git_paths.worktree_root,
+            main_workspace.repo_path(),
+            &repo,
+            working_copy_factory,
+            git_paths.workspace_name,
+        )
+        .await?;
+        writeln!(
+            ui.status(),
+            "Created jj workspace for Git worktree at \"{}\".",
+            git_paths.worktree_root.display()
+        )?;
+        Ok(Some(workspace))
+    }
+
+    #[cfg(not(feature = "git"))]
+    async fn auto_init_git_worktree_workspace(
+        &self,
+        _ui: &Ui,
+    ) -> Result<Option<Workspace>, CommandError> {
+        Ok(None)
+    }
+
+    pub async fn load_from_workspace(
         &self,
         ui: &Ui,
         workspace: Workspace,
@@ -2338,6 +2458,169 @@ to the current parents may contain changes from multiple commits.
             tx,
             id_prefix_context,
         }
+    }
+
+    #[cfg(feature = "git")]
+    fn git_worktree_repo_context(&self) -> Result<Option<GitWorktreeRepoContext>, CommandError> {
+        if jj_lib::git::get_git_repo(self.repo().store()).is_err() {
+            return Ok(None);
+        }
+        let workspace_store = SimpleWorkspaceStore::load(self.repo_path())?;
+        let Some(main_workspace_root) =
+            workspace_abs_path(self.repo_path(), &workspace_store, WorkspaceName::DEFAULT)?
+        else {
+            return Ok(None);
+        };
+        if !main_workspace_root.join(".git").exists() {
+            return Ok(None);
+        }
+        let git_executable: PathBuf = self.settings().get("git.executable-path")?;
+        if git_rev_parse_path(&git_executable, &main_workspace_root, "--git-common-dir")?.is_none()
+        {
+            return Ok(None);
+        }
+        Ok(Some(GitWorktreeRepoContext {
+            workspace_store,
+            main_workspace_root,
+            git_executable,
+        }))
+    }
+
+    #[cfg(feature = "git")]
+    pub fn ensure_current_workspace_git_worktree(&self, ui: &Ui) -> Result<bool, CommandError> {
+        if self.env.working_copy_shared_with_git || self.workspace_name() == WorkspaceName::DEFAULT
+        {
+            return Ok(false);
+        }
+        if self.workspace_root().join(".git").exists() {
+            return Ok(false);
+        }
+        let Some(ctx) = self.git_worktree_repo_context()? else {
+            return Ok(false);
+        };
+        if !git_head_resolves(&ctx.git_executable, &ctx.main_workspace_root)? {
+            return Ok(false);
+        }
+        create_git_worktree_in_existing_workspace(
+            &ctx.git_executable,
+            &ctx.main_workspace_root,
+            self.workspace_root(),
+        )?;
+        writeln!(
+            ui.status(),
+            "Created Git worktree for the current workspace."
+        )?;
+        Ok(true)
+    }
+
+    #[cfg(not(feature = "git"))]
+    pub fn ensure_current_workspace_git_worktree(&self, _ui: &Ui) -> Result<bool, CommandError> {
+        Ok(false)
+    }
+
+    #[cfg(feature = "git")]
+    pub async fn forget_removed_git_worktrees(&mut self, _ui: &Ui) -> Result<(), CommandError> {
+        let Some(ctx) = self.git_worktree_repo_context()? else {
+            return Ok(());
+        };
+        let live_worktree_paths =
+            git_worktree_paths(&ctx.git_executable, &ctx.main_workspace_root)?;
+        self.repair_moved_git_worktree_paths(&ctx.workspace_store, &live_worktree_paths)?;
+        let removed_workspaces = self
+            .repo()
+            .view()
+            .wc_commit_ids()
+            .keys()
+            .filter(|name| name.as_str() != WorkspaceName::DEFAULT.as_str())
+            .filter_map(|name| {
+                let path = workspace_abs_path(self.repo_path(), &ctx.workspace_store, name)
+                    .ok()
+                    .flatten()?;
+                if !path.exists()
+                    || (path.join(".git").is_file() && !live_worktree_paths.contains(&path))
+                {
+                    Some(name.clone())
+                } else {
+                    None
+                }
+            })
+            .collect_vec();
+        if removed_workspaces.is_empty() {
+            return Ok(());
+        }
+
+        let description = if let [workspace_name] = removed_workspaces.as_slice() {
+            format!(
+                "forget removed Git worktree workspace {}",
+                workspace_name.as_symbol()
+            )
+        } else {
+            format!(
+                "forget removed Git worktree workspaces {}",
+                removed_workspaces
+                    .iter()
+                    .map(|workspace_name| workspace_name.as_symbol())
+                    .join(", ")
+            )
+        };
+        let mut tx = start_repo_transaction(
+            self.repo(),
+            self.workspace_name(),
+            self.env.command.string_args(),
+        );
+        for workspace_name in &removed_workspaces {
+            tx.repo_mut().remove_workspace(workspace_name).await?;
+        }
+        rebase_mutable_descendants(&self.env, &mut tx).await?;
+        ctx.workspace_store.forget(
+            &removed_workspaces
+                .iter()
+                .map(|name| name.as_ref())
+                .collect_vec(),
+        )?;
+        let repo = tx.commit(description).await?;
+        self.user_repo = ReadonlyUserRepo::new(repo);
+        Ok(())
+    }
+
+    #[cfg(feature = "git")]
+    fn repair_moved_git_worktree_paths(
+        &self,
+        workspace_store: &SimpleWorkspaceStore,
+        live_worktree_paths: &HashSet<PathBuf>,
+    ) -> Result<(), CommandError> {
+        for path in live_worktree_paths {
+            if path == self.workspace_root() || !path.join(".jj").is_dir() {
+                continue;
+            }
+            repair_jj_repo_link(path, self.repo_path())?;
+            let Ok(workspace) = self.env.command.load_workspace_at(path, self.settings()) else {
+                continue;
+            };
+            if workspace.repo_path() != self.repo_path()
+                || self
+                    .repo()
+                    .view()
+                    .get_wc_commit_id(workspace.workspace_name())
+                    .is_none()
+            {
+                continue;
+            }
+            let old_path = workspace_abs_path(
+                self.repo_path(),
+                workspace_store,
+                workspace.workspace_name(),
+            )?;
+            if old_path.as_deref() != Some(path) && !old_path.is_some_and(|path| path.exists()) {
+                workspace_store.add(workspace.workspace_name(), path)?;
+            }
+        }
+        Ok(())
+    }
+
+    #[cfg(not(feature = "git"))]
+    pub async fn forget_removed_git_worktrees(&mut self, _ui: &Ui) -> Result<(), CommandError> {
+        Ok(())
     }
 
     async fn finish_transaction(

--- a/cli/src/commands/workspace/add.rs
+++ b/cli/src/commands/workspace/add.rs
@@ -56,8 +56,16 @@ enum SparseInheritance {
 #[derive(clap::Args, Clone, Debug)]
 pub struct WorkspaceAddArgs {
     /// Where to create the new workspace
-    #[arg(value_hint = clap::ValueHint::DirPath)]
-    destination: String,
+    #[arg(value_hint = clap::ValueHint::DirPath, required_unless_present = "adopt")]
+    destination: Option<String>,
+
+    /// Adopt the current Git worktree as a jj workspace
+    ///
+    /// When run inside a Git worktree that belongs to a colocated jj
+    /// repository, creates a jj workspace for it. No destination path
+    /// is needed.
+    #[arg(long)]
+    adopt: bool,
 
     /// A name for the workspace
     ///
@@ -110,8 +118,13 @@ pub async fn cmd_workspace_add(
     command: &CommandHelper,
     args: &WorkspaceAddArgs,
 ) -> Result<(), CommandError> {
+    if args.adopt {
+        return cmd_workspace_add_adopt(ui, command).await;
+    }
+
+    let destination = args.destination.as_ref().expect("destination is required");
     let old_workspace_command = command.workspace_helper(ui).await?;
-    let destination_path = command.cwd().join(&args.destination);
+    let destination_path = command.cwd().join(destination);
     let workspace_name = if let Some(name) = &args.name {
         name.to_owned()
     } else {
@@ -200,11 +213,11 @@ pub async fn cmd_workspace_add(
     )?;
     // Show a warning if the user passed a path without a separator, since they
     // may have intended the argument to only be the name for the workspace.
-    if !args.destination.contains(std::path::is_separator) {
+    if !destination.contains(std::path::is_separator) {
         writeln!(
             ui.warning_default(),
             r#"Workspace created inside current directory. If this was unintentional, delete the "{}" directory and run `jj workspace forget {name}` to remove it."#,
-            args.destination,
+            destination,
             name = workspace_name.as_symbol()
         )?;
     }
@@ -292,4 +305,64 @@ pub async fn cmd_workspace_add(
     )
     .await?;
     Ok(())
+}
+
+#[cfg(feature = "git")]
+async fn cmd_workspace_add_adopt(ui: &mut Ui, command: &CommandHelper) -> Result<(), CommandError> {
+    use jj_lib::git::GitSettings;
+    use jj_lib::repo::Repo as _;
+    use jj_lib::workspace::Workspace;
+
+    use crate::git_util::discover_git_worktree_paths;
+
+    let git_settings = GitSettings::from_settings(command.settings())?;
+    let Some(git_paths) = discover_git_worktree_paths(&git_settings, command.cwd())? else {
+        return Err(user_error(
+            "Not inside a Git worktree. Run this from within a Git worktree to adopt it.",
+        ));
+    };
+    let main_workspace_root = match git_paths.common_git_dir.parent() {
+        Some(path) if path.join(".jj").is_dir() => path,
+        _ => {
+            return Err(user_error(
+                "The Git worktree's main repository is not a colocated jj repo.",
+            ));
+        }
+    };
+    let (main_settings, _) = command.settings_for_new_workspace(ui, main_workspace_root)?;
+    let main_workspace = command.load_workspace_at(main_workspace_root, &main_settings)?;
+    let working_copy_factory = command.get_working_copy_factory_at(main_workspace_root)?;
+    let repo = main_workspace.repo_loader().load_at_head().await?;
+    if repo
+        .view()
+        .get_wc_commit_id(&git_paths.workspace_name)
+        .is_some()
+    {
+        return Err(user_error(format!(
+            "Workspace '{}' already exists.",
+            git_paths.workspace_name.as_str()
+        )));
+    }
+    let (_workspace, _repo) = Workspace::init_workspace_with_existing_repo(
+        &git_paths.worktree_root,
+        main_workspace.repo_path(),
+        &repo,
+        working_copy_factory,
+        git_paths.workspace_name,
+    )
+    .await?;
+    writeln!(
+        ui.status(),
+        r#"Created jj workspace for Git worktree at "{}"."#,
+        git_paths.worktree_root.display()
+    )?;
+    Ok(())
+}
+
+#[cfg(not(feature = "git"))]
+async fn cmd_workspace_add_adopt(
+    _ui: &mut Ui,
+    _command: &CommandHelper,
+) -> Result<(), CommandError> {
+    Err(user_error("Git support is required for --adopt"))
 }

--- a/cli/src/commands/workspace/mod.rs
+++ b/cli/src/commands/workspace/mod.rs
@@ -17,6 +17,7 @@ mod forget;
 mod list;
 mod rename;
 mod root;
+mod sync;
 mod update_stale;
 
 use clap::Subcommand;
@@ -32,6 +33,8 @@ use self::rename::WorkspaceRenameArgs;
 use self::rename::cmd_workspace_rename;
 use self::root::WorkspaceRootArgs;
 use self::root::cmd_workspace_root;
+use self::sync::WorkspaceSyncArgs;
+use self::sync::cmd_workspace_sync;
 use self::update_stale::WorkspaceUpdateStaleArgs;
 use self::update_stale::cmd_workspace_update_stale;
 use crate::cli_util::CommandHelper;
@@ -56,6 +59,7 @@ pub(crate) enum WorkspaceCommand {
     List(WorkspaceListArgs),
     Rename(WorkspaceRenameArgs),
     Root(WorkspaceRootArgs),
+    Sync(WorkspaceSyncArgs),
     UpdateStale(WorkspaceUpdateStaleArgs),
 }
 
@@ -71,6 +75,7 @@ pub(crate) async fn cmd_workspace(
         WorkspaceCommand::List(args) => cmd_workspace_list(ui, command, args).await,
         WorkspaceCommand::Rename(args) => cmd_workspace_rename(ui, command, args).await,
         WorkspaceCommand::Root(args) => cmd_workspace_root(ui, command, args).await,
+        WorkspaceCommand::Sync(args) => cmd_workspace_sync(ui, command, args).await,
         WorkspaceCommand::UpdateStale(args) => cmd_workspace_update_stale(ui, command, args).await,
     }
 }

--- a/cli/src/commands/workspace/sync.rs
+++ b/cli/src/commands/workspace/sync.rs
@@ -1,0 +1,51 @@
+// Copyright 2026 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use tracing::instrument;
+
+use crate::cli_util::CommandHelper;
+use crate::command_error::CommandError;
+use crate::ui::Ui;
+
+/// Synchronize jj workspaces with Git worktrees
+///
+/// In a colocated Git repository, this command reconciles jj workspace
+/// state with Git worktree state:
+///
+/// * Adopts Git worktrees created externally (e.g. via `git worktree add`) by
+///   creating corresponding jj workspaces.
+///
+/// * Forgets jj workspaces whose Git worktrees have been removed.
+///
+/// * Repairs workspace paths for Git worktrees that have been moved.
+///
+/// This is equivalent to the automatic synchronization performed when
+/// `git.auto-sync-worktrees` is enabled (the default), but can be run
+/// manually when that setting is disabled.
+#[derive(clap::Args, Clone, Debug)]
+pub struct WorkspaceSyncArgs {}
+
+#[instrument(skip_all)]
+pub async fn cmd_workspace_sync(
+    ui: &mut Ui,
+    command: &CommandHelper,
+    _args: &WorkspaceSyncArgs,
+) -> Result<(), CommandError> {
+    let workspace = command.load_workspace_or_auto_init_git_worktree(ui).await?;
+    let env = command.workspace_environment(ui, &workspace)?;
+    let mut workspace_command = command.load_from_workspace(ui, workspace, env).await?;
+    workspace_command.ensure_current_workspace_git_worktree(ui)?;
+    workspace_command.forget_removed_git_worktrees(ui).await?;
+    Ok(())
+}

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -549,6 +549,11 @@
                     "description": "Path to the git executable",
                     "default": "git"
                 },
+                "auto-sync-worktrees": {
+                    "type": "boolean",
+                    "description": "Automatically synchronize jj workspaces with Git worktrees in colocated repositories",
+                    "default": true
+                },
                 "colocate": {
                     "type": "boolean",
                     "description": "Whether to colocate the working copy with the git repository",

--- a/cli/src/config/misc.toml
+++ b/cli/src/config/misc.toml
@@ -25,6 +25,7 @@ disabled-branches = []
 # no builtin aliases
 
 [git]
+auto-sync-worktrees = true
 colocate = true
 object-hash = "sha1"
 private-commits = "none()"

--- a/cli/src/git_util.rs
+++ b/cli/src/git_util.rs
@@ -20,6 +20,7 @@ use std::io::Write as _;
 use std::iter;
 use std::mem;
 use std::path::Path;
+use std::path::PathBuf;
 use std::process::Command;
 use std::time::Duration;
 use std::time::Instant;
@@ -54,6 +55,7 @@ use crate::cli_util::print_updated_commits;
 use crate::command_error::CommandError;
 use crate::command_error::cli_error;
 use crate::command_error::user_error;
+use crate::command_error::user_error_with_message;
 use crate::formatter::Formatter;
 use crate::formatter::FormatterExt as _;
 use crate::revset_util::parse_remote_auto_track_bookmarks_map;
@@ -634,6 +636,76 @@ pub fn remove_git_worktree(
         }
     }
     Ok(())
+}
+
+pub struct GitWorktreePaths {
+    pub worktree_root: PathBuf,
+    pub common_git_dir: PathBuf,
+    pub workspace_name: jj_lib::ref_name::WorkspaceNameBuf,
+}
+
+pub fn discover_git_worktree_paths(
+    git_settings: &GitSettings,
+    cwd: &Path,
+) -> Result<Option<GitWorktreePaths>, CommandError> {
+    let Some(worktree_root) = git_rev_parse_path(git_settings, cwd, "--show-toplevel")? else {
+        return Ok(None);
+    };
+    let Some(git_dir) = git_rev_parse_path(git_settings, cwd, "--git-dir")? else {
+        return Ok(None);
+    };
+    let Some(common_git_dir) = git_rev_parse_path(git_settings, cwd, "--git-common-dir")? else {
+        return Ok(None);
+    };
+    if git_dir == common_git_dir {
+        return Ok(None);
+    }
+    let Some(workspace_name) = git_dir.file_name().and_then(|name| name.to_str()) else {
+        return Ok(None);
+    };
+    if workspace_name.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(GitWorktreePaths {
+        worktree_root,
+        common_git_dir,
+        workspace_name: workspace_name.into(),
+    }))
+}
+
+fn git_rev_parse_path(
+    git_settings: &GitSettings,
+    cwd: &Path,
+    arg: &str,
+) -> Result<Option<PathBuf>, CommandError> {
+    let Ok(output) = Command::new(&git_settings.executable_path)
+        .arg("rev-parse")
+        .arg(arg)
+        .current_dir(cwd)
+        .output()
+    else {
+        return Ok(None);
+    };
+    if !output.status.success() {
+        return Ok(None);
+    }
+    let Ok(path) = String::from_utf8(output.stdout) else {
+        return Ok(None);
+    };
+    let path = Path::new(path.trim());
+    let path = if path.is_absolute() {
+        path.to_owned()
+    } else {
+        cwd.join(path)
+    };
+    match dunce::canonicalize(&path) {
+        Ok(path) => Ok(Some(path)),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(err) => Err(user_error_with_message(
+            format!("Failed to resolve git path '{}'", path.display()),
+            err,
+        )),
+    }
 }
 
 #[cfg(test)]

--- a/cli/src/git_util.rs
+++ b/cli/src/git_util.rs
@@ -14,7 +14,9 @@
 
 //! Git utilities shared by various commands.
 
+use std::collections::HashSet;
 use std::error;
+use std::fs;
 use std::io;
 use std::io::Write as _;
 use std::iter;
@@ -30,6 +32,7 @@ use crossterm::terminal::Clear;
 use crossterm::terminal::ClearType;
 use indoc::writedoc;
 use itertools::Itertools as _;
+use jj_lib::file_util;
 use jj_lib::git;
 use jj_lib::git::FailedRefExportReason;
 use jj_lib::git::GitExportStats;
@@ -43,10 +46,14 @@ use jj_lib::git::GitSettings;
 use jj_lib::git::GitSidebandLineTerminator;
 use jj_lib::git::GitSubprocessCallback;
 use jj_lib::op_store::RemoteRefState;
+use jj_lib::ref_name::WorkspaceName;
+use jj_lib::ref_name::WorkspaceNameBuf;
 use jj_lib::repo::ReadonlyRepo;
 use jj_lib::repo::Repo;
 use jj_lib::settings::RemoteSettingsMap;
 use jj_lib::workspace::Workspace;
+use jj_lib::workspace_store::SimpleWorkspaceStore;
+use jj_lib::workspace_store::WorkspaceStore as _;
 use unicode_width::UnicodeWidthStr as _;
 
 use crate::cleanup_guard::CleanupGuard;
@@ -71,6 +78,20 @@ pub fn is_colocated_git_workspace(workspace: &Workspace) -> bool {
     };
     if git_workdir == workspace.workspace_root() {
         return true;
+    }
+    if workspace.workspace_root().join(".git").is_file() {
+        let Ok(worktree_repo) = gix::open(workspace.workspace_root()) else {
+            return false;
+        };
+        let Ok(worktree_common_dir) = dunce::canonicalize(worktree_repo.common_dir()) else {
+            return false;
+        };
+        let Ok(backend_common_dir) = dunce::canonicalize(git_backend.git_repo().common_dir())
+        else {
+            return false;
+        };
+        return worktree_repo.git_dir() != worktree_repo.common_dir()
+            && worktree_common_dir == backend_common_dir;
     }
     // Colocated workspace should have ".git" directory, file, or symlink. Compare
     // its parent as the git_workdir might be resolved from the real ".git" path.
@@ -648,13 +669,14 @@ pub fn discover_git_worktree_paths(
     git_settings: &GitSettings,
     cwd: &Path,
 ) -> Result<Option<GitWorktreePaths>, CommandError> {
-    let Some(worktree_root) = git_rev_parse_path(git_settings, cwd, "--show-toplevel")? else {
+    let git_executable = &git_settings.executable_path;
+    let Some(worktree_root) = git_rev_parse_path(git_executable, cwd, "--show-toplevel")? else {
         return Ok(None);
     };
-    let Some(git_dir) = git_rev_parse_path(git_settings, cwd, "--git-dir")? else {
+    let Some(git_dir) = git_rev_parse_path(git_executable, cwd, "--git-dir")? else {
         return Ok(None);
     };
-    let Some(common_git_dir) = git_rev_parse_path(git_settings, cwd, "--git-common-dir")? else {
+    let Some(common_git_dir) = git_rev_parse_path(git_executable, cwd, "--git-common-dir")? else {
         return Ok(None);
     };
     if git_dir == common_git_dir {
@@ -673,12 +695,12 @@ pub fn discover_git_worktree_paths(
     }))
 }
 
-fn git_rev_parse_path(
-    git_settings: &GitSettings,
+pub(crate) fn git_rev_parse_path(
+    git_executable: &Path,
     cwd: &Path,
     arg: &str,
 ) -> Result<Option<PathBuf>, CommandError> {
-    let Ok(output) = Command::new(&git_settings.executable_path)
+    let Ok(output) = Command::new(git_executable)
         .arg("rev-parse")
         .arg(arg)
         .current_dir(cwd)
@@ -706,6 +728,154 @@ fn git_rev_parse_path(
             err,
         )),
     }
+}
+
+pub(crate) struct GitWorktreeRepoContext {
+    pub(crate) workspace_store: SimpleWorkspaceStore,
+    pub(crate) main_workspace_root: PathBuf,
+    pub(crate) git_executable: PathBuf,
+}
+
+pub(crate) fn git_head_resolves(git_executable: &Path, cwd: &Path) -> Result<bool, CommandError> {
+    let output = std::process::Command::new(git_executable)
+        .args(["rev-parse", "--verify", "--quiet", "HEAD"])
+        .current_dir(cwd)
+        .output()
+        .map_err(|err| user_error(format!("Failed to run `git rev-parse`: {err}")))?;
+    Ok(output.status.success())
+}
+
+pub(crate) fn workspace_abs_path(
+    repo_path: &Path,
+    workspace_store: &SimpleWorkspaceStore,
+    workspace_name: &WorkspaceName,
+) -> Result<Option<PathBuf>, CommandError> {
+    let Some(path) = workspace_store.get_workspace_path(workspace_name)? else {
+        return Ok(None);
+    };
+    let path = if path.is_absolute() {
+        path
+    } else {
+        repo_path.join(path)
+    };
+    match dunce::canonicalize(&path) {
+        Ok(path) => Ok(Some(path)),
+        Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(Some(path)),
+        Err(err) => Err(user_error_with_message(
+            format!("Failed to resolve workspace path '{}'", path.display()),
+            err,
+        )),
+    }
+}
+
+pub(crate) fn repair_jj_repo_link(
+    workspace_root: &Path,
+    repo_path: &Path,
+) -> Result<(), CommandError> {
+    let jj_dir = workspace_root.join(".jj");
+    let repo_file_path = jj_dir.join("repo");
+    if !repo_file_path.is_file() {
+        return Ok(());
+    }
+    let jj_dir_abs = dunce::canonicalize(&jj_dir).map_err(|err| {
+        user_error_with_message(format!("Failed to resolve '{}'", jj_dir.display()), err)
+    })?;
+    let repo_dir = dunce::canonicalize(repo_path).map_err(|err| {
+        user_error_with_message(format!("Failed to resolve '{}'", repo_path.display()), err)
+    })?;
+    let path_to_store = file_util::relative_path(&jj_dir_abs, &repo_dir);
+    let path_to_store = if path_to_store.is_relative() {
+        file_util::slash_path(&path_to_store).into_owned()
+    } else {
+        path_to_store
+    };
+    let repo_dir_bytes = file_util::path_to_bytes(&path_to_store)
+        .map_err(|err| user_error_with_message("Failed to encode jj repo path", err))?;
+    if fs::read(&repo_file_path).ok().as_deref() == Some(repo_dir_bytes) {
+        return Ok(());
+    }
+    fs::write(&repo_file_path, repo_dir_bytes)
+        .map_err(|err| user_error_with_message("Failed to repair jj workspace link", err))?;
+    Ok(())
+}
+
+pub(crate) fn git_worktree_paths(
+    git_executable: &Path,
+    main_workspace_root: &Path,
+) -> Result<HashSet<PathBuf>, CommandError> {
+    let output = std::process::Command::new(git_executable)
+        .args(["worktree", "list", "--porcelain", "-z"])
+        .current_dir(main_workspace_root)
+        .output()
+        .map_err(|err| user_error(format!("Failed to run `git worktree list`: {err}")))?;
+    if !output.status.success() {
+        return Err(user_error(format!(
+            "Failed to list Git worktrees: {}",
+            String::from_utf8_lossy(&output.stderr)
+        )));
+    }
+    let mut paths = HashSet::new();
+    for field in output.stdout.split_str(b"\0") {
+        let Some(path) = field.strip_prefix(b"worktree ") else {
+            continue;
+        };
+        let Ok(path) = path.to_str() else {
+            continue;
+        };
+        if let Ok(path) = dunce::canonicalize(path) {
+            paths.insert(path);
+        }
+    }
+    Ok(paths)
+}
+
+pub(crate) fn create_git_worktree_in_existing_workspace(
+    git_executable: &Path,
+    main_workspace_root: &Path,
+    workspace_root: &Path,
+) -> Result<(), CommandError> {
+    let parent = workspace_root.parent().unwrap_or(workspace_root);
+    let temp_dir = tempfile::Builder::new()
+        .prefix(".jj-git-worktree-")
+        .tempdir_in(parent)
+        .map_err(|err| user_error_with_message("Failed to create temporary Git worktree", err))?;
+    let output = std::process::Command::new(git_executable)
+        .args(["worktree", "add", "--detach", "--no-checkout"])
+        .arg(temp_dir.path())
+        .arg("HEAD")
+        .current_dir(main_workspace_root)
+        .output()
+        .map_err(|err| user_error(format!("Failed to run `git worktree add`: {err}")))?;
+    if !output.status.success() {
+        return Err(user_error(format!(
+            "Failed to create Git worktree: {}",
+            String::from_utf8_lossy(&output.stderr)
+        )));
+    }
+
+    let temp_dot_git = temp_dir.path().join(".git");
+    let git_file = fs::read_to_string(&temp_dot_git)
+        .map_err(|err| user_error_with_message("Failed to read temporary Git worktree", err))?;
+    let Some(git_dir) = git_file.trim().strip_prefix("gitdir: ") else {
+        return Err(user_error(
+            "Temporary Git worktree has unexpected .git file",
+        ));
+    };
+    let git_dir = Path::new(git_dir);
+    let git_dir = if git_dir.is_absolute() {
+        git_dir.to_owned()
+    } else {
+        temp_dir.path().join(git_dir)
+    };
+    let dot_git = workspace_root.join(".git");
+    fs::rename(&temp_dot_git, &dot_git)
+        .map_err(|err| user_error_with_message("Failed to install Git worktree file", err))?;
+    fs::write(git_dir.join("gitdir"), dot_git.to_string_lossy().as_bytes())
+        .map_err(|err| user_error_with_message("Failed to update Git worktree metadata", err))?;
+    temp_dir
+        .close()
+        .map_err(|err| user_error_with_message("Failed to remove temporary Git worktree", err))?;
+    Ok(())
 }
 
 #[cfg(test)]

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -132,6 +132,7 @@ This document contains the help content for the `jj` command-line program.
 * [`jj workspace list`↴](#jj-workspace-list)
 * [`jj workspace rename`↴](#jj-workspace-rename)
 * [`jj workspace root`↴](#jj-workspace-root)
+* [`jj workspace sync`↴](#jj-workspace-sync)
 * [`jj workspace update-stale`↴](#jj-workspace-update-stale)
 
 ## `jj`
@@ -3774,6 +3775,7 @@ Each workspace also has own sparse patterns.
 * `list` — List workspaces
 * `rename` — Renames the current workspace
 * `root` — Show the workspace root directory
+* `sync` — Synchronize jj workspaces with Git worktrees
 * `update-stale` — Update a workspace that has become stale
 
 
@@ -3880,6 +3882,24 @@ Show the workspace root directory
 ###### **Options:**
 
 * `--name <NAME>` — Name of the workspace (defaults to current)
+
+
+
+## `jj workspace sync`
+
+Synchronize jj workspaces with Git worktrees
+
+In a colocated Git repository, this command reconciles jj workspace state with Git worktree state:
+
+* Adopts Git worktrees created externally (e.g. via `git worktree add`) by creating corresponding jj workspaces.
+
+* Forgets jj workspaces whose Git worktrees have been removed.
+
+* Repairs workspace paths for Git worktrees that have been moved.
+
+This is equivalent to the automatic synchronization performed when `git.auto-sync-worktrees` is enabled (the default), but can be run manually when that setting is disabled.
+
+**Usage:** `jj workspace sync`
 
 
 

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -3784,7 +3784,7 @@ Add a workspace
 
 By default, the new workspace inherits the sparse patterns of the current workspace. You can override this with the `--sparse-patterns` option.
 
-**Usage:** `jj workspace add [OPTIONS] <DESTINATION>`
+**Usage:** `jj workspace add [OPTIONS] [DESTINATION]`
 
 ###### **Arguments:**
 
@@ -3792,6 +3792,9 @@ By default, the new workspace inherits the sparse patterns of the current worksp
 
 ###### **Options:**
 
+* `--adopt` — Adopt the current Git worktree as a jj workspace
+
+   When run inside a Git worktree that belongs to a colocated jj repository, creates a jj workspace for it. No destination path is needed.
 * `--name <NAME>` — A name for the workspace
 
    To override the default, which is the basename of the destination directory.

--- a/cli/tests/test_workspaces.rs
+++ b/cli/tests/test_workspaces.rs
@@ -186,6 +186,179 @@ fn test_workspaces_add_adopt_git_worktree() {
 }
 
 #[test]
+fn test_git_worktree_auto_workspace() {
+    let test_env = TestEnvironment::default();
+    test_env.add_config("git.colocate = true");
+    test_env.run_jj_in(".", ["git", "init", "main"]).success();
+    let main_dir = test_env.work_dir("main");
+    let linked_dir = test_env.work_dir("linked");
+
+    main_dir.write_file("file", "contents");
+    main_dir.run_jj(["commit", "-m", "initial"]).success();
+    let output = std::process::Command::new("git")
+        .args(["worktree", "add", "--detach"])
+        .arg(linked_dir.root())
+        .arg("HEAD")
+        .current_dir(main_dir.root())
+        .output()
+        .expect("git worktree add failed to spawn");
+    assert!(
+        output.status.success(),
+        "git worktree add failed with {}:\n{}\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(!linked_dir.root().join(".jj").exists());
+
+    let output = linked_dir.run_jj(["status"]);
+    insta::assert_snapshot!(output.normalize_backslash(), @r#"
+    The working copy has no changes.
+    Working copy  (@) : pmmvwywv 058f604d (empty) (no description set)
+    Parent commit (@-): qpvuntsm 7b22a8cb initial
+    [EOF]
+    ------- stderr -------
+    Created jj workspace for Git worktree at "$TEST_ENV/linked".
+    [EOF]
+    "#);
+    assert!(linked_dir.root().join(".jj").is_dir());
+
+    let output = main_dir.run_jj(["workspace", "list"]);
+    insta::assert_snapshot!(output.normalize_backslash(), @r#"
+    default: . rlvkpnrz 504e3d8c (empty) (no description set)
+    linked: ../linked pmmvwywv 058f604d (empty) (no description set)
+    [EOF]
+    "#);
+
+    let output = std::process::Command::new("git")
+        .args(["worktree", "remove", "--force"])
+        .arg(linked_dir.root())
+        .current_dir(main_dir.root())
+        .output()
+        .expect("git worktree remove failed to spawn");
+    assert!(
+        output.status.success(),
+        "git worktree remove failed with {}:\n{}\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let output = main_dir.run_jj(["workspace", "list"]);
+    insta::assert_snapshot!(output.normalize_backslash(), @r#"
+    default: . rlvkpnrz 504e3d8c (empty) (no description set)
+    [EOF]
+    "#);
+}
+
+#[test]
+fn test_git_worktree_custom_workspace_name_not_forgotten() {
+    let test_env = TestEnvironment::default();
+    test_env.add_config("git.colocate = true");
+    test_env.run_jj_in(".", ["git", "init", "main"]).success();
+    let main_dir = test_env.work_dir("main");
+
+    main_dir.write_file("file", "contents");
+    main_dir.run_jj(["commit", "-m", "initial"]).success();
+    main_dir
+        .run_jj(["workspace", "add", "--name", "foo", "../bar"])
+        .success();
+
+    let output = main_dir.run_jj(["workspace", "list"]);
+    insta::assert_snapshot!(output.normalize_backslash(), @r#"
+    default: . rlvkpnrz 504e3d8c (empty) (no description set)
+    foo: ../bar pmmvwywv 058f604d (empty) (no description set)
+    [EOF]
+    "#);
+}
+
+#[test]
+fn test_git_worktree_move_repairs_workspace_path() {
+    let test_env = TestEnvironment::default();
+    test_env.add_config("git.colocate = true");
+    test_env.run_jj_in(".", ["git", "init", "main"]).success();
+    let main_dir = test_env.work_dir("main");
+    let secondary_dir = test_env.work_dir("secondary");
+    let moved_dir = test_env.work_dir("nested/moved");
+
+    main_dir.write_file("file", "contents");
+    main_dir.run_jj(["commit", "-m", "initial"]).success();
+    main_dir
+        .run_jj(["workspace", "add", "../secondary"])
+        .success();
+    main_dir.create_dir("../nested");
+    let output = std::process::Command::new("git")
+        .args(["worktree", "move"])
+        .arg(secondary_dir.root())
+        .arg(moved_dir.root())
+        .current_dir(main_dir.root())
+        .output()
+        .expect("git worktree move failed to spawn");
+    assert!(
+        output.status.success(),
+        "git worktree move failed with {}:\n{}\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let output = main_dir.run_jj(["workspace", "list"]);
+    insta::assert_snapshot!(output.normalize_backslash(), @r#"
+    default: . rlvkpnrz 504e3d8c (empty) (no description set)
+    secondary: ../nested/moved pmmvwywv 058f604d (empty) (no description set)
+    [EOF]
+    "#);
+
+    let output = moved_dir.run_jj(["status"]);
+    insta::assert_snapshot!(output.normalize_backslash(), @r#"
+    The working copy has no changes.
+    Working copy  (@) : pmmvwywv 058f604d (empty) (no description set)
+    Parent commit (@-): qpvuntsm 7b22a8cb initial
+    [EOF]
+    "#);
+}
+
+#[test]
+fn test_git_worktree_created_after_unborn_head() {
+    let test_env = TestEnvironment::default();
+    test_env
+        .run_jj_in(".", ["git", "init", "--colocate", "main"])
+        .success();
+    let main_dir = test_env.work_dir("main");
+    let secondary_dir = test_env.work_dir("secondary");
+    let git_repo = git::open(main_dir.root());
+
+    main_dir
+        .run_jj(["workspace", "add", "../secondary"])
+        .success();
+    assert!(!secondary_dir.root().join(".git").exists());
+
+    git::set_symbolic_reference(&git_repo, "HEAD", "refs/heads/master");
+    git::add_commit(
+        &git_repo,
+        "refs/heads/master",
+        "file",
+        b"contents",
+        "initial",
+        &[],
+    );
+
+    let output = secondary_dir.run_jj(["status"]);
+    insta::assert_snapshot!(output.normalize_backslash(), @r#"
+    Working copy changes:
+    D file
+    Working copy  (@) : kkmpptxz 7ab2fc04 (no description set)
+    Parent commit (@-): slsumksp 97358f54 master | initial
+    [EOF]
+    ------- stderr -------
+    Created Git worktree for the current workspace.
+    Done importing changes from the underlying Git repo.
+    [EOF]
+    "#);
+    assert!(secondary_dir.root().join(".git").is_file());
+}
+
+#[test]
 fn test_workspaces_add_with_message() {
     let test_env = TestEnvironment::default();
     test_env.run_jj_in(".", ["git", "init", "main"]).success();
@@ -1440,8 +1613,8 @@ fn test_colocated_workspace_update_stale() {
         .success();
     secondary_dir.run_jj(["git", "export"]).success();
 
-    // Create new Git ref and commit which will be imported later by "jj
-    // workspace update-stale".
+    // Create new Git ref and commit which will be imported by the next command
+    // that reads the colocated Git repo.
     git::add_commit(&git_repo, "refs/heads/book2", "file", b"", "book2", &[]);
 
     insta::assert_snapshot!(get_log_output(&secondary_dir), @r#"
@@ -1449,45 +1622,46 @@ fn test_colocated_workspace_update_stale() {
     │ ○  f562bf82f2da default@
     ├─╯
     ○  30ed2f28b710
+    │ ○  7fe3ff3b9a60 book2 "book2"
+    ├─╯
     │ ○  e97ad7861f78 book1 "new book1"
     ├─╯
     │ ○  f656b467890b "old book1"
     ├─╯
     ◆  000000000000
     [EOF]
+    ------- stderr -------
+    Done importing changes from the underlying Git repo.
+    [EOF]
     "#);
 
-    // The main workspace's working copy is now stale.
+    // The main workspace imports the new Git HEAD from the colocated Git repo.
     let output = main_dir.run_jj(["st"]);
     insta::assert_snapshot!(output, @"
-    ------- stderr -------
-    Error: The working copy is stale (not updated since operation 572e45b3fba3).
-    Hint: Run `jj workspace update-stale` to update it.
-    See https://docs.jj-vcs.dev/latest/working-copy/#stale-working-copy for more information.
+    Working copy changes:
+    M file
+    Working copy  (@) : kpqxywon 29acff94 (no description set)
+    Parent commit (@-): qpvuntsm 30ed2f28 (no description set)
     [EOF]
-    [exit status: 1]
+    ------- stderr -------
+    Reset the working copy parent to the new Git HEAD.
+    [EOF]
     ");
 
-    // Before the fix, this would fail with the same "working copy is stale" error
-    // because the colocated repo reload logic would reload to HEAD before
-    // snapshotting, breaking the recovery.
+    // The workspace is already fresh after importing the Git HEAD.
     let output = main_dir.run_jj(["workspace", "update-stale"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: rlvkpnrz f562bf82 (empty) (no description set)
-    Parent commit (@-)      : qpvuntsm 30ed2f28 (no description set)
-    Added 0 files, modified 1 files, removed 0 files
-    Updated working copy to fresh commit f562bf82f2da
-    Done importing changes from the underlying Git repo.
+    Attempted recovery, but the working copy is not stale.
     [EOF]
     ");
 
-    // Verify the workspace is now up-to-date. New bookmark "book2" should have
-    // been imported by the previous command.
+    // The workspace is fresh, but still has the local file change.
     let output = main_dir.run_jj(["st"]);
     insta::assert_snapshot!(output, @"
-    The working copy has no changes.
-    Working copy  (@) : rlvkpnrz f562bf82 (empty) (no description set)
+    Working copy changes:
+    M file
+    Working copy  (@) : kpqxywon 29acff94 (no description set)
     Parent commit (@-): qpvuntsm 30ed2f28 (no description set)
     [EOF]
     ");
@@ -1495,7 +1669,7 @@ fn test_colocated_workspace_update_stale() {
     // The updated bookmark "book1" shouldn't be re-imported as an external
     // change. If it were, the "old book1" revision would be abandoned.
     insta::assert_snapshot!(get_log_output(&main_dir), @r#"
-    @  f562bf82f2da default@
+    @  29acff943ebf default@
     │ ○  9cb8253861b5 secondary@
     ├─╯
     ○  30ed2f28b710

--- a/cli/tests/test_workspaces.rs
+++ b/cli/tests/test_workspaces.rs
@@ -144,6 +144,48 @@ fn test_workspaces_add_colocated_unborn_git_head() {
 }
 
 #[test]
+fn test_workspaces_add_adopt_git_worktree() {
+    let test_env = TestEnvironment::default();
+    test_env.add_config("git.auto-sync-worktrees = false");
+    test_env
+        .run_jj_in(".", ["git", "init", "--colocate", "main"])
+        .success();
+    let main_dir = test_env.work_dir("main");
+    let linked_dir = test_env.work_dir("linked");
+
+    main_dir.write_file("file", "contents");
+    main_dir.run_jj(["commit", "-m", "initial"]).success();
+    let output = std::process::Command::new("git")
+        .args(["worktree", "add", "--detach"])
+        .arg(linked_dir.root())
+        .arg("HEAD")
+        .current_dir(main_dir.root())
+        .output()
+        .expect("git worktree add failed to spawn");
+    assert!(
+        output.status.success(),
+        "git worktree add failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(!linked_dir.root().join(".jj").exists());
+
+    let output = linked_dir.run_jj(["workspace", "add", "--adopt"]);
+    insta::assert_snapshot!(output.normalize_backslash(), @r#"
+    ------- stderr -------
+    Created jj workspace for Git worktree at "$TEST_ENV/linked".
+    [EOF]
+    "#);
+    assert!(linked_dir.root().join(".jj").is_dir());
+
+    let output = main_dir.run_jj(["workspace", "list"]);
+    insta::assert_snapshot!(output.normalize_backslash(), @r#"
+    default: . rlvkpnrz 504e3d8c (empty) (no description set)
+    linked: ../linked kkmpptxz 2b17ac71 (empty) (no description set)
+    [EOF]
+    "#);
+}
+
+#[test]
 fn test_workspaces_add_with_message() {
     let test_env = TestEnvironment::default();
     test_env.run_jj_in(".", ["git", "init", "main"]).success();


### PR DESCRIPTION
Add --adopt flag to `jj workspace add` that adopts the current Git worktree as a jj workspace. This works by discovering the parent jj repo via `git rev-parse` and creating a jj workspace in the worktree directory.

This provides an explicit way to create a jj workspace for an externally-created git worktree.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
