### PR TITLE
config: add -K (quit-on-intr) to default less pager flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed bugs
 
+* The default pager flags now include `-K` (`--quit-on-intr`), so pressing
+  Ctrl+C in `less` exits cleanly instead of leaving the terminal in a
+  corrupted state (raw mode, visible escape sequences, broken input).
+
 * A side of a conflict whose contents end with a carriage return no longer loses
   that byte when the materialized conflict is parsed back, such as when a
   conflicted file is snapshotted from the working copy.

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -115,7 +115,7 @@
                 },
                 "pager": {
                     "description": "Pager to use for displaying command output",
-                    "default": "less -FRX",
+                    "default": "less -FRXK",
                     "oneOf": [
                         {
                             "$ref": "#/properties/ui/definitions/command"

--- a/cli/src/config/misc.toml
+++ b/cli/src/config/misc.toml
@@ -36,7 +36,7 @@ color = "auto"
 diff-formatter = ":color-words"
 diff-instructions = true
 graph.style = "curved"
-pager = { command = ["less", "-FRX"], env = { LESSCHARSET = "utf-8" } }
+pager = { command = ["less", "-FRXK"], env = { LESSCHARSET = "utf-8" } }
 paginate = "auto"
 progress-indicator = true
 quiet = false

--- a/cli/tests/test_config_command.rs
+++ b/cli/tests/test_config_command.rs
@@ -1392,7 +1392,7 @@ fn test_config_get_yields_values_consistent_with_schema_defaults() -> TestResult
             // The default for `ui.pager` is a table; `ui.pager.command` is an array and `jj config
             // get` currently cannot print that. The schema default omits the env variable
             // `LESSCHARSET` and gives the default as a plain string.
-            "ui.pager" => insta::assert_snapshot!(schema_default, @r#""less -FRX""#),
+            "ui.pager" => insta::assert_snapshot!(schema_default, @r#""less -FRXK""#),
 
             // The `immutable_heads()` revset actually defaults to `builtin_immutable_heads()` but
             // this would be a poor starting point for a custom revset, so the schema "inlines"

--- a/docs/config.md
+++ b/docs/config.md
@@ -882,7 +882,7 @@ show-cryptographic-signatures = true
 ## Pager
 
 By default, jj will paginate output that would scroll off the screen. It does
-this by passing output through `less -FRX` on most platforms (on Windows it uses
+this by passing output through `less -FRXK` on most platforms (on Windows it uses
 [the pager](#builtin-pager) that is built-in to jj).
 
 Which pager to use can be customized by setting `ui.pager`. When choosing a
@@ -896,14 +896,14 @@ tool-specific environments that should not affect other programs. The generic
 Examples:
 
 ```shell
-# Pipe output through `less -FRX` (default on non-Windows platforms)
-$ jj config set --user ui.pager "less -FRX"
+# Pipe output through `less -FRXK` (default on non-Windows platforms)
+$ jj config set --user ui.pager "less -FRXK"
 
 # Use the built-in pager (default on Windows)
 $ jj config set --user ui.pager :builtin
 
 # Use `$PAGER` environment variable if set (on non-Windows platforms)
-$ jj config set --user ui.pager '["sh", "-c", "exec ${PAGER:-less -FRX}"]'
+$ jj config set --user ui.pager '["sh", "-c", "exec ${PAGER:-less -FRXK}"]'
 ```
 
 Additionally, paging behavior can be toggled via `ui.paginate` like so:

--- a/web/docs/src/content/docs/config.md
+++ b/web/docs/src/content/docs/config.md
@@ -719,7 +719,7 @@ show-cryptographic-signatures = true
 ## Pager
 
 By default, jj will paginate output that would scroll off the screen. It does
-this by passing output through `less -FRX` on most platforms (on Windows it uses
+this by passing output through `less -FRXK` on most platforms (on Windows it uses
 [the pager](#builtin-pager) that is built-in to jj).
 
 Which pager to use can be customized by setting `ui.pager`. When choosing a
@@ -729,14 +729,14 @@ pager, ensure that it either supports color codes or that you disable color (see
 Examples:
 
 ```shell
-# Pipe output through `less -FRX` (default on non-Windows platforms)
-$ jj config set --user ui.pager "less -FRX"
+# Pipe output through `less -FRXK` (default on non-Windows platforms)
+$ jj config set --user ui.pager "less -FRXK"
 
 # Use the built-in pager (default on Windows)
 $ jj config set --user ui.pager :builtin
 
 # Use `$PAGER` environment variable if set (on non-Windows platforms)
-$ jj config set --user ui.pager '["sh", "-c", "exec ${PAGER:-less -FRX}"]'
+$ jj config set --user ui.pager '["sh", "-c", "exec ${PAGER:-less -FRXK}"]'
 ```
 
 Additionally, paging behavior can be toggled via `ui.paginate` like so:


### PR DESCRIPTION
Pressing Ctrl+C while in the less pager leaves the terminal in raw mode, causing escape sequences to render as visible text and control characters (e.g. Ctrl+W, Ctrl+C) to be passed through as literal bytes rather than interpreted by the terminal line discipline. This makes the shell prompt unusable until the user runs `reset`.

<img width="707" height="153" alt="image" src="https://github.com/user-attachments/assets/146aa544-a1fb-4c6b-9e7f-272508211136" />


Adding the -K flag makes less treat Ctrl+C as a clean quit (like pressing q), ensuring proper terminal state restoration on exit. The full default flags are now -FRXK.

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [x] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
