### PR TITLE
cli: run: add sparse patterns options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,10 @@ None
   or array of string patterns, or with the repeatable `--remote` flag,
   which also accepts string patterns.
 
+* `jj run` now uses the sparse patterns from the workspace it's run from.
+  Use the `--sparse-patterns` option to control this behavior (evaluated
+  per each `jj run` invocation).
+
 ### Fixed bugs
 
 * [The default `immutable_heads()` set](docs/config.md#set-of-immutable-commits)

--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -53,6 +53,7 @@ use jj_lib::merge::Merge;
 use jj_lib::merged_tree::MergedTree;
 use jj_lib::object_id::ObjectId as _;
 use jj_lib::repo::Repo as _;
+use jj_lib::repo_path::RepoPathBuf;
 use jj_lib::working_copy::SnapshotOptions;
 use tokio::runtime::Builder;
 use tokio::sync::mpsc;
@@ -67,6 +68,7 @@ use crate::cli_util::WorkspaceCommandHelper;
 use crate::cli_util::WorkspaceCommandTransaction;
 use crate::command_error::CommandError;
 use crate::command_error::CommandErrorKind;
+use crate::commands::workspace::SparseInheritance;
 use crate::ui::Ui;
 
 #[derive(Debug, thiserror::Error)]
@@ -166,6 +168,9 @@ struct WorkspacePool {
     /// When true, wipe each slot's working copy on acquisition so every commit
     /// starts from a freshly checked-out tree (no artifact reuse).
     clean: bool,
+    /// Sparse patterns that influence what parts of the tree are materialized
+    /// when running the command. If None, whole tree is materialized.
+    sparsity: Option<Vec<RepoPathBuf>>,
 }
 
 impl WorkspacePool {
@@ -174,6 +179,7 @@ impl WorkspacePool {
         size: NonZeroUsize,
         auto_tracking_matcher: Box<dyn Matcher>,
         clean: bool,
+        sparsity: Option<Vec<RepoPathBuf>>,
     ) -> Result<Self, RunError> {
         // The parent() call is needed to not write under `.jj/repo/`.
         let base_path = repo_path.parent().unwrap().join("run").join("default");
@@ -183,6 +189,7 @@ impl WorkspacePool {
             size,
             auto_tracking_matcher,
             clean,
+            sparsity,
         })
     }
 
@@ -256,6 +263,18 @@ impl WorkspacePool {
                 &settings,
             )
         };
+
+        if let Some(sparse_patterns) = &self.sparsity {
+            tree_state
+                .set_sparse_patterns(sparse_patterns.clone())
+                .map_err(|_| RunError::FailedCheckout(commit.id().clone()))?;
+        } else {
+            // Users can specify `--sparse-args full` to materialize whole tree,
+            // without having to clear the run "workspace" first with `--clean`.
+            tree_state
+                .set_sparse_patterns(vec![RepoPathBuf::root()])
+                .map_err(|_| RunError::FailedCheckout(commit.id().clone()))?;
+        }
 
         tree_state
             .check_out(&commit.tree())
@@ -661,6 +680,16 @@ pub struct RunArgs {
     /// `jj run` itself.
     #[arg(long)]
     ignore_errors: bool,
+
+    /// How to handle sparse patterns when running the command. This is
+    /// controlled per `jj run` invocation.
+    ///
+    /// If sparse patterns were inherited in a run and a subsequent run is
+    /// passed `--sparse-args full`, but no `--clean`, then the command will
+    /// run in fully materialized workspace together with all artifacts left
+    /// from the previous run.
+    #[arg(long, value_enum, default_value_t = SparseInheritance::Copy)]
+    sparse_patterns: SparseInheritance,
 }
 
 /// Precedence: `--jobs`, `run.jobs` config, 1.
@@ -754,6 +783,15 @@ pub async fn cmd_run(
     let store = workspace_command.repo().store().clone();
     let auto_tracking_matcher = workspace_command.auto_tracking_matcher(ui)?;
 
+    let sparsity = match args.sparse_patterns {
+        SparseInheritance::Full => None,
+        SparseInheritance::Empty => Some(vec![]),
+        SparseInheritance::Copy => {
+            let sparse_patterns = workspace_command.working_copy().sparse_patterns()?.to_vec();
+            Some(sparse_patterns)
+        }
+    };
+
     let mut tx = workspace_command.start_transaction();
 
     let rt = {
@@ -769,6 +807,7 @@ pub async fn cmd_run(
         jobs,
         auto_tracking_matcher,
         args.clean,
+        sparsity,
     )?);
 
     let spec = Arc::new(CommandSpec {

--- a/cli/src/commands/workspace/add.rs
+++ b/cli/src/commands/workspace/add.rs
@@ -42,7 +42,7 @@ use crate::ui::Ui;
 
 /// How to handle sparse patterns when creating a new workspace.
 #[derive(clap::ValueEnum, Clone, Debug, Eq, PartialEq)]
-enum SparseInheritance {
+pub(crate) enum SparseInheritance {
     /// Copy all sparse patterns from the current workspace.
     Copy,
     /// Include all files in the new workspace.

--- a/cli/src/commands/workspace/mod.rs
+++ b/cli/src/commands/workspace/mod.rs
@@ -22,6 +22,7 @@ mod update_stale;
 use clap::Subcommand;
 use tracing::instrument;
 
+pub(crate) use self::add::SparseInheritance;
 use self::add::WorkspaceAddArgs;
 use self::add::cmd_workspace_add;
 use self::forget::WorkspaceForgetArgs;

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -3136,6 +3136,20 @@ $ jj run -j 4 -- pre-commit run .github/pre-commit.yaml
    Any changes made by a failed command will not be saved, but changes from successful commands are still applied atomically at the end.
 
    The exit code from any failed command will not impact the exit code of `jj run` itself.
+* `--sparse-patterns <SPARSE_PATTERNS>` — How to handle sparse patterns when running the command. This is controlled per `jj run` invocation.
+
+   If sparse patterns were inherited in a run and a subsequent run is passed `--sparse-args full`, but no `--clean`, then the command will run in fully materialized workspace together with all artifacts left from the previous run.
+
+  Default value: `copy`
+
+  Possible values:
+  - `copy`:
+    Copy all sparse patterns from the current workspace
+  - `full`:
+    Include all files in the new workspace
+  - `empty`:
+    Clear all files from the workspace (it will be empty)
+
 
 
 

--- a/cli/tests/test_run_command.rs
+++ b/cli/tests/test_run_command.rs
@@ -2083,3 +2083,100 @@ fn test_run_multi_commit_partial_diff() {
         .to_string();
     assert_eq!(log_commit_a_before, log_commit_a_after);
 }
+
+#[test]
+fn test_run_sparse() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+    work_dir.write_file("a", "");
+    work_dir.run_jj(&["commit", "-m", "A"]).success();
+    work_dir.write_file("b", "");
+    work_dir.run_jj(&["commit", "-m", "B"]).success();
+    work_dir.write_file("c", "");
+    work_dir.run_jj(&["commit", "-m", "C"]).success();
+    insta::assert_snapshot!(get_log_output(&work_dir), @r"
+    @  zsuskulnrvyrovkzqrwmxqlsskqntxvp
+    ○  kkmpptxzrspxrzommnulwmwkkqwworplC
+    │
+    ○  rlvkpnrzqnoowoytxnquwvuryrwnrmlpB
+    │
+    ○  qpvuntsmwlqtpsluzzsnyyzlmlwvmlnuA
+    │
+    ◆  zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz
+    [EOF]
+    ");
+    let stdout = work_dir
+        .run_jj(&["run", "-r", "..@", "--", "ls"])
+        .success()
+        .stdout;
+    insta::assert_snapshot!(stdout, @r"
+        a
+        a
+        b
+        a
+        b
+        c
+        a
+        b
+        c
+        [EOF]
+        ");
+
+    work_dir
+        .run_jj(&["sparse", "set", "--clear", "--add", "a", "--add", "b"])
+        .success();
+
+    let stdout = work_dir
+        .run_jj(&["run", "-r", "..@", "--", "ls"])
+        .success()
+        .stdout;
+    insta::assert_snapshot!(stdout, @r"
+        a
+        a
+        b
+        a
+        b
+        a
+        b
+        [EOF]
+        ");
+
+    let stdout = work_dir
+        .run_jj(&["run", "-r", "..@", "--sparse-patterns", "copy", "--", "ls"])
+        .success()
+        .stdout;
+    insta::assert_snapshot!(stdout, @r"
+        a
+        a
+        b
+        a
+        b
+        a
+        b
+        [EOF]
+        ");
+
+    let stdout = work_dir
+        .run_jj(&["run", "-r", "..@", "--sparse-patterns", "empty", "--", "ls"])
+        .success()
+        .stdout;
+    insta::assert_snapshot!(stdout, @"");
+
+    let stdout = work_dir
+        .run_jj(&["run", "-r", "..@", "--sparse-patterns", "full", "--", "ls"])
+        .success()
+        .stdout;
+    insta::assert_snapshot!(stdout, @r"
+        a
+        a
+        b
+        a
+        b
+        c
+        a
+        b
+        c
+        [EOF]
+        ");
+}


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

This is a way to add sparse patterns to the `run` command. Current implementation is very simple if not crude, but I don't think the final version (if accepted) will differ substantially. I left a few comments with TBD items, probably best discussed inline.

<s>I do want to emphasize one thing though, namely, that `--remove` pattern doesn't perform nearly as well as what should be an otherwise equivalent set of `--clear` and `--add` commands, and I'm not sure whether this is expected or not (didn't have time to dig into it yet, as I only run into it preparing the example below while opening this PR). *Most likely, this is an error on my side, so please review with this in mind.*</s>

If there proves to be interest in the feature, I'll add tests and check off other items of the list.

I think this can really make a difference, for example (in short, having a 4GB file, `jj run -- ls` won't complete in under 10s, but now we can exclude the big file using a sparse pattern and then it do so instantly (not with `--remove` though)):

```
gasper@capablanca /tmp> jj git init foo && cd foo && touch haha hihi hoho hehe
Initialized repo in "foo"
gasper@capablanca /t/foo> dd if=/dev/zero of=chungus bs=1G count=4 && jj --config snapshot.max-new-file-size=4G st
4+0 records in
4+0 records out
4294967296 bytes transferred in 0.686670 secs (6254776379 bytes/sec)
Working copy changes:
A chungus
A haha
A hehe
A hihi
A hoho
Working copy  (@) : wstwunnx 47decb2c (no description set)
Parent commit (@-): zzzzzzzz 00000000 (empty) (no description set)
gasper@capablanca /t/foo> gtimeout 10 jj run -- ls
gasper@capablanca /t/foo [124]> gtimeout 1 /Users/gasper/repos/jj/target/debug/jj run --remove chungus -- ls
gasper@capablanca /t/foo [124]> gtimeout 1 /Users/gasper/repos/jj/target/debug/jj run --clear --add haha --add hehe --add hihi --add hoho -- ls
haha
hehe
hihi
hoho
Nothing changed.
gasper@capablanca /t/foo> gtimeout 1 /Users/gasper/repos/jj/target/debug/jj run --clean -- ls
gasper@capablanca /t/foo [124]> gtimeout 1 /Users/gasper/repos/jj/target/debug/jj run --remove chungus -- ls
gasper@capablanca /t/foo [124]>
```

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
