### PR TITLE
git colocation: support child workspaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   config is `true`. `jj workspace forget` removes the corresponding Git
   worktree when one exists.
 
+* `jj git colocation status`/`enable`/`disable` now work on child
+  workspaces. `status` correctly reports colocation state and includes
+  the workspace name. `enable` creates a Git worktree and `disable`
+  removes it, allowing colocation to be toggled after workspace
+  creation.
+
 ### Fixed bugs
 
 ## [0.45.1] - 2026-09-03

--- a/cli/src/commands/git/colocation.rs
+++ b/cli/src/commands/git/colocation.rs
@@ -19,6 +19,7 @@ use itertools::Itertools as _;
 use jj_lib::commit::Commit;
 use jj_lib::file_util::IoResultExt as _;
 use jj_lib::git;
+use jj_lib::git::GitSubprocessOptions;
 use jj_lib::op_store::RefTarget;
 use jj_lib::repo::Repo as _;
 
@@ -29,6 +30,7 @@ use crate::command_error::user_error;
 use crate::command_error::user_error_with_message;
 use crate::commands::git::maybe_add_gitignore;
 use crate::git_util::is_colocated_git_workspace;
+use crate::git_util::unlink_git_worktree;
 use crate::ui::Ui;
 
 /// Show the current colocation status
@@ -71,24 +73,6 @@ pub async fn cmd_git_colocation(
     }
 }
 
-/// Check that the repository supports colocation commands
-/// which means that the repo is backed by Git and is a main workspace
-fn workspace_supports_git_colocation_commands(
-    workspace_command: &WorkspaceCommandHelper,
-) -> Result<(), CommandError> {
-    // Check if backend is Git (will show an error otherwise)
-    git::get_git_backend(workspace_command.repo().store())?;
-
-    // Ensure that this is the main workspace
-    let repo_dir = workspace_command.workspace_root().join(".jj").join("repo");
-    if repo_dir.is_file() {
-        return Err(user_error(
-            "This command cannot be used in a non-main Jujutsu workspace",
-        ));
-    }
-    Ok(())
-}
-
 async fn cmd_git_colocation_status(
     ui: &mut Ui,
     command: &CommandHelper,
@@ -96,19 +80,23 @@ async fn cmd_git_colocation_status(
 ) -> Result<(), CommandError> {
     let workspace_command = command.workspace_helper(ui).await?;
 
-    // Make sure that the workspace supports git colocation commands
-    workspace_supports_git_colocation_commands(&workspace_command)?;
+    git::get_git_backend(workspace_command.repo().store())?;
 
     let is_colocated = is_colocated_git_workspace(workspace_command.workspace())?;
     let workspace_name = workspace_command.workspace_name();
     let git_head = workspace_command.repo().view().git_head(workspace_name);
 
     if is_colocated {
-        writeln!(ui.stdout(), "Workspace is currently colocated with Git.")?;
+        writeln!(
+            ui.stdout(),
+            "Workspace '{}' is currently colocated with Git.",
+            workspace_name.as_symbol()
+        )?;
     } else {
         writeln!(
             ui.stdout(),
-            "Workspace is currently not colocated with Git."
+            "Workspace '{}' is currently not colocated with Git.",
+            workspace_name.as_symbol()
         )?;
     }
 
@@ -132,11 +120,12 @@ async fn cmd_git_colocation_status(
             ui.hint_default(),
             "To disable colocation, run: `jj git colocation disable`"
         )?;
-    } else if !workspace_command
-        .repo_path()
-        .join("store")
-        .join("git")
-        .exists()
+    } else if !is_child_workspace(&workspace_command)
+        && !workspace_command
+            .repo_path()
+            .join("store")
+            .join("git")
+            .exists()
     {
         writeln!(
             ui.hint_default(),
@@ -159,11 +148,9 @@ async fn cmd_git_colocation_enable(
     _args: &GitColocationEnableArgs,
 ) -> Result<(), CommandError> {
     let workspace_command = command.workspace_helper(ui).await?;
+    let git_backend = git::get_git_backend(workspace_command.repo().store())?;
 
-    // Make sure that the workspace supports git colocation commands
-    workspace_supports_git_colocation_commands(&workspace_command)?;
-
-    // Then ensure that the workspace is not already colocated before proceeding
+    // Ensure that the workspace is not already colocated before proceeding
     if is_colocated_git_workspace(workspace_command.workspace())? {
         writeln!(ui.status(), "Workspace is already colocated with Git.")?;
         return Ok(());
@@ -177,48 +164,53 @@ async fn cmd_git_colocation_enable(
         .clone();
 
     let workspace_root = workspace_command.workspace_root();
-    let jj_repo_path = workspace_command.repo_path();
-    let git_store_path = jj_repo_path.join("store").join("git");
-    let git_target_path = jj_repo_path.join("store").join("git_target");
-    let dot_git_path = workspace_root.join(".git");
 
-    // Move the git repository from .jj/repo/store/git to .git
-    std::fs::rename(&git_store_path, &dot_git_path).map_err(|err| match err.kind() {
-        ErrorKind::AlreadyExists | ErrorKind::DirectoryNotEmpty => {
-            user_error("A .git directory already exists in the workspace root. Cannot colocate.")
-        }
-        // An external Git repository (e.g. created by `jj git init
-        // --git-repo=<path>`) isn't managed by jj and cannot be moved.
-        // workspace_supports_git_colocation_commands() already ensured that
-        // the backend is Git.
-        ErrorKind::NotFound => {
-            let git_backend = git::get_git_backend(workspace_command.repo().store()).unwrap();
-            user_error(format!(
+    if is_child_workspace(&workspace_command) {
+        let subprocess_options = GitSubprocessOptions::from_settings(workspace_command.settings())?;
+        git::create_worktree(
+            workspace_command.repo().store(),
+            subprocess_options,
+            workspace_root,
+        )?;
+    } else {
+        let jj_repo_path = workspace_command.repo_path();
+        let git_store_path = jj_repo_path.join("store").join("git");
+        let git_target_path = jj_repo_path.join("store").join("git_target");
+        let dot_git_path = workspace_root.join(".git");
+
+        // Move the git repository from .jj/repo/store/git to .git
+        std::fs::rename(&git_store_path, &dot_git_path).map_err(|err| match err.kind() {
+            ErrorKind::AlreadyExists | ErrorKind::DirectoryNotEmpty => user_error(
+                "A .git directory already exists in the workspace root. Cannot colocate.",
+            ),
+            // An external Git repository (e.g. created by `jj git init
+            // --git-repo=<path>`) isn't managed by jj and cannot be moved.
+            ErrorKind::NotFound => user_error(format!(
                 "Cannot colocate a workspace backed by an external Git repository at {}",
                 git_backend.git_repo_path().display()
-            ))
-        }
-        _ => user_error_with_message(
-            "Failed to move Git repository from .jj/repo/store/git to workspace root directory.",
-            err,
-        ),
-    })?;
+            )),
+            _ => user_error_with_message(
+                "Failed to move Git repository from .jj/repo/store/git to workspace root \
+                 directory.",
+                err,
+            ),
+        })?;
 
-    // Update the git_target file to point to the new location of the git repo
-    let git_target_content = "../../../.git";
-    std::fs::write(&git_target_path, git_target_content).context(git_target_path)?;
+        // Update the git_target file to point to the new location
+        let git_target_content = "../../../.git";
+        std::fs::write(&git_target_path, git_target_content).context(git_target_path)?;
 
-    // Then we must make the Git repository non-bare
-    set_git_repo_bare(&dot_git_path, false)?;
+        // Make the Git repository non-bare
+        set_git_repo_bare(&dot_git_path, false)?;
+    }
 
     // Reload the workspace command helper to ensure it picks up the changes
     let mut workspace_command = reload_workspace_helper(ui, command, workspace_command).await?;
 
-    // Add a .jj/.gitignore file (if needed) to ensure that the colocated Git
-    // repository does not track Jujutsu's repository
+    // Add .jj/.gitignore to prevent Git from tracking jj's repo
     maybe_add_gitignore(&workspace_command)?;
 
-    // Finally, update git HEAD to point to the working-copy commit's parent
+    // Update git HEAD to point to the working-copy commit's parent
     let wc_commit = workspace_command
         .repo()
         .store()
@@ -240,45 +232,49 @@ async fn cmd_git_colocation_disable(
     _args: &GitColocationDisableArgs,
 ) -> Result<(), CommandError> {
     let workspace_command = command.workspace_helper(ui).await?;
+    git::get_git_backend(workspace_command.repo().store())?;
 
-    // Make sure that the repository supports git colocation commands
-    workspace_supports_git_colocation_commands(&workspace_command)?;
-
-    // Then ensure that the repo is colocated before proceeding
     if !is_colocated_git_workspace(workspace_command.workspace())? {
         writeln!(ui.status(), "Workspace is already not colocated with Git.")?;
         return Ok(());
     }
 
     let workspace_root = workspace_command.workspace_root();
-    let dot_jj_path = workspace_root.join(".jj");
-    let git_store_path = workspace_command.repo_path().join("store").join("git");
-    let git_target_path = workspace_command
-        .repo_path()
-        .join("store")
-        .join("git_target");
-    let dot_git_path = workspace_root.join(".git");
-    let jj_gitignore_path = dot_jj_path.join(".gitignore");
 
-    // Move the Git repository from .git into .jj/repo/store/git
-    std::fs::rename(&dot_git_path, &git_store_path).map_err(|e| {
-        user_error_with_message("Failed to move Git repository to .jj/repo/store/git", e)
-    })?;
+    if is_child_workspace(&workspace_command) {
+        let subprocess_options = GitSubprocessOptions::from_settings(workspace_command.settings())?;
+        unlink_git_worktree(
+            ui,
+            workspace_command.repo().store(),
+            subprocess_options,
+            workspace_root,
+        )?;
+    } else {
+        let git_store_path = workspace_command.repo_path().join("store").join("git");
+        let git_target_path = workspace_command
+            .repo_path()
+            .join("store")
+            .join("git_target");
+        let dot_git_path = workspace_root.join(".git");
 
-    // Make the Git repository bare
-    set_git_repo_bare(&git_store_path, true)?;
+        // Move the Git repository from .git into .jj/repo/store/git
+        std::fs::rename(&dot_git_path, &git_store_path).map_err(|e| {
+            user_error_with_message("Failed to move Git repository to .jj/repo/store/git", e)
+        })?;
 
-    // Update the git_target file to point to the internal git store
-    let git_target_content = "git";
-    std::fs::write(&git_target_path, git_target_content).context(&git_target_path)?;
+        // Make the Git repository bare
+        set_git_repo_bare(&git_store_path, true)?;
 
-    // Remove the .jj/.gitignore file if it exists
-    std::fs::remove_file(&jj_gitignore_path).ok();
+        // Update the git_target file to point to the internal git store
+        let git_target_content = "git";
+        std::fs::write(&git_target_path, git_target_content).context(&git_target_path)?;
+    }
+
+    // Remove the .jj/.gitignore since Git no longer needs to ignore jj's repo
+    std::fs::remove_file(workspace_root.join(".jj").join(".gitignore")).ok();
 
     // Reload the workspace command helper to ensure it picks up the changes
     let mut workspace_command = reload_workspace_helper(ui, command, workspace_command).await?;
-
-    // And finally, remove the git HEAD reference
     remove_git_head(ui, &mut workspace_command).await?;
 
     writeln!(
@@ -366,4 +362,12 @@ async fn reload_workspace_helper(
     let repo = workspace.repo_loader().load_at(&op).await?;
     let workspace_command = command.for_workable_repo(ui, workspace, repo)?;
     Ok(workspace_command)
+}
+
+fn is_child_workspace(workspace_command: &WorkspaceCommandHelper) -> bool {
+    workspace_command
+        .workspace_root()
+        .join(".jj")
+        .join("repo")
+        .is_file()
 }

--- a/cli/tests/test_git_colocated.rs
+++ b/cli/tests/test_git_colocated.rs
@@ -60,7 +60,7 @@ fn test_git_colocated() -> TestResult {
         @"97358f54806c7cd005ed5ade68a779595efbae7e"
     );
     insta::assert_snapshot!(get_colocation_status(&work_dir), @"
-    Workspace is currently colocated with Git.
+    Workspace 'default' is currently colocated with Git.
     Last imported/exported Git HEAD: 97358f54806c7cd005ed5ade68a779595efbae7e
     [EOF]
     ");
@@ -79,7 +79,7 @@ fn test_git_colocated() -> TestResult {
         @"97358f54806c7cd005ed5ade68a779595efbae7e"
     );
     insta::assert_snapshot!(get_colocation_status(&work_dir), @"
-    Workspace is currently colocated with Git.
+    Workspace 'default' is currently colocated with Git.
     Last imported/exported Git HEAD: 97358f54806c7cd005ed5ade68a779595efbae7e
     [EOF]
     ");
@@ -99,7 +99,7 @@ fn test_git_colocated() -> TestResult {
         @"9dfe8c7005c8dff6078ecdfd953c6bfddc633c90"
     );
     insta::assert_snapshot!(get_colocation_status(&work_dir), @"
-    Workspace is currently colocated with Git.
+    Workspace 'default' is currently colocated with Git.
     Last imported/exported Git HEAD: 9dfe8c7005c8dff6078ecdfd953c6bfddc633c90
     [EOF]
     ");
@@ -190,7 +190,7 @@ fn test_git_colocated_new_wc_commit_when_wc_immutable() {
         .run_jj(["bookmark", "create", "-r@", "main"])
         .success();
     insta::assert_snapshot!(get_colocation_status(&work_dir), @"
-    Workspace is currently colocated with Git.
+    Workspace 'default' is currently colocated with Git.
     Last imported/exported Git HEAD: eb7b8a1f02b8d0915290e1163a3526bfa4e417fa
     [EOF]
     ");
@@ -231,7 +231,7 @@ fn test_git_colocated_new_wc_commit_when_wc_immutable() {
     [EOF]
     ");
     insta::assert_snapshot!(get_colocation_status(&work_dir), @"
-    Workspace is currently colocated with Git.
+    Workspace 'default' is currently colocated with Git.
     Last imported/exported Git HEAD: 1d3e40a35156c275f7a535fdaa50cb5882d500eb
     [EOF]
     ");
@@ -258,7 +258,7 @@ fn test_git_colocated_update_stale_resets_git_head() {
     work_dir.write_file("file2", "b\n");
     work_dir.run_jj(["status"]).success();
     insta::assert_snapshot!(get_colocation_status(&work_dir), @"
-    Workspace is currently colocated with Git.
+    Workspace 'default' is currently colocated with Git.
     Last imported/exported Git HEAD: df69548750502d54d6f207b500d25da43ed6fe1e
     [EOF]
     ");
@@ -287,7 +287,7 @@ fn test_git_colocated_update_stale_resets_git_head() {
 
     // Git HEAD should point to the amended "parent", not the stale one
     insta::assert_snapshot!(get_colocation_status(&work_dir), @"
-    Workspace is currently colocated with Git.
+    Workspace 'default' is currently colocated with Git.
     Last imported/exported Git HEAD: 239acdab88e2b438ed43a99471a385d3832190ec
     [EOF]
     ");
@@ -341,7 +341,7 @@ fn test_git_colocated_unborn_bookmark() -> TestResult {
     [EOF]
     ");
     insta::assert_snapshot!(get_colocation_status(&work_dir), @"
-    Workspace is currently colocated with Git.
+    Workspace 'default' is currently colocated with Git.
     Last imported/exported Git HEAD: (none)
     [EOF]
     ");
@@ -369,7 +369,7 @@ fn test_git_colocated_unborn_bookmark() -> TestResult {
     [EOF]
     ");
     insta::assert_snapshot!(get_colocation_status(&work_dir), @"
-    Workspace is currently colocated with Git.
+    Workspace 'default' is currently colocated with Git.
     Last imported/exported Git HEAD: (none)
     [EOF]
     ");
@@ -406,7 +406,7 @@ fn test_git_colocated_unborn_bookmark() -> TestResult {
     [EOF]
     ");
     insta::assert_snapshot!(get_colocation_status(&work_dir), @"
-    Workspace is currently colocated with Git.
+    Workspace 'default' is currently colocated with Git.
     Last imported/exported Git HEAD: ff5366846b039b25c6c4998fa74dca821c246243
     [EOF]
     ");
@@ -447,7 +447,7 @@ fn test_git_colocated_unborn_bookmark() -> TestResult {
     [EOF]
     ");
     insta::assert_snapshot!(get_colocation_status(&work_dir), @"
-    Workspace is currently colocated with Git.
+    Workspace 'default' is currently colocated with Git.
     Last imported/exported Git HEAD: (none)
     [EOF]
     ");
@@ -481,7 +481,7 @@ fn test_git_colocated_unborn_bookmark() -> TestResult {
     [EOF]
     ");
     insta::assert_snapshot!(get_colocation_status(&work_dir), @"
-    Workspace is currently colocated with Git.
+    Workspace 'default' is currently colocated with Git.
     Last imported/exported Git HEAD: bb21bc2dce2af92973fdd6d42686d77bd16bc466
     [EOF]
     ");
@@ -882,7 +882,7 @@ fn test_git_colocated_checkout_non_empty_working_copy() -> TestResult {
     [EOF]
     ");
     insta::assert_snapshot!(get_colocation_status(&work_dir), @"
-    Workspace is currently colocated with Git.
+    Workspace 'default' is currently colocated with Git.
     Last imported/exported Git HEAD: 97358f54806c7cd005ed5ade68a779595efbae7e
     [EOF]
     ");
@@ -1239,7 +1239,7 @@ fn test_git_colocated_undo_head_move() -> TestResult {
     [EOF]
     ");
     insta::assert_snapshot!(get_colocation_status(&work_dir), @"
-    Workspace is currently colocated with Git.
+    Workspace 'default' is currently colocated with Git.
     Last imported/exported Git HEAD: e8849ae12c709f2321908879bc724fdb2ab8a781
     [EOF]
     ");
@@ -1253,7 +1253,7 @@ fn test_git_colocated_undo_head_move() -> TestResult {
     [EOF]
     ");
     insta::assert_snapshot!(get_colocation_status(&work_dir), @"
-    Workspace is currently colocated with Git.
+    Workspace 'default' is currently colocated with Git.
     Last imported/exported Git HEAD: (none)
     [EOF]
     ");
@@ -1269,7 +1269,7 @@ fn test_git_colocated_undo_head_move() -> TestResult {
     [EOF]
     ");
     insta::assert_snapshot!(get_colocation_status(&work_dir), @"
-    Workspace is currently colocated with Git.
+    Workspace 'default' is currently colocated with Git.
     Last imported/exported Git HEAD: 23e6e06a7471634da3567ef975fadf883082658f
     [EOF]
     ");
@@ -1299,7 +1299,7 @@ fn test_git_colocated_undo_head_move() -> TestResult {
     [EOF]
     ");
     insta::assert_snapshot!(get_colocation_status(&work_dir), @"
-    Workspace is currently colocated with Git.
+    Workspace 'default' is currently colocated with Git.
     Last imported/exported Git HEAD: e8849ae12c709f2321908879bc724fdb2ab8a781
     [EOF]
     ");
@@ -1951,7 +1951,7 @@ fn test_git_colocated_operation_cleanup() -> TestResult {
     [EOF]
     ");
     insta::assert_snapshot!(get_colocation_status(&work_dir), @"
-    Workspace is currently colocated with Git.
+    Workspace 'default' is currently colocated with Git.
     Last imported/exported Git HEAD: cf3bb116ded416d9b202e71303f260e504c2eeb9
     [EOF]
     ");

--- a/cli/tests/test_git_colocation.rs
+++ b/cli/tests/test_git_colocation.rs
@@ -59,7 +59,7 @@ fn test_git_colocation_enable_success() -> TestResult {
 
     // And that there is no Git HEAD yet
     insta::assert_snapshot!(get_colocation_status(&work_dir), @"
-    Workspace is currently not colocated with Git.
+    Workspace 'default' is currently not colocated with Git.
     Last imported/exported Git HEAD: (none)
     [EOF]
     ");
@@ -90,7 +90,7 @@ fn test_git_colocation_enable_success() -> TestResult {
 
     // Verify that Git HEAD was set correctly
     insta::assert_snapshot!(get_colocation_status(&work_dir), @"
-    Workspace is currently colocated with Git.
+    Workspace 'default' is currently colocated with Git.
     Last imported/exported Git HEAD: e8849ae12c709f2321908879bc724fdb2ab8a781
     [EOF]
     ");
@@ -128,7 +128,7 @@ fn test_git_colocation_enable_empty() {
 
     // Verify that Git HEAD was set correctly
     insta::assert_snapshot!(get_colocation_status(&work_dir), @"
-    Workspace is currently colocated with Git.
+    Workspace 'default' is currently colocated with Git.
     Last imported/exported Git HEAD: (none)
     [EOF]
     ");
@@ -209,7 +209,7 @@ fn test_git_colocation_enable_external_git_repo() {
     // The status hint shouldn't suggest enabling colocation
     let output = work_dir.run_jj(["git", "colocation", "status"]);
     insta::assert_snapshot!(output, @"
-    Workspace is currently not colocated with Git.
+    Workspace 'default' is currently not colocated with Git.
     Last imported/exported Git HEAD: (none)
     [EOF]
     ------- stderr -------
@@ -243,7 +243,7 @@ fn test_git_colocation_disable_success() {
 
     // Verify that Git HEAD is set
     insta::assert_snapshot!(get_colocation_status(&work_dir), @"
-    Workspace is currently colocated with Git.
+    Workspace 'default' is currently colocated with Git.
     Last imported/exported Git HEAD: e8849ae12c709f2321908879bc724fdb2ab8a781
     [EOF]
     ");
@@ -275,7 +275,7 @@ fn test_git_colocation_disable_success() {
 
     // Verify that Git HEAD was removed correctly
     insta::assert_snapshot!(get_colocation_status(&work_dir), @"
-    Workspace is currently not colocated with Git.
+    Workspace 'default' is currently not colocated with Git.
     Last imported/exported Git HEAD: (none)
     [EOF]
     ");
@@ -301,7 +301,7 @@ fn test_git_colocation_disable_empty() {
 
     // Verify that Git HEAD is unset
     insta::assert_snapshot!(get_colocation_status(&work_dir), @"
-    Workspace is currently colocated with Git.
+    Workspace 'default' is currently colocated with Git.
     Last imported/exported Git HEAD: (none)
     [EOF]
     ");
@@ -356,7 +356,7 @@ fn test_git_colocation_status_non_colocated() {
     // Check status - should show non-colocated
     let output = work_dir.run_jj(["git", "colocation", "status"]);
     insta::assert_snapshot!(output, @"
-    Workspace is currently not colocated with Git.
+    Workspace 'default' is currently not colocated with Git.
     Last imported/exported Git HEAD: (none)
     [EOF]
     ------- stderr -------
@@ -378,7 +378,7 @@ fn test_git_colocation_status_colocated() {
     // Check status - should show colocated
     let output = work_dir.run_jj(["git", "colocation", "status"]);
     insta::assert_snapshot!(output, @"
-    Workspace is currently colocated with Git.
+    Workspace 'default' is currently colocated with Git.
     Last imported/exported Git HEAD: (none)
     [EOF]
     ------- stderr -------
@@ -400,26 +400,156 @@ fn test_git_colocation_in_secondary_workspace() {
     let secondary_dir = test_env.work_dir("secondary");
 
     let output = secondary_dir.run_jj(["git", "colocation", "status"]);
-    insta::assert_snapshot!(output, @"
-    ------- stderr -------
-    Error: This command cannot be used in a non-main Jujutsu workspace
+    insta::assert_snapshot!(output, @r#"
+    Workspace 'secondary' is currently not colocated with Git.
+    Last imported/exported Git HEAD: (none)
     [EOF]
-    [exit status: 1]
-    ");
+    ------- stderr -------
+    Hint: To enable colocation, run: `jj git colocation enable`
+    [EOF]
+    "#);
 
     let output = secondary_dir.run_jj(["git", "colocation", "enable"]);
-    insta::assert_snapshot!(output, @"
+    insta::assert_snapshot!(output, @r#"
     ------- stderr -------
-    Error: This command cannot be used in a non-main Jujutsu workspace
+    Workspace successfully converted into a colocated Jujutsu/Git workspace.
     [EOF]
-    [exit status: 1]
-    ");
+    "#);
+    assert!(test_env.env_root().join("secondary/.git").is_file());
 
     let output = secondary_dir.run_jj(["git", "colocation", "disable"]);
-    insta::assert_snapshot!(output, @"
+    insta::assert_snapshot!(output.normalize_backslash(), @r#"
     ------- stderr -------
-    Error: This command cannot be used in a non-main Jujutsu workspace
+    Removed Git worktree for "$TEST_ENV/secondary".
+    Workspace successfully converted into a non-colocated Jujutsu/Git workspace.
+    [EOF]
+    "#);
+    assert!(!test_env.env_root().join("secondary/.git").exists());
+}
+
+#[test]
+fn test_git_colocation_enable_disable_child_workspace() {
+    let test_env = TestEnvironment::default();
+    test_env.add_config("git.colocate = true");
+    test_env
+        .run_jj_in(".", ["git", "init", "--colocate", "main"])
+        .success();
+    let main_dir = test_env.work_dir("main");
+
+    main_dir.write_file("file", "contents");
+    main_dir.run_jj(["commit", "-m", "initial"]).success();
+
+    main_dir
+        .run_jj(["workspace", "add", "--no-colocate", "../secondary"])
+        .success();
+    let secondary_dir = test_env.work_dir("secondary");
+
+    assert!(!test_env.env_root().join("secondary/.git").exists());
+
+    let output = secondary_dir.run_jj(["git", "colocation", "status"]);
+    insta::assert_snapshot!(output, @r#"
+    Workspace 'secondary' is currently not colocated with Git.
+    Last imported/exported Git HEAD: (none)
+    [EOF]
+    ------- stderr -------
+    Hint: To enable colocation, run: `jj git colocation enable`
+    [EOF]
+    "#);
+
+    let output = secondary_dir.run_jj(["git", "colocation", "enable"]);
+    insta::assert_snapshot!(output, @r#"
+    ------- stderr -------
+    Workspace successfully converted into a colocated Jujutsu/Git workspace.
+    [EOF]
+    "#);
+    assert!(test_env.env_root().join("secondary/.git").is_file());
+
+    // The workspace's .jj directory must be excluded, or Git would report it as
+    // untracked in the worktree.
+    assert!(
+        test_env
+            .env_root()
+            .join("secondary/.jj/.gitignore")
+            .is_file()
+    );
+    let secondary_repo = git::open(test_env.env_root().join("secondary"));
+    insta::assert_debug_snapshot!(git::status(&secondary_repo), @r#"
+    [
+        GitStatus {
+            path: ".jj/.gitignore",
+            status: Worktree(
+                Ignored,
+            ),
+        },
+        GitStatus {
+            path: ".jj/repo",
+            status: Worktree(
+                Ignored,
+            ),
+        },
+        GitStatus {
+            path: ".jj/working_copy",
+            status: Worktree(
+                Ignored,
+            ),
+        },
+    ]
+    "#);
+
+    let output = secondary_dir.run_jj(["git", "colocation", "status", "--quiet"]);
+    insta::assert_snapshot!(output, @r#"
+    Workspace 'secondary' is currently colocated with Git.
+    Last imported/exported Git HEAD: 7b22a8cbe888adcb4d5ff6dd46a38049e870c6ab
+    [EOF]
+    "#);
+
+    let output = secondary_dir.run_jj(["git", "colocation", "disable"]);
+    insta::assert_snapshot!(output.normalize_backslash(), @r#"
+    ------- stderr -------
+    Removed Git worktree for "$TEST_ENV/secondary".
+    Workspace successfully converted into a non-colocated Jujutsu/Git workspace.
+    [EOF]
+    "#);
+    assert!(!test_env.env_root().join("secondary/.git").exists());
+    assert!(
+        !test_env
+            .env_root()
+            .join("secondary/.jj/.gitignore")
+            .exists()
+    );
+
+    let output = secondary_dir.run_jj(["git", "colocation", "status", "--quiet"]);
+    insta::assert_snapshot!(output, @r#"
+    Workspace 'secondary' is currently not colocated with Git.
+    Last imported/exported Git HEAD: (none)
+    [EOF]
+    "#);
+}
+
+#[test]
+fn test_git_colocation_enable_child_workspace_with_existing_git_dir() -> TestResult {
+    let test_env = TestEnvironment::default();
+    test_env.add_config("git.colocate = true");
+    test_env
+        .run_jj_in(".", ["git", "init", "--colocate", "main"])
+        .success();
+    let main_dir = test_env.work_dir("main");
+    main_dir
+        .run_jj(["workspace", "add", "--no-colocate", "../secondary"])
+        .success();
+    let secondary_dir = test_env.work_dir("secondary");
+    secondary_dir.create_dir(".git");
+
+    let main_repo = git::open(test_env.env_root().join("main"));
+    let worktree_count = main_repo.worktrees()?.len();
+
+    let output = secondary_dir.run_jj(["git", "colocation", "enable"]);
+    insta::assert_snapshot!(output, @r#"
+    ------- stderr -------
+    Error: A .git file or directory already exists in the Git worktree destination
     [EOF]
     [exit status: 1]
-    ");
+    "#);
+    assert_eq!(main_repo.worktrees()?.len(), worktree_count);
+    Ok(())
 }

--- a/cli/tests/test_git_init.rs
+++ b/cli/tests/test_git_init.rs
@@ -222,7 +222,7 @@ fn test_git_init_external(bare: bool) {
         ");
         // Non-colocated repo shouldn't record the Git HEAD
         insta::assert_snapshot!(get_colocation_status(&work_dir), @"
-        Workspace is currently not colocated with Git.
+        Workspace 'default' is currently not colocated with Git.
         Last imported/exported Git HEAD: (none)
         [EOF]
         ");
@@ -479,7 +479,7 @@ fn test_git_init_colocated_via_git_repo_path() {
     [EOF]
     ");
     insta::assert_snapshot!(get_colocation_status(&work_dir), @"
-    Workspace is currently colocated with Git.
+    Workspace 'default' is currently colocated with Git.
     Last imported/exported Git HEAD: e80a42cccd069007c7a2bb427ac7f1d10b408633
     [EOF]
     ");
@@ -494,7 +494,7 @@ fn test_git_init_colocated_via_git_repo_path() {
     [EOF]
     ");
     insta::assert_snapshot!(get_colocation_status(&work_dir), @"
-    Workspace is currently colocated with Git.
+    Workspace 'default' is currently colocated with Git.
     Last imported/exported Git HEAD: f3fe58bc88ccfb820b930a21297d8e48bf76ac2a
     [EOF]
     ");
@@ -528,7 +528,7 @@ fn test_git_init_colocated_via_git_repo_path_gitlink() {
     [EOF]
     ");
     insta::assert_snapshot!(get_colocation_status(&jj_work_dir), @"
-    Workspace is currently colocated with Git.
+    Workspace 'default' is currently colocated with Git.
     Last imported/exported Git HEAD: e80a42cccd069007c7a2bb427ac7f1d10b408633
     [EOF]
     ");
@@ -543,7 +543,7 @@ fn test_git_init_colocated_via_git_repo_path_gitlink() {
     [EOF]
     ");
     insta::assert_snapshot!(get_colocation_status(&jj_work_dir), @"
-    Workspace is currently colocated with Git.
+    Workspace 'default' is currently colocated with Git.
     Last imported/exported Git HEAD: f3fe58bc88ccfb820b930a21297d8e48bf76ac2a
     [EOF]
     ");
@@ -576,7 +576,7 @@ fn test_git_init_colocated_via_git_repo_path_symlink_directory() -> TestResult {
     [EOF]
     ");
     insta::assert_snapshot!(get_colocation_status(&jj_work_dir), @"
-    Workspace is currently colocated with Git.
+    Workspace 'default' is currently colocated with Git.
     Last imported/exported Git HEAD: e80a42cccd069007c7a2bb427ac7f1d10b408633
     [EOF]
     ");
@@ -591,7 +591,7 @@ fn test_git_init_colocated_via_git_repo_path_symlink_directory() -> TestResult {
     [EOF]
     ");
     insta::assert_snapshot!(get_colocation_status(&jj_work_dir), @"
-    Workspace is currently colocated with Git.
+    Workspace 'default' is currently colocated with Git.
     Last imported/exported Git HEAD: f3fe58bc88ccfb820b930a21297d8e48bf76ac2a
     [EOF]
     ");
@@ -630,7 +630,7 @@ fn test_git_init_colocated_via_git_repo_path_symlink_directory_without_bare_conf
     [EOF]
     ");
     insta::assert_snapshot!(get_colocation_status(&jj_work_dir), @"
-    Workspace is currently colocated with Git.
+    Workspace 'default' is currently colocated with Git.
     Last imported/exported Git HEAD: e80a42cccd069007c7a2bb427ac7f1d10b408633
     [EOF]
     ");
@@ -645,7 +645,7 @@ fn test_git_init_colocated_via_git_repo_path_symlink_directory_without_bare_conf
     [EOF]
     ");
     insta::assert_snapshot!(get_colocation_status(&jj_work_dir), @"
-    Workspace is currently colocated with Git.
+    Workspace 'default' is currently colocated with Git.
     Last imported/exported Git HEAD: f3fe58bc88ccfb820b930a21297d8e48bf76ac2a
     [EOF]
     ");
@@ -686,7 +686,7 @@ fn test_git_init_colocated_via_git_repo_path_symlink_gitlink() -> TestResult {
     [EOF]
     ");
     insta::assert_snapshot!(get_colocation_status(&jj_work_dir), @"
-    Workspace is currently colocated with Git.
+    Workspace 'default' is currently colocated with Git.
     Last imported/exported Git HEAD: e80a42cccd069007c7a2bb427ac7f1d10b408633
     [EOF]
     ");
@@ -701,7 +701,7 @@ fn test_git_init_colocated_via_git_repo_path_symlink_gitlink() -> TestResult {
     [EOF]
     ");
     insta::assert_snapshot!(get_colocation_status(&jj_work_dir), @"
-    Workspace is currently colocated with Git.
+    Workspace 'default' is currently colocated with Git.
     Last imported/exported Git HEAD: f3fe58bc88ccfb820b930a21297d8e48bf76ac2a
     [EOF]
     ");
@@ -928,7 +928,7 @@ fn test_git_init_external_but_git_dir_exists() {
     [EOF]
     ");
     insta::assert_snapshot!(get_colocation_status(&work_dir), @"
-    Workspace is currently not colocated with Git.
+    Workspace 'default' is currently not colocated with Git.
     Last imported/exported Git HEAD: (none)
     [EOF]
     ");
@@ -957,7 +957,7 @@ fn test_git_init_colocated_via_flag_git_dir_exists() {
     [EOF]
     ");
     insta::assert_snapshot!(get_colocation_status(&work_dir), @"
-    Workspace is currently colocated with Git.
+    Workspace 'default' is currently colocated with Git.
     Last imported/exported Git HEAD: e80a42cccd069007c7a2bb427ac7f1d10b408633
     [EOF]
     ");
@@ -972,7 +972,7 @@ fn test_git_init_colocated_via_flag_git_dir_exists() {
     [EOF]
     ");
     insta::assert_snapshot!(get_colocation_status(&work_dir), @"
-    Workspace is currently colocated with Git.
+    Workspace 'default' is currently colocated with Git.
     Last imported/exported Git HEAD: f3fe58bc88ccfb820b930a21297d8e48bf76ac2a
     [EOF]
     ");
@@ -1002,7 +1002,7 @@ fn test_git_init_colocated_via_config_git_dir_exists() {
     [EOF]
     ");
     insta::assert_snapshot!(get_colocation_status(&work_dir), @"
-    Workspace is currently colocated with Git.
+    Workspace 'default' is currently colocated with Git.
     Last imported/exported Git HEAD: e80a42cccd069007c7a2bb427ac7f1d10b408633
     [EOF]
     ");
@@ -1017,7 +1017,7 @@ fn test_git_init_colocated_via_config_git_dir_exists() {
     [EOF]
     ");
     insta::assert_snapshot!(get_colocation_status(&work_dir), @"
-    Workspace is currently colocated with Git.
+    Workspace 'default' is currently colocated with Git.
     Last imported/exported Git HEAD: f3fe58bc88ccfb820b930a21297d8e48bf76ac2a
     [EOF]
     ");
@@ -1080,7 +1080,7 @@ fn test_git_init_colocated_via_flag_overrides_false_config() {
     [EOF]
     ");
     insta::assert_snapshot!(get_colocation_status(&work_dir), @"
-    Workspace is currently colocated with Git.
+    Workspace 'default' is currently colocated with Git.
     Last imported/exported Git HEAD: e80a42cccd069007c7a2bb427ac7f1d10b408633
     [EOF]
     ");
@@ -1104,7 +1104,7 @@ fn test_git_init_colocated_via_flag_git_dir_not_exists() {
     [EOF]
     ");
     insta::assert_snapshot!(get_colocation_status(&work_dir), @"
-    Workspace is currently colocated with Git.
+    Workspace 'default' is currently colocated with Git.
     Last imported/exported Git HEAD: (none)
     [EOF]
     ");
@@ -1122,7 +1122,7 @@ fn test_git_init_colocated_via_flag_git_dir_not_exists() {
     [EOF]
     ");
     insta::assert_snapshot!(get_colocation_status(&work_dir), @"
-    Workspace is currently colocated with Git.
+    Workspace 'default' is currently colocated with Git.
     Last imported/exported Git HEAD: (none)
     [EOF]
     ");
@@ -1276,7 +1276,7 @@ fn test_git_init_colocate_in_git_worktree() {
 
     let worktree_dir = test_env.work_dir("worktree");
     insta::assert_snapshot!(get_colocation_status(&worktree_dir), @"
-    Workspace is currently colocated with Git.
+    Workspace 'default' is currently colocated with Git.
     Last imported/exported Git HEAD: e80a42cccd069007c7a2bb427ac7f1d10b408633
     [EOF]
     ");

--- a/cli/tests/test_workspaces.rs
+++ b/cli/tests/test_workspaces.rs
@@ -2208,6 +2208,15 @@ fn test_workspaces_add_forget_colocated() {
     ]
     "#);
 
+    // The child workspace reports itself as colocated.
+    let secondary_dir = test_env.work_dir("secondary");
+    let output = secondary_dir.run_jj(["git", "colocation", "status", "--quiet"]);
+    insta::assert_snapshot!(output, @"
+    Workspace 'secondary' is currently colocated with Git.
+    Last imported/exported Git HEAD: 7b22a8cbe888adcb4d5ff6dd46a38049e870c6ab
+    [EOF]
+    ");
+
     // Forgetting the workspace disconnects the worktree, but leaves the
     // directory contents in place.
     let output = main_dir.run_jj(["workspace", "forget", "secondary"]);

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -34,6 +34,7 @@ use futures::TryStreamExt as _;
 use futures::stream;
 use gix::refspec::Instruction;
 use itertools::Itertools as _;
+use tempfile::TempDir;
 use thiserror::Error;
 
 use crate::backend::BackendError;
@@ -44,6 +45,7 @@ use crate::commit::Commit;
 use crate::config::ConfigGetError;
 use crate::file_util::IoResultExt as _;
 use crate::file_util::PathError;
+use crate::file_util::is_empty_dir;
 use crate::git_backend::GitBackend;
 use crate::git_subprocess::GitFetchStatus;
 pub use crate::git_subprocess::GitProgress;
@@ -1826,6 +1828,14 @@ fn update_git_head(
 pub enum GitCreateWorktreeError {
     #[error(transparent)]
     Subprocess(#[from] GitSubprocessError),
+    #[error("Failed to inspect the Git worktree destination")]
+    Destination(#[source] PathError),
+    #[error("Failed to create temporary directory for Git worktree")]
+    TempDir(#[source] std::io::Error),
+    #[error("A .git file or directory already exists in the Git worktree destination")]
+    ExistingGitLink,
+    #[error("Failed to move .git gitlink file into place")]
+    MoveGitLink(#[source] PathError),
     #[error(transparent)]
     Git(Box<dyn std::error::Error + Send + Sync>),
     #[error(transparent)]
@@ -1838,12 +1848,16 @@ impl GitCreateWorktreeError {
     }
 }
 
-/// Creates a Git worktree at `destination` to back a new jj workspace.
+/// Creates a Git worktree at `destination` to back a jj workspace.
 ///
-/// The worktree is created empty, with HEAD unborn. jj populates the working
-/// copy itself, and the subsequent HEAD export (see [`reset_head()`]) points
-/// HEAD at the parent of the new working-copy commit. Git is only responsible
-/// for the `.git` gitlink and the worktree bookkeeping under
+/// Nothing is checked out: the worktree is created with HEAD unborn, so jj
+/// remains responsible for the working-copy contents. `destination` may
+/// already hold a populated jj workspace, as it does when colocation is
+/// enabled after the fact.
+///
+/// For a new workspace, the subsequent HEAD export (see [`reset_head()`])
+/// points HEAD at the parent of the new working-copy commit. Git is only
+/// responsible for the `.git` gitlink and the worktree bookkeeping under
 /// `.git/worktrees/`.
 pub fn create_worktree(
     store: &Store,
@@ -1857,8 +1871,18 @@ pub fn create_worktree(
     // be taken by an exported bookmark.
     let branch_name = format!("jj-worktree-{:016x}", rand::random::<u64>());
     let git_ctx = GitSubprocessContext::from_git_backend(git_backend, subprocess_options);
-    git_ctx.spawn_worktree_add(destination, &branch_name)?;
 
+    let destination_is_populated = destination.exists()
+        && !is_empty_dir(destination).map_err(GitCreateWorktreeError::Destination)?;
+    if destination_is_populated {
+        add_worktree_to_populated_dir(&git_ctx, destination, &branch_name)?;
+    } else {
+        git_ctx.spawn_worktree_add(destination, &branch_name)?;
+    }
+
+    // Must run after the gitlink at `destination` resolves, i.e. after any
+    // `git worktree repair` above.
+    //
     // Nullifying HEAD puts the worktree in the same "HEAD has no commit yet"
     // state jj uses everywhere else, so that a `git commit` in the new
     // worktree can't materialize the branch nobody asked for. If the
@@ -1878,6 +1902,34 @@ pub fn create_worktree(
         None,
     )
     .map_err(GitCreateWorktreeError::from_git)
+}
+
+/// Adds a worktree for a directory that already has contents.
+///
+/// `git worktree add` refuses to use a non-empty directory, so the worktree is
+/// created in a temporary directory inside `destination`, its gitlink moved
+/// into place, and the recorded paths repaired.
+fn add_worktree_to_populated_dir(
+    git_ctx: &GitSubprocessContext,
+    destination: &Path,
+    branch_name: &str,
+) -> Result<(), GitCreateWorktreeError> {
+    let dot_git = destination.join(".git");
+    if dot_git.exists() {
+        return Err(GitCreateWorktreeError::ExistingGitLink);
+    }
+    let tmp_dir = TempDir::new_in(destination).map_err(GitCreateWorktreeError::TempDir)?;
+    let tmp_path = tmp_dir.path();
+    git_ctx.spawn_worktree_add(tmp_path, branch_name)?;
+
+    std::fs::rename(tmp_path.join(".git"), &dot_git)
+        .context(&dot_git)
+        .map_err(GitCreateWorktreeError::MoveGitLink)?;
+    if let Err(err) = git_ctx.spawn_worktree_repair(destination) {
+        std::fs::remove_file(&dot_git).ok();
+        return Err(err.into());
+    }
+    Ok(())
 }
 
 #[derive(Debug, Error)]

--- a/lib/src/git_subprocess.rs
+++ b/lib/src/git_subprocess.rs
@@ -326,6 +326,23 @@ impl GitSubprocessContext {
         parse_git_worktree_output(output)
     }
 
+    /// Fix up the paths Git recorded for the worktree at `worktree_path`,
+    /// after the worktree or the repository has been moved.
+    pub(crate) fn spawn_worktree_repair(
+        &self,
+        worktree_path: &Path,
+    ) -> Result<(), GitSubprocessError> {
+        let mut command = self.create_command();
+        command.stdout(Stdio::null());
+        command.args(["-c", "worktree.useRelativePaths=true"]);
+        command.args(["worktree", "repair", "--"]);
+        command.arg(worktree_path);
+
+        let output = wait_with_output(self.spawn_cmd(command)?)?;
+
+        parse_git_worktree_output(output)
+    }
+
     /// Remove the bookkeeping of worktrees whose directories are gone.
     pub(crate) fn spawn_worktree_prune(&self) -> Result<(), GitSubprocessError> {
         let mut command = self.create_command();


### PR DESCRIPTION
`jj git colocation status` now correctly identifies child workspaces backed by Git worktrees (gitlink files) as colocated and includes the workspace name in its output.

`jj git colocation enable` and `disable` now work on child workspaces. For child workspaces, `enable` creates a Git worktree and `disable` removes it, allowing colocation to be toggled after workspace creation.

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
