### PR TITLE
cli: merge_tools/external: bail out if the files are the same when re-reading conflicts

### DIFF
--- a/cli/src/merge_tools/external.rs
+++ b/cli/src/merge_tools/external.rs
@@ -307,6 +307,10 @@ async fn run_mergetool_external_single_file(
         Merge::normal(new_file_id)
     };
 
+    if new_file_ids == file.unsimplified_ids {
+        return Err(ConflictResolveError::EmptyOrUnchanged);
+    }
+
     // If the exit status indicated there should be conflict markers but there
     // weren't any, it's likely that the tool generated invalid conflict markers, so
     // we need to inform the user. If we didn't treat this as an error, the user

--- a/cli/tests/test_resolve_command.rs
+++ b/cli/tests/test_resolve_command.rs
@@ -412,6 +412,41 @@ fn test_resolution() -> TestResult {
     [EOF]
     ");
 
+    // Check that we error if the files are unchanged and
+    // `merge-tool-edits-conflict-markers=true`
+    work_dir.run_jj(["op", "restore", &setup_opid]).success();
+    insta::assert_snapshot!(work_dir.run_jj(["diff", "--git"]), @"");
+    std::fs::write(&editor_script, "")?;
+    let output = work_dir.run_jj([
+        "resolve",
+        "--config=merge-tools.fake-editor.merge-tool-edits-conflict-markers=true",
+    ]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    Resolving conflicts in: file
+    Error: Failed to resolve conflicts
+    Caused by: The output file is either unchanged or empty after the editor quit (run with --debug to see the exact invocation).
+    [EOF]
+    [exit status: 1]
+    ");
+    insta::assert_snapshot!(
+        std::fs::read_to_string(test_env.env_root().join("editor1"))?, @r#"
+    <<<<<<< conflict 1 of 1
+    %%%%%%% diff from: rlvkpnrz 1792382a "base"
+    \\\\\\\        to: zsuskuln 45537d53 "a"
+    -base
+    +a
+    +++++++ royxmykx 89d1b299 "b"
+    b
+    >>>>>>> conflict 1 of 1 ends
+    "#);
+    insta::assert_snapshot!(work_dir.run_jj(["op", "restore", &setup_opid]), @"
+    ------- stderr -------
+    Restored to operation: e036363e2dbe (2001-02-03 08:05:15) create bookmark conflict pointing to commit fbebe50eff6c300d0fc9e7c16b45fa9fc0a78ecb
+    Nothing changed.
+    [EOF]
+    ");
+
     // Check that merge tool can leave conflict markers by returning exit code 1
     // when using `merge-conflict-exit-codes = [1]`. The Git "diff3" conflict
     // markers should also be parsed correctly.
@@ -442,14 +477,14 @@ fn test_resolution() -> TestResult {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Resolving conflicts in: file
-    Working copy  (@) now at: vruxwmqv 097d6249 conflict | (conflict) conflict
+    Working copy  (@) now at: vruxwmqv 53e4a6c8 conflict | (conflict) conflict
     Parent commit (@-)      : zsuskuln 45537d53 a | a
     Parent commit (@-)      : royxmykx 89d1b299 b | b
     Added 0 files, modified 1 files, removed 0 files
     Warning: There are unresolved conflicts at these paths:
     file    2-sided conflict
     New conflicts appeared in 1 commits:
-      vruxwmqv 097d6249 conflict | (conflict) conflict
+      vruxwmqv 53e4a6c8 conflict | (conflict) conflict
     Hint: To resolve the conflicts, start by creating a commit on top of
     the conflicted commit:
       jj new vruxwmqv


### PR DESCRIPTION
Previously, we were always updating the tree, even if the files were unchanged by the external editor.

Fixes https://github.com/jj-vcs/jj/issues/9138.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
