### PR TITLE
workspace: restore paths across undo and redo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed bugs
 
+* `jj undo` now restores workspace paths when undoing `jj workspace forget`.
+  It also recreates workspace directories when undoing `jj workspace delete`,
+  if the path is still available, and `jj redo` removes those directories
+  again.
+
 * The default pager flags now include `-K` (`--quit-on-intr`), so pressing
   Ctrl+C in `less` exits cleanly instead of leaving the terminal in a
   corrupted state (raw mode, visible escape sequences, broken input).

--- a/cli/src/command_error.rs
+++ b/cli/src/command_error.rs
@@ -351,6 +351,9 @@ impl From<WorkspaceInitError> for CommandError {
             WorkspaceInitError::CheckOutCommit(err) => {
                 internal_error_with_message("Failed to check out the initial commit", err)
             }
+            WorkspaceInitError::Checkout(err) => {
+                internal_error_with_message("Failed to check out the working copy", err)
+            }
             WorkspaceInitError::Path(err) => {
                 internal_error_with_message("Failed to access the repository", err)
             }

--- a/cli/src/commands/redo.rs
+++ b/cli/src/commands/redo.rs
@@ -23,6 +23,8 @@ use crate::command_error::user_error;
 use crate::commands::operation::DEFAULT_REVERT_WHAT;
 use crate::commands::operation::view_with_desired_portions_restored;
 use crate::commands::undo::UNDO_OP_DESC_PREFIX;
+use crate::commands::undo::WORKSPACE_DELETE_OP_DESC_PREFIX;
+use crate::commands::undo::remove_workspace_directories;
 use crate::ui::Ui;
 
 /// Redo the most recently undone operation
@@ -150,11 +152,10 @@ pub async fn cmd_redo(
     }
 
     let mut tx = workspace_command.start_transaction();
-    let new_view = view_with_desired_portions_restored(
-        target_op_parent.view().await?.store_view(),
-        tx.base_repo().view().store_view(),
-        &DEFAULT_REVERT_WHAT,
-    );
+    let old_view = tx.base_repo().view().store_view().clone();
+    let restored_view = target_op_parent.view().await?.store_view().clone();
+    let new_view =
+        view_with_desired_portions_restored(&restored_view, &old_view, &DEFAULT_REVERT_WHAT);
     tx.repo_mut().set_view(new_view);
     if let Some(mut formatter) = ui.status_formatter() {
         write!(formatter, "Restored to operation: ")?;
@@ -167,6 +168,14 @@ pub async fn cmd_redo(
         format!("{REDO_OP_DESC_PREFIX}{}", target_op_parent.id().hex()),
     )
     .await?;
+
+    if target_op_parent
+        .metadata()
+        .description
+        .starts_with(WORKSPACE_DELETE_OP_DESC_PREFIX)
+    {
+        remove_workspace_directories(ui, &workspace_command, &old_view, &restored_view)?;
+    }
 
     Ok(())
 }

--- a/cli/src/commands/undo.rs
+++ b/cli/src/commands/undo.rs
@@ -15,8 +15,15 @@
 use itertools::Itertools as _;
 use jj_lib::object_id::ObjectId as _;
 use jj_lib::op_store::OperationId;
+use jj_lib::op_store::View;
+use jj_lib::ref_name::WorkspaceNameBuf;
+use jj_lib::repo::Repo as _;
+use jj_lib::workspace::Workspace;
+use jj_lib::workspace_store::SimpleWorkspaceStore;
+use jj_lib::workspace_store::WorkspaceStore as _;
 
 use crate::cli_util::CommandHelper;
+use crate::cli_util::WorkspaceCommandHelper;
 use crate::command_error::CommandError;
 use crate::command_error::internal_error;
 use crate::command_error::user_error;
@@ -43,6 +50,7 @@ use crate::ui::Ui;
 pub struct UndoArgs {}
 
 pub(crate) const UNDO_OP_DESC_PREFIX: &str = "undo: restore to operation ";
+pub(crate) const WORKSPACE_DELETE_OP_DESC_PREFIX: &str = "delete workspace";
 
 pub async fn cmd_undo(
     ui: &mut Ui,
@@ -148,12 +156,22 @@ pub async fn cmd_undo(
             .await?;
     }
 
+    let old_view = workspace_command.repo().view().store_view().clone();
+    let restored_view = target_op_parent.view().await?.store_view().clone();
+    let restores_workspace_delete = target_op
+        .metadata()
+        .description
+        .starts_with(WORKSPACE_DELETE_OP_DESC_PREFIX);
+    if restores_workspace_delete {
+        check_workspace_restore_directories_available(
+            &workspace_command,
+            &old_view,
+            &restored_view,
+        )?;
+    }
     let mut tx = workspace_command.start_transaction();
-    let new_view = view_with_desired_portions_restored(
-        target_op_parent.view().await?.store_view(),
-        tx.base_repo().view().store_view(),
-        &DEFAULT_REVERT_WHAT,
-    );
+    let new_view =
+        view_with_desired_portions_restored(&restored_view, &old_view, &DEFAULT_REVERT_WHAT);
     tx.repo_mut().set_view(new_view);
     if let Some(mut formatter) = ui.status_formatter() {
         let template = tx.base_workspace_helper().operation_summary_template();
@@ -172,5 +190,160 @@ pub async fn cmd_undo(
     )
     .await?;
 
+    if restores_workspace_delete {
+        restore_workspace_directories(ui, command, &workspace_command, &old_view, &restored_view)
+            .await?;
+    }
+
     Ok(())
+}
+
+pub(crate) async fn restore_workspace_directories(
+    ui: &mut Ui,
+    command: &CommandHelper,
+    workspace_command: &WorkspaceCommandHelper,
+    old_view: &View,
+    new_view: &View,
+) -> Result<(), CommandError> {
+    let workspace_store = SimpleWorkspaceStore::load(workspace_command.repo_path())?;
+    let working_copy_factory = command.get_working_copy_factory()?;
+    for workspace_name in new_view
+        .wc_commit_ids
+        .keys()
+        .filter(|workspace_name| !old_view.wc_commit_ids.contains_key(*workspace_name))
+        .cloned()
+        .collect_vec()
+    {
+        let Some(rel_path) = workspace_store.get_workspace_path(&workspace_name)? else {
+            continue;
+        };
+        let workspace_path = normalize_maybe_missing(workspace_command.repo_path().join(rel_path))?;
+        if workspace_path.exists() {
+            return Err(workspace_restore_blocked_error(
+                &workspace_name,
+                &workspace_path,
+            ));
+        }
+        let Some(wc_commit_id) = workspace_command
+            .repo()
+            .view()
+            .get_wc_commit_id(&workspace_name)
+        else {
+            continue;
+        };
+        let wc_commit = workspace_command
+            .repo()
+            .store()
+            .get_commit_async(wc_commit_id)
+            .await?;
+        Workspace::restore_workspace_with_existing_repo(
+            &workspace_path,
+            workspace_command.repo_path(),
+            workspace_command.repo(),
+            working_copy_factory,
+            workspace_name,
+            &wc_commit,
+        )
+        .await?;
+        writeln!(
+            ui.status(),
+            r#"Restored workspace directory "{}"."#,
+            workspace_path.display()
+        )?;
+    }
+    Ok(())
+}
+
+fn check_workspace_restore_directories_available(
+    workspace_command: &WorkspaceCommandHelper,
+    old_view: &View,
+    new_view: &View,
+) -> Result<(), CommandError> {
+    let workspace_store = SimpleWorkspaceStore::load(workspace_command.repo_path())?;
+    for workspace_name in new_view
+        .wc_commit_ids
+        .keys()
+        .filter(|workspace_name| !old_view.wc_commit_ids.contains_key(*workspace_name))
+        .cloned()
+        .collect_vec()
+    {
+        let Some(rel_path) = workspace_store.get_workspace_path(&workspace_name)? else {
+            continue;
+        };
+        let workspace_path = normalize_maybe_missing(workspace_command.repo_path().join(rel_path))?;
+        if workspace_path.exists() {
+            return Err(workspace_restore_blocked_error(
+                &workspace_name,
+                &workspace_path,
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn workspace_restore_blocked_error(
+    workspace_name: &WorkspaceNameBuf,
+    workspace_path: &std::path::Path,
+) -> CommandError {
+    user_error(format!(
+        "Cannot restore workspace '{}' because directory '{}' already exists",
+        workspace_name.as_symbol(),
+        workspace_path.display()
+    ))
+    .hinted("Move the directory away, then retry `jj undo`.")
+}
+
+pub(crate) fn remove_workspace_directories(
+    ui: &mut Ui,
+    workspace_command: &WorkspaceCommandHelper,
+    old_view: &View,
+    new_view: &View,
+) -> Result<(), CommandError> {
+    let workspace_store = SimpleWorkspaceStore::load(workspace_command.repo_path())?;
+    for workspace_name in old_view
+        .wc_commit_ids
+        .keys()
+        .filter(|workspace_name| !new_view.wc_commit_ids.contains_key(*workspace_name))
+        .cloned()
+        .collect_vec()
+    {
+        let Some(rel_path) = workspace_store.get_workspace_path(&workspace_name)? else {
+            continue;
+        };
+        let Ok(workspace_path) =
+            normalize_maybe_missing(workspace_command.repo_path().join(rel_path))
+        else {
+            continue;
+        };
+        if workspace_path.join(".jj").join("repo").is_dir() || !workspace_path.exists() {
+            continue;
+        }
+        if let Err(err) = std::fs::remove_dir_all(&workspace_path) {
+            writeln!(
+                ui.warning_default(),
+                r#"Failed to remove workspace directory "{}": {err}"#,
+                workspace_path.display()
+            )?;
+        } else {
+            writeln!(
+                ui.status(),
+                r#"Removed workspace directory "{}"."#,
+                workspace_path.display()
+            )?;
+        }
+    }
+    Ok(())
+}
+
+fn normalize_maybe_missing(path: std::path::PathBuf) -> Result<std::path::PathBuf, CommandError> {
+    if path.exists() {
+        return Ok(dunce::canonicalize(path)?);
+    }
+    let Some(parent) = path.parent() else {
+        return Ok(path);
+    };
+    let Some(file_name) = path.file_name() else {
+        return Ok(dunce::canonicalize(parent)?);
+    };
+    Ok(dunce::canonicalize(parent)?.join(file_name))
 }

--- a/cli/src/commands/workspace/forget.rs
+++ b/cli/src/commands/workspace/forget.rs
@@ -15,8 +15,6 @@
 use clap_complete::ArgValueCandidates;
 use itertools::Itertools as _;
 use jj_lib::ref_name::WorkspaceNameBuf;
-use jj_lib::workspace_store::SimpleWorkspaceStore;
-use jj_lib::workspace_store::WorkspaceStore as _;
 use tracing::instrument;
 
 use crate::cli_util::CommandHelper;
@@ -83,9 +81,6 @@ pub(super) async fn forget_workspaces(
     forget_ws: &[&WorkspaceNameBuf],
     description_verb: &str,
 ) -> Result<(), CommandError> {
-    let workspace_store = SimpleWorkspaceStore::load(workspace_command.repo_path())?;
-    workspace_store.forget(&forget_ws.iter().map(|x| x.as_ref()).collect_vec())?;
-
     // bundle every workspace forget into a single transaction, so that e.g.
     // undo correctly restores all of them at once.
     let mut tx = workspace_command.start_transaction();

--- a/cli/tests/test_workspaces.rs
+++ b/cli/tests/test_workspaces.rs
@@ -1621,8 +1621,8 @@ fn test_workspaces_forget_multi_transaction() {
     let output = main_dir.run_jj(["workspace", "list"]);
     insta::assert_snapshot!(output.normalize_backslash(), @"
     default: . rlvkpnrz f6bf8819 (empty) (no description set)
-    second: pmmvwywv 31da1455 (empty) (no description set)
-    third: rzvqmyuk bf5b5b4d (empty) (no description set)
+    second: ../second pmmvwywv 31da1455 (empty) (no description set)
+    third: ../third rzvqmyuk bf5b5b4d (empty) (no description set)
     [EOF]
     ");
 }
@@ -1903,6 +1903,107 @@ fn test_workspaces_delete_current_workspace() {
     [EOF]
     "#);
     assert!(!test_env.env_root().join("secondary").exists());
+}
+
+#[test]
+fn test_workspaces_delete_undo_redo_restores_directory() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "main"]).success();
+    let main_dir = test_env.work_dir("main");
+
+    main_dir.write_file("file", "contents");
+    main_dir.run_jj(["commit", "-m", "initial"]).success();
+
+    main_dir
+        .run_jj(["workspace", "add", "../secondary"])
+        .success();
+    let secondary_dir = test_env.work_dir("secondary");
+    secondary_dir.write_file("secondary_file", "secondary contents");
+
+    main_dir
+        .run_jj(["workspace", "delete", "secondary"])
+        .success();
+    assert!(!test_env.env_root().join("secondary").exists());
+
+    let output = main_dir.run_jj(["undo"]);
+    insta::assert_snapshot!(output.normalize_backslash(), @r#"
+    ------- stderr -------
+    Undid operation: 393d77283fee (2001-02-03 08:05:10) delete workspace secondary
+    Restored to operation: 014a22bea38d (2001-02-03 08:05:10) snapshot working copy
+    Restored workspace directory "$TEST_ENV/secondary".
+    [EOF]
+    "#);
+    assert!(
+        test_env
+            .env_root()
+            .join("secondary/secondary_file")
+            .is_file()
+    );
+
+    let output = main_dir.run_jj(["redo"]);
+    insta::assert_snapshot!(output.normalize_backslash(), @r#"
+    ------- stderr -------
+    Restored to operation: 393d77283fee (2001-02-03 08:05:10) delete workspace secondary
+    Removed workspace directory "$TEST_ENV/secondary".
+    [EOF]
+    "#);
+    assert!(!test_env.env_root().join("secondary").exists());
+}
+
+#[test]
+fn test_workspaces_delete_undo_refuses_existing_directory() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "main"]).success();
+    let main_dir = test_env.work_dir("main");
+
+    main_dir.write_file("file", "contents");
+    main_dir.run_jj(["commit", "-m", "initial"]).success();
+
+    main_dir
+        .run_jj(["workspace", "add", "../secondary"])
+        .success();
+    main_dir
+        .run_jj(["workspace", "delete", "secondary"])
+        .success();
+    assert!(!test_env.env_root().join("secondary").exists());
+
+    let secondary_dir = test_env.work_dir("secondary");
+    secondary_dir.write_file("new-owner.txt", "do not delete");
+
+    let output = main_dir.run_jj(["undo"]);
+    insta::assert_snapshot!(output.normalize_backslash(), @r#"
+    ------- stderr -------
+    Error: Cannot restore workspace 'secondary' because directory '$TEST_ENV/secondary' already exists
+    Hint: Move the directory away, then retry `jj undo`.
+    [EOF]
+    [exit status: 1]
+    "#);
+    assert!(
+        test_env
+            .env_root()
+            .join("secondary/new-owner.txt")
+            .is_file()
+    );
+
+    let output = main_dir.run_jj(["workspace", "list"]);
+    insta::assert_snapshot!(output.normalize_backslash(), @r#"
+    default: . rlvkpnrz 504e3d8c (empty) (no description set)
+    [EOF]
+    "#);
+
+    let output = main_dir.run_jj(["redo"]);
+    insta::assert_snapshot!(output, @r#"
+    ------- stderr -------
+    Error: Nothing to redo
+    [EOF]
+    [exit status: 1]
+    "#);
+    assert!(
+        test_env
+            .env_root()
+            .join("secondary/new-owner.txt")
+            .is_file()
+    );
 }
 
 /// Test context of commit summary template

--- a/docs/working-copy.md
+++ b/docs/working-copy.md
@@ -94,7 +94,9 @@ the files around.
 Use `jj workspace delete` to forget a workspace and remove its directory from
 disk. Tracked changes are snapshotted before the directory is removed, but
 ignored files in that directory are deleted. The main workspace cannot be
-deleted, and deleting the current workspace is rejected on Windows.
+deleted, and deleting the current workspace is rejected on Windows. `jj undo`
+recreates the workspace directory and checks out the snapshotted working-copy
+commit if the path is still available; `jj redo` removes it again.
 
 ## Stale working copy
 

--- a/lib/src/workspace.rs
+++ b/lib/src/workspace.rs
@@ -72,6 +72,8 @@ pub enum WorkspaceInitError {
     #[error(transparent)]
     CheckOutCommit(#[from] CheckOutCommitError),
     #[error(transparent)]
+    Checkout(#[from] CheckoutError),
+    #[error(transparent)]
     WorkingCopyState(#[from] WorkingCopyStateError),
     #[error(transparent)]
     Path(#[from] PathError),
@@ -405,6 +407,71 @@ impl Workspace {
         )?;
         workspace_store.add(workspace.workspace_name(), workspace.workspace_root())?;
         Ok((workspace, repo))
+    }
+
+    pub async fn restore_workspace_with_existing_repo(
+        workspace_root: &Path,
+        repo_path: &Path,
+        repo: &Arc<ReadonlyRepo>,
+        working_copy_factory: &dyn WorkingCopyFactory,
+        workspace_name: WorkspaceNameBuf,
+        wc_commit: &Commit,
+    ) -> Result<Self, WorkspaceInitError> {
+        if !workspace_root.exists() {
+            fs::create_dir(workspace_root).context(workspace_root)?;
+        } else if !file_util::is_empty_dir(workspace_root)? {
+            return Err(WorkspaceInitError::DestinationExists(
+                workspace_root.to_path_buf(),
+            ));
+        }
+
+        let jj_dir = create_jj_dir(workspace_root)?;
+
+        async {
+            let repo_dir = dunce::canonicalize(repo_path).context(repo_path)?;
+            let jj_dir_abs = dunce::canonicalize(&jj_dir).context(&jj_dir)?;
+            let path_to_store = file_util::relative_path(&jj_dir_abs, &repo_dir);
+            let path_to_store = if path_to_store.is_relative() {
+                file_util::slash_path(&path_to_store).into_owned()
+            } else {
+                path_to_store
+            };
+            let repo_dir_bytes = file_util::path_to_bytes(&path_to_store)
+                .map_err(WorkspaceInitError::EncodeRepoPath)?;
+            let repo_file_path = jj_dir.join("repo");
+            fs::write(&repo_file_path, repo_dir_bytes).context(&repo_file_path)?;
+
+            let working_copy_state_path = jj_dir.join("working_copy");
+            std::fs::create_dir(&working_copy_state_path).context(&working_copy_state_path)?;
+            let working_copy = working_copy_factory.init_working_copy(
+                repo.store().clone(),
+                workspace_root.to_path_buf(),
+                working_copy_state_path.clone(),
+                repo.op_id().clone(),
+                workspace_name,
+                repo.settings(),
+            )?;
+            let working_copy_type_path = working_copy_state_path.join("type");
+            fs::write(&working_copy_type_path, working_copy.name())
+                .context(&working_copy_type_path)?;
+
+            let workspace_store = SimpleWorkspaceStore::load(repo_path)?;
+            let mut workspace = Self::new(
+                workspace_root,
+                repo_dir,
+                working_copy,
+                repo.loader().clone(),
+            )?;
+            workspace
+                .check_out(repo.op_id().clone(), None, wc_commit)
+                .await?;
+            workspace_store.add(workspace.workspace_name(), workspace.workspace_root())?;
+            Ok(workspace)
+        }
+        .await
+        .inspect_err(|_err| {
+            std::fs::remove_dir_all(jj_dir).ok();
+        })
     }
 
     pub fn load(

--- a/web/docs/src/content/docs/working-copy.md
+++ b/web/docs/src/content/docs/working-copy.md
@@ -93,7 +93,9 @@ the files around.
 Use `jj workspace delete` to forget a workspace and remove its directory from
 disk. Tracked changes are snapshotted before the directory is removed, but
 ignored files in that directory are deleted. The main workspace cannot be
-deleted, and deleting the current workspace is rejected on Windows.
+deleted, and deleting the current workspace is rejected on Windows. `jj undo`
+recreates the workspace directory and checks out the snapshotted working-copy
+commit if the path is still available; `jj redo` removes it again.
 
 ## Stale working copy
 


### PR DESCRIPTION
Keep workspace-store path entries when forgetting or deleting workspaces so undo has the local path metadata needed to restore the repo view correctly. For deleted workspaces, undo recreates the workspace directory and checks out the snapshotted working-copy commit. If the restore path already exists, undo fails before changing the repo view so redo cannot delete unrelated replacement contents.

Redo removes directories for workspaces removed by a redone workspace delete operation.

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
