### PR TITLE
tests: merge_tools: use associated types for SM tests

### DIFF
--- a/cli/src/merge_tools/builtin.rs
+++ b/cli/src/merge_tools/builtin.rs
@@ -2176,7 +2176,7 @@ mod tests {
 
         type Reference = WorkingCopyReferenceStateMachine;
 
-        fn init_test(ref_state: &WorkingCopyReferenceStateMachine) -> Self::SystemUnderTest {
+        fn init_test(ref_state: &Self::Reference) -> Self::SystemUnderTest {
             let test_repo = TestRepo::init();
             let initial_tree = ref_state.create_tree(&test_repo.repo);
             Self {
@@ -2187,8 +2187,8 @@ mod tests {
 
         fn apply(
             state: Self::SystemUnderTest,
-            ref_state: &WorkingCopyReferenceStateMachine,
-            transition: Transition,
+            ref_state: &Self::Reference,
+            transition: <Self::Reference as ReferenceStateMachine>::Transition,
         ) -> Self::SystemUnderTest {
             match transition {
                 Transition::Commit => {
@@ -2206,10 +2206,7 @@ mod tests {
             }
         }
 
-        fn check_invariants(
-            state: &Self::SystemUnderTest,
-            ref_state: &WorkingCopyReferenceStateMachine,
-        ) {
+        fn check_invariants(state: &Self::SystemUnderTest, ref_state: &Self::Reference) {
             let store = state.test_repo.repo.store();
             let left_tree = &state.prev_tree;
             let right_tree = ref_state.create_tree(&state.test_repo.repo);
@@ -2267,7 +2264,7 @@ mod tests {
         type SystemUnderTest = Self;
         type Reference = WorkingCopyWithSelectionStateMachine;
 
-        fn init_test(ref_state: &WorkingCopyWithSelectionStateMachine) -> Self::SystemUnderTest {
+        fn init_test(ref_state: &Self::Reference) -> Self::SystemUnderTest {
             let test_repo = TestRepo::init();
             let initial_tree = ref_state.working_copy.create_tree(&test_repo.repo);
             Self {
@@ -2279,8 +2276,8 @@ mod tests {
 
         fn apply(
             state: Self::SystemUnderTest,
-            ref_state: &WorkingCopyWithSelectionStateMachine,
-            transition: Transition,
+            ref_state: &Self::Reference,
+            transition: <Self::Reference as ReferenceStateMachine>::Transition,
         ) -> Self::SystemUnderTest {
             match transition {
                 Transition::Commit => {
@@ -2304,10 +2301,7 @@ mod tests {
             }
         }
 
-        fn check_invariants(
-            state: &Self::SystemUnderTest,
-            ref_state: &WorkingCopyWithSelectionStateMachine,
-        ) {
+        fn check_invariants(state: &Self::SystemUnderTest, ref_state: &Self::Reference) {
             let store = state.test_repo.repo.store();
             let left_tree = &state.prev_tree;
             let right_tree = ref_state.working_copy.create_tree(&state.test_repo.repo);


### PR DESCRIPTION
Using associated types instead of concrete impls
makes it easier to grok the trait impl and what
it requires/entails, which might help future
implementors looking for an example on which to
base their own state-machine-based tests.

While very unlikely for the impl at hand, this
should also improve the ergonomics of switching
out concrete type of the reference state-machine.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [ ] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
