### PR TITLE
cli: fix typo in update_commit_order comment

### DIFF
--- a/cli/src/commands/arrange.rs
+++ b/cli/src/commands/arrange.rs
@@ -272,7 +272,7 @@ impl State {
 
     /// Update the current UI commit order after parents have changed.
     fn update_commit_order(&mut self) {
-        // Use the original order to get a determinisic order.
+        // Use the original order to get a deterministic order.
         // TODO: Use TopoGroupedGraph so the order better matches `jj log`
         let commit_ids: Vec<&CommitId> = dag_walk::topo_order_reverse(
             self.head_order.iter(),


### PR DESCRIPTION
`determinisic` -> `deterministic` in a comment in `cli/src/commands/arrange.rs`. Comment-only, no behaviour change.