### PR TITLE
windows: don't attach an invisible console to subprocesses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,14 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed bugs
 
+* On Windows, `jj` no longer hangs when a subprocess needs to prompt the user,
+  such as `ssh` asking for a key passphrase or for confirmation of an unknown
+  host key. Subprocesses started from a terminal now inherit its console, rather
+  than being given an invisible one by `CREATE_NO_WINDOW` for the prompt to
+  disappear into.
+  [#6745](https://github.com/jj-vcs/jj/issues/6745)
+  [#8547](https://github.com/jj-vcs/jj/issues/8547)
+
 ## [0.45.1] - 2026-09-03
 
 This release fixes an error that prevented the new jj-core crate from being

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2680,6 +2680,7 @@ dependencies = [
  "toml_edit",
  "tracing",
  "watchman_client",
+ "windows-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,6 +141,7 @@ tracing-subscriber = { version = "0.3.23", default-features = false, features = 
 unicode-width = "0.2.2"
 watchman_client = "0.9.0"
 whoami = "2.1.2"
+windows-sys = { version = "0.61.2", features = ["Win32_System_Console"] }
 winreg = "0.56"
 
 # put all inter-workspace libraries, i.e. those that use 'path = ...' here in

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -67,6 +67,9 @@ watchman_client = { workspace = true, optional = true }
 [target.'cfg(unix)'.dependencies]
 rustix = { workspace = true }
 
+[target.'cfg(windows)'.dependencies]
+windows-sys = { workspace = true }
+
 [dev-dependencies]
 assert_matches = { workspace = true }
 eyre = { workspace = true }

--- a/lib/src/git_subprocess.rs
+++ b/lib/src/git_subprocess.rs
@@ -40,6 +40,7 @@ use crate::merge::Diff;
 use crate::ref_name::GitRefNameBuf;
 use crate::ref_name::RefNameBuf;
 use crate::ref_name::RemoteName;
+use crate::subprocess_util::suppress_console_window;
 
 // * 2.29.0 introduced `git fetch --no-write-fetch-head`
 // * 2.40 still receives security patches (latest one was in Jan/2025)
@@ -100,13 +101,7 @@ impl GitSubprocessContext {
     /// Create the Git command
     fn create_command(&self) -> Command {
         let mut git_cmd = Command::new(&self.options.executable_path);
-        // Hide console window on Windows (https://stackoverflow.com/a/60958956)
-        #[cfg(windows)]
-        {
-            use std::os::windows::process::CommandExt as _;
-            const CREATE_NO_WINDOW: u32 = 0x08000000;
-            git_cmd.creation_flags(CREATE_NO_WINDOW);
-        }
+        suppress_console_window(&mut git_cmd);
 
         // TODO: here we are passing the full path to the git_dir, which can lead to UNC
         // bugs in Windows. The ideal way to do this is to pass the workspace

--- a/lib/src/gpg_signing.rs
+++ b/lib/src/gpg_signing.rs
@@ -31,6 +31,7 @@ use crate::signing::SigStatus;
 use crate::signing::SignError;
 use crate::signing::SigningBackend;
 use crate::signing::Verification;
+use crate::subprocess_util::suppress_console_window;
 
 /// Search for one of these in the output from `--status-fd=1`.
 ///
@@ -185,13 +186,7 @@ impl GpgBackend {
 
     fn create_command(&self) -> Command {
         let mut command = Command::new(&self.program);
-        // Hide console window on Windows (https://stackoverflow.com/a/60958956)
-        #[cfg(windows)]
-        {
-            use std::os::windows::process::CommandExt as _;
-            const CREATE_NO_WINDOW: u32 = 0x08000000;
-            command.creation_flags(CREATE_NO_WINDOW);
-        }
+        suppress_console_window(&mut command);
 
         command
             .stdin(Stdio::piped())
@@ -267,13 +262,7 @@ impl GpgsmBackend {
 
     fn create_command(&self) -> Command {
         let mut command = Command::new(&self.program);
-        // Hide console window on Windows (https://stackoverflow.com/a/60958956)
-        #[cfg(windows)]
-        {
-            use std::os::windows::process::CommandExt as _;
-            const CREATE_NO_WINDOW: u32 = 0x08000000;
-            command.creation_flags(CREATE_NO_WINDOW);
-        }
+        suppress_console_window(&mut command);
 
         command
             .stdin(Stdio::piped())

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -16,7 +16,7 @@
 
 #![warn(missing_docs)]
 #![deny(unused_must_use)]
-#![forbid(unsafe_code)]
+#![deny(unsafe_code)]
 
 pub mod absorb;
 pub mod annotate;
@@ -101,6 +101,7 @@ pub mod stacked_table;
 pub mod store;
 pub use jj_core::str_util;
 pub mod submodule_store;
+pub mod subprocess_util;
 #[cfg(feature = "testing")]
 pub mod test_signing_backend;
 pub mod time_util;

--- a/lib/src/ssh_signing.rs
+++ b/lib/src/ssh_signing.rs
@@ -33,6 +33,7 @@ use crate::signing::SigStatus;
 use crate::signing::SignError;
 use crate::signing::SigningBackend;
 use crate::signing::Verification;
+use crate::subprocess_util::suppress_console_window;
 
 #[derive(Debug)]
 pub struct SshBackend {
@@ -155,13 +156,7 @@ impl SshBackend {
 
     fn create_command(&self) -> Command {
         let mut command = Command::new(&self.program);
-        // Hide console window on Windows (https://stackoverflow.com/a/60958956)
-        #[cfg(windows)]
-        {
-            use std::os::windows::process::CommandExt as _;
-            const CREATE_NO_WINDOW: u32 = 0x08000000;
-            command.creation_flags(CREATE_NO_WINDOW);
-        }
+        suppress_console_window(&mut command);
 
         command
             .stdin(Stdio::piped())

--- a/lib/src/subprocess_util.rs
+++ b/lib/src/subprocess_util.rs
@@ -1,0 +1,65 @@
+// Copyright 2026 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Common helpers for configuring subprocesses
+
+use std::process::Command;
+
+/// Keeps a console window from popping up when `jj` is used from a GUI
+/// application on Windows.
+///
+/// The flag is only set if the current process has no console. When `jj` runs
+/// in a terminal, its console is passed down to the child instead. That
+/// matters for programs that prompt the user, such as `ssh` asking for a key
+/// passphrase or for confirmation of an unknown host key: those prompts are
+/// written to the console, not to the inherited standard streams.
+///
+/// Setting `CREATE_NO_WINDOW` unconditionally gives the child an *invisible*
+/// console, which the child then happily prompts on, leaving `jj` waiting
+/// forever for input that the user can neither see nor provide.
+#[cfg(windows)]
+pub fn suppress_console_window(command: &mut Command) {
+    use std::os::windows::process::CommandExt as _;
+
+    // Note that `DETACHED_PROCESS` is not used here, even though that's how Git
+    // hides the window (see `compat/mingw.c`). It leaves the child without a
+    // console at all, and Win32-OpenSSH then busy-loops in `readpassphrase()`
+    // when it has to prompt, flooding stderr instead of failing.
+    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
+    if !has_console() {
+        command.creation_flags(CREATE_NO_WINDOW);
+    }
+}
+
+/// Does nothing on platforms other than Windows.
+#[cfg(not(windows))]
+pub fn suppress_console_window(_command: &mut Command) {}
+
+/// Returns whether the current process has a console window.
+///
+/// [`std::io::IsTerminal`] can't be used for this: it is false whenever the
+/// standard streams are redirected, even though a console is still attached
+/// and usable for prompting.
+#[cfg(windows)]
+#[allow(unsafe_code)]
+fn has_console() -> bool {
+    use windows_sys::Win32::System::Console::GetConsoleWindow;
+
+    // SAFETY: `GetConsoleWindow()` takes no arguments, has no preconditions,
+    // and only returns a window handle (or null) without touching any memory
+    // we own.
+    let hwnd = unsafe { GetConsoleWindow() };
+    !hwnd.is_null()
+}


### PR DESCRIPTION
On Windows, jj started its subprocesses with `CREATE_NO_WINDOW` so that no
console window pops up when jj is used from a GUI application (#5931). That flag
does not mean "no console", though: it gives the child an *invisible* console.
`ssh` and `ssh-keygen` then detect a console and write their prompts to it, so
asking for a key passphrase or for confirmation of an unknown host key blocks
forever on input that the user can neither see nor provide — jj hangs without
printing anything (#8547, #6745). Plain `git` works in the same terminal, with
the same key and the same `ssh-keygen.exe`, because it never hands a child an
invisible console (`compat/mingw.c` only hides the window when the parent has
no console itself).

This sets the flag only when jj itself has no console window, as reported by
`GetConsoleWindow()`. A jj run from a terminal now passes its console down, so
prompts are visible and can be answered; with no console the behaviour is
unchanged, so #5931 still holds. `GetConsoleWindow()` comes from `windows-sys`
(already in the dependency tree) and needs `unsafe`, so `jj-lib` goes from
`forbid(unsafe_code)` to `deny(unsafe_code)` with an `allow` scoped to that one
function.

`DETACHED_PROCESS` (what Git uses in the no-console case) was tried first, but
it leaves the child without a console at all, and Win32-OpenSSH does not handle
that: `readpassphrase()` neither blocks nor fails, it spins. Same `ssh` command
from a console-less parent, over 10 seconds:

| creation flags | bytes on stderr | behaviour |
| --- | --- | --- |
| `DETACHED_PROCESS` | 4,100,152 | busy loop, emitting `?` forever |
| `CREATE_NO_WINDOW` | 56 | blocks silently (unchanged from main) |

Since jj buffers the git subprocess's stderr, that would trade a silent hang for
an unbounded one.

## Testing

Windows 11, OpenSSH_for_Windows_10.0p2, SSH key with a passphrase that is *not*
loaded into ssh-agent, `signing.backend = "ssh"`:

| | before | after |
| --- | --- | --- |
| `jj git init` from a terminal | hangs silently, forever | prompts `Enter passphrase for "...":`; typing it produces a signed commit |
| `jj git fetch` from a terminal, host key not in `known_hosts` | hangs silently, forever | prompts `Are you sure you want to continue connecting (yes/no/[fingerprint])?` and answering works |
| either, with no console (GUI-like parent) | hangs silently | unchanged |
| `jj git clone git@github.com:...` (key in ssh-agent) | works | works, with and without a console |

No automated test: the behaviour depends on whether a console is attached to the
test process, which CI cannot reproduce.

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [ ] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
