### PR TITLE
bisect: --find-good: fix the docs

### DIFF
--- a/cli/src/commands/bisect/run.rs
+++ b/cli/src/commands/bisect/run.rs
@@ -40,10 +40,10 @@ use crate::ui::Ui;
 /// details).
 ///
 /// It is assumed that if a given revision is "bad", then all its descendants
-/// in the input range are also "bad".
-///
-/// The target of the bisection can be inverted to look for the first "good"
-/// revision by passing `--find-good`.
+/// in the input range are also "bad". Pass `--find-good` to invert this
+/// assumption: if a given revision is "good", all of its descendants are
+/// assumed to be "good". `jj bisect run` will then look for the first "good"
+/// revision.
 ///
 /// Hint: You can pass your shell as the command, then run manual tests in a
 /// script. When you're done, make sure to exit the shell with an appropriate
@@ -101,9 +101,12 @@ pub(crate) struct BisectRunArgs {
 
     /// Find the first good revision instead
     ///
-    /// The interpretation of exit statuses will be inverted (excluding special
-    /// exit statuses), so status 0 means bad and other non-zero statuses mean
-    /// good.
+    /// Normally, `jj bisect run` looks for a revision in the provided `REVSETS`
+    /// that's bad and whose parents are good. With `--find-good`, `jj
+    /// bisect run` instead finds a commit that's good and whose parents are bad.
+    ///
+    /// `COMMAND` is still expected to exit with code 0 if and only if the
+    /// revision is good.
     #[arg(long, value_name = "TARGET", default_value_t = false)]
     find_good: bool,
 }

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -339,10 +339,10 @@ by running the given command (see the documentation for `<COMMAND>` for
 details).
 
 It is assumed that if a given revision is "bad", then all its descendants
-in the input range are also "bad".
-
-The target of the bisection can be inverted to look for the first "good"
-revision by passing `--find-good`.
+in the input range are also "bad". Pass `--find-good` to invert this
+assumption: if a given revision is "good", all of its descendants are
+assumed to be "good". `jj bisect run` will then look for the first "good"
+revision.
 
 Hint: You can pass your shell as the command, then run manual tests in a
 script. When you're done, make sure to exit the shell with an appropriate
@@ -377,7 +377,9 @@ cargo test"
    The union of all given ranges are used as the input for the bisection.
 * `--find-good` — Find the first good revision instead
 
-   The interpretation of exit statuses will be inverted (excluding special exit statuses), so status 0 means bad and other non-zero statuses mean good.
+   Normally, `jj bisect run` looks for a revision in the provided `REVSETS` that's bad and whose parents are good. With `--find-good`, `jj bisect run` instead finds a commit that's good and whose parents are bad.
+
+   `COMMAND` is still expected to exit with code 0 if and only if the revision is good.
 
   Default value: `false`
 


### PR DESCRIPTION
Looking at `test_bisect_run_with_args`, `fake-bisector` is being called with `--require-file=c` (= exit code 0 iff the file c is present), but with  `--find-good` "status 0 means bad and other non-zero statuses mean good"  (or so claims `jj bisect run --help`).

So, when evaluating commit `c` adding file `c`, fake-bisector finds the file `c`, has an exit code 0, and that should make the commit _bad,_ not good.

However, the overall behavior of `jj` is self-consistent: jj calls the  commits with the file 'good," the rest of the commits "bad," then  declares that the comment that added the file was the first "good"  commit. And that's what you'd expect to see from the incantation: `jj  bisect run --find-good fake-bisector --require-file=c` _should_ behave  like it does in the test.

The bug, then, is in the documentation. It's not true that  `--find-good` inverts how `COMMAND` is interpreted: `COMMAND` is still  expected to have exit codes 0 for good commits, and non-zero for bad  commits. It's the expectations about the edges of the range that are  flipped.

This commit fixes the docs accordingly.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
