### PR TITLE
jj bisect run --trust-endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `jj workspace add` uses `git worktree add --orphan`, which was added in
   2.42.0.
 
+* `jj bisect run` now runs some consistency checks before proceeding to bisect.
+  This helps ensure that the command can tell good and bad revisions apart,
+  and that the working copy does go from bad to good over the provided revset.
+  Use the new flag `--trust-endpoints` to disable these checks.
+
 ### Deprecations
 
 ### New features

--- a/cli/src/commands/bisect/run.rs
+++ b/cli/src/commands/bisect/run.rs
@@ -87,6 +87,13 @@ pub(crate) struct BisectRunArgs {
     /// will abort the bisection, and any other non-zero exit status means the
     /// revision is "bad".
     ///
+    /// In order for bisection to be meaningful, `COMMAND` must succeed for
+    /// every revision in `heads(REVSETS)`, and it must fail for every revision
+    /// in `parents(connected(REVSETS)) ~ connected(REVSETS)`; if you are using
+    /// `--find-good`, these checks are reversed. (Visit
+    /// <https://docs.jj-vcs.dev/latest/revsets/>
+    /// for more information about the jj revset language.)
+    ///
     /// The target's commit ID is available to the command in the
     /// `$JJ_BISECT_TARGET` environment variable.
     #[arg(value_name = "COMMAND")]
@@ -109,6 +116,15 @@ pub(crate) struct BisectRunArgs {
     /// revision is good.
     #[arg(long, value_name = "TARGET", default_value_t = false)]
     find_good: bool,
+
+    /// Skip the pre-bisection checks
+    ///
+    /// By default, `COMMAND` will be run on every revision `jj bisect run`
+    /// assumes to be good or bad before bisection actually begins, as detailed
+    /// under the documentation for `COMMAND`. This flag disables these
+    /// checks.
+    #[arg(long)]
+    trust_endpoints: bool,
 }
 
 #[instrument(skip_all)]
@@ -135,9 +151,46 @@ pub(crate) async fn cmd_bisect_run(
 
     let initial_repo = workspace_command.repo().clone();
 
-    let mut bisector = Bisector::new(initial_repo.as_ref(), input_range).await?;
+    let mut bisector =
+        Bisector::new(initial_repo.as_ref(), input_range, !args.trust_endpoints).await?;
+
     let bisection_result = loop {
         match bisector.next_step().await? {
+            jj_lib::bisect::NextStep::Verify {
+                commit,
+                expected_evaluation,
+            } => {
+                // with --find-good, the assumptions on endpoint commits are flipped
+                let expected = expected_evaluation.invert_if(args.find_good);
+
+                {
+                    let mut formatter = ui.stdout_formatter();
+                    writeln!(
+                        formatter,
+                        "Pre-bisection check: ensuring this revision is {expected}:"
+                    )?;
+                    let commit_template = workspace_command.commit_summary_template();
+                    commit_template.format(&commit, formatter.as_mut())?;
+                    writeln!(formatter)?;
+                }
+
+                let cmd = get_command(args);
+                let EvaluationOutcome {
+                    evaluation: actual,
+                    exit_code,
+                } = evaluate_commit(ui, &mut workspace_command, cmd, &commit).await?;
+
+                if actual != expected {
+                    let mut formatter = ui.stdout_formatter();
+                    writeln!(
+                        formatter,
+                        "Cannot bisect: this revision was expected to be {expected}, but was \
+                         {actual} (exit status: {exit_code}) instead."
+                    )?;
+                    break BisectionResult::VerificationFailed;
+                }
+            }
+
             jj_lib::bisect::NextStep::Evaluate(commit) => {
                 {
                     let mut formatter = ui.stdout_formatter();
@@ -164,7 +217,8 @@ pub(crate) async fn cmd_bisect_run(
                 }
 
                 let cmd = get_command(args);
-                let evaluation = evaluate_commit(ui, &mut workspace_command, cmd, &commit).await?;
+                let EvaluationOutcome { evaluation, .. } =
+                    evaluate_commit(ui, &mut workspace_command, cmd, &commit).await?;
 
                 {
                     let mut formatter = ui.stdout_formatter();
@@ -183,13 +237,9 @@ pub(crate) async fn cmd_bisect_run(
                     writeln!(formatter)?;
                 }
 
-                if args.find_good {
-                    // If we're looking for the first good revision,
-                    // invert the evaluation result.
-                    bisector.mark(commit.id().clone(), evaluation.invert());
-                } else {
-                    bisector.mark(commit.id().clone(), evaluation);
-                }
+                // If we're looking for the first good revision,
+                // invert the evaluation result.
+                bisector.mark(commit.id().clone(), evaluation.invert_if(args.find_good));
 
                 // Reload the workspace because the evaluation command may run `jj` commands.
                 workspace_command = command.workspace_helper(ui).await?;
@@ -211,8 +261,15 @@ pub(crate) async fn cmd_bisect_run(
         short_operation_hash(initial_repo.op_id())
     )?;
 
-    let target = if args.find_good { "good" } else { "bad" };
+    let target = if args.find_good {
+        Evaluation::Good
+    } else {
+        Evaluation::Bad
+    };
     match bisection_result {
+        BisectionResult::VerificationFailed => {
+            return Err(user_error("Bisection preconditions failed"));
+        }
         BisectionResult::Abort => {
             return Err(user_error("Bisection aborted"));
         }
@@ -269,12 +326,17 @@ fn get_command(args: &BisectRunArgs) -> std::process::Command {
     }
 }
 
+struct EvaluationOutcome {
+    evaluation: Evaluation,
+    exit_code: i32,
+}
+
 async fn evaluate_commit(
     ui: &mut Ui,
     workspace_command: &mut WorkspaceCommandHelper,
     mut cmd: std::process::Command,
     commit: &Commit,
-) -> Result<Evaluation, CommandError> {
+) -> Result<EvaluationOutcome, CommandError> {
     let mut tx = workspace_command.start_transaction();
     let commit_id_hex = commit.id().hex();
     tx.check_out(commit)?;
@@ -303,5 +365,8 @@ async fn evaluate_commit(
         }
     };
 
-    Ok(evaluation)
+    Ok(EvaluationOutcome {
+        evaluation,
+        exit_code: status.code().unwrap_or(-1),
+    })
 }

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -363,6 +363,8 @@ cargo test"
 
    Each revision being checked will be directly edited (will become the current working copy) before running this command. The exit status of the command will be used to mark revisions as "good" or "bad": status 0 means "good", 125 means to skip the revision, 127 (command not found) will abort the bisection, and any other non-zero exit status means the revision is "bad".
 
+   In order for bisection to be meaningful, `COMMAND` must succeed for every revision in `heads(REVSETS)`, and it must fail for every revision in `parents(connected(REVSETS)) ~ connected(REVSETS)`; if you are using `--find-good`, these checks are reversed. (Visit <https://docs.jj-vcs.dev/latest/revsets/> for more information about the jj revset language.)
+
    The target's commit ID is available to the command in the `$JJ_BISECT_TARGET` environment variable.
 * `<ARGS>` — Arguments to pass to the command
 
@@ -382,6 +384,9 @@ cargo test"
    `COMMAND` is still expected to exit with code 0 if and only if the revision is good.
 
   Default value: `false`
+* `--trust-endpoints` — Skip the pre-bisection checks
+
+   By default, `COMMAND` will be run on every revision `jj bisect run` assumes to be good or bad before bisection actually begins, as detailed under the documentation for `COMMAND`. This flag disables these checks.
 
 
 

--- a/cli/tests/test_bisect_command.rs
+++ b/cli/tests/test_bisect_command.rs
@@ -71,7 +71,7 @@ fn test_bisect_run() -> TestResult {
     create_commit(&work_dir, "f", &["e"]);
 
     std::fs::write(&bisection_script, ["fail"].join("\0"))?;
-    insta::assert_snapshot!(work_dir.run_jj(["bisect", "run", "--range=..", &bisector_path]), @"
+    insta::assert_snapshot!(work_dir.run_jj(["bisect", "run", "--range=..", "--trust-endpoints", &bisector_path]), @"
     Bisecting: 5 revisions left to test after this (roughly 3 steps)
     Now evaluating: royxmykx dffaa0d4 c | c
     fake-bisector testing commit dffaa0d4daccf6cee70bac3498fae3b3fd5d6b5b
@@ -111,7 +111,7 @@ fn test_bisect_run() -> TestResult {
     // Try with legacy command argument
     std::fs::write(&bisection_script, ["fail"].join("\0"))?;
     // Testing only stderr to avoid a variable op id in the stdout.
-    insta::assert_snapshot!(work_dir.run_jj(["bisect", "run", "--range=..", "--command", &bisector_path]).success().stderr, @"
+    insta::assert_snapshot!(work_dir.run_jj(["bisect", "run", "--range=..", "--trust-endpoints", "--command", &bisector_path]).success().stderr, @"
     Warning: `--command` is deprecated; use positional arguments instead: `jj bisect run --range=... -- $FAKE_BISECTOR_PATH`
     Working copy  (@) now at: nkmrtpmo 1601f7b4 (empty) (no description set)
     Parent commit (@-)      : royxmykx dffaa0d4 c | c
@@ -137,6 +137,168 @@ fn test_bisect_run() -> TestResult {
 }
 
 #[test]
+// like test_bisect::test_bisect_nonlinear
+// bisecting over commits 0,1,2,3,4,5,6 with 5 being the first bad commit
+// this fails because 6 should also be bad!
+fn test_bisect_run_nonlinear_no_merge() -> TestResult {
+    let mut test_env = TestEnvironment::default();
+    let bisector_path = fake_bisector_path();
+    test_env.set_up_fake_bisector();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    // h
+    // |\
+    // f g
+    // | |
+    // d e
+    // | |
+    // b c
+    // |/
+    // a
+
+    create_commit(&work_dir, "a", &[]);
+    create_commit(&work_dir, "b", &["a"]);
+    create_commit(&work_dir, "c", &["a"]);
+    create_commit(&work_dir, "d", &["b"]);
+    create_commit(&work_dir, "e", &["c"]);
+    create_commit(&work_dir, "f", &["d"]);
+    create_commit(&work_dir, "g", &["e"]);
+    create_commit(&work_dir, "h", &["f", "g"]);
+
+    // rather than complicating fake_bisector, we try and --find-good
+    insta::assert_snapshot!(work_dir.run_jj(["bisect", "run", "--range=ancestors(parents(h))", "--find-good", "--", &bisector_path, "--require-file=f"]), @"
+    Pre-bisection check: ensuring this revision is good:
+    kmkuslsw 3548fddf f | f
+    fake-bisector testing commit 3548fddfc5b69ba4c5b78a19c1cc6d39e52e5a22
+    Pre-bisection check: ensuring this revision is good:
+    lylxulpl 97949f0f g | g
+    fake-bisector testing commit 97949f0f52afedfc72ef44d63d21266bbfc42774
+    Cannot bisect: this revision was expected to be good, but was bad (exit status: 1) instead.
+    Search complete. To discard any revisions created during search, run:
+      jj op restore 7d0937f0feb3
+    [EOF]
+    ------- stderr -------
+    Working copy  (@) now at: xznxytkn 08be40de (empty) (no description set)
+    Parent commit (@-)      : kmkuslsw 3548fddf f | f
+    Added 0 files, modified 0 files, removed 4 files
+    Working copy  (@) now at: smwtzssm fc3a931c (empty) (no description set)
+    Parent commit (@-)      : lylxulpl 97949f0f g | g
+    Added 3 files, modified 0 files, removed 3 files
+    Error: Bisection preconditions failed
+    [EOF]
+    [exit status: 1]
+    ");
+    insta::assert_snapshot!(get_log_output(&work_dir), @"
+    @  smwtzssmuxzk fc3a931c8da8 '' files:
+    │ ○  nkmrtpmomlro b47137c13576 'h' files: h
+    ╭─┤
+    ○ │  lylxulplsnyw 97949f0f52af 'g' files: g
+    ○ │  znkkpsqqskkl efcb3d331401 'e' files: e
+    ○ │  royxmykxtrkr 991a7501d660 'c' files: c
+    │ ○  kmkuslswpqwq 3548fddfc5b6 'f' files: f
+    │ ○  vruxwmqvtpmx 01a5f35e756c 'd' files: d
+    │ ○  zsuskulnrvyr 123b4d91f6e5 'b' files: b
+    ├─╯
+    ○  rlvkpnrzqnoo 7d980be7a1d4 'a' files: a
+    ◆  zzzzzzzzzzzz 000000000000 '' files:
+    [EOF]
+    ");
+    Ok(())
+}
+
+// like test_bisect_run_nonlinear_with_merge, but we include the merge commit.
+// that makes it okay for commit f to be the first bad one.
+#[test]
+fn test_bisect_run_nonlinear_with_merge() -> TestResult {
+    let mut test_env = TestEnvironment::default();
+    let bisector_path = fake_bisector_path();
+    test_env.set_up_fake_bisector();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    // h
+    // |\
+    // f g
+    // | |
+    // d e
+    // | |
+    // b c
+    // |/
+    // a
+
+    create_commit(&work_dir, "a", &[]);
+    create_commit(&work_dir, "b", &["a"]);
+    create_commit(&work_dir, "c", &["a"]);
+    create_commit(&work_dir, "d", &["b"]);
+    create_commit(&work_dir, "e", &["c"]);
+    create_commit(&work_dir, "f", &["d"]);
+    create_commit(&work_dir, "g", &["e"]);
+    create_commit(&work_dir, "h", &["f", "g"]);
+
+    insta::assert_snapshot!(work_dir.run_jj(["bisect", "run", "--range=..", "--find-good", "--", &bisector_path, "--require-file=f"]), @"
+    Pre-bisection check: ensuring this revision is good:
+    nkmrtpmo b47137c1 h | h
+    fake-bisector testing commit b47137c135761c932a7d0c1619d6121868eb7df9
+    Pre-bisection check: ensuring this revision is bad:
+    zzzzzzzz 00000000 (empty) (no description set)
+    fake-bisector testing commit 0000000000000000000000000000000000000000
+    Bisecting: 7 revisions left to test after this (roughly 3 steps)
+    Now evaluating: vruxwmqv 01a5f35e d | d
+    fake-bisector testing commit 01a5f35e756cec7f8543120aeedcce0d086a2504
+    The revision is bad.
+
+    Bisecting: 4 revisions left to test after this (roughly 3 steps)
+    Now evaluating: znkkpsqq efcb3d33 e | e
+    fake-bisector testing commit efcb3d33140196e8aa5157e4c865e9a4c513f8bb
+    The revision is bad.
+
+    Bisecting: 2 revisions left to test after this (roughly 2 steps)
+    Now evaluating: kmkuslsw 3548fddf f | f
+    fake-bisector testing commit 3548fddfc5b69ba4c5b78a19c1cc6d39e52e5a22
+    The revision is good.
+
+    Search complete. To discard any revisions created during search, run:
+      jj op restore 7d0937f0feb3
+    The first good revision is: kmkuslsw 3548fddf f | f
+    [EOF]
+    ------- stderr -------
+    Working copy  (@) now at: xznxytkn 8d14f10f (empty) (no description set)
+    Parent commit (@-)      : nkmrtpmo b47137c1 h | h
+    Working copy  (@) now at: smwtzssm 71beb6f1 (empty) (no description set)
+    Parent commit (@-)      : zzzzzzzz 00000000 (empty) (no description set)
+    Added 0 files, modified 0 files, removed 8 files
+    Working copy  (@) now at: zlusorwl 1576a092 (empty) (no description set)
+    Parent commit (@-)      : vruxwmqv 01a5f35e d | d
+    Added 3 files, modified 0 files, removed 0 files
+    Working copy  (@) now at: ukzzzykq 05f4e27a (empty) (no description set)
+    Parent commit (@-)      : znkkpsqq efcb3d33 e | e
+    Added 2 files, modified 0 files, removed 2 files
+    Working copy  (@) now at: lqoxyrsk 4967f850 (empty) (no description set)
+    Parent commit (@-)      : kmkuslsw 3548fddf f | f
+    Added 3 files, modified 0 files, removed 2 files
+    [EOF]
+    ");
+
+    insta::assert_snapshot!(get_log_output(&work_dir), @"
+    @  lqoxyrskwpry 4967f85032d5 '' files:
+    │ ○  nkmrtpmomlro b47137c13576 'h' files: h
+    ╭─┤
+    │ ○  lylxulplsnyw 97949f0f52af 'g' files: g
+    │ ○  znkkpsqqskkl efcb3d331401 'e' files: e
+    │ ○  royxmykxtrkr 991a7501d660 'c' files: c
+    ○ │  kmkuslswpqwq 3548fddfc5b6 'f' files: f
+    ○ │  vruxwmqvtpmx 01a5f35e756c 'd' files: d
+    ○ │  zsuskulnrvyr 123b4d91f6e5 'b' files: b
+    ├─╯
+    ○  rlvkpnrzqnoo 7d980be7a1d4 'a' files: a
+    ◆  zzzzzzzzzzzz 000000000000 '' files:
+    [EOF]
+    ");
+    Ok(())
+}
+
+#[test]
 fn test_bisect_run_find_first_good() {
     let mut test_env = TestEnvironment::default();
     let bisector_path = fake_bisector_path();
@@ -151,7 +313,7 @@ fn test_bisect_run_find_first_good() {
     create_commit(&work_dir, "e", &["d"]);
     create_commit(&work_dir, "f", &["e"]);
 
-    insta::assert_snapshot!(work_dir.run_jj(["bisect", "run", "--range=..", "--find-good", &bisector_path]), @"
+    insta::assert_snapshot!(work_dir.run_jj(["bisect", "run", "--range=..", "--find-good", "--trust-endpoints", &bisector_path]), @"
     Bisecting: 5 revisions left to test after this (roughly 3 steps)
     Now evaluating: royxmykx dffaa0d4 c | c
     fake-bisector testing commit dffaa0d4daccf6cee70bac3498fae3b3fd5d6b5b
@@ -202,7 +364,13 @@ fn test_bisect_run_missing_bisector() {
     create_commit(&work_dir, "e", &["d"]);
     create_commit(&work_dir, "f", &["e"]);
 
-    let output = work_dir.run_jj(["bisect", "run", "--range=..", "nonexistent"]);
+    let output = work_dir.run_jj([
+        "bisect",
+        "run",
+        "--range=..",
+        "--trust-endpoints",
+        "nonexistent",
+    ]);
     if cfg!(unix) {
         insta::assert_snapshot!(output, @"
         Bisecting: 5 revisions left to test after this (roughly 3 steps)
@@ -249,7 +417,7 @@ fn test_bisect_run_with_args() {
     create_commit(&work_dir, "e", &["d"]);
     create_commit(&work_dir, "f", &["e"]);
 
-    insta::assert_snapshot!(work_dir.run_jj(["bisect", "run", "--range=..", "--find-good", "--", &bisector_path, "--require-file=c"]), @"
+    insta::assert_snapshot!(work_dir.run_jj(["bisect", "run", "--range=..", "--find-good", "--trust-endpoints", "--", &bisector_path, "--require-file=c"]), @"
     Bisecting: 5 revisions left to test after this (roughly 3 steps)
     Now evaluating: royxmykx dffaa0d4 c | c
     fake-bisector testing commit dffaa0d4daccf6cee70bac3498fae3b3fd5d6b5b
@@ -312,7 +480,7 @@ fn test_bisect_run_crash() -> TestResult {
 
     // bisector crash is equivalent to a failure
     std::fs::write(&bisection_script, ["crash"].join("\0"))?;
-    insta::assert_snapshot!(work_dir.run_jj(["bisect", "run", "--range=..", &bisector_path]), @"
+    insta::assert_snapshot!(work_dir.run_jj(["bisect", "run", "--range=..", "--trust-endpoints", &bisector_path]), @"
     Bisecting: 5 revisions left to test after this (roughly 3 steps)
     Now evaluating: royxmykx dffaa0d4 c | c
     fake-bisector testing commit dffaa0d4daccf6cee70bac3498fae3b3fd5d6b5b
@@ -353,7 +521,7 @@ fn test_bisect_run_abort() -> TestResult {
 
     // stop immediately on failure
     std::fs::write(&bisection_script, ["abort"].join("\0"))?;
-    insta::assert_snapshot!(work_dir.run_jj(["bisect", "run", "--range=..", &bisector_path]), @"
+    insta::assert_snapshot!(work_dir.run_jj(["bisect", "run", "--range=..", "--trust-endpoints", &bisector_path]), @"
     Bisecting: 2 revisions left to test after this (roughly 2 steps)
     Now evaluating: rlvkpnrz 7d980be7 a | a
     fake-bisector testing commit 7d980be7a1d499e4d316ab4c01242885032f7eaf
@@ -386,7 +554,7 @@ fn test_bisect_run_skip() -> TestResult {
     create_commit(&work_dir, "b", &["a"]);
 
     std::fs::write(&bisection_script, ["skip"].join("\0"))?;
-    insta::assert_snapshot!(work_dir.run_jj(["bisect", "run", "--range=..", &bisector_path]), @"
+    insta::assert_snapshot!(work_dir.run_jj(["bisect", "run", "--range=..", "--trust-endpoints", &bisector_path]), @"
     Bisecting: 1 revisions left to test after this (roughly 1 steps)
     Now evaluating: rlvkpnrz 7d980be7 a | a
     fake-bisector testing commit 7d980be7a1d499e4d316ab4c01242885032f7eaf
@@ -422,7 +590,7 @@ fn test_bisect_run_multiple_results() {
     create_commit(&work_dir, "c", &["a"]);
     create_commit(&work_dir, "d", &["c"]);
 
-    insta::assert_snapshot!(work_dir.run_jj(["bisect", "run", "--range=a|b|c|d", &bisector_path]), @"
+    insta::assert_snapshot!(work_dir.run_jj(["bisect", "run", "--range=a|b|c|d", "--trust-endpoints", &bisector_path]), @"
     Bisecting: 2 revisions left to test after this (roughly 2 steps)
     Now evaluating: rlvkpnrz 7d980be7 a | a
     fake-bisector testing commit 7d980be7a1d499e4d316ab4c01242885032f7eaf
@@ -468,7 +636,7 @@ fn test_bisect_run_write_file() -> TestResult {
         &bisection_script,
         ["write new-file\nsome contents", "fail"].join("\0"),
     )?;
-    insta::assert_snapshot!(work_dir.run_jj(["bisect", "run", "--range=..", &bisector_path]), @"
+    insta::assert_snapshot!(work_dir.run_jj(["bisect", "run", "--range=..", "--trust-endpoints", &bisector_path]), @"
     Bisecting: 4 revisions left to test after this (roughly 3 steps)
     Now evaluating: zsuskuln 123b4d91 b | b
     fake-bisector testing commit 123b4d91f6e5e39bfed39bae3bacf9380dc79078
@@ -534,7 +702,7 @@ fn test_bisect_run_jj_command() -> TestResult {
     create_commit(&work_dir, "e", &["d"]);
 
     std::fs::write(&bisection_script, ["jj new -mtesting", "fail"].join("\0"))?;
-    insta::assert_snapshot!(work_dir.run_jj(["bisect", "run", "--range=..", &bisector_path]), @"
+    insta::assert_snapshot!(work_dir.run_jj(["bisect", "run", "--range=..", "--trust-endpoints", &bisector_path]), @"
     Bisecting: 4 revisions left to test after this (roughly 3 steps)
     Now evaluating: zsuskuln 123b4d91 b | b
     fake-bisector testing commit 123b4d91f6e5e39bfed39bae3bacf9380dc79078

--- a/lib/src/bisect.rs
+++ b/lib/src/bisect.rs
@@ -16,6 +16,8 @@
 
 use std::collections::HashSet;
 use std::collections::VecDeque;
+use std::fmt;
+use std::iter;
 use std::pin::pin;
 use std::sync::Arc;
 
@@ -45,7 +47,7 @@ pub enum BisectionError {
 
 /// Indicates whether a given commit was good, bad, or if it could not be
 /// determined.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum Evaluation {
     /// The commit was good
     Good,
@@ -70,6 +72,25 @@ impl Evaluation {
             Abort => Abort,
         }
     }
+
+    /// Returns the inverted evaluation if `condition` is true.
+    pub fn invert_if(self, condition: bool) -> Self {
+        if condition { self.invert() } else { self }
+    }
+}
+impl fmt::Display for Evaluation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::Good => "good",
+                Self::Bad => "bad",
+                Self::Skip => "skipped",
+                Self::Abort => "aborted",
+            }
+        )
+    }
 }
 
 /// Performs bisection to find the first bad commit in a range.
@@ -80,6 +101,7 @@ pub struct Bisector<'repo> {
     bad_commits: HashSet<CommitId>,
     skipped_commits: HashSet<CommitId>,
     aborted: bool,
+    verifications: Vec<(CommitId, Evaluation)>,
 }
 
 /// The result of bisection.
@@ -101,11 +123,20 @@ pub enum BisectionResult {
     Indeterminate,
     /// Bisection was aborted.
     Abort,
+    /// Bisection preconditions were not met.
+    VerificationFailed,
 }
 
 /// The next bisection step.
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum NextStep {
+    /// The commit must evaluate a certain way.
+    Verify {
+        /// The commit being verified.
+        commit: Commit,
+        /// If the commit does not evaluate to this, bisection isn't possible.
+        expected_evaluation: Evaluation,
+    },
     /// The commit must be evaluated.
     Evaluate(Commit),
     /// Bisection is complete.
@@ -115,20 +146,50 @@ pub enum NextStep {
 impl<'repo> Bisector<'repo> {
     /// Create a new bisector. The range's heads are assumed to be bad.
     /// Parents of the range's roots are assumed to be good.
+    /// If `verify_preconditions` is true, these assumptions are verified.
     pub async fn new(
         repo: &'repo dyn Repo,
         input_range: Arc<ResolvedRevsetExpression>,
+        verify_preconditions: bool,
     ) -> Result<Self, BisectionError> {
-        let bad_commits = input_range
+        let bad_commits: Vec<CommitId> = input_range
             .heads()
             .evaluate(repo)?
             .stream()
             .try_collect()
             .await?;
+        let good_commits: Vec<CommitId> = input_range
+            .connected()
+            .parents()
+            .minus(&input_range.connected())
+            .evaluate(repo)?
+            .stream()
+            .try_collect()
+            .await?;
+
+        let verifications: Vec<(CommitId, Evaluation)> = if verify_preconditions {
+            // these will be run in reverse order
+            iter::empty()
+                .chain(
+                    good_commits
+                        .iter()
+                        .map(|commit_id| (commit_id.clone(), Evaluation::Good)),
+                )
+                .chain(
+                    bad_commits
+                        .iter()
+                        .map(|commit_id| (commit_id.clone(), Evaluation::Bad)),
+                )
+                .collect()
+        } else {
+            vec![]
+        };
+
         Ok(Self {
             repo,
             input_range,
-            bad_commits,
+            verifications,
+            bad_commits: HashSet::from_iter(bad_commits),
             good_commits: HashSet::new(),
             skipped_commits: HashSet::new(),
             aborted: false,
@@ -228,7 +289,13 @@ impl<'repo> Bisector<'repo> {
         // TODO: Handle long ranges of skipped revisions better
         let to_evaluate_expr = self.candidates().bisect().latest(1);
         let to_evaluate_set = to_evaluate_expr.evaluate(self.repo)?;
-        if let Some(commit_id) = pin!(to_evaluate_set.stream()).try_next().await? {
+        if let Some(verification) = self.verifications.pop() {
+            let commit = self.repo.store().get_commit_async(&verification.0).await?;
+            Ok(NextStep::Verify {
+                commit,
+                expected_evaluation: verification.1,
+            })
+        } else if let Some(commit_id) = pin!(to_evaluate_set.stream()).try_next().await? {
             let commit = self.repo.store().get_commit_async(&commit_id).await?;
             Ok(NextStep::Evaluate(commit))
         } else {

--- a/lib/tests/test_bisect.rs
+++ b/lib/tests/test_bisect.rs
@@ -31,11 +31,33 @@ fn test_bisection<'a>(
     repo: &dyn Repo,
     input_range: &Arc<ResolvedRevsetExpression>,
     results: impl IntoIterator<Item = (&'a CommitId, Evaluation)>,
+    verify_preconditions: bool,
 ) -> BisectionResult {
-    let mut bisector = Bisector::new(repo, input_range.clone()).block_on().unwrap();
+    let mut bisector = Bisector::new(repo, input_range.clone(), verify_preconditions)
+        .block_on()
+        .unwrap();
     let mut iter = results.into_iter().enumerate();
     loop {
         match bisector.next_step().block_on().unwrap() {
+            NextStep::Verify {
+                commit,
+                expected_evaluation: evaluation,
+            } => {
+                let (i, (expected_id, expected_evaluation)) =
+                    iter.next().expect("More commits than expected were tested");
+                let description = commit.description();
+                assert_eq!(
+                    commit.id(),
+                    expected_id,
+                    "Attempt to test unexpected commit at iteration {i}: {commit:#?} with \
+                     description {description}"
+                );
+                assert_eq!(
+                    evaluation, expected_evaluation,
+                    "Pre-bisection check at iteration {i} was {evaluation:#?}; should've been \
+                     {expected_evaluation:#?}"
+                );
+            }
             NextStep::Evaluate(commit) => {
                 let (i, (expected_id, result)) =
                     iter.next().expect("More commits than expected were tested");
@@ -61,7 +83,7 @@ fn test_bisect_empty_input() {
 
     let input_range = ResolvedRevsetExpression::none();
     let expected_tests = [];
-    let result = test_bisection(repo.as_ref(), &input_range, expected_tests);
+    let result = test_bisection(repo.as_ref(), &input_range, expected_tests, true);
     assert_matches!(result, BisectionResult::Indeterminate);
 }
 
@@ -88,7 +110,7 @@ fn test_bisect_linear() {
         (commit1.id(), Evaluation::Bad),
         (root_commit.id(), Evaluation::Bad),
     ];
-    let result = test_bisection(tx.repo(), &input_range, expected_tests);
+    let result = test_bisection(tx.repo(), &input_range, expected_tests, false);
     assert_eq!(result, BisectionResult::Found(vec![root_commit.clone()]));
 
     // Commit 1 is the first bad commit
@@ -97,7 +119,7 @@ fn test_bisect_linear() {
         (commit1.id(), Evaluation::Bad),
         (root_commit.id(), Evaluation::Good),
     ];
-    let result = test_bisection(tx.repo(), &input_range, expected_tests);
+    let result = test_bisection(tx.repo(), &input_range, expected_tests, false);
     assert_eq!(result, BisectionResult::Found(vec![commit1.clone()]));
 
     // Commit 3 is the first bad commit
@@ -106,7 +128,7 @@ fn test_bisect_linear() {
         (commit1.id(), Evaluation::Good),
         (commit2.id(), Evaluation::Good),
     ];
-    let result = test_bisection(tx.repo(), &input_range, expected_tests);
+    let result = test_bisection(tx.repo(), &input_range, expected_tests, false);
     assert_eq!(result, BisectionResult::Found(vec![commit3.clone()]));
 
     // Commit 5 is the first bad commit
@@ -115,7 +137,7 @@ fn test_bisect_linear() {
         (commit5.id(), Evaluation::Bad),
         (commit4.id(), Evaluation::Good),
     ];
-    let result = test_bisection(tx.repo(), &input_range, expected_tests);
+    let result = test_bisection(tx.repo(), &input_range, expected_tests, false);
     assert_eq!(result, BisectionResult::Found(vec![commit5.clone()]));
 
     // Commit 7 is the first bad commit
@@ -124,7 +146,7 @@ fn test_bisect_linear() {
         (commit5.id(), Evaluation::Good),
         (commit6.id(), Evaluation::Good),
     ];
-    let result = test_bisection(tx.repo(), &input_range, expected_tests);
+    let result = test_bisection(tx.repo(), &input_range, expected_tests, false);
     assert_eq!(result, BisectionResult::Found(vec![commit7.clone()]));
 
     // Commit 2 is the first bad commit but commit 3 is skipped
@@ -134,7 +156,7 @@ fn test_bisect_linear() {
         (root_commit.id(), Evaluation::Good),
         (commit1.id(), Evaluation::Good),
     ];
-    let result = test_bisection(tx.repo(), &input_range, expected_tests);
+    let result = test_bisection(tx.repo(), &input_range, expected_tests, false);
     assert_eq!(result, BisectionResult::Found(vec![commit2.clone()]));
 
     // Commit 4 is the first bad commit but commit 3 is skipped
@@ -144,7 +166,7 @@ fn test_bisect_linear() {
         (commit5.id(), Evaluation::Bad),
         (commit4.id(), Evaluation::Bad),
     ];
-    let result = test_bisection(tx.repo(), &input_range, expected_tests);
+    let result = test_bisection(tx.repo(), &input_range, expected_tests, false);
     assert_eq!(
         result,
         BisectionResult::FoundDespiteSkips {
@@ -162,7 +184,7 @@ fn test_bisect_linear() {
         (root_commit.id(), Evaluation::Good),
         (commit1.id(), Evaluation::Skip),
     ];
-    let result = test_bisection(tx.repo(), &input_range, expected_tests);
+    let result = test_bisection(tx.repo(), &input_range, expected_tests, false);
     assert_eq!(
         result,
         BisectionResult::FoundDespiteSkips {
@@ -183,23 +205,39 @@ fn test_bisect_linear() {
         (root_commit.id(), Evaluation::Skip),
         (commit6.id(), Evaluation::Good),
     ];
-    let result = test_bisection(tx.repo(), &input_range, expected_tests);
+    let result = test_bisection(tx.repo(), &input_range, expected_tests, false);
     assert_eq!(result, BisectionResult::Found(vec![commit7.clone()]));
 
-    // Gaps in the input range are allowed
-    let input_range = ResolvedRevsetExpression::commits(vec![
-        commit7.id().clone(),
-        commit4.id().clone(),
-        commit2.id().clone(),
-        commit1.id().clone(),
-    ]);
-    // Commit 4 is the first bad commit
-    let expected_tests = [
-        (commit2.id(), Evaluation::Good),
-        (commit4.id(), Evaluation::Bad),
-    ];
-    let result = test_bisection(tx.repo(), &input_range, expected_tests);
-    assert_eq!(result, BisectionResult::Found(vec![commit4.clone()]));
+    // Tests with gap in the input
+    {
+        // Gaps in the input range are allowed
+        let input_range = ResolvedRevsetExpression::commits(vec![
+            commit7.id().clone(),
+            commit4.id().clone(),
+            commit2.id().clone(),
+            commit1.id().clone(),
+        ]);
+
+        // Commit 4 is the first bad commit
+        let bisection_result = BisectionResult::Found(vec![commit4.clone()]);
+
+        let bisection_steps = [
+            (commit2.id(), Evaluation::Good),
+            (commit4.id(), Evaluation::Bad),
+        ];
+        let result = test_bisection(tx.repo(), &input_range, bisection_steps.clone(), false);
+        assert_eq!(result, bisection_result);
+
+        // Same, but now verifying preconditions
+        let expected_tests = [
+            (commit7.id(), Evaluation::Bad),
+            (root_commit.id(), Evaluation::Good),
+        ]
+        .into_iter()
+        .chain(bisection_steps);
+        let result = test_bisection(tx.repo(), &input_range, expected_tests, true);
+        assert_eq!(result, bisection_result);
+    }
 }
 
 #[test]
@@ -226,24 +264,34 @@ fn test_bisect_nonlinear() {
     let commit6 = write_random_commit_with_parents(tx.repo_mut(), &[&commit4]);
     let commit7 = write_random_commit_with_parents(tx.repo_mut(), &[&commit5, &commit6]);
 
-    let input_range = ResolvedRevsetExpression::commit(commit7.id().clone()).ancestors();
+    let root_commit_expr = ResolvedRevsetExpression::commit(root_commit.id().clone());
+    let commit6_expr = ResolvedRevsetExpression::commit(commit6.id().clone());
+    let commit7_expr = ResolvedRevsetExpression::commit(commit7.id().clone());
 
-    // Root commit is the first bad commit
-    let expected_tests = [
-        (commit3.id(), Evaluation::Bad),
-        (root_commit.id(), Evaluation::Bad),
-    ];
-    let result = test_bisection(tx.repo(), &input_range, expected_tests);
-    assert_eq!(result, BisectionResult::Found(vec![root_commit.clone()]));
+    let input_range = commit7_expr.ancestors();
+    let input_range_without_root = input_range.minus(&root_commit_expr);
+    let input_range_without_merge = input_range.minus(&commit7_expr);
+    let input_range_single_branch = root_commit_expr.range(&commit6_expr).union(&commit7_expr);
 
-    // Commit 3 is the first bad commit
-    let expected_tests = [
-        (commit3.id(), Evaluation::Bad),
-        (root_commit.id(), Evaluation::Good),
-        (commit1.id(), Evaluation::Good),
-    ];
-    let result = test_bisection(tx.repo(), &input_range, expected_tests);
-    assert_eq!(result, BisectionResult::Found(vec![commit3.clone()]));
+    // Test with the full diamond
+    {
+        let bisection_result = BisectionResult::Found(vec![root_commit.clone()]);
+
+        let bisection_tests = [
+            (commit3.id(), Evaluation::Bad),
+            (root_commit.id(), Evaluation::Bad),
+        ];
+        let result = test_bisection(tx.repo(), &input_range, bisection_tests.clone(), false);
+        assert_eq!(result, bisection_result);
+
+        // If the root commit is part of the revset, it's allowed to be bad
+        // No commit gets checked to be Good
+        let expected_tests = [(commit7.id(), Evaluation::Bad)]
+            .into_iter()
+            .chain(bisection_tests.clone());
+        let result = test_bisection(tx.repo(), &input_range, expected_tests, true);
+        assert_eq!(result, bisection_result);
+    }
 
     // Commit 4 is the first bad commit
     let expected_tests = [
@@ -251,7 +299,7 @@ fn test_bisect_nonlinear() {
         (commit4.id(), Evaluation::Bad),
         (commit2.id(), Evaluation::Good),
     ];
-    let result = test_bisection(tx.repo(), &input_range, expected_tests);
+    let result = test_bisection(tx.repo(), &input_range, expected_tests, false);
     assert_eq!(result, BisectionResult::Found(vec![commit4.clone()]));
 
     // Commit 6 is the first bad commit
@@ -261,8 +309,93 @@ fn test_bisect_nonlinear() {
         (commit5.id(), Evaluation::Good),
         (commit6.id(), Evaluation::Bad),
     ];
-    let result = test_bisection(tx.repo(), &input_range, expected_tests);
+    let result = test_bisection(tx.repo(), &input_range, expected_tests.clone(), false);
     assert_eq!(result, BisectionResult::Found(vec![commit6.clone()]));
+
+    // Test without the base of the diamond
+    {
+        let bisection_result = BisectionResult::Found(vec![commit3.clone()]);
+
+        let bisection_tests = [
+            (commit3.id(), Evaluation::Bad),
+            (commit1.id(), Evaluation::Good),
+        ];
+        let result = test_bisection(
+            tx.repo(),
+            &input_range_without_root,
+            bisection_tests.clone(),
+            false,
+        );
+        assert_eq!(result, bisection_result);
+
+        let expected_tests = [
+            (commit7.id(), Evaluation::Bad),
+            // root_commit is also verified
+            (root_commit.id(), Evaluation::Good),
+        ]
+        .into_iter()
+        .chain(bisection_tests.clone());
+        let result = test_bisection(tx.repo(), &input_range_without_root, expected_tests, true);
+        assert_eq!(result, bisection_result);
+    }
+
+    // Tests with just one side of the diamond (0::6|7)
+    {
+        let bisection_result = BisectionResult::Found(vec![commit6.clone()]);
+
+        let bisection_tests = [
+            (commit4.id(), Evaluation::Good),
+            (commit6.id(), Evaluation::Bad),
+        ];
+        let result = test_bisection(
+            tx.repo(),
+            &input_range_single_branch,
+            bisection_tests.clone(),
+            false,
+        );
+        assert_eq!(result, bisection_result);
+
+        let expected_tests = [
+            (commit7.id(), Evaluation::Bad),
+            (root_commit.id(), Evaluation::Good),
+            // the head of the other side is also checked
+            (commit5.id(), Evaluation::Good),
+        ]
+        .into_iter()
+        .chain(bisection_tests);
+        let result = test_bisection(tx.repo(), &input_range_single_branch, expected_tests, true);
+        assert_eq!(result, bisection_result);
+    }
+
+    // Test without the head of the diamond
+    {
+        // We need bad commits on both sides!
+        // See test_bisect_command::test_bisect_run_nonlinear_no_merge for a test case
+        // where only either of these commits is bad
+        let bisection_result = BisectionResult::Found(vec![commit5.clone(), commit2.clone()]);
+
+        let bisection_tests = [
+            (commit2.id(), Evaluation::Bad),
+            (commit1.id(), Evaluation::Good),
+            (commit3.id(), Evaluation::Good),
+        ];
+        let result = test_bisection(
+            tx.repo(),
+            &input_range_without_merge,
+            bisection_tests.clone(),
+            false,
+        );
+        assert_eq!(result, bisection_result);
+
+        let expected_tests = [
+            (commit5.id(), Evaluation::Bad),
+            (commit6.id(), Evaluation::Bad),
+        ]
+        .into_iter()
+        .chain(bisection_tests);
+        let result = test_bisection(tx.repo(), &input_range_without_merge, expected_tests, true);
+        assert_eq!(result, bisection_result);
+    }
 }
 
 #[test]
@@ -274,6 +407,7 @@ fn test_bisect_disjoint_sets() {
     // |/
     // 0
     let mut tx = repo.start_transaction();
+    let root_commit = repo.store().root_commit();
     let commit1 = write_random_commit(tx.repo_mut());
     let commit2 = write_random_commit(tx.repo_mut());
 
@@ -282,10 +416,22 @@ fn test_bisect_disjoint_sets() {
 
     // Both commit 1 and commit 2 are (implicitly) the first bad commits
     let expected_tests = [];
-    let result = test_bisection(tx.repo(), &input_range, expected_tests);
+    let result = test_bisection(tx.repo(), &input_range, expected_tests, false);
     assert_eq!(
         result,
         BisectionResult::Found(vec![commit2.clone(), commit1.clone()])
+    );
+
+    // Both commit 1 and commit 2 are (implicitly) the first bad commits
+    test_bisection(
+        tx.repo(),
+        &input_range,
+        [
+            (commit1.id(), Evaluation::Bad),
+            (commit2.id(), Evaluation::Bad),
+            (root_commit.id(), Evaluation::Good),
+        ],
+        true,
     );
 }
 
@@ -310,6 +456,6 @@ fn test_bisect_abort() {
         (commit3.id(), Evaluation::Good),
         (commit5.id(), Evaluation::Abort),
     ];
-    let result = test_bisection(tx.repo(), &input_range, expected_tests);
+    let result = test_bisection(tx.repo(), &input_range, expected_tests, false);
     assert_eq!(result, BisectionResult::Abort);
 }


### PR DESCRIPTION
This commit implements https://github.com/jj-vcs/jj/issues/9188. This used to be a "backend" commit and a "frontend" commit; unfortunately, both commits ended up modifying both src/bisect.rs and commands/bisect/run.rs; I have then decided to squash them together.

The most interesting implementation decision has been determining what exactly IS an endpoint; particularly, identifying the revisions that we can expect to be bad. According to git grep, the entire concept of "endpoints" is novel to this codebase. (Not sure I like the name...)

My first choice was `parents(roots(REVSETS))`. There's not much to say about it; as a choice, it seemed to fit every test that was already in the codebase. Martin, however, pointed out a new scenario: what if you take the setup in test_bisect_nonlinear and bisect over commits 0|1|3|5|7? It would be desirable to check that commit 7's other parent, commit 6, is also good. (Let's call this the missing parent usecase.)

Martin then suggested I use a slightly different expression: `parents(REVSETS) ~ REVSETS`. That does handle the missing parent usecase! But it also broke the "Gaps in the input range are allowed" usecase in test_bisect_linear: if REVSET is "1|2|4|7", that makes the bad endpoints 0, 3 and 6. But if we assert that commit 6 has to be good, that should imply that the first bad commit has to be commit 7. Instead, the bisection_steps remain evaluating commits 2 and 4.

This reveals another implementation decision that I have (implicitly) made: the results of the precondition checks are NOT used to populate the rest of the bisector. This turns out to matter depending on how you define an endpoint!

The next idea, and what's currently implemented, is then `parents(connected(REVSETS)) ~ connected(REVSETS)`. I'm not well versed enough in the revset language to determine if this any different to `parents(roots(REVSETS))`; both will handle gaps in the input, but both will also fail to handle missing parents! connected(0|1|3|5|7) *does* include commit 6.

Given that we weren't able (yet) to find a good/simple definition of these endpoints (and, following feedback from Joseph, we actually do quote these definitions in the --help blurb for `jj bisect run`), I wonder if these expressions should've been added to the revset language itself; something like "root_endpoints()" and "head_endpoints()"...