### PR TITLE
nix: fix usage of `isLinux`, `isDarwin`

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -42,7 +42,7 @@ in
       [
         installShellFiles
       ]
-      ++ lib.optionals stdenv.isLinux [
+      ++ lib.optionals stdenv.hostPlatform.isLinux [
         mold
       ];
     buildInputs = [];
@@ -58,7 +58,7 @@ in
     env = {
       RUST_BACKTRACE = 1;
       CARGO_INCREMENTAL = "0"; # https://github.com/rust-lang/rust/issues/139110
-      RUSTFLAGS = lib.optionalString stdenv.isLinux "-C link-arg=-fuse-ld=mold";
+      RUSTFLAGS = lib.optionalString stdenv.hostPlatform.isLinux "-C link-arg=-fuse-ld=mold";
       NIX_JJ_GIT_HASH = gitRev;
     };
 

--- a/flake.nix
+++ b/flake.nix
@@ -53,9 +53,13 @@
 
       # But, whenever we are running CI builds or checks, we want to use a
       # smaller closure. This reduces the CI impact on fresh clones/VMs, etc.
-      rustMinimalPlatform =
-        let platform = pkgs.rust-bin.selectLatestNightlyWith (t: t.minimal);
-        in pkgs.makeRustPlatform { rustc = platform; cargo = platform; };
+      rustMinimalPlatform = let
+        platform = pkgs.rust-bin.selectLatestNightlyWith (t: t.minimal);
+      in
+        pkgs.makeRustPlatform {
+          rustc = platform;
+          cargo = platform;
+        };
     in {
       formatter = pkgs.alejandra;
 
@@ -111,9 +115,9 @@
         # efficient than the defaults. these noticeably improve link time even for
         # medium sized rust projects like jj
         rustLinkerFlags =
-          if pkgs.stdenv.isLinux
+          if pkgs.stdenv.hostPlatform.isLinux
           then ["-fuse-ld=mold" "-Wl,--compress-debug-sections=zstd"]
-          else if pkgs.stdenv.isDarwin
+          else if pkgs.stdenv.hostPlatform.isDarwin
           then
             # on darwin, /usr/bin/ld actually looks at the environment variable
             # $DEVELOPER_DIR, which is set by the nix stdenv, and if set,


### PR DESCRIPTION
`stdenv.{isLinux,isDarwin}` are deprecated on newer versions of `nixpkgs`.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.