### PR TITLE
git: reopen gix::Repository when worktree path matters

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -998,6 +998,11 @@ impl WorkspaceCommandEnvironment {
         cwd
     }
 
+    pub fn workspace_root(&self) -> &Path {
+        let RepoPathUiConverter::Fs { cwd: _, base } = &self.path_converter;
+        base
+    }
+
     pub fn workspace_name(&self) -> &WorkspaceName {
         &self.workspace_name
     }

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -687,12 +687,14 @@ impl CommandHelper {
                             && self.should_commit_transaction()
                         {
                             let workspace_name = workspace_command.env.workspace_name();
+                            let workspace_root = workspace_command.env.workspace_root();
                             let mut tx =
                                 start_repo_transaction(repo, workspace_name, self.string_args());
                             try_reset_git_head(
                                 ui,
                                 tx.repo_mut(),
                                 workspace_name,
+                                workspace_root,
                                 &desired_wc_commit,
                                 git_import_export_lock,
                             )
@@ -968,7 +970,7 @@ impl WorkspaceCommandEnvironment {
             base: workspace.workspace_root().to_owned(),
         };
         #[cfg(feature = "git")]
-        let working_copy_shared_with_git = crate::git_util::is_colocated_git_workspace(workspace);
+        let working_copy_shared_with_git = crate::git_util::is_colocated_git_workspace(workspace)?;
         #[cfg(not(feature = "git"))]
         let working_copy_shared_with_git = false;
         let mut env = Self {
@@ -1385,8 +1387,9 @@ impl WorkspaceCommandHelper {
     ) -> Result<(), CommandError> {
         assert!(self.may_snapshot_working_copy);
         let workspace_name = self.workspace_name().to_owned();
+        let workspace_root = self.workspace_root().to_owned();
         let mut tx = self.start_transaction();
-        jj_lib::git::import_head(tx.repo_mut(), &workspace_name).await?;
+        jj_lib::git::import_head(tx.repo_mut(), &workspace_name, &workspace_root).await?;
         if !tx.repo().has_changes() {
             return Ok(());
         }
@@ -2178,12 +2181,14 @@ to the current parents may contain changes from multiple commits.
             #[cfg(feature = "git")]
             if self.env.working_copy_shared_with_git && self.env.command.should_commit_transaction()
             {
+                let workspace_root = self.env.workspace_root();
                 if wc_immutable {
                     // New working-copy commit is created on top. Reset Git HEAD and index.
                     try_reset_git_head(
                         ui,
                         mut_repo,
                         &workspace_name,
+                        workspace_root,
                         &new_wc_commit,
                         git_import_export_lock,
                     )
@@ -2198,9 +2203,15 @@ to the current parents may contain changes from multiple commits.
                 } else {
                     let old_tree = wc_commit.tree();
                     let new_tree = new_wc_commit.tree();
-                    export_working_copy_changes_to_git(ui, mut_repo, &old_tree, &new_tree)
-                        .await
-                        .map_err(snapshot_command_error)?;
+                    export_working_copy_changes_to_git(
+                        ui,
+                        mut_repo,
+                        workspace_root,
+                        &old_tree,
+                        &new_tree,
+                    )
+                    .await
+                    .map_err(snapshot_command_error)?;
                 }
             }
 
@@ -2382,6 +2393,7 @@ to the current parents may contain changes from multiple commits.
                     ui,
                     tx.repo_mut(),
                     self.workspace_name(),
+                    self.workspace_root(),
                     wc_commit,
                     git_import_export_lock,
                 )
@@ -2687,11 +2699,12 @@ to the current parents may contain changes from multiple commits.
 pub async fn export_working_copy_changes_to_git(
     ui: &Ui,
     mut_repo: &mut MutableRepo,
+    workspace_root: &Path,
     old_tree: &MergedTree,
     new_tree: &MergedTree,
 ) -> Result<(), CommandError> {
     let repo = mut_repo.base_repo().as_ref();
-    jj_lib::git::update_intent_to_add(repo, old_tree, new_tree).await?;
+    jj_lib::git::update_intent_to_add(repo, workspace_root, old_tree, new_tree).await?;
     let stats = jj_lib::git::export_refs(mut_repo)?;
     crate::git_util::print_git_export_stats(ui, &stats)?;
     Ok(())
@@ -2700,6 +2713,7 @@ pub async fn export_working_copy_changes_to_git(
 pub async fn export_working_copy_changes_to_git(
     _ui: &Ui,
     _mut_repo: &mut MutableRepo,
+    _workspace_root: &Path,
     _old_tree: &MergedTree,
     _new_tree: &MergedTree,
 ) -> Result<(), CommandError> {
@@ -2711,6 +2725,7 @@ async fn try_reset_git_head(
     ui: &Ui,
     mut_repo: &mut MutableRepo,
     workspace_name: &WorkspaceName,
+    workspace_root: &Path,
     wc_commit: &Commit,
     _git_import_export_lock: &GitImportExportLock,
 ) -> Result<(), CommandError> {
@@ -2721,7 +2736,7 @@ async fn try_reset_git_head(
     // This can still fail if HEAD was updated concurrently by another JJ process
     // (overlapping transaction) or a non-JJ process (e.g., git checkout). In that
     // case, the actual state will be imported on the next snapshot.
-    match jj_lib::git::reset_head(mut_repo, workspace_name, wc_commit).await {
+    match jj_lib::git::reset_head(mut_repo, workspace_name, workspace_root, wc_commit).await {
         Ok(()) => Ok(()),
         Err(err @ jj_lib::git::GitResetHeadError::UpdateHeadRef(_)) => {
             writeln!(ui.warning_default(), "{err}")?;

--- a/cli/src/commands/file/untrack.rs
+++ b/cli/src/commands/file/untrack.rs
@@ -55,6 +55,7 @@ pub(crate) async fn cmd_file_untrack(
         workspace_command.snapshot_options_with_start_tracking_matcher(&auto_tracking_matcher)?;
 
     let working_copy_shared_with_git = workspace_command.working_copy_shared_with_git();
+    let workspace_root = workspace_command.workspace_root().to_owned();
 
     let mut tx = workspace_command.start_transaction().into_inner();
     let (mut locked_ws, wc_commit) = workspace_command.start_working_copy_mutation().await?;
@@ -106,7 +107,14 @@ Make sure they're ignored, then try again.",
         writeln!(ui.status(), "Rebased {num_rebased} descendant commits.")?;
     }
     if working_copy_shared_with_git {
-        export_working_copy_changes_to_git(ui, tx.repo_mut(), &wc_tree, &new_commit.tree()).await?;
+        export_working_copy_changes_to_git(
+            ui,
+            tx.repo_mut(),
+            &workspace_root,
+            &wc_tree,
+            &new_commit.tree(),
+        )
+        .await?;
     }
     let repo = tx.commit("untrack paths").await?;
     locked_ws.finish(repo.op_id().clone()).await?;

--- a/cli/src/commands/git/colocation.rs
+++ b/cli/src/commands/git/colocation.rs
@@ -99,7 +99,7 @@ async fn cmd_git_colocation_status(
     // Make sure that the workspace supports git colocation commands
     workspace_supports_git_colocation_commands(&workspace_command)?;
 
-    let is_colocated = is_colocated_git_workspace(workspace_command.workspace());
+    let is_colocated = is_colocated_git_workspace(workspace_command.workspace())?;
     let workspace_name = workspace_command.workspace_name();
     let git_head = workspace_command.repo().view().git_head(workspace_name);
 
@@ -164,7 +164,7 @@ async fn cmd_git_colocation_enable(
     workspace_supports_git_colocation_commands(&workspace_command)?;
 
     // Then ensure that the workspace is not already colocated before proceeding
-    if is_colocated_git_workspace(workspace_command.workspace()) {
+    if is_colocated_git_workspace(workspace_command.workspace())? {
         writeln!(ui.status(), "Workspace is already colocated with Git.")?;
         return Ok(());
     }
@@ -245,7 +245,7 @@ async fn cmd_git_colocation_disable(
     workspace_supports_git_colocation_commands(&workspace_command)?;
 
     // Then ensure that the repo is colocated before proceeding
-    if !is_colocated_git_workspace(workspace_command.workspace()) {
+    if !is_colocated_git_workspace(workspace_command.workspace())? {
         writeln!(ui.status(), "Workspace is already not colocated with Git.")?;
         return Ok(());
     }
@@ -325,8 +325,9 @@ async fn set_git_head_to_wc_parent(
     wc_commit: &Commit,
 ) -> Result<(), CommandError> {
     let workspace_name = workspace_command.workspace_name().to_owned();
+    let workspace_root = workspace_command.workspace_root().to_owned();
     let mut tx = workspace_command.start_transaction();
-    git::reset_head(tx.repo_mut(), &workspace_name, wc_commit).await?;
+    git::reset_head(tx.repo_mut(), &workspace_name, &workspace_root, wc_commit).await?;
     if tx.repo().has_changes() {
         tx.finish(ui, "set git head to working copy parent").await?;
     }

--- a/cli/src/commands/git/init.rs
+++ b/cli/src/commands/git/init.rs
@@ -246,7 +246,7 @@ async fn do_init(
                 Workspace::init_external_git(&settings, workspace_root, git_repo_path).await?;
             // Import refs first so all the reachable commits are indexed in
             // chronological order.
-            let colocated = is_colocated_git_workspace(&workspace);
+            let colocated = is_colocated_git_workspace(&workspace)?;
             let repo =
                 init_git_refs(ui, repo, command.string_args(), &workspace, colocated).await?;
             let mut workspace_command = command.for_workable_repo(ui, workspace, repo)?;

--- a/cli/src/git_util.rs
+++ b/cli/src/git_util.rs
@@ -40,6 +40,7 @@ use jj_lib::git::GitRefKind;
 use jj_lib::git::GitSettings;
 use jj_lib::git::GitSidebandLineTerminator;
 use jj_lib::git::GitSubprocessCallback;
+use jj_lib::git_backend::GitRepoAtWorkdirError;
 use jj_lib::op_store::RemoteRefState;
 use jj_lib::repo::ReadonlyRepo;
 use jj_lib::repo::Repo;
@@ -59,22 +60,16 @@ use crate::revset_util::parse_remote_auto_track_bookmarks_map;
 use crate::ui::ProgressOutput;
 use crate::ui::Ui;
 
-pub fn is_colocated_git_workspace(workspace: &Workspace) -> bool {
+pub fn is_colocated_git_workspace(workspace: &Workspace) -> Result<bool, CommandError> {
     let Ok(git_backend) = git::get_git_backend(workspace.repo_loader().store()) else {
-        return false;
+        return Ok(false);
     };
-    let Some(git_workdir) = git_backend.git_workdir() else {
-        return false; // Bare repository
-    };
-    if git_workdir == workspace.workspace_root() {
-        return true;
+    match git_backend.open_git_repo_at_workdir(workspace.workspace_root()) {
+        Ok(_) => Ok(true),
+        Err(GitRepoAtWorkdirError::NotFound { .. }) => Ok(false),
+        Err(GitRepoAtWorkdirError::Unrelated { .. }) => Ok(false),
+        Err(err @ GitRepoAtWorkdirError::Other(_)) => Err(user_error(err)),
     }
-    // Colocated workspace should have ".git" directory, file, or symlink. Compare
-    // its parent as the git_workdir might be resolved from the real ".git" path.
-    let Ok(dot_git_path) = dunce::canonicalize(workspace.workspace_root().join(".git")) else {
-        return false;
-    };
-    dunce::canonicalize(git_workdir).ok().as_deref() == dot_git_path.parent()
 }
 
 /// Parses user-specified remote URL or path to absolute form.

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -23,6 +23,7 @@ use std::ffi::OsString;
 use std::fs::File;
 use std::iter;
 use std::num::NonZeroU32;
+use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -1172,13 +1173,16 @@ fn remotely_pinned_commit_ids(view: &View) -> Vec<CommitId> {
 /// the child of the new HEAD revision.
 pub async fn import_head(
     mut_repo: &mut MutableRepo,
-    workspace: &WorkspaceName,
+    workspace_name: &WorkspaceName,
+    workspace_root: &Path,
 ) -> Result<(), GitImportError> {
     let store = mut_repo.store();
     let git_backend = get_git_backend(store)?;
-    let git_repo = git_backend.git_repo();
+    let git_repo = git_backend
+        .open_git_repo_at_workdir(workspace_root)
+        .map_err(GitImportError::from_git)?;
 
-    let old_git_head = mut_repo.view().git_head(workspace);
+    let old_git_head = mut_repo.view().git_head(workspace_name);
     let new_git_head_id = if let Ok(oid) = git_repo.head_id() {
         Some(CommitId::from_bytes(oid.as_bytes()))
     } else {
@@ -1205,7 +1209,7 @@ pub async fn import_head(
         mut_repo.add_head(&commit).await?;
     }
 
-    mut_repo.set_git_head_target(workspace, RefTarget::resolved(new_git_head_id));
+    mut_repo.set_git_head_target(workspace_name, RefTarget::resolved(new_git_head_id));
     Ok(())
 }
 
@@ -1836,10 +1840,14 @@ impl GitResetHeadError {
 /// the Git index.
 pub async fn reset_head(
     mut_repo: &mut MutableRepo,
-    workspace: &WorkspaceName,
+    workspace_name: &WorkspaceName,
+    workspace_root: &Path,
     wc_commit: &Commit,
 ) -> Result<(), GitResetHeadError> {
-    let git_repo = get_git_repo(mut_repo.store())?;
+    let git_backend = get_git_backend(mut_repo.store())?;
+    let git_repo = git_backend
+        .open_git_repo_at_workdir(workspace_root)
+        .map_err(GitResetHeadError::from_git)?;
 
     let first_parent_id = &wc_commit.parent_ids()[0];
     let new_head_target = if first_parent_id != mut_repo.store().root_commit_id() {
@@ -1849,7 +1857,7 @@ pub async fn reset_head(
     };
 
     // If the first parent of the working copy has changed, reset the Git HEAD.
-    let old_head_target = mut_repo.git_head(workspace);
+    let old_head_target = mut_repo.git_head(workspace_name);
     if *old_head_target != new_head_target {
         let expected_ref = if let Some(id) = old_head_target.as_normal() {
             // We have to check the actual HEAD state because we don't record a
@@ -1870,7 +1878,7 @@ pub async fn reset_head(
         let new_oid = new_head_target.as_normal().map(owned_oid_from_commit_id);
         update_git_head(&git_repo, expected_ref, new_oid)
             .map_err(|err| GitResetHeadError::UpdateHeadRef(err.into()))?;
-        mut_repo.set_git_head_target(workspace, new_head_target);
+        mut_repo.set_git_head_target(workspace_name, new_head_target);
     }
 
     // If there is an ongoing operation (merge, rebase, etc.), we need to clean it
@@ -2091,10 +2099,14 @@ fn build_index_from_merged_tree(
 /// parent(s) has changed.
 pub async fn update_intent_to_add(
     repo: &dyn Repo,
+    workspace_root: &Path,
     old_tree: &MergedTree,
     new_tree: &MergedTree,
 ) -> Result<(), GitResetHeadError> {
-    let git_repo = get_git_repo(repo.store())?;
+    let git_backend = get_git_backend(repo.store())?;
+    let git_repo = git_backend
+        .open_git_repo_at_workdir(workspace_root)
+        .map_err(GitResetHeadError::from_git)?;
     let mut index = git_repo
         .index_or_empty()
         .map_err(GitResetHeadError::from_git)?;

--- a/lib/src/git_backend.rs
+++ b/lib/src/git_backend.rs
@@ -158,6 +158,19 @@ impl From<GitBackendError> for BackendError {
 }
 
 #[derive(Debug, Error)]
+pub enum GitRepoAtWorkdirError {
+    #[error("No Git repository found at {path}")]
+    NotFound {
+        path: PathBuf,
+        source: gix::discover::is_git::Error,
+    },
+    #[error("Unrelated Git repository found at {path}")]
+    Unrelated { path: PathBuf },
+    #[error("Failed to open Git repository")]
+    Other(#[source] Box<dyn std::error::Error + Send + Sync>),
+}
+
+#[derive(Debug, Error)]
 pub enum GitGcError {
     #[error("Failed to run git gc command")]
     GcCommand(#[source] std::io::Error),
@@ -352,19 +365,54 @@ impl GitBackend {
         self.repo.lock().unwrap()
     }
 
-    /// Returns new thread-local instance to access to the underlying Git repo.
+    /// Returns a new thread-local handle for the underlying Git repository.
+    ///
+    /// Use [`Self::open_git_repo_at_workdir()`] for worktree operations.
     pub fn git_repo(&self) -> gix::Repository {
         self.base_repo.to_thread_local()
+    }
+
+    /// Reopens the repository at the given workspace path. Returns a new
+    /// thread-local handle.
+    pub fn open_git_repo_at_workdir(
+        &self,
+        path: &Path,
+    ) -> Result<gix::Repository, GitRepoAtWorkdirError> {
+        // Try the open repository first.
+        let open_repo = self.git_repo();
+        if let Some(workdir) = open_repo.workdir()
+            && (workdir == path || dunce::canonicalize(path).is_ok_and(|path| workdir == path))
+        {
+            return Ok(open_repo);
+        }
+
+        // The input path doesn't include ".git".
+        let opts = open_repo.open_options().clone().open_path_as_is(false);
+        let work_repo = gix::ThreadSafeRepository::open_opts(path, opts)
+            .map_err(|err| match err {
+                gix::open::Error::NotARepository { path, source } => {
+                    GitRepoAtWorkdirError::NotFound { path, source }
+                }
+                err => GitRepoAtWorkdirError::Other(err.into()),
+            })?
+            .to_thread_local();
+        let canonicalize = |path: &Path| {
+            dunce::canonicalize(path).map_err(|err| GitRepoAtWorkdirError::Other(err.into()))
+        };
+        if open_repo.common_dir() == work_repo.common_dir()
+            || canonicalize(open_repo.common_dir())? == canonicalize(work_repo.common_dir())?
+        {
+            // The last (path, work_repo) can be cached if needed.
+            Ok(work_repo)
+        } else {
+            let path = path.to_owned();
+            Err(GitRepoAtWorkdirError::Unrelated { path })
+        }
     }
 
     /// Path to the `.git` directory or the repository itself if it's bare.
     pub fn git_repo_path(&self) -> &Path {
         self.base_repo.path()
-    }
-
-    /// Path to the working directory if the repository isn't bare.
-    pub fn git_workdir(&self) -> Option<&Path> {
-        self.base_repo.work_dir()
     }
 
     fn shallow_root_ids(&self, git_repo: &gix::Repository) -> BackendResult<&[CommitId]> {
@@ -1652,6 +1700,48 @@ mod tests {
         )
         .unwrap()
         .to_thread_local()
+    }
+
+    #[test]
+    fn open_git_repo_at_workdir() -> TestResult {
+        let settings = user_settings();
+        let temp_dir = new_temp_dir();
+        let store_path = temp_dir.path().join("store");
+        fs::create_dir(&store_path)?;
+
+        let git_repo_path = temp_dir.path().join("git1");
+        let git_repo = git_init(&git_repo_path, gix::hash::Kind::default());
+        let other_git_repo_path = temp_dir.path().join("git2");
+        let _other_git_repo = git_init(&other_git_repo_path, gix::hash::Kind::default());
+
+        let worktree_dir = temp_dir.path().join("git1-wt");
+        let output = Command::new("git")
+            .args(["worktree", "add", "--orphan"])
+            .arg(&worktree_dir)
+            .current_dir(&git_repo_path)
+            .output()?;
+        assert!(output.status.success(), "{output:?}");
+
+        let backend = GitBackend::init_external(&settings, &store_path, git_repo.path())?;
+
+        assert_matches!(
+            backend.open_git_repo_at_workdir(&git_repo_path),
+            Ok(repo) if repo.workdir() == Some(backend.git_repo().workdir().unwrap())
+        );
+        assert_matches!(
+            backend.open_git_repo_at_workdir(&worktree_dir),
+            Ok(repo) if repo.workdir() == Some(worktree_dir.as_ref())
+        );
+        assert_matches!(
+            backend.open_git_repo_at_workdir(&temp_dir.path().join("unknown")),
+            Err(GitRepoAtWorkdirError::NotFound { .. })
+        );
+        assert_matches!(
+            backend.open_git_repo_at_workdir(&other_git_repo_path),
+            Err(GitRepoAtWorkdirError::Unrelated { .. })
+        );
+
+        Ok(())
     }
 
     #[test_case(gix::hash::Kind::Sha1 ; "sha1")]

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -21,6 +21,7 @@ use std::io::Write as _;
 use std::iter;
 use std::path::Path;
 use std::path::PathBuf;
+use std::process::Command;
 use std::slice;
 use std::sync::Arc;
 use std::sync::Barrier;
@@ -40,6 +41,7 @@ use jj_lib::commit::Commit;
 use jj_lib::commit_builder::CommitBuilder;
 use jj_lib::config::ConfigLayer;
 use jj_lib::config::ConfigSource;
+use jj_lib::default_backend_factories::default_working_copy_factory;
 use jj_lib::git;
 use jj_lib::git::FailedRefExportReason;
 use jj_lib::git::GitFetch;
@@ -219,7 +221,8 @@ fn rewrite_commit(repo: &mut MutableRepo, predecessor: &Commit, description: &st
 
 fn import_head(mut_repo: &mut MutableRepo, workspace: &Workspace) -> Result<(), GitImportError> {
     let workspace_name = workspace.workspace_name();
-    git::import_head(mut_repo, workspace_name).block_on()
+    let workspace_root = workspace.workspace_root();
+    git::import_head(mut_repo, workspace_name, workspace_root).block_on()
 }
 
 fn reset_head(
@@ -228,7 +231,8 @@ fn reset_head(
     wc_commit: &Commit,
 ) -> Result<(), GitResetHeadError> {
     let workspace_name = workspace.workspace_name();
-    git::reset_head(mut_repo, workspace_name, wc_commit).block_on()
+    let workspace_root = workspace.workspace_root();
+    git::reset_head(mut_repo, workspace_name, workspace_root, wc_commit).block_on()
 }
 
 /// Fetches and imports all refs with the default configuration.
@@ -2561,6 +2565,62 @@ fn test_import_refs_detached_head() -> TestResult {
         repo.view().git_head(WorkspaceName::DEFAULT),
         &RefTarget::normal(jj_id(commit1))
     );
+    Ok(())
+}
+
+#[test]
+fn test_import_export_head_bare_and_worktree() -> TestResult {
+    // The main workspace is backed by a bare Git repository
+    let test_repo = TestRepo::init_with_backend(TestRepoBackend::Git);
+    let repo = &test_repo.repo;
+    let git_repo = get_git_repo(repo);
+    let commit1_oid = empty_git_commit(&git_repo, "refs/heads/commit1", &[]);
+    assert!(git_repo.is_bare());
+    assert!(git_repo.head()?.is_unborn());
+
+    // Create a new colocated workspace
+    let workspace_root = test_repo.env.root().join("wt");
+    let output = Command::new("git")
+        .args(["worktree", "add", "--detach"])
+        .arg(&workspace_root)
+        .arg(commit1_oid.to_string())
+        .current_dir(git_repo.path())
+        .output()?;
+    assert!(output.status.success(), "{output:?}");
+    let (workspace, repo) = Workspace::init_workspace_with_existing_repo(
+        &workspace_root,
+        test_repo.repo_path(),
+        repo,
+        &*default_working_copy_factory(),
+        "wt".into(),
+    )
+    .block_on()?;
+    let work_git_repo = get_git_backend(&repo).open_git_repo_at_workdir(&workspace_root)?;
+
+    // Git HEAD shouldn't be imported yet
+    assert_eq!(
+        repo.view().git_head(workspace.workspace_name()),
+        RefTarget::absent_ref()
+    );
+
+    // Import Git HEAD from "wt"
+    let mut tx = repo.start_transaction();
+    import_head(tx.repo_mut(), &workspace)?;
+    assert_eq!(
+        tx.repo().view().git_head(workspace.workspace_name()),
+        &RefTarget::normal(jj_id(commit1_oid))
+    );
+
+    // Export Git HEAD, which should update the "wt" HEAD
+    let commit2 = write_random_commit(tx.repo_mut());
+    let wc_commit = tx
+        .repo_mut()
+        .check_out(workspace.workspace_name().to_owned(), &commit2)
+        .block_on()?;
+    reset_head(tx.repo_mut(), &workspace, &wc_commit)?;
+    assert!(git_repo.head()?.is_unborn());
+    assert_eq!(work_git_repo.head_id()?, git_id(&commit2));
+
     Ok(())
 }
 

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -85,6 +85,7 @@ use jj_lib::settings::UserSettings;
 use jj_lib::signing::Signer;
 use jj_lib::str_util::StringExpression;
 use jj_lib::str_util::StringMatcher;
+use jj_lib::workspace::Workspace;
 use maplit::btreemap;
 use maplit::hashset;
 use pollster::FutureExt as _;
@@ -216,6 +217,20 @@ fn rewrite_commit(repo: &mut MutableRepo, predecessor: &Commit, description: &st
         .unwrap()
 }
 
+fn import_head(mut_repo: &mut MutableRepo, workspace: &Workspace) -> Result<(), GitImportError> {
+    let workspace_name = workspace.workspace_name();
+    git::import_head(mut_repo, workspace_name).block_on()
+}
+
+fn reset_head(
+    mut_repo: &mut MutableRepo,
+    workspace: &Workspace,
+    wc_commit: &Commit,
+) -> Result<(), GitResetHeadError> {
+    let workspace_name = workspace.workspace_name();
+    git::reset_head(mut_repo, workspace_name, wc_commit).block_on()
+}
+
 /// Fetches and imports all refs with the default configuration.
 fn fetch_import_all(mut_repo: &mut MutableRepo, remote: &RemoteName) -> GitImportStats {
     let git_settings = GitSettings::from_settings(mut_repo.base_repo().settings()).unwrap();
@@ -282,7 +297,7 @@ fn test_import_refs() -> TestResult {
 
     let old_heads = repo.view().heads();
     let mut tx = repo.start_transaction();
-    git::import_head(tx.repo_mut(), WorkspaceName::DEFAULT).block_on()?;
+    import_head(tx.repo_mut(), &test_workspace.workspace)?;
     let stats = git::import_refs(tx.repo_mut(), &import_options).block_on()?;
     tx.repo_mut().rebase_descendants().block_on()?;
     let repo = tx.commit("test").block_on()?;
@@ -569,14 +584,14 @@ fn test_import_refs_reimport_git_head_does_not_count() -> TestResult {
     testutils::git::set_head_to_id(&git_repo, commit);
 
     let mut tx = repo.start_transaction();
-    git::import_head(tx.repo_mut(), WorkspaceName::DEFAULT).block_on()?;
+    import_head(tx.repo_mut(), &test_workspace.workspace)?;
     git::import_refs(tx.repo_mut(), &import_options).block_on()?;
     tx.repo_mut().rebase_descendants().block_on()?;
 
     // Delete the bookmark and re-import. The commit should still be there since
     // HEAD points to it
     git_repo.find_reference("refs/heads/main")?.delete()?;
-    git::import_head(tx.repo_mut(), WorkspaceName::DEFAULT).block_on()?;
+    import_head(tx.repo_mut(), &test_workspace.workspace)?;
     git::import_refs(tx.repo_mut(), &import_options).block_on()?;
     tx.repo_mut().rebase_descendants().block_on()?;
     assert!(!tx.repo().view().heads().contains(&jj_id(commit)));
@@ -599,7 +614,7 @@ fn test_import_refs_reimport_git_head_without_ref() -> TestResult {
     testutils::git::set_head_to_id(&git_repo, git_id(&commit1));
 
     // Import HEAD.
-    git::import_head(tx.repo_mut(), WorkspaceName::DEFAULT).block_on()?;
+    import_head(tx.repo_mut(), &test_workspace.workspace)?;
     git::import_refs(tx.repo_mut(), &import_options).block_on()?;
     tx.repo_mut().rebase_descendants().block_on()?;
     assert!(tx.repo().view().heads().contains(commit1.id()));
@@ -612,7 +627,7 @@ fn test_import_refs_reimport_git_head_without_ref() -> TestResult {
     // would be moved by `git checkout` command. This isn't always true because the
     // detached HEAD commit could be rewritten by e.g. `git commit --amend` command,
     // but it should be safer than abandoning old checkout branch.
-    git::import_head(tx.repo_mut(), WorkspaceName::DEFAULT).block_on()?;
+    import_head(tx.repo_mut(), &test_workspace.workspace)?;
     git::import_refs(tx.repo_mut(), &import_options).block_on()?;
     tx.repo_mut().rebase_descendants().block_on()?;
     assert!(tx.repo().view().heads().contains(commit1.id()));
@@ -641,7 +656,7 @@ fn test_import_refs_reimport_git_head_with_moved_ref() -> TestResult {
     testutils::git::set_head_to_id(&git_repo, git_id(&commit1));
 
     // Import HEAD and main.
-    git::import_head(tx.repo_mut(), WorkspaceName::DEFAULT).block_on()?;
+    import_head(tx.repo_mut(), &test_workspace.workspace)?;
     git::import_refs(tx.repo_mut(), &import_options).block_on()?;
     tx.repo_mut().rebase_descendants().block_on()?;
     assert!(tx.repo().view().heads().contains(commit1.id()));
@@ -657,13 +672,13 @@ fn test_import_refs_reimport_git_head_with_moved_ref() -> TestResult {
     testutils::git::set_head_to_id(&git_repo, git_id(&commit2));
 
     // Reimport HEAD and main, which abandons the old main branch.
-    git::import_head(tx.repo_mut(), WorkspaceName::DEFAULT).block_on()?;
+    import_head(tx.repo_mut(), &test_workspace.workspace)?;
     git::import_refs(tx.repo_mut(), &import_options).block_on()?;
     tx.repo_mut().rebase_descendants().block_on()?;
     assert!(!tx.repo().view().heads().contains(commit1.id()));
     assert!(tx.repo().view().heads().contains(commit2.id()));
     // Reimport HEAD and main, which abandons the old main bookmark.
-    git::import_head(tx.repo_mut(), WorkspaceName::DEFAULT).block_on()?;
+    import_head(tx.repo_mut(), &test_workspace.workspace)?;
     git::import_refs(tx.repo_mut(), &import_options).block_on()?;
     tx.repo_mut().rebase_descendants().block_on()?;
     assert!(!tx.repo().view().heads().contains(commit1.id()));
@@ -1348,7 +1363,7 @@ fn test_import_refs_reimport_git_head_with_fixed_ref() -> TestResult {
     testutils::git::set_head_to_id(&git_repo, git_id(&commit1));
 
     // Import HEAD and main.
-    git::import_head(tx.repo_mut(), WorkspaceName::DEFAULT).block_on()?;
+    import_head(tx.repo_mut(), &test_workspace.workspace)?;
     git::import_refs(tx.repo_mut(), &import_options).block_on()?;
     tx.repo_mut().rebase_descendants().block_on()?;
     assert!(tx.repo().view().heads().contains(commit1.id()));
@@ -1358,7 +1373,7 @@ fn test_import_refs_reimport_git_head_with_fixed_ref() -> TestResult {
     testutils::git::set_head_to_id(&git_repo, git_id(&commit2));
 
     // Reimport HEAD, which shouldn't abandon the old HEAD branch.
-    git::import_head(tx.repo_mut(), WorkspaceName::DEFAULT).block_on()?;
+    import_head(tx.repo_mut(), &test_workspace.workspace)?;
     git::import_refs(tx.repo_mut(), &import_options).block_on()?;
     tx.repo_mut().rebase_descendants().block_on()?;
     assert!(tx.repo().view().heads().contains(commit1.id()));
@@ -2481,7 +2496,7 @@ fn test_import_refs_missing_git_commit() -> TestResult {
     git_repo.find_reference("refs/heads/main")?.delete()?;
     testutils::git::set_head_to_id(&git_repo, commit2);
     let mut tx = repo.start_transaction();
-    let result = git::import_head(tx.repo_mut(), WorkspaceName::DEFAULT).block_on();
+    let result = import_head(tx.repo_mut(), &test_workspace.workspace);
     assert_matches!(
         result,
         Err(GitImportError::MissingHeadTarget {
@@ -2512,7 +2527,7 @@ fn test_import_refs_missing_git_commit() -> TestResult {
     testutils::git::set_head_to_id(&git_repo, commit1);
     fs::rename(&object_file, &backup_object_file)?;
     let mut tx = repo.start_transaction();
-    let result = git::import_head(tx.repo_mut(), WorkspaceName::DEFAULT).block_on();
+    let result = import_head(tx.repo_mut(), &test_workspace.workspace);
     assert!(result.is_ok());
     Ok(())
 }
@@ -2531,7 +2546,7 @@ fn test_import_refs_detached_head() -> TestResult {
 
     let old_heads = repo.view().heads();
     let mut tx = repo.start_transaction();
-    git::import_head(tx.repo_mut(), WorkspaceName::DEFAULT).block_on()?;
+    import_head(tx.repo_mut(), &test_workspace.workspace)?;
     git::import_refs(tx.repo_mut(), &import_options).block_on()?;
     tx.repo_mut().rebase_descendants().block_on()?;
     let repo = tx.commit("test").block_on()?;
@@ -2561,7 +2576,7 @@ fn test_export_refs_no_detach() -> TestResult {
     testutils::git::set_symbolic_reference(&git_repo, "HEAD", "refs/heads/main");
     let mut tx = repo.start_transaction();
     let mut_repo = tx.repo_mut();
-    git::import_head(mut_repo, WorkspaceName::DEFAULT).block_on()?;
+    import_head(mut_repo, &test_workspace.workspace)?;
     git::import_refs(mut_repo, &import_options).block_on()?;
     mut_repo.rebase_descendants().block_on()?;
 
@@ -2599,7 +2614,7 @@ fn test_export_refs_bookmark_changed() -> TestResult {
 
     let mut tx = repo.start_transaction();
     let mut_repo = tx.repo_mut();
-    git::import_head(mut_repo, WorkspaceName::DEFAULT).block_on()?;
+    import_head(mut_repo, &test_workspace.workspace)?;
     git::import_refs(mut_repo, &import_options).block_on()?;
     mut_repo.rebase_descendants().block_on()?;
     let stats = git::export_refs(mut_repo)?;
@@ -2734,7 +2749,7 @@ fn test_export_refs_current_bookmark_changed() -> TestResult {
     testutils::git::set_symbolic_reference(&git_repo, "HEAD", "refs/heads/main");
     let mut tx = repo.start_transaction();
     let mut_repo = tx.repo_mut();
-    git::import_head(mut_repo, WorkspaceName::DEFAULT).block_on()?;
+    import_head(mut_repo, &test_workspace.workspace)?;
     git::import_refs(mut_repo, &import_options).block_on()?;
     mut_repo.rebase_descendants().block_on()?;
     let stats = git::export_refs(mut_repo)?;
@@ -2788,7 +2803,7 @@ fn test_export_refs_worktree_head_changed() -> TestResult {
 
     let mut tx = repo.start_transaction();
     let mut_repo = tx.repo_mut();
-    git::import_head(mut_repo, WorkspaceName::DEFAULT).block_on()?;
+    import_head(mut_repo, &test_workspace.workspace)?;
     git::import_refs(mut_repo, &import_options).block_on()?;
     mut_repo.rebase_descendants().block_on()?;
 
@@ -2832,7 +2847,7 @@ fn test_export_refs_worktree_no_detach() -> TestResult {
 
     let mut tx = repo.start_transaction();
     let mut_repo = tx.repo_mut();
-    git::import_head(mut_repo, WorkspaceName::DEFAULT).block_on()?;
+    import_head(mut_repo, &test_workspace.workspace)?;
     git::import_refs(mut_repo, &import_options).block_on()?;
     mut_repo.rebase_descendants().block_on()?;
 
@@ -2907,7 +2922,7 @@ fn test_export_refs_unborn_git_bookmark(move_placeholder_ref: bool) -> TestResul
     testutils::git::set_symbolic_reference(&git_repo, "HEAD", "refs/heads/main");
     let mut tx = repo.start_transaction();
     let mut_repo = tx.repo_mut();
-    git::import_head(mut_repo, WorkspaceName::DEFAULT).block_on()?;
+    import_head(mut_repo, &test_workspace.workspace)?;
     git::import_refs(mut_repo, &import_options).block_on()?;
     mut_repo.rebase_descendants().block_on()?;
     let stats = git::export_refs(mut_repo)?;
@@ -3608,7 +3623,7 @@ fn test_reset_head_to_root() -> TestResult {
         .write_unwrap();
 
     // Set Git HEAD to commit2's parent (i.e. commit1)
-    git::reset_head(tx.repo_mut(), WorkspaceName::DEFAULT, &commit2).block_on()?;
+    reset_head(tx.repo_mut(), &test_workspace.workspace, &commit2)?;
     assert!(git_repo.head()?.is_detached(), "HEAD is detached");
     assert_eq!(
         tx.repo().git_head(WorkspaceName::DEFAULT),
@@ -3616,7 +3631,7 @@ fn test_reset_head_to_root() -> TestResult {
     );
 
     // Set Git HEAD back to root
-    git::reset_head(tx.repo_mut(), WorkspaceName::DEFAULT, &commit1).block_on()?;
+    reset_head(tx.repo_mut(), &test_workspace.workspace, &commit1)?;
     assert!(git_repo.head()?.is_unborn(), "HEAD is unborn");
     assert!(tx.repo().git_head(WorkspaceName::DEFAULT).is_absent());
 
@@ -3627,7 +3642,7 @@ fn test_reset_head_to_root() -> TestResult {
         gix::refs::transaction::PreviousValue::MustNotExist,
         "",
     )?;
-    git::reset_head(tx.repo_mut(), WorkspaceName::DEFAULT, &commit2).block_on()?;
+    reset_head(tx.repo_mut(), &test_workspace.workspace, &commit2)?;
     assert!(git_repo.head_id().is_ok());
     assert_eq!(
         tx.repo().git_head(WorkspaceName::DEFAULT),
@@ -3636,7 +3651,7 @@ fn test_reset_head_to_root() -> TestResult {
     assert!(git_repo.find_reference("refs/jj/root").is_ok());
 
     // Set Git HEAD back to root
-    git::reset_head(tx.repo_mut(), WorkspaceName::DEFAULT, &commit1).block_on()?;
+    reset_head(tx.repo_mut(), &test_workspace.workspace, &commit1)?;
     assert!(git_repo.head()?.is_unborn(), "HEAD is unborn");
     assert!(tx.repo().git_head(WorkspaceName::DEFAULT).is_absent());
     // The placeholder ref should be deleted
@@ -3666,7 +3681,7 @@ fn test_reset_head_detached_out_of_sync() -> TestResult {
     let commit5 = write_random_commit(tx.repo_mut());
 
     // unborn -> commit1 (= commit2's parent)
-    git::reset_head(tx.repo_mut(), WorkspaceName::DEFAULT, &commit2).block_on()?;
+    reset_head(tx.repo_mut(), &test_workspace.workspace, &commit2)?;
     assert_eq!(
         tx.repo().git_head(WorkspaceName::DEFAULT),
         &RefTarget::normal(commit1.id().clone())
@@ -3677,7 +3692,7 @@ fn test_reset_head_detached_out_of_sync() -> TestResult {
 
     // {expected: commit1, actual: commit5} -> commit1 (= commit3's parent):
     // works because the expected HEAD is unchanged.
-    git::reset_head(tx.repo_mut(), WorkspaceName::DEFAULT, &commit3).block_on()?;
+    reset_head(tx.repo_mut(), &test_workspace.workspace, &commit3)?;
     assert_eq!(
         tx.repo().git_head(WorkspaceName::DEFAULT),
         &RefTarget::normal(commit1.id().clone())
@@ -3685,7 +3700,7 @@ fn test_reset_head_detached_out_of_sync() -> TestResult {
 
     // {expected: commit1, actual: commit5} -> commit3 (= commit4's parent)
     assert_matches!(
-        git::reset_head(tx.repo_mut(), WorkspaceName::DEFAULT, &commit4).block_on(),
+        reset_head(tx.repo_mut(), &test_workspace.workspace, &commit4),
         Err(GitResetHeadError::UpdateHeadRef(_))
     );
     assert_eq!(
@@ -3695,14 +3710,14 @@ fn test_reset_head_detached_out_of_sync() -> TestResult {
     );
 
     // Import the HEAD moved by external process
-    git::import_head(tx.repo_mut(), WorkspaceName::DEFAULT).block_on()?;
+    import_head(tx.repo_mut(), &test_workspace.workspace)?;
     assert_eq!(
         tx.repo().git_head(WorkspaceName::DEFAULT),
         &RefTarget::normal(commit5.id().clone())
     );
 
     // commit5 -> commit3 (= commit4's parent)
-    git::reset_head(tx.repo_mut(), WorkspaceName::DEFAULT, &commit4).block_on()?;
+    reset_head(tx.repo_mut(), &test_workspace.workspace, &commit4)?;
     assert_eq!(
         tx.repo().git_head(WorkspaceName::DEFAULT),
         &RefTarget::normal(commit3.id().clone())
@@ -3747,7 +3762,7 @@ fn test_reset_head_with_index() -> TestResult {
         .write_unwrap();
 
     // Set Git HEAD to commit2's parent (i.e. commit1)
-    git::reset_head(tx.repo_mut(), WorkspaceName::DEFAULT, &commit2).block_on()?;
+    reset_head(tx.repo_mut(), &test_workspace.workspace, &commit2)?;
     insta::assert_snapshot!(get_index_state(workspace_root), @"");
 
     // Add "staged changes" to the Git index
@@ -3759,7 +3774,7 @@ fn test_reset_head_with_index() -> TestResult {
     insta::assert_snapshot!(get_index_state(workspace_root), @"Unconflicted file.txt Mode(FILE)");
 
     // Reset head and the Git index
-    git::reset_head(tx.repo_mut(), WorkspaceName::DEFAULT, &commit2).block_on()?;
+    reset_head(tx.repo_mut(), &test_workspace.workspace, &commit2)?;
     insta::assert_snapshot!(get_index_state(workspace_root), @"");
     Ok(())
 }
@@ -3797,7 +3812,7 @@ fn test_reset_head_with_index_no_conflict() -> TestResult {
         .write_unwrap();
 
     // Reset head to working copy commit
-    git::reset_head(mut_repo, WorkspaceName::DEFAULT, &wc_commit).block_on()?;
+    reset_head(mut_repo, &test_workspace.workspace, &wc_commit)?;
 
     // Git index should contain all files from the tree.
     // `Mode(DIR | SYMLINK)` actually means `MODE(COMMIT)`, as in a git submodule.
@@ -3886,7 +3901,7 @@ fn test_reset_head_with_index_merge_conflict() -> TestResult {
         .write_unwrap();
 
     // Reset head to working copy commit with merge conflict
-    git::reset_head(mut_repo, WorkspaceName::DEFAULT, &wc_commit).block_on()?;
+    reset_head(mut_repo, &test_workspace.workspace, &wc_commit)?;
 
     // Index should contain conflicted files from merge of parent commits.
     // `Mode(DIR | SYMLINK)` actually means `MODE(COMMIT)`, as in a git submodule.
@@ -3945,7 +3960,7 @@ fn test_reset_head_with_index_file_directory_conflict() -> TestResult {
         .write_unwrap();
 
     // Reset head to working copy commit with file-directory conflict
-    git::reset_head(mut_repo, WorkspaceName::DEFAULT, &wc_commit).block_on()?;
+    reset_head(mut_repo, &test_workspace.workspace, &wc_commit)?;
 
     // Only the file should be added to the index (the tree should be skipped).
     insta::assert_snapshot!(get_index_state(workspace_root), @"Theirs test Mode(FILE)");

--- a/lib/tests/test_init.rs
+++ b/lib/tests/test_init.rs
@@ -67,7 +67,7 @@ fn test_init_internal_git(object_hash: gix::hash::Kind) -> TestResult {
         git_backend.git_repo_path(),
         canonical.join(PathBuf::from_iter([".jj", "repo", "store", "git"])),
     );
-    assert!(git_backend.git_workdir().is_none());
+    assert!(git_backend.git_repo().workdir().is_none());
     assert_eq!(
         std::fs::read_to_string(repo_path.join("store").join("git_target"))?,
         "git"
@@ -91,7 +91,7 @@ fn test_init_colocated_git(object_hash: gix::hash::Kind) -> TestResult {
     let repo_path = canonical.join(".jj").join("repo");
     assert_eq!(workspace.workspace_root(), &canonical);
     assert_eq!(git_backend.git_repo_path(), canonical.join(".git"));
-    assert_eq!(git_backend.git_workdir(), Some(canonical.as_ref()));
+    assert_eq!(git_backend.git_repo().workdir(), Some(canonical.as_ref()));
     assert_eq!(
         std::fs::read_to_string(repo_path.join("store").join("git_target"))?,
         "../../../.git"
@@ -124,7 +124,7 @@ fn test_init_external_git() -> TestResult {
         canonical.join("git").join(".git")
     );
     assert_eq!(
-        git_backend.git_workdir(),
+        git_backend.git_repo().workdir(),
         Some(canonical.join("git").as_ref())
     );
 


### PR DESCRIPTION
# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [ ] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
