### PR TITLE
run: do not rewrite commits when tree is unchanged

### DIFF
--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -16,7 +16,6 @@
 
 use std::cmp::min;
 use std::collections::HashMap;
-use std::collections::HashSet;
 use std::fmt;
 use std::fs;
 use std::io;
@@ -360,8 +359,6 @@ struct RunJob {
     /// run (i.e. the commit was skipped). May be a conflicted tree when the
     /// command left conflicts in the working copy.
     new_tree: Option<MergedTree>,
-    /// Was the tree even modified.
-    dirty: bool,
     /// Bytes the subprocess wrote to its stdout, captured in full.
     stdout: Vec<u8>,
     /// Bytes the subprocess wrote to its stderr, captured in full.
@@ -465,7 +462,6 @@ async fn rewrite_commit(
                 old_id,
                 old_tree,
                 new_tree: None,
-                dirty: false,
                 stdout: Vec::new(),
                 stderr: Vec::new(),
                 skipped: true,
@@ -561,7 +557,6 @@ async fn rewrite_commit(
         old_id,
         old_tree,
         new_tree,
-        dirty,
         stdout: output.stdout,
         stderr: output.stderr,
         skipped: false,
@@ -767,7 +762,6 @@ pub async fn cmd_run(
         builder.enable_time();
         builder.build().unwrap()
     };
-    let mut done_commits = HashSet::new();
     let (sender_tx, mut receiver) = mpsc::channel(jobs.get());
 
     let pool = Arc::new(WorkspacePool::new(
@@ -837,10 +831,9 @@ pub async fn cmd_run(
                             return Err(error);
                         }
                     }
-                    if res.dirty
-                        && let Some(new_tree) = res.new_tree
+                    if let Some(new_tree) = res.new_tree
+                        && new_tree.tree_ids_and_labels() != res.old_tree.tree_ids_and_labels()
                     {
-                        done_commits.insert(res.old_id.clone());
                         rewritten_commits.insert(res.old_id.clone(), (res.old_tree, new_tree));
                     }
                 }
@@ -888,13 +881,19 @@ pub async fn cmd_run(
                         builder.set_tree(merged).write().await?;
                     }
                     (None, true) => {
-                        // Descendant outside the run set — keep its content.
-                        rewriter.reparent().write().await?;
-                        num_reparented += 1;
+                        // Descendant outside the run set or unmodified commit —
+                        // keep its content if an ancestor changed.
+                        if rewriter.parents_changed() {
+                            rewriter.reparent().write().await?;
+                            num_reparented += 1;
+                        }
                     }
                     (None, false) => {
-                        // Default: propagate the diff into descendants.
-                        rewriter.rebase().await?.write().await?;
+                        // Default: propagate the diff into descendants if an
+                        // ancestor changed.
+                        if rewriter.parents_changed() {
+                            rewriter.rebase().await?.write().await?;
+                        }
                     }
                 }
                 Ok(())

--- a/cli/tests/test_run_command.rs
+++ b/cli/tests/test_run_command.rs
@@ -20,6 +20,7 @@ use insta::assert_snapshot;
 use crate::common::TestEnvironment;
 use crate::common::TestWorkDir;
 use crate::common::create_commit_with_files;
+use crate::common::fake_editor_path;
 
 #[test]
 fn test_run_simple() {
@@ -271,8 +272,8 @@ fn test_run_from_subdir_skips_commits_without_it() {
     insta::assert_snapshot!(output.stderr, @r"
     Skipped commit 3bb1f1ca3c09a8e6be46ef48515803464b16b426: directory does not exist: sub
     Rewrote 1 commits.
-    Working copy  (@) now at: kkmpptxz 3548431a (empty) (no description set)
-    Parent commit (@-)      : rlvkpnrz 3aa9a235 with-sub
+    Working copy  (@) now at: kkmpptxz 47736de8 (empty) (no description set)
+    Parent commit (@-)      : rlvkpnrz cb2b6779 with-sub
     Added 1 files, modified 0 files, removed 0 files
     [EOF]
     ");
@@ -487,8 +488,8 @@ fn test_run_ignore_errors_rewrites_successes() {
         output.success(), @r"
     ------- stderr -------
     Rewrote 1 commits.
-    Working copy  (@) now at: zsuskuln f3c3b6ac b | b
-    Parent commit (@-)      : rlvkpnrz 2385de9f a | a
+    Working copy  (@) now at: zsuskuln 8dcecfe7 b | b
+    Parent commit (@-)      : rlvkpnrz b42c1b2c a | a
     Added 1 files, modified 0 files, removed 0 files
     [EOF]
     "
@@ -1979,4 +1980,104 @@ fn test_run_on_conflicted_commit() {
     touched.txt
     [EOF]
     ");
+}
+
+#[test]
+fn test_run_touches_file_without_diff() {
+    let mut test_env = TestEnvironment::default();
+    let edit_script = test_env.set_up_fake_editor();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+    work_dir.write_file("file.txt", "content\n");
+    work_dir.run_jj(&["commit", "-m", "initial"]).success();
+
+    let log_before = work_dir
+        .run_jj(&["log", "-T", "commit_id.short()"])
+        .success()
+        .stdout
+        .to_string();
+
+    std::fs::write(&edit_script, "write\ncontent\n").unwrap();
+    let output = work_dir
+        .run_jj(&["run", "-r", "@-", "--", &fake_editor_path(), "file.txt"])
+        .success();
+    insta::assert_snapshot!(output.stderr, @r"
+    Nothing changed.
+    [EOF]
+    ");
+
+    let log_after = work_dir
+        .run_jj(&["log", "-T", "commit_id.short()"])
+        .success()
+        .stdout
+        .to_string();
+    assert_eq!(log_before, log_after);
+}
+
+#[test]
+fn test_run_multi_commit_partial_diff() {
+    let mut test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let fake_formatter = assert_cmd::cargo::cargo_bin("fake-formatter");
+    assert!(fake_formatter.is_file());
+    let fake_formatter_path = fake_formatter.to_string_lossy().into_owned();
+    test_env.add_paths_to_normalize(fake_formatter.clone(), "$FAKE_FORMATTER_PATH");
+    let work_dir = test_env.work_dir("repo");
+
+    // First commit has only root-level file; no `sub/` exists.
+    work_dir.write_file("file_a.txt", "content_a\n");
+    work_dir.run_jj(&["describe", "-m", "commit_a"]).success();
+
+    // Second commit adds `sub/file_b.txt`.
+    work_dir.run_jj(&["new", "-m", "commit_b"]).success();
+    work_dir.write_file("sub/file_b.txt", "content_b\n");
+
+    let log_commit_a_before = work_dir
+        .run_jj(&[
+            "log",
+            "-r",
+            "description('commit_a')",
+            "-T",
+            "commit_id.short()",
+        ])
+        .success()
+        .stdout
+        .to_string();
+
+    let sub_dir = work_dir.dir("sub");
+    let output = sub_dir
+        .run_jj(&[
+            "run",
+            "-r",
+            "..@",
+            "--",
+            &fake_formatter_path,
+            "--tee",
+            "ran.txt",
+        ])
+        .success()
+        .normalize_backslash();
+
+    insta::assert_snapshot!(output.stderr, @r"
+    Skipped commit 9c0b665484a6ebf6770a7f72511c1a9c8ea75183: directory does not exist: sub
+    Rewrote 1 commits.
+    Working copy  (@) now at: kkmpptxz 54d102ff commit_b
+    Parent commit (@-)      : qpvuntsm 9c0b6654 commit_a
+    Added 1 files, modified 0 files, removed 0 files
+    [EOF]
+    ");
+
+    // commit_a was skipped and must NOT have been rewritten
+    let log_commit_a_after = work_dir
+        .run_jj(&[
+            "log",
+            "-r",
+            "description('commit_a')",
+            "-T",
+            "commit_id.short()",
+        ])
+        .success()
+        .stdout
+        .to_string();
+    assert_eq!(log_commit_a_before, log_commit_a_after);
 }

--- a/docs/paid_contributors.md
+++ b/docs/paid_contributors.md
@@ -23,6 +23,7 @@ See [contribution docs](contributing.md#code-reviews) for details on this policy
 
 * 06393993
 * 2079884FDavid
+* aabmass
 * ajaspers
 * algmyr
 * AM5800


### PR DESCRIPTION
`jj run` previously relied on the snapshot's dirty flag to decide if a
commit should be rewritten. However, filesystem metadata changes (such as
mtimes modified by `touch` or an idempotent formatter) mark the snapshot
dirty even when tree contents and conflict states are identical.

Fix this by comparing the resulting tree against the original tree
instead of checking the dirty flag. In addition, guard descendant
rewriting in `transform_descendants` so commits are only rebased or
reparented when their parents actually changed.

Closes #10020
