### PR TITLE
squash: Print hint when `--revision` resolves to multiple revisions

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -1820,18 +1820,19 @@ to the current parents may contain changes from multiple commits.
         op_walk::resolve_op_with_repo(self.repo(), op_str).block_on()
     }
 
-    /// Resolve a revset to a single revision. Return an error if the revset is
-    /// empty or has multiple revisions.
+    /// Resolves a revset to a single revision. Returns an error if the revset
+    /// is empty or has multiple revisions.
     pub async fn resolve_single_rev(
         &self,
         ui: &Ui,
         revision_arg: &RevisionArg,
     ) -> Result<Commit, CommandError> {
         let expression = self.parse_revset(ui, revision_arg)?;
-        revset_util::evaluate_revset_to_single_commit(revision_arg.as_ref(), &expression, || {
-            self.commit_summary_template()
-        })
-        .await
+        revset_util::evaluate_revset_to_single_commit(&expression)
+            .await
+            .map_err(|err| {
+                err.to_command_error(revision_arg.as_ref(), &self.commit_summary_template())
+            })
     }
 
     /// Evaluates revset expressions to set of commit IDs. The

--- a/cli/src/commands/squash.rs
+++ b/cli/src/commands/squash.rs
@@ -46,6 +46,8 @@ use crate::description_util::description_template;
 use crate::description_util::edit_description;
 use crate::description_util::join_message_paragraphs;
 use crate::description_util::try_combine_messages;
+use crate::revset_util::RevsetEvaluationSizeError;
+use crate::revset_util::evaluate_revset_to_single_commit;
 use crate::ui::Ui;
 
 /// Move changes from a revision into another revision
@@ -216,9 +218,25 @@ pub(crate) async fn cmd_squash(
         // a little faster.
         sources.reverse();
     } else {
-        let source = workspace_command
-            .resolve_single_rev(ui, args.revision.as_ref().unwrap_or(&RevisionArg::AT))
-            .await?;
+        let revision_arg = args.revision.as_ref().unwrap_or(&RevisionArg::AT);
+        let source_expression = workspace_command.parse_revset(ui, revision_arg)?;
+        let source = evaluate_revset_to_single_commit(&source_expression)
+            .await
+            .map_err(|err| {
+                let was_multiple = matches!(err, RevsetEvaluationSizeError::Multiple(_, _));
+                let command_error = err.to_command_error(
+                    revision_arg.as_ref(),
+                    &workspace_command.commit_summary_template(),
+                );
+                if was_multiple {
+                    command_error.hinted(
+                        "--revision must resolve to a single revision. Use --from and --into \
+                         instead if you want to squash multiple revisions.",
+                    )
+                } else {
+                    command_error
+                }
+            })?;
         let mut parents = source.parents().await?;
         if parents.len() != 1 {
             return Err(

--- a/cli/src/revset_util.rs
+++ b/cli/src/revset_util.rs
@@ -225,29 +225,61 @@ pub(super) fn try_resolve_trunk_alias(
     Ok(Some(resolved))
 }
 
-pub(super) async fn evaluate_revset_to_single_commit<'a>(
-    revision_str: &str,
+/// Error when evaluating a revset into a single commit.
+#[derive(Debug)]
+pub enum RevsetEvaluationSizeError {
+    /// The revset evaluated to no commits.
+    Empty,
+    /// The revset evaluated to multiple commits. The vector only contains a few
+    /// commits (enough for an error message), and the bool indicates whether
+    /// there were more; do not expect this to be the entire evaluated revset.
+    Multiple(Vec<Commit>, bool),
+    /// An error occurred during revset evaluation; size unknown.
+    Other(UserRevsetEvaluationError),
+}
+
+impl RevsetEvaluationSizeError {
+    pub fn to_command_error(
+        self,
+        revision_str: &str,
+        commit_summary_template: &TemplateRenderer<'_, Commit>,
+    ) -> CommandError {
+        match self {
+            Self::Empty => user_error(format!(
+                "Revset `{revision_str}` didn't resolve to any revisions"
+            )),
+            Self::Multiple(commits, has_more) => format_multiple_revisions_error(
+                revision_str,
+                &commits,
+                has_more,
+                commit_summary_template,
+            ),
+            Self::Other(error) => error.into(),
+        }
+    }
+}
+
+pub(super) async fn evaluate_revset_to_single_commit(
     expression: &RevsetExpressionEvaluator<'_>,
-    commit_summary_template: impl FnOnce() -> TemplateRenderer<'a, Commit>,
-) -> Result<Commit, CommandError> {
-    let commits: Vec<_> = expression
-        .evaluate_to_commits()?
-        .take(6)
+) -> Result<Commit, RevsetEvaluationSizeError> {
+    // The number of commits to pass to the error (will be shown in the error
+    // message).
+    let max_commits = 5;
+    let mut commits: Vec<_> = expression
+        .evaluate_to_commits()
+        .map_err(RevsetEvaluationSizeError::Other)?
+        .take(max_commits + 1)
         .try_collect()
-        .await?;
+        .await
+        .map_err(UserRevsetEvaluationError::Evaluation)
+        .map_err(RevsetEvaluationSizeError::Other)?;
     match commits.as_slice() {
         [commit] => Ok(commit.clone()),
-        [] => Err(user_error(format!(
-            "Revset `{revision_str}` didn't resolve to any revisions"
-        ))),
+        [] => Err(RevsetEvaluationSizeError::Empty),
         _ => {
-            let elided = commits.len() > 5;
-            Err(format_multiple_revisions_error(
-                revision_str,
-                &commits[..std::cmp::min(5, commits.len())],
-                elided,
-                &commit_summary_template(),
-            ))
+            let has_more = commits.len() > max_commits;
+            commits.truncate(max_commits);
+            Err(RevsetEvaluationSizeError::Multiple(commits, has_more))
         }
     }
 }

--- a/cli/tests/test_squash_command.rs
+++ b/cli/tests/test_squash_command.rs
@@ -396,6 +396,55 @@ fn test_squash_partial() -> TestResult {
 }
 
 #[test]
+fn test_squash_revision_flag_exactly_one_errors() {
+    // Test error cases where the `--revision` flag does not resolve to a single
+    // revision.
+
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    work_dir.write_file("file1", "a\n");
+    work_dir.run_jj(["bookmark", "create", "a"]).success();
+    work_dir.run_jj(["new"]).success();
+    work_dir.write_file("file1", "b\n");
+    work_dir.run_jj(["bookmark", "create", "b"]).success();
+    work_dir.run_jj(["new"]).success();
+    work_dir.write_file("file1", "c\n");
+    work_dir.run_jj(["bookmark", "create", "c"]).success();
+
+    insta::assert_snapshot!(get_log_output(&work_dir), @"
+    @  68a8af64312c c
+    ○  ffe91d7f157b b
+    ○  eb7b8a1f02b8 a
+    ◆  000000000000 (empty)
+    [EOF]
+    ");
+
+    // Try to squash multiple revisions.
+    let output = work_dir.run_jj(["squash", "-rb|c"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    Error: Revset `b|c` resolved to more than one revision
+    Hint: The revset `b|c` resolved to these revisions:
+      mzvwutvl 68a8af64 c | (no description set)
+      kkmpptxz ffe91d7f b | (no description set)
+    Hint: --revision must resolve to a single revision. Use --from and --into instead if you want to squash multiple revisions.
+    [EOF]
+    [exit status: 1]
+    ");
+
+    // Try to squash no revisions.
+    let output = work_dir.run_jj(["squash", "-rb&c"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    Error: Revset `b&c` didn't resolve to any revisions
+    [EOF]
+    [exit status: 1]
+    ");
+}
+
+#[test]
 fn test_squash_keep_emptied() {
     let test_env = TestEnvironment::default();
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();


### PR DESCRIPTION
There has been recent work on #5301 to support multiple revisions (PR #9670), but until then it might be nice to point users to how to fix the problem they ran into.

Closes #9433.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
