### PR TITLE
working_copy: avoid "empty" fsmonitor saves

### DIFF
--- a/lib/src/local_working_copy.rs
+++ b/lib/src/local_working_copy.rs
@@ -959,6 +959,7 @@ fn file_state(metadata: &Metadata) -> Result<Option<FileState>, MtimeOutOfRange>
 struct FsmonitorMatcher {
     matcher: Option<Box<dyn Matcher>>,
     watchman_clock: Option<crate::protos::local_working_copy::WatchmanClock>,
+    should_update_watchman_clock: bool,
 }
 
 /// Settings specific to the tree state of the [`LocalWorkingCopy`] backend.
@@ -1304,11 +1305,11 @@ impl TreeState {
 
         let sparse_matcher = self.sparse_matcher();
 
-        let fsmonitor_clock_needs_save = self.fsmonitor_settings != FsmonitorSettings::None;
-        let mut is_dirty = fsmonitor_clock_needs_save;
+        let mut is_dirty = false;
         let FsmonitorMatcher {
             matcher: fsmonitor_matcher,
             watchman_clock,
+            should_update_watchman_clock,
         } = self
             .make_fsmonitor_matcher(&self.fsmonitor_settings)
             .await?;
@@ -1323,7 +1324,10 @@ impl TreeState {
         );
         if matcher.visit(RepoPath::root()).is_nothing() {
             // No need to load the current tree, set up channels, etc.
-            self.watchman_clock = watchman_clock;
+            if should_update_watchman_clock {
+                is_dirty |= self.watchman_clock != watchman_clock;
+                self.watchman_clock = watchman_clock;
+            }
             return Ok((is_dirty, SnapshotStats::default()));
         }
 
@@ -1413,12 +1417,17 @@ impl TreeState {
         // Since untracked paths aren't cached in the tree state, we'll need to
         // rescan the working directory changes to report or track them later.
         // TODO: store untracked paths and update watchman_clock?
-        if (stats.untracked_paths.is_empty() && stats.invalid_utf8_paths.is_empty())
-            || watchman_clock.is_none()
-        {
-            self.watchman_clock = watchman_clock;
-        } else {
-            tracing::info!("not updating watchman clock because there are untracked files");
+        // A failed monitor query has no clock and causes a full scan. Clear the
+        // old clock after that scan even if it found untracked paths.
+        if should_update_watchman_clock {
+            if (stats.untracked_paths.is_empty() && stats.invalid_utf8_paths.is_empty())
+                || watchman_clock.is_none()
+            {
+                is_dirty |= self.watchman_clock != watchman_clock;
+                self.watchman_clock = watchman_clock;
+            } else {
+                tracing::info!("not updating watchman clock because there are untracked files");
+            }
         }
         Ok((is_dirty, stats))
     }
@@ -1449,6 +1458,13 @@ impl TreeState {
                 });
             }
         };
+        // Do not advance the clock when the monitor reports no changed paths.
+        // This avoids rewriting the tree state just to save the new clock.
+        // Reusing the older clock may make a later query do more work, but it
+        // cannot omit changes.
+        let should_update_watchman_clock = changed_files
+            .as_ref()
+            .is_none_or(|changed_files| !changed_files.is_empty());
         let matcher: Option<Box<dyn Matcher>> = match changed_files {
             None => None,
             Some(changed_files) => {
@@ -1486,6 +1502,7 @@ impl TreeState {
         Ok(FsmonitorMatcher {
             matcher,
             watchman_clock,
+            should_update_watchman_clock,
         })
     }
 }

--- a/lib/tests/test_local_working_copy.rs
+++ b/lib/tests/test_local_working_copy.rs
@@ -53,6 +53,7 @@ use jj_lib::merge::SameChange;
 use jj_lib::merged_tree::MergedTree;
 use jj_lib::merged_tree_builder::MergedTreeBuilder;
 use jj_lib::op_store::OperationId;
+use jj_lib::protos::local_working_copy as working_copy_proto;
 use jj_lib::ref_name::WorkspaceName;
 use jj_lib::repo::ReadonlyRepo;
 use jj_lib::repo::Repo as _;
@@ -69,6 +70,7 @@ use jj_lib::working_copy::UntrackedReason;
 use jj_lib::working_copy::WorkingCopy as _;
 use jj_lib::workspace::Workspace;
 use pollster::FutureExt as _;
+use prost::Message as _;
 use test_case::test_case;
 use testutils::CommitBuilderExt as _;
 use testutils::TestRepo;
@@ -2706,6 +2708,17 @@ fn test_fsmonitor() -> TestResult {
         state_path.clone(),
         &tree_state_settings,
     )?;
+    // Seed the tree state with a clock from an earlier monitor query.
+    let tree_state_path = state_path.join("tree_state");
+    let old_watchman_clock = working_copy_proto::WatchmanClock {
+        watchman_clock: Some(
+            working_copy_proto::watchman_clock::WatchmanClock::StringClock("c:1:1".to_string()),
+        ),
+    };
+    let mut proto =
+        working_copy_proto::TreeState::decode(std::fs::read(&tree_state_path)?.as_slice())?;
+    proto.watchman_clock = Some(old_watchman_clock.clone());
+    std::fs::write(&tree_state_path, proto.encode_to_vec())?;
 
     let foo_path = repo_path("foo");
     let bar_path = repo_path("bar");
@@ -2735,24 +2748,30 @@ fn test_fsmonitor() -> TestResult {
             &settings,
         )
         .unwrap();
-        tree_state
+        let (is_dirty, _) = tree_state
             .snapshot(&empty_snapshot_options())
             .block_on()
             .unwrap();
-        tree_state
+        (is_dirty, tree_state)
     };
 
-    let tree_state = snapshot(&[]);
+    let (is_dirty, mut tree_state) = snapshot(&[]);
+    // An empty response should not require saving the tree state.
+    assert!(!is_dirty);
     assert_tree_eq!(*tree_state.current_tree(), repo.store().empty_merged_tree());
+    // Saving explicitly verifies that the in-memory clock was retained.
+    tree_state.save()?;
+    let proto = working_copy_proto::TreeState::decode(std::fs::read(&tree_state_path)?.as_slice())?;
+    assert_eq!(proto.watchman_clock, Some(old_watchman_clock));
 
-    let tree_state = snapshot(&[foo_path]);
+    let (_, tree_state) = snapshot(&[foo_path]);
     insta::assert_snapshot!(testutils::dump_tree(tree_state.current_tree()), @r#"
     merged tree (sides: 1)
       tree 2a5341b103917cfdb48a
         file "foo" (e99c2057c15160add351): "foo\n"
     "#);
 
-    let mut tree_state = snapshot(&[foo_path, bar_path, nested_path, ignored_path]);
+    let (_, mut tree_state) = snapshot(&[foo_path, bar_path, nested_path, ignored_path]);
     insta::assert_snapshot!(testutils::dump_tree(tree_state.current_tree()), @r#"
     merged tree (sides: 1)
       tree 1c5c336421714b1df7bb
@@ -2764,7 +2783,7 @@ fn test_fsmonitor() -> TestResult {
 
     testutils::write_working_copy_file(&workspace_root, foo_path, "updated foo\n");
     testutils::write_working_copy_file(&workspace_root, bar_path, "updated bar\n");
-    let tree_state = snapshot(&[foo_path]);
+    let (_, tree_state) = snapshot(&[foo_path]);
     insta::assert_snapshot!(testutils::dump_tree(tree_state.current_tree()), @r#"
     merged tree (sides: 1)
       tree f653dfa18d0b025bdb9e
@@ -2774,7 +2793,7 @@ fn test_fsmonitor() -> TestResult {
     "#);
 
     std::fs::remove_file(foo_path.to_fs_path_unchecked(&workspace_root))?;
-    let mut tree_state = snapshot(&[foo_path]);
+    let (_, mut tree_state) = snapshot(&[foo_path]);
     insta::assert_snapshot!(testutils::dump_tree(tree_state.current_tree()), @r#"
     merged tree (sides: 1)
       tree b7416fc248a038b920c3


### PR DESCRIPTION
I've been looking at jj's performance in a large (for me) repository: Firefox.

It only became bearable with fsmonitor/watchman but I discovered that even with no files changing advancing the fsmonitor clock triggered the complete tree state rewrite.

I figured we could just keep the old clock if there are no changes.

Here are some "jj st" numbers from my system (macOS 26.5.2, M1 Pro,
fast NVMe, hardcoded WATCHMAN_SOCK to avoid watchman socket discovery):

    jj version                Runs  Median ms  Mean ms   Min ms   Max ms
    stable 0.44.0             20    210.990    257.952   190.111  836.981
    7190eda8 + this patch     20    135.723    136.843   127.764  153.652

I expect this to be safe as querying again from the older clock can replay paths, but it cannot omit future file updates.

Stable minus custom is 75.267 ms median, 121.109 ms mean, 62.347 ms minimum, and 683.329 ms maximum.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
