### PR TITLE
matchers: wrap globset::Glob in newtype to enforce parsing options

### DIFF
--- a/lib/src/fileset.rs
+++ b/lib/src/fileset.rs
@@ -20,8 +20,6 @@ use std::path;
 use std::slice;
 use std::sync::LazyLock;
 
-use globset::Glob;
-use globset::GlobBuilder;
 use itertools::Itertools as _;
 use thiserror::Error;
 
@@ -44,6 +42,7 @@ use crate::matchers::GlobsMatcher;
 use crate::matchers::IntersectionMatcher;
 use crate::matchers::Matcher;
 use crate::matchers::NothingMatcher;
+use crate::matchers::PathGlobPattern;
 use crate::matchers::PrefixMatcher;
 use crate::matchers::UnionMatcher;
 use crate::repo_path::RelativePathParseError;
@@ -81,14 +80,14 @@ pub enum FilePattern {
         /// Prefix directory path where the `pattern` will be evaluated.
         dir: RepoPathBuf,
         /// Glob pattern relative to `dir`.
-        pattern: Box<Glob>,
+        pattern: Box<PathGlobPattern>,
     },
     /// Matches path prefix with glob pattern.
     PrefixGlob {
         /// Prefix directory path where the `pattern` will be evaluated.
         dir: RepoPathBuf,
         /// Glob pattern relative to `dir`.
-        pattern: Box<Glob>,
+        pattern: Box<PathGlobPattern>,
     },
     // TODO: add more patterns:
     // - FilesInPath: files in directory, non-recursively?
@@ -280,11 +279,12 @@ impl FilePattern {
     }
 }
 
-pub(super) fn parse_file_glob(input: &str, icase: bool) -> Result<Glob, globset::Error> {
-    GlobBuilder::new(input)
-        .literal_separator(true)
-        .case_insensitive(icase)
-        .build()
+fn parse_file_glob(input: &str, icase: bool) -> Result<PathGlobPattern, globset::Error> {
+    if icase {
+        PathGlobPattern::parse_i(input)
+    } else {
+        PathGlobPattern::parse(input)
+    }
 }
 
 /// Checks if a character is a glob metacharacter.
@@ -646,15 +646,6 @@ mod tests {
 
     fn insta_settings() -> insta::Settings {
         let mut settings = insta::Settings::clone_current();
-        // Elide parsed glob options and tokens, which aren't interesting.
-        settings.add_filter(
-            r"(?m)^(\s{12}opts):\s*GlobOptions\s*\{\n(\s{16}.*\n)*\s{12}\},",
-            "$1: _,",
-        );
-        settings.add_filter(
-            r"(?m)^(\s{12}tokens):\s*Tokens\(\n(\s{16}.*\n)*\s{12}\),",
-            "$1: _,",
-        );
         // Collapse short "Thing(_,)" repeatedly to save vertical space and make
         // the output more readable.
         for _ in 0..4 {
@@ -699,11 +690,10 @@ mod tests {
         Pattern(
             PrefixGlob {
                 dir: "cur",
-                pattern: Glob {
+                pattern: PathGlobPattern {
                     glob: "*.*",
                     re: "(?-u)^[^/]*\\.[^/]*$",
-                    opts: _,
-                    tokens: _,
+                    ..
                 },
             },
         )
@@ -772,11 +762,10 @@ mod tests {
         Pattern(
             FileGlob {
                 dir: "cur*",
-                pattern: Glob {
+                pattern: PathGlobPattern {
                     glob: "*",
                     re: "(?-u)^[^/]*$",
-                    opts: _,
-                    tokens: _,
+                    ..
                 },
             },
         )
@@ -786,11 +775,10 @@ mod tests {
         Pattern(
             FileGlob {
                 dir: "cur*",
-                pattern: Glob {
+                pattern: PathGlobPattern {
                     glob: "*",
                     re: "(?-u)^[^/]*$",
-                    opts: _,
-                    tokens: _,
+                    ..
                 },
             },
         )
@@ -800,11 +788,10 @@ mod tests {
         Pattern(
             FileGlob {
                 dir: "",
-                pattern: Glob {
+                pattern: PathGlobPattern {
                     glob: "*",
                     re: "(?-u)^[^/]*$",
-                    opts: _,
-                    tokens: _,
+                    ..
                 },
             },
         )
@@ -815,11 +802,10 @@ mod tests {
         Pattern(
             FileGlob {
                 dir: "cur*",
-                pattern: Glob {
+                pattern: PathGlobPattern {
                     glob: "**",
                     re: "(?-u)^.*$",
-                    opts: _,
-                    tokens: _,
+                    ..
                 },
             },
         )
@@ -829,11 +815,10 @@ mod tests {
         Pattern(
             FileGlob {
                 dir: "foo",
-                pattern: Glob {
+                pattern: PathGlobPattern {
                     glob: "b?r/baz",
                     re: "(?-u)^b[^/]r/baz$",
-                    opts: _,
-                    tokens: _,
+                    ..
                 },
             },
         )
@@ -853,11 +838,10 @@ mod tests {
             Pattern(
                 FileGlob {
                     dir: "foo",
-                    pattern: Glob {
+                    pattern: PathGlobPattern {
                         glob: "*/bar",
                         re: "(?-u)^[^/]*/bar$",
-                        opts: _,
-                        tokens: _,
+                        ..
                     },
                 },
             )
@@ -869,11 +853,10 @@ mod tests {
             Pattern(
                 FileGlob {
                     dir: "cur*",
-                    pattern: Glob {
+                    pattern: PathGlobPattern {
                         glob: "..\\foo\\*\\bar",
                         re: "(?-u)^\\.\\.foo\\*bar$",
-                        opts: _,
-                        tokens: _,
+                        ..
                     },
                 },
             )
@@ -897,11 +880,10 @@ mod tests {
         Pattern(
             FileGlob {
                 dir: "",
-                pattern: Glob {
+                pattern: PathGlobPattern {
                     glob: "*",
                     re: "(?-u)^[^/]*$",
-                    opts: _,
-                    tokens: _,
+                    ..
                 },
             },
         )
@@ -911,11 +893,10 @@ mod tests {
         Pattern(
             FileGlob {
                 dir: "foo/bar",
-                pattern: Glob {
+                pattern: PathGlobPattern {
                     glob: "b[az]",
                     re: "(?-u)^b[az]$",
-                    opts: _,
-                    tokens: _,
+                    ..
                 },
             },
         )
@@ -925,11 +906,10 @@ mod tests {
         Pattern(
             FileGlob {
                 dir: "foo/bar",
-                pattern: Glob {
+                pattern: PathGlobPattern {
                     glob: "b{ar,az}",
                     re: "(?-u)^b(?:ar|az)$",
-                    opts: _,
-                    tokens: _,
+                    ..
                 },
             },
         )
@@ -946,11 +926,10 @@ mod tests {
             Pattern(
                 FileGlob {
                     dir: "foo",
-                    pattern: Glob {
+                    pattern: PathGlobPattern {
                         glob: "bar\\baz",
                         re: "(?-u)^barbaz$",
-                        opts: _,
-                        tokens: _,
+                        ..
                     },
                 },
             )
@@ -978,11 +957,10 @@ mod tests {
         Pattern(
             FileGlob {
                 dir: "cur",
-                pattern: Glob {
+                pattern: PathGlobPattern {
                     glob: "*.TXT",
                     re: "(?-u)(?i)^[^/]*\\.TXT$",
-                    opts: _,
-                    tokens: _,
+                    ..
                 },
             },
         )
@@ -994,11 +972,10 @@ mod tests {
         Pattern(
             FileGlob {
                 dir: "cur",
-                pattern: Glob {
+                pattern: PathGlobPattern {
                     glob: "[Ff]oo",
                     re: "(?-u)(?i)^[Ff]oo$",
-                    opts: _,
-                    tokens: _,
+                    ..
                 },
             },
         )
@@ -1010,11 +987,10 @@ mod tests {
         Pattern(
             FileGlob {
                 dir: "",
-                pattern: Glob {
+                pattern: PathGlobPattern {
                     glob: "*.Rs",
                     re: "(?-u)(?i)^[^/]*\\.Rs$",
-                    opts: _,
-                    tokens: _,
+                    ..
                 },
             },
         )
@@ -1026,11 +1002,10 @@ mod tests {
         Pattern(
             FileGlob {
                 dir: "cur",
-                pattern: Glob {
+                pattern: PathGlobPattern {
                     glob: "SubDir/*.rs",
                     re: "(?-u)(?i)^SubDir/[^/]*\\.rs$",
-                    opts: _,
-                    tokens: _,
+                    ..
                 },
             },
         )
@@ -1042,11 +1017,10 @@ mod tests {
         Pattern(
             FileGlob {
                 dir: "cur/SubDir",
-                pattern: Glob {
+                pattern: PathGlobPattern {
                     glob: "*.rs",
                     re: "(?-u)^[^/]*\\.rs$",
-                    opts: _,
-                    tokens: _,
+                    ..
                 },
             },
         )
@@ -1058,11 +1032,10 @@ mod tests {
         Pattern(
             FileGlob {
                 dir: "",
-                pattern: Glob {
+                pattern: PathGlobPattern {
                     glob: "SomeDir/*.rs",
                     re: "(?-u)(?i)^SomeDir/[^/]*\\.rs$",
-                    opts: _,
-                    tokens: _,
+                    ..
                 },
             },
         )
@@ -1074,11 +1047,10 @@ mod tests {
         Pattern(
             FileGlob {
                 dir: "cur",
-                pattern: Glob {
+                pattern: PathGlobPattern {
                     glob: "SomeFile*.txt",
                     re: "(?-u)(?i)^SomeFile[^/]*\\.txt$",
-                    opts: _,
-                    tokens: _,
+                    ..
                 },
             },
         )
@@ -1120,11 +1092,10 @@ mod tests {
         Pattern(
             PrefixGlob {
                 dir: "cur*",
-                pattern: Glob {
+                pattern: PathGlobPattern {
                     glob: "*",
                     re: "(?-u)^[^/]*$",
-                    opts: _,
-                    tokens: _,
+                    ..
                 },
             },
         )
@@ -1136,11 +1107,10 @@ mod tests {
         Pattern(
             PrefixGlob {
                 dir: "",
-                pattern: Glob {
+                pattern: PathGlobPattern {
                     glob: "foo",
                     re: "(?-u)(?i)^foo$",
-                    opts: _,
-                    tokens: _,
+                    ..
                 },
             },
         )
@@ -1160,11 +1130,10 @@ mod tests {
         Pattern(
             PrefixGlob {
                 dir: "",
-                pattern: Glob {
+                pattern: PathGlobPattern {
                     glob: "*",
                     re: "(?-u)^[^/]*$",
-                    opts: _,
-                    tokens: _,
+                    ..
                 },
             },
         )
@@ -1176,11 +1145,10 @@ mod tests {
         Pattern(
             PrefixGlob {
                 dir: "_",
-                pattern: Glob {
+                pattern: PathGlobPattern {
                     glob: "foo",
                     re: "(?-u)(?i)^foo$",
-                    opts: _,
-                    tokens: _,
+                    ..
                 },
             },
         )
@@ -1329,13 +1297,13 @@ mod tests {
         let file_glob_expr = |dir: &str, pattern: &str| {
             FilesetExpression::pattern(FilePattern::FileGlob {
                 dir: repo_path_buf(dir),
-                pattern: Box::new(parse_file_glob(pattern, false).unwrap()),
+                pattern: Box::new(PathGlobPattern::parse(pattern).unwrap()),
             })
         };
         let prefix_glob_expr = |dir: &str, pattern: &str| {
             FilesetExpression::pattern(FilePattern::PrefixGlob {
                 dir: repo_path_buf(dir),
-                pattern: Box::new(parse_file_glob(pattern, false).unwrap()),
+                pattern: Box::new(PathGlobPattern::parse(pattern).unwrap()),
             })
         };
 

--- a/lib/src/matchers.rs
+++ b/lib/src/matchers.rs
@@ -15,9 +15,11 @@
 #![expect(missing_docs)]
 
 use std::collections::HashSet;
+use std::fmt;
 use std::fmt::Debug;
 
 use globset::Glob;
+use globset::GlobBuilder;
 use itertools::Itertools as _;
 use tracing::instrument;
 
@@ -300,7 +302,7 @@ impl Matcher for GlobsMatcher {
 /// Constructs [`GlobsMatcher`] from patterns.
 #[derive(Clone, Debug)]
 pub struct GlobsMatcherBuilder<'a> {
-    dir_patterns: Vec<(&'a RepoPath, &'a Glob)>,
+    dir_patterns: Vec<(&'a RepoPath, &'a PathGlobPattern)>,
     matches_prefix_paths: bool,
 }
 
@@ -320,7 +322,7 @@ impl<'a> GlobsMatcherBuilder<'a> {
     ///
     /// The `dir` should be the longest directory path that contains no glob
     /// meta characters.
-    pub fn add(&mut self, dir: &'a RepoPath, pattern: &'a Glob) {
+    pub fn add(&mut self, dir: &'a RepoPath, pattern: &'a PathGlobPattern) {
         self.dir_patterns.push((dir, pattern));
     }
 
@@ -337,10 +339,10 @@ impl<'a> GlobsMatcherBuilder<'a> {
             // Based on new_regex() in globset. We don't use GlobSet because
             // RepoPath separator should be "/" on all platforms.
             let mut regex_builder = if matches_prefix_paths {
-                let regex_patterns = chunk.map(|(_, pattern)| glob_to_prefix_regex(pattern));
+                let regex_patterns = chunk.map(|(_, pattern)| pattern.to_prefix_regex());
                 regex::bytes::RegexSetBuilder::new(regex_patterns)
             } else {
-                regex::bytes::RegexSetBuilder::new(chunk.map(|(_, pattern)| pattern.regex()))
+                regex::bytes::RegexSetBuilder::new(chunk.map(|(_, pattern)| pattern.as_regex()))
             };
             let regex = regex_builder
                 .dot_matches_new_line(true)
@@ -358,15 +360,60 @@ impl<'a> GlobsMatcherBuilder<'a> {
     }
 }
 
-fn glob_to_prefix_regex(glob: &Glob) -> String {
-    // Here we rely on the implementation detail of the globset crate.
-    // Alternatively, we can construct an anchored regex automaton and test
-    // prefix matching by feeding characters one by one.
-    let prefix = glob
-        .regex()
-        .strip_suffix('$')
-        .expect("glob regex should be anchored");
-    format!("{prefix}(?:/|$)")
+/// Wrapper for a [`Glob`] parsed with `literal_separator = true`.
+#[derive(Clone)]
+pub struct PathGlobPattern(Glob);
+
+impl Debug for PathGlobPattern {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PathGlobPattern")
+            .field("glob", &self.0.glob())
+            .field("re", &self.0.regex())
+            // Omit opts and tokens
+            .finish_non_exhaustive()
+    }
+}
+
+impl PathGlobPattern {
+    /// Parses case-sensitive glob pattern.
+    pub fn parse(input: &str) -> Result<Self, globset::Error> {
+        Self::parse_inner(input, false)
+    }
+
+    /// Parses case-insensitive glob pattern.
+    pub fn parse_i(input: &str) -> Result<Self, globset::Error> {
+        Self::parse_inner(input, true)
+    }
+
+    fn parse_inner(input: &str, icase: bool) -> Result<Self, globset::Error> {
+        let glob = GlobBuilder::new(input)
+            .literal_separator(true)
+            .case_insensitive(icase)
+            .build()?;
+        Ok(Self(glob))
+    }
+
+    /// Returns the original glob pattern.
+    pub fn as_str(&self) -> &str {
+        self.0.glob()
+    }
+
+    /// Returns the regular expression string for this glob.
+    pub fn as_regex(&self) -> &str {
+        self.0.regex()
+    }
+
+    fn to_prefix_regex(&self) -> String {
+        // Here we rely on the implementation detail of the globset crate.
+        // Alternatively, we can construct an anchored regex automaton and test
+        // prefix matching by feeding characters one by one.
+        let prefix = self
+            .0
+            .regex()
+            .strip_suffix('$')
+            .expect("glob regex should be anchored");
+        format!("{prefix}(?:/|$)")
+    }
 }
 
 /// Matches paths that are matched by any of the input matchers.
@@ -526,7 +573,6 @@ mod tests {
     use maplit::hashset;
 
     use super::*;
-    use crate::fileset::parse_file_glob;
 
     fn repo_path(value: &str) -> &RepoPath {
         RepoPath::from_internal_string(value).unwrap()
@@ -536,12 +582,11 @@ mod tests {
         RepoPathComponentBuf::new(value).unwrap()
     }
 
-    fn glob(s: &str) -> Glob {
-        let icase = false;
-        parse_file_glob(s, icase).unwrap()
+    fn glob(s: &str) -> PathGlobPattern {
+        PathGlobPattern::parse(s).unwrap()
     }
 
-    fn new_file_globs_matcher(dir_patterns: &[(&RepoPath, Glob)]) -> GlobsMatcher {
+    fn new_file_globs_matcher(dir_patterns: &[(&RepoPath, PathGlobPattern)]) -> GlobsMatcher {
         let mut builder = GlobsMatcher::builder();
         for (dir, pattern) in dir_patterns {
             builder.add(dir, pattern);
@@ -549,7 +594,7 @@ mod tests {
         builder.build()
     }
 
-    fn new_prefix_globs_matcher(dir_patterns: &[(&RepoPath, Glob)]) -> GlobsMatcher {
+    fn new_prefix_globs_matcher(dir_patterns: &[(&RepoPath, PathGlobPattern)]) -> GlobsMatcher {
         let mut builder = GlobsMatcher::builder().prefix_paths(true);
         for (dir, pattern) in dir_patterns {
             builder.add(dir, pattern);

--- a/lib/tests/test_merged_tree.rs
+++ b/lib/tests/test_merged_tree.rs
@@ -15,7 +15,6 @@
 use std::collections::HashMap;
 
 use futures::StreamExt as _;
-use globset::GlobBuilder;
 use itertools::Itertools as _;
 use jj_lib::backend::CommitId;
 use jj_lib::backend::CopyHistory;
@@ -34,6 +33,7 @@ use jj_lib::matchers::EverythingMatcher;
 use jj_lib::matchers::FilesMatcher;
 use jj_lib::matchers::GlobsMatcher;
 use jj_lib::matchers::Matcher;
+use jj_lib::matchers::PathGlobPattern;
 use jj_lib::matchers::PrefixMatcher;
 use jj_lib::merge::Diff;
 use jj_lib::merge::Merge;
@@ -1955,10 +1955,7 @@ fn test_diff_with_trees_glob_matcher_for_path() -> TestResult {
     let merged2 = MergedTree::resolved(repo.store().clone(), tree2.id().clone());
 
     let mut builder = GlobsMatcher::builder().prefix_paths(true);
-    let glob = GlobBuilder::new("**/m")
-        .literal_separator(true)
-        .case_insensitive(false)
-        .build()?;
+    let glob = PathGlobPattern::parse("**/m")?;
     builder.add(RepoPath::root(), &glob);
     let matcher = builder.build();
     // Just make sure the matcher is configured as expected.


### PR DESCRIPTION
# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [ ] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
