### PR TITLE
mise: drop windows_default_inline_shell_args from repo config

### DIFF
--- a/.config/mise.toml
+++ b/.config/mise.toml
@@ -11,10 +11,6 @@ rust_version = "1.89"
 uv_version = "0.8.13"
 node_version = "24"
 
-[settings]
-# the default cmd doesn't support shell expansion, use PowerShell instead
-windows_default_inline_shell_args = "pwsh -Command"
-
 [tools]
 # We need cargo-binstall so that Mise would download "cargo:" tools instead of building them.
 "cargo-binstall" = "latest"

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -474,6 +474,15 @@ the configuration file at `.config/mise.toml`.
 You can customize this configuration using
 [a `mise.local.toml` file](https://mise.jdx.dev/configuration.html#mise-toml).
 
+On Windows, some tasks use shell expansion, which the default `cmd /c` doesn't
+support. `mise` only honors the shell settings from your global configuration,
+so set this in `~/.config/mise/config.toml` to run tasks with PowerShell:
+
+```toml
+[settings]
+windows_default_inline_shell_args = "pwsh -Command"
+```
+
 ## Previewing the HTML documentation
 
 The documentation for `jj` is automatically published online at


### PR DESCRIPTION
`mise` marks shell-argument settings as global-only and strips them from any non-global config at parse time, since they are a code execution vector. This happens on every platform, so the setting never took effect for Windows contributors either; all it did was print a warning on every `mise` invocation in the repo:

    mise WARN  windows_default_inline_shell_args in non-global config
    /path/to/jj/.config/mise.toml is ignored for security reasons

`mise` has no per-task or per-config way to select a shell only on Windows (`shell` applies to all platforms), so document the global setting in the contributing guide instead. That is the only place `mise` will honor it.
