### PR TITLE
dependabot-action: remove `--rebase` strategy flag

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -19,7 +19,7 @@ jobs:
     if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
     steps:
     - name: Enable auto-merge for Dependabot PRs
-      run: gh pr merge --auto --rebase "$PR_URL"
+      run: gh pr merge --auto "$PR_URL"
       env:
         PR_URL: ${{github.event.pull_request.html_url}}
         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
While the docs of `gh pr merge` describe the strategy flags as "not required" when a merge-queue is being used, the failure in CI suggests that the flag is in fact _in conflict_ with the use of merge-queues:

    ! The merge strategy for main is set by the merge queue

As a result otherwise green dependabot PRs are _not_ being merged automatically.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
