### PR TITLE
revsets: limit similar revision suggestions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed bugs
 
+* Revision suggestions in error hints are now limited to five names, followed by
+  the number of additional matches, instead of printing every similar bookmark
+  or tag name. [#8017](https://github.com/jj-vcs/jj/issues/8017).
+
 * `jj arrange` now scrolls the viewport to keep the selected commit visible
   when the commit stack is taller than the terminal.
   [#9033](https://github.com/jj-vcs/jj/issues/9033).

--- a/cli/src/command_error.rs
+++ b/cli/src/command_error.rs
@@ -224,14 +224,39 @@ pub fn internal_error_with_message(
     CommandError::with_message(CommandErrorKind::Internal, message, source)
 }
 
-fn format_similarity_hint<S: AsRef<str>>(candidates: &[S]) -> Option<String> {
+const MAX_REVISION_HINT_CANDIDATES: usize = 5;
+
+fn format_similarity_hint_with_limit<S: AsRef<str>>(
+    candidates: &[S],
+    max_candidates: usize,
+) -> Option<String> {
     match candidates {
         [] => None,
         names => {
-            let quoted_names = names.iter().map(|s| format!("`{}`", s.as_ref())).join(", ");
-            Some(format!("Did you mean {quoted_names}?"))
+            let quoted_names = names
+                .iter()
+                .take(max_candidates)
+                .map(|s| format!("`{}`", s.as_ref()))
+                .join(", ");
+            let omitted_count = names.len().saturating_sub(max_candidates);
+            if omitted_count == 0 {
+                Some(format!("Did you mean {quoted_names}?"))
+            } else {
+                let noun = if omitted_count == 1 {
+                    "other"
+                } else {
+                    "others"
+                };
+                Some(format!(
+                    "Did you mean {quoted_names}, or {omitted_count} {noun}?"
+                ))
+            }
         }
     }
+}
+
+fn format_similarity_hint<S: AsRef<str>>(candidates: &[S]) -> Option<String> {
+    format_similarity_hint_with_limit(candidates, candidates.len())
 }
 
 impl From<io::Error> for CommandError {
@@ -925,7 +950,9 @@ fn revset_resolution_error_hints(err: &RevsetResolutionError) -> Vec<String> {
         RevsetResolutionError::NoSuchRevision {
             name: _,
             candidates,
-        } => format_similarity_hint(candidates).into_iter().collect(),
+        } => format_similarity_hint_with_limit(candidates, MAX_REVISION_HINT_CANDIDATES)
+            .into_iter()
+            .collect(),
         RevsetResolutionError::DivergentChangeId {
             symbol,
             visible_targets,

--- a/cli/tests/test_revset_output.rs
+++ b/cli/tests/test_revset_output.rs
@@ -447,6 +447,48 @@ fn test_function_name_hint() {
 }
 
 #[test]
+fn test_revision_name_hint_is_truncated() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+    let evaluate = || work_dir.run_jj(["log", "-r", "feature-branch"]);
+
+    for suffix in 0..5 {
+        let name = format!("feature-branch-{suffix}");
+        work_dir.run_jj(["bookmark", "create", &name]).success();
+    }
+    insta::assert_snapshot!(evaluate(), @"
+    ------- stderr -------
+    Error: Revision `feature-branch` doesn't exist
+    Hint: Did you mean `feature-branch-0`, `feature-branch-1`, `feature-branch-2`, `feature-branch-3`, `feature-branch-4`?
+    [EOF]
+    [exit status: 1]
+    ");
+
+    work_dir
+        .run_jj(["bookmark", "create", "feature-branch-5"])
+        .success();
+    insta::assert_snapshot!(evaluate(), @"
+    ------- stderr -------
+    Error: Revision `feature-branch` doesn't exist
+    Hint: Did you mean `feature-branch-0`, `feature-branch-1`, `feature-branch-2`, `feature-branch-3`, `feature-branch-4`, or 1 other?
+    [EOF]
+    [exit status: 1]
+    ");
+
+    work_dir
+        .run_jj(["bookmark", "create", "feature-branch-6", "feature-branch-7"])
+        .success();
+    insta::assert_snapshot!(evaluate(), @"
+    ------- stderr -------
+    Error: Revision `feature-branch` doesn't exist
+    Hint: Did you mean `feature-branch-0`, `feature-branch-1`, `feature-branch-2`, `feature-branch-3`, `feature-branch-4`, or 3 others?
+    [EOF]
+    [exit status: 1]
+    ");
+}
+
+#[test]
 fn test_bad_symbol_or_argument_should_not_be_optimized_out() {
     let test_env = TestEnvironment::default();
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();


### PR DESCRIPTION
Limit missing-revision hints to five similar names and report how many candidates were omitted. Parser, fileset, and template similarity hints remain unchanged.

Fixes #8017

Validation:

- `cargo +nightly fmt --all -- --check`
- `cargo +stable clippy -p jj-cli --all-features --all-targets -- -D warnings`
- `cargo test -p jj-cli test_revset_output --test runner`
- `cargo test -p jj-cli test_bookmark_list_filtered --test runner`
- `cargo test -p jj-cli --lib`

Codex assisted with implementation and test drafting; the changes and prose were reviewed and validated before submission.

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`) — not applicable
- [ ] I have updated the config schema (`cli/src/config-schema.json`) — not applicable
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
