### PR TITLE
bookmark: Add git remote origin hint

### DIFF
--- a/cli/src/commands/bookmark/mod.rs
+++ b/cli/src/commands/bookmark/mod.rs
@@ -238,9 +238,13 @@ fn warn_unmatched_remotes(ui: &Ui, view: &View, name_expr: &StringExpression) ->
     if names.peek().is_none() {
         return Ok(());
     }
+    let remotes_display_string = names.map(|name| name.as_symbol()).join(", ");
     writeln!(
         ui.warning_default(),
-        "No matching remotes for names: {}",
-        names.map(|name| name.as_symbol()).join(", ")
+        "No matching remotes for names: {remotes_display_string}"
+    )?;
+    writeln!(
+        ui.hint_default(),
+        "To add the missing remote, run `jj git remote add {remotes_display_string} <origin>`"
     )
 }

--- a/cli/tests/test_bookmark_command.rs
+++ b/cli/tests/test_bookmark_command.rs
@@ -1982,6 +1982,7 @@ fn test_bookmark_track_untrack_patterns() -> TestResult {
     ------- stderr -------
     Warning: No matching bookmarks for names: maine
     Warning: No matching remotes for names: unknown
+    Hint: To add the missing remote, run `jj git remote add unknown <origin>`
     Nothing changed.
     [EOF]
     ");


### PR DESCRIPTION
When setting up a new repo, I had to look up this command - figured it could just be a jj hint instead!

Before:

<img width="1149" height="64" alt="image" src="https://github.com/user-attachments/assets/706463db-4e4f-4722-9d87-90e9d0782e10" />

After:
<img width="1310" height="107" alt="image" src="https://github.com/user-attachments/assets/c05ef9ae-0397-4a54-8ca0-0c2e5a4cae0d" />


# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
