### PR TITLE
github: bump CI timeout once more

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,10 +65,11 @@ jobs:
     #
     # 2025-03-20 (aseipp): peak p99 builds seemed to be long, bump 15m -> 20m
     # 2025-10-06 (aseipp): x86 macos runners consistently slower, bump 20m -> 25m
+    # 2026-08-28 (slerpy): x86 macos & arm windows are timing out, bump 25m -> 30m
     #
     # The "nix flake" jobs below use the same timeout, so update there too if
     # you update here.
-    timeout-minutes: 25
+    timeout-minutes: 30
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1


### PR DESCRIPTION
Tests are hitting the 25 mins timeout, see for example:
- https://github.com/jj-vcs/jj/actions/runs/33185259072/job/98896493999
- https://github.com/jj-vcs/jj/actions/runs/33118030133/job/98677716314
- https://github.com/jj-vcs/jj/actions/runs/33074218872/job/98524077425

Previous bump: https://github.com/jj-vcs/jj/pull/7658

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
