### PR TITLE
cli_util: Propagate backend errors when filtering paths

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -55,6 +55,7 @@ use indexmap::IndexSet;
 use indoc::indoc;
 use indoc::writedoc;
 use itertools::Itertools as _;
+use jj_lib::backend::BackendError;
 use jj_lib::backend::BackendResult;
 use jj_lib::backend::ChangeId;
 use jj_lib::backend::CommitId;
@@ -3379,11 +3380,10 @@ pub fn print_unmatched_explicit_paths<'a>(
     workspace_command: &WorkspaceCommandHelper,
     expression: &FilesetExpression,
     trees: impl IntoIterator<Item = &'a MergedTree>,
-) -> io::Result<()> {
+) -> Result<(), CommandError> {
     let mut explicit_paths = expression.explicit_paths().collect_vec();
     for tree in trees {
-        // TODO: propagate errors
-        explicit_paths.retain(|&path| tree.path_value(path).block_on().unwrap().is_absent());
+        retain_paths_absent_from_merge_tree(&mut explicit_paths, tree)?;
     }
 
     if !explicit_paths.is_empty() {
@@ -3397,6 +3397,22 @@ pub fn print_unmatched_explicit_paths<'a>(
         )?;
     }
 
+    Ok(())
+}
+
+pub fn retain_paths_absent_from_merge_tree(
+    paths: &mut Vec<&RepoPath>,
+    tree: &MergedTree,
+) -> Result<(), BackendError> {
+    *paths = paths
+        .drain(..)
+        .map(|path| {
+            tree.path_value(path)
+                .block_on()
+                .map(|m| m.is_absent().then_some(path))
+        })
+        .filter_map_ok(std::convert::identity)
+        .try_collect()?;
     Ok(())
 }
 

--- a/cli/src/commands/log.rs
+++ b/cli/src/commands/log.rs
@@ -32,13 +32,13 @@ use jj_lib::revset::RevsetEvaluationError;
 use jj_lib::revset::RevsetExpression;
 use jj_lib::revset::RevsetFilterPredicate;
 use jj_lib::revset::RevsetStreamExt as _;
-use pollster::FutureExt as _;
 use tracing::instrument;
 
 use crate::cli_util::CommandHelper;
 use crate::cli_util::LogContentFormat;
 use crate::cli_util::RevisionArg;
 use crate::cli_util::format_template;
+use crate::cli_util::retain_paths_absent_from_merge_tree;
 use crate::command_error::CommandError;
 use crate::complete;
 use crate::diff_util::DiffFormatArgs;
@@ -312,9 +312,7 @@ pub(crate) async fn cmd_log(
                 )?;
 
                 let tree = commit.map(|c| c.tree()).unwrap();
-                // TODO: propagate errors
-                explicit_paths
-                    .retain(|&path| tree.path_value(path).block_on().unwrap().is_absent());
+                retain_paths_absent_from_merge_tree(&mut explicit_paths, &tree)?;
 
                 for elided_target in elided_targets {
                     let elided_key = (elided_target, true);
@@ -362,9 +360,7 @@ pub(crate) async fn cmd_log(
                 }
 
                 let tree = commit.tree();
-                // TODO: propagate errors
-                explicit_paths
-                    .retain(|&path| tree.path_value(path).block_on().unwrap().is_absent());
+                retain_paths_absent_from_merge_tree(&mut explicit_paths, &tree)?;
             }
         }
 


### PR DESCRIPTION
Minor internal change; fixes three `// TODO` comments.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
