### PR TITLE
cli: propagate error and async-ness from print_unmatched_explicit_paths()

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -48,8 +48,10 @@ use clap::error::ContextKind;
 use clap::error::ContextValue;
 use clap_complete::ArgValueCandidates;
 use clap_complete::ArgValueCompleter;
+use futures::StreamExt as _;
 use futures::TryStreamExt as _;
 use futures::future::try_join_all;
+use futures::stream;
 use indexmap::IndexMap;
 use indexmap::IndexSet;
 use indoc::indoc;
@@ -3374,16 +3376,23 @@ Discard the conflicting changes with `jj restore --from {}`.",
 
 /// Prints warning about explicit paths that don't match any of the tree
 /// entries.
-pub fn print_unmatched_explicit_paths<'a>(
+pub async fn print_unmatched_explicit_paths<'a>(
     ui: &Ui,
     workspace_command: &WorkspaceCommandHelper,
     expression: &FilesetExpression,
     trees: impl IntoIterator<Item = &'a MergedTree>,
-) -> io::Result<()> {
+) -> Result<(), CommandError> {
     let mut explicit_paths = expression.explicit_paths().collect_vec();
     for tree in trees {
-        // TODO: propagate errors
-        explicit_paths.retain(|&path| tree.path_value(path).block_on().unwrap().is_absent());
+        explicit_paths = stream::iter(explicit_paths)
+            .filter_map(|path| async move {
+                tree.path_value(path)
+                    .await
+                    .map(|value| value.is_absent().then_some(path))
+                    .transpose()
+            })
+            .try_collect()
+            .await?;
     }
 
     if !explicit_paths.is_empty() {

--- a/cli/src/commands/absorb.rs
+++ b/cli/src/commands/absorb.rs
@@ -104,7 +104,8 @@ pub(crate) async fn cmd_absorb(
         &workspace_command,
         &fileset_expression,
         [&source_commit.tree()],
-    )?;
+    )
+    .await?;
 
     let diff_selector =
         workspace_command.diff_selector(ui, args.tool.as_deref(), args.interactive)?;

--- a/cli/src/commands/diff.rs
+++ b/cli/src/commands/diff.rs
@@ -229,6 +229,7 @@ pub(crate) async fn cmd_diff(
         &workspace_command,
         &fileset_expression,
         [&from_tree, &to_tree],
-    )?;
+    )
+    .await?;
     Ok(())
 }

--- a/cli/src/commands/diffedit.rs
+++ b/cli/src/commands/diffedit.rs
@@ -176,6 +176,7 @@ don't make any changes, then the operation will be aborted.",
         &workspace_command,
         &fileset_expression,
         [&base_tree, &tree],
-    )?;
+    )
+    .await?;
     Ok(())
 }

--- a/cli/src/commands/file/chmod.rs
+++ b/cli/src/commands/file/chmod.rs
@@ -78,7 +78,7 @@ pub(crate) async fn cmd_file_chmod(
     // parse_union_filesets(). paths = [] should be "none()" if supported.
     let fileset_expression = workspace_command.parse_file_patterns(ui, &args.paths)?;
     let matcher = fileset_expression.to_matcher();
-    print_unmatched_explicit_paths(ui, &workspace_command, &fileset_expression, [&tree])?;
+    print_unmatched_explicit_paths(ui, &workspace_command, &fileset_expression, [&tree]).await?;
 
     let mut tx = workspace_command.start_transaction();
 

--- a/cli/src/commands/file/list.rs
+++ b/cli/src/commands/file/list.rs
@@ -90,6 +90,6 @@ pub(crate) async fn cmd_file_list(
         };
         template.format(&entry, formatter.as_mut())?;
     }
-    print_unmatched_explicit_paths(ui, &workspace_command, &fileset_expression, [&tree])?;
+    print_unmatched_explicit_paths(ui, &workspace_command, &fileset_expression, [&tree]).await?;
     Ok(())
 }

--- a/cli/src/commands/file/search.rs
+++ b/cli/src/commands/file/search.rs
@@ -161,7 +161,7 @@ pub(crate) async fn cmd_file_search(
             MaterializedTreeValue::Tree(_) => panic!("Entry for tree in file listing"),
         }
     }
-    print_unmatched_explicit_paths(ui, &workspace_command, &fileset_expression, [&tree])?;
+    print_unmatched_explicit_paths(ui, &workspace_command, &fileset_expression, [&tree]).await?;
     Ok(())
 }
 

--- a/cli/src/commands/file/show.rs
+++ b/cli/src/commands/file/show.rs
@@ -131,7 +131,7 @@ pub(crate) async fn cmd_file_show(
             .map_ok(|(path, value)| TreeEntry { path, value }),
     )
     .await?;
-    print_unmatched_explicit_paths(ui, &workspace_command, &fileset_expression, [&tree])?;
+    print_unmatched_explicit_paths(ui, &workspace_command, &fileset_expression, [&tree]).await?;
     Ok(())
 }
 

--- a/cli/src/commands/file/untrack.rs
+++ b/cli/src/commands/file/untrack.rs
@@ -118,7 +118,7 @@ Make sure they're ignored, then try again.",
     }
     let repo = tx.commit("untrack paths").await?;
     locked_ws.finish(repo.op_id().clone()).await?;
-    print_unmatched_explicit_paths(ui, &workspace_command, &fileset_expression, [&wc_tree])?;
+    print_unmatched_explicit_paths(ui, &workspace_command, &fileset_expression, [&wc_tree]).await?;
     print_snapshot_stats(ui, &stats, workspace_command.env().path_converter())?;
     Ok(())
 }

--- a/cli/src/commands/fix.rs
+++ b/cli/src/commands/fix.rs
@@ -243,7 +243,8 @@ pub(crate) async fn cmd_fix(
         .block_on()
     });
 
-    print_unmatched_explicit_paths(ui, tx.base_workspace_helper(), &fileset_expression, &trees)?;
+    print_unmatched_explicit_paths(ui, tx.base_workspace_helper(), &fileset_expression, &trees)
+        .await?;
 
     let summary = fix_files(
         commit_ids,

--- a/cli/src/commands/interdiff.rs
+++ b/cli/src/commands/interdiff.rs
@@ -107,7 +107,8 @@ pub(crate) async fn cmd_interdiff(
             &to.parent_tree(repo.as_ref()).await?,
             &to.tree(),
         ],
-    )?;
+    )
+    .await?;
 
     let diff_renderer = workspace_command.diff_renderer_for(&args.format)?;
     ui.request_pager();

--- a/cli/src/commands/log.rs
+++ b/cli/src/commands/log.rs
@@ -32,7 +32,6 @@ use jj_lib::revset::RevsetEvaluationError;
 use jj_lib::revset::RevsetExpression;
 use jj_lib::revset::RevsetFilterPredicate;
 use jj_lib::revset::RevsetStreamExt as _;
-use pollster::FutureExt as _;
 use tracing::instrument;
 
 use crate::cli_util::CommandHelper;
@@ -141,7 +140,6 @@ pub(crate) async fn cmd_log(
     let settings = workspace_command.settings();
 
     let fileset_expression = workspace_command.parse_file_patterns(ui, &args.paths)?;
-    let mut explicit_paths = fileset_expression.explicit_paths().collect_vec();
     let revset_expression = {
         // only use default revset if neither revset nor path are specified
         let mut expression = if args.revisions.is_empty() && args.paths.is_empty() {
@@ -222,6 +220,24 @@ pub(crate) async fn cmd_log(
             .labeled(["log", "commit", "node"]);
     }
 
+    let mut unmatched_explicit_paths = fileset_expression.explicit_paths().collect_vec();
+    let mut update_unmatched_explicit_paths = async |commit: &Commit| -> Result<(), CommandError> {
+        if unmatched_explicit_paths.is_empty() {
+            return Ok(());
+        }
+        let tree = &commit.tree();
+        unmatched_explicit_paths = stream::iter(unmatched_explicit_paths.iter().copied())
+            .filter_map(|path| async move {
+                tree.path_value(path)
+                    .await
+                    .map(|value| value.is_absent().then_some(path))
+                    .transpose()
+            })
+            .try_collect()
+            .await?;
+        Ok(())
+    };
+
     {
         ui.request_pager();
         let mut formatter = ui.stdout_formatter();
@@ -282,6 +298,7 @@ pub(crate) async fn cmd_log(
                 let mut buffer = vec![];
                 let key = (commit_id, false);
                 let commit = store.get_commit_async(&key.0).await?;
+                update_unmatched_explicit_paths(&commit).await?;
                 let within_graph =
                     with_content_format.sub_width(graph.width(&key, &graphlog_edges));
                 within_graph
@@ -310,11 +327,6 @@ pub(crate) async fn cmd_log(
                     &node_symbol,
                     &String::from_utf8_lossy(&buffer),
                 )?;
-
-                let tree = commit.map(|c| c.tree()).unwrap();
-                // TODO: propagate errors
-                explicit_paths
-                    .retain(|&path| tree.path_value(path).block_on().unwrap().is_absent());
 
                 for elided_target in elided_targets {
                     let elided_key = (elided_target, true);
@@ -349,6 +361,7 @@ pub(crate) async fn cmd_log(
             };
             let mut commit_stream = id_stream.commits(store);
             while let Some(commit) = commit_stream.try_next().await? {
+                update_unmatched_explicit_paths(&commit).await?;
                 with_content_format
                     .write(formatter, async |formatter| {
                         template.format(&commit, formatter)
@@ -360,16 +373,11 @@ pub(crate) async fn cmd_log(
                         .show_patch(ui, formatter, &commit, matcher.as_ref(), width)
                         .await?;
                 }
-
-                let tree = commit.tree();
-                // TODO: propagate errors
-                explicit_paths
-                    .retain(|&path| tree.path_value(path).block_on().unwrap().is_absent());
             }
         }
 
-        if !explicit_paths.is_empty() {
-            let ui_paths = explicit_paths
+        if !unmatched_explicit_paths.is_empty() {
+            let ui_paths = unmatched_explicit_paths
                 .iter()
                 .map(|&path| workspace_command.format_file_path(path))
                 .join(", ");

--- a/cli/src/commands/resolve.rs
+++ b/cli/src/commands/resolve.rs
@@ -88,7 +88,7 @@ pub(crate) async fn cmd_resolve(
     let tree = commit.tree();
     let conflicts = tree.conflicts_matching(&matcher).collect_vec();
 
-    print_unmatched_explicit_paths(ui, &workspace_command, &fileset_expression, [&tree])?;
+    print_unmatched_explicit_paths(ui, &workspace_command, &fileset_expression, [&tree]).await?;
 
     if conflicts.is_empty() {
         return Err(cli_error(if args.paths.is_empty() {

--- a/cli/src/commands/restore.rs
+++ b/cli/src/commands/restore.rs
@@ -176,7 +176,8 @@ pub(crate) async fn cmd_restore(
         &workspace_command,
         &fileset_expression,
         [&to_tree, &from_tree],
-    )?;
+    )
+    .await?;
 
     if new_tree.tree_ids() == to_commit.tree_ids() {
         writeln!(ui.status(), "Nothing changed.")?;

--- a/cli/src/commands/split.rs
+++ b/cli/src/commands/split.rs
@@ -246,7 +246,8 @@ impl SplitArgs {
                 &target_commit.parent_tree(repo.as_ref()).await?,
                 &target_commit.tree(),
             ],
-        )?;
+        )
+        .await?;
 
         Ok(ResolvedSplitArgs {
             target_commit,

--- a/cli/src/commands/squash.rs
+++ b/cli/src/commands/squash.rs
@@ -343,7 +343,8 @@ pub(crate) async fn cmd_squash(
         tx.base_workspace_helper(),
         &fileset_expression,
         source_commits.iter().map(|commit| &commit.selected_tree),
-    )?;
+    )
+    .await?;
 
     if let Some(squashed) = rewrite::squash_commits(
         tx.repo_mut(),

--- a/cli/src/commands/status.rs
+++ b/cli/src/commands/status.rs
@@ -89,12 +89,8 @@ pub(crate) async fn cmd_status(
 
     if let Some(wc_commit) = &maybe_wc_commit {
         let status = collect_working_copy_status(repo.as_ref(), wc_commit, snapshot_stats).await?;
-        print_unmatched_explicit_paths(
-            ui,
-            &workspace_command,
-            &fileset_expression,
-            [&status.tree],
-        )?;
+        print_unmatched_explicit_paths(ui, &workspace_command, &fileset_expression, [&status.tree])
+            .await?;
 
         if !status.has_any_tracked_changes() && !status.has_any_untracked_paths() {
             writeln!(formatter, "The working copy has no changes.")?;


### PR DESCRIPTION
# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [ ] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
