### PR TITLE
jj-core: add description to Cargo.toml

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "jj-core"
+description = "Core types and algorithms for Jujutsu - an experimental version control system"
 version.workspace = true
 license.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md` — not user-visible, and #10067 did not add an entry for the sibling LICENSE change either
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`) — n/a
- [ ] I have updated the config schema (`cli/src/config-schema.json`) — n/a
- [ ] I have added/updated tests to cover my changes — n/a for manifest metadata
- [x] I fully understand the code that I am submitting (what it does, how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with an eye towards deleting anything that is irrelevant, clarifying anything that is confusing, and adding details that are relevant. This includes, for example, commit descriptions, PR descriptions, and code comments.

---

`jj-core` is the only package in the workspace without a `description`, including `testutils` and `gen-protos`, which set `publish = false` and still have one.

```
jj-cli                 'Jujutsu - an experimental version control system'
jj-lib                 'Library for Jujutsu - an experimental version control system'
jj-core-proc-macros    'Proc macros for the jj-core crate'
testutils              'Integration test utils for the jj-lib crate'
gen-protos             'Generate Protocol Buffers definitions for the jj-lib crate'
jj-core                None
```

`cargo package -p jj-core` warns about it today:

```
warning: manifest has no description
  |
  = note: see https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for more info
```

The warning is gone after this change, and `Cargo.lock` is untouched. crates.io requires the field, and `jj-core` is publishable — no `publish = false` — but not yet on crates.io, so the crate cannot go out as it stands.

The wording follows `jj-lib`'s pattern and reflects what the crate holds: content hashing, DAG walking, diff and merge, matchers, and the path/name/object-id types.

I have not reproduced the crates.io rejection itself, only the local `cargo package` warning; `cargo package` still fails further along for an unrelated reason, since `jj-core-proc-macros` is not on the index yet either.
