### PR TITLE
rustfmt: disable wrap_comments for now

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,6 +1,9 @@
 edition = "2024"
 max_width = 100
-wrap_comments = true
+# TODO: wrap_comments is temporarily disabled due to a large formatting change
+# in rustfmt 1.10.0-nightly (9085017724 2026-08-30). Decide whether to re-enable
+# this option with some adjustments or leave it disabled.
+# wrap_comments = true
 format_strings = true
 error_on_line_overflow = true
 group_imports = "StdExternalCrate"


### PR DESCRIPTION
I'm not sure if we like the new formatting. Let's unblock CI by temporarily disabling this option.

Alternative to #10081

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [ ] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
