### PR TITLE
watchman: cache the socket path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2761,6 +2761,7 @@ dependencies = [
  "rustix",
  "rustversion",
  "serde",
+ "serde_bser",
  "smallvec",
  "strsim",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,6 +111,7 @@ sapling-renderdag = "0.1.0"
 sapling-streampager = "0.12.0"
 scm-record = "0.10.0"
 serde = { version = "1.0", features = ["derive", "rc"] }
+serde_bser = "0.4.0"
 serde_json = "1.0.150"
 shlex = "2.0.1"
 slab = "0.4.12"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -55,6 +55,7 @@ rayon = { workspace = true }
 ref-cast = { workspace = true }
 regex = { workspace = true }
 serde = { workspace = true }
+serde_bser = { workspace = true, optional = true }
 smallvec = { workspace = true }
 strsim = { workspace = true }
 tempfile = { workspace = true }
@@ -86,7 +87,7 @@ nix = { workspace = true, features = [ "fs" ] }
 [features]
 default = ["git"]
 git = ["dep:gix"]
-watchman = ["dep:watchman_client", "dep:tokio"]
+watchman = ["dep:serde_bser", "dep:tokio", "dep:watchman_client"]
 testing = ["git"]
 
 [lints]

--- a/lib/src/fsmonitor.rs
+++ b/lib/src/fsmonitor.rs
@@ -83,11 +83,19 @@ impl FsmonitorSettings {
 /// installed on the system.
 #[cfg(feature = "watchman")]
 pub mod watchman {
+    use std::env;
+    use std::fs;
+    use std::io;
+    use std::io::ErrorKind;
+    use std::io::Write as _;
     use std::path::Path;
     use std::path::PathBuf;
 
+    use etcetera::BaseStrategy as _;
     use itertools::Itertools as _;
+    use tempfile::NamedTempFile;
     use thiserror::Error;
+    use tracing::Instrument as _;
     use tracing::info;
     use tracing::instrument;
     use watchman_client::expr;
@@ -97,6 +105,128 @@ pub mod watchman {
     use watchman_client::prelude::QueryRequestCommon;
     use watchman_client::prelude::QueryResult;
     use watchman_client::prelude::TriggerRequest;
+
+    const WATCHMAN_COMMAND: &str = "watchman";
+
+    fn endpoint_cache_path() -> Option<PathBuf> {
+        let strategy = etcetera::choose_base_strategy().ok()?;
+        Some(strategy.cache_dir().join("jj").join("watchman-endpoint"))
+    }
+
+    fn read_cached_endpoint(path: &Path) -> Option<PathBuf> {
+        match fs::read_to_string(path) {
+            Ok(endpoint) => Some(endpoint.into()),
+            Err(err) if err.kind() == ErrorKind::NotFound => None,
+            Err(err) => {
+                tracing::debug!(?path, ?err, "failed to read cached Watchman endpoint");
+                None
+            }
+        }
+    }
+
+    fn write_cached_endpoint(path: &Path, endpoint: &Path) -> io::Result<()> {
+        let cache_dir = path
+            .parent()
+            .ok_or_else(|| io::Error::other("Watchman cache path has no parent"))?;
+        fs::create_dir_all(cache_dir)?;
+        // Multiple jj processes can refresh this shared cache concurrently. Write to
+        // a temporary file in the same directory, then atomically replace the cache.
+        let mut temp_file = NamedTempFile::new_in(cache_dir)?;
+        let endpoint = endpoint
+            .to_str()
+            .ok_or_else(|| io::Error::other("Watchman endpoint is not valid UTF-8"))?;
+        temp_file.write_all(endpoint.as_bytes())?;
+        crate::file_util::persist_temp_file(temp_file, path)?;
+        Ok(())
+    }
+
+    fn discovery_error(reason: impl ToString, stderr: &[u8]) -> watchman_client::Error {
+        watchman_client::Error::ConnectionDiscovery {
+            watchman_path: PathBuf::from(WATCHMAN_COMMAND),
+            reason: reason.to_string(),
+            stderr: String::from_utf8_lossy(stderr).into_owned(),
+        }
+    }
+
+    async fn discover_endpoint() -> Result<PathBuf, watchman_client::Error> {
+        // Connector performs discovery internally but does not expose the resolved
+        // endpoint. Run the same Watchman command here so the result can be cached.
+        let output = tokio::process::Command::new(WATCHMAN_COMMAND)
+            .args(["--output-encoding", "bser-v2", "get-sockname"])
+            .output()
+            .instrument(tracing::trace_span!("run watchman get-sockname"))
+            .await
+            .map_err(|err| discovery_error(err, &[]))?;
+        // Use Watchman's native encoding, matching watchman_client's own discovery.
+        let response: watchman_client::pdu::GetSockNameResponse =
+            serde_bser::from_slice(&output.stdout)
+                .map_err(|err| discovery_error(err, &output.stderr))?;
+        if let Some(message) = response.error {
+            return Err(watchman_client::Error::WatchmanServerError {
+                message,
+                command: "get-sockname".to_owned(),
+            });
+        }
+        let response_debug = format!("{response:#?}");
+        response
+            .sockname
+            .ok_or_else(|| watchman_client::Error::MissingField {
+                fieldname: "sockname",
+                command: "get-sockname".to_owned(),
+                response: response_debug,
+            })
+    }
+
+    async fn connect() -> Result<watchman_client::Client, watchman_client::Error> {
+        // A nonempty WATCHMAN_SOCK is an explicit user override. Preserve
+        // watchman_client's existing behavior and do not read or update the cache.
+        if env::var_os("WATCHMAN_SOCK").is_some_and(|value| !value.is_empty()) {
+            return watchman_client::Connector::new().connect().await;
+        }
+
+        let cache_path = endpoint_cache_path();
+        if let Some(endpoint) = cache_path.as_deref().and_then(read_cached_endpoint) {
+            // Watchman can replace its socket when the server restarts. Treat the
+            // cached endpoint as a hint and verify that it belongs to a responsive
+            // Watchman server before returning the client.
+            match watchman_client::Connector::new()
+                .unix_domain_socket(&endpoint)
+                .connect()
+                .await
+            {
+                Ok(client) => match client.version().await {
+                    Ok(_) => return Ok(client),
+                    Err(err) => tracing::debug!(
+                        ?endpoint,
+                        ?err,
+                        "cached Watchman endpoint failed validation"
+                    ),
+                },
+                Err(err) => tracing::debug!(
+                    ?endpoint,
+                    ?err,
+                    "failed to connect to cached Watchman endpoint"
+                ),
+            }
+        }
+
+        // The cached endpoint is absent or stale. Ask Watchman for its current
+        // endpoint and validate the connection before making it the new cache entry.
+        let endpoint = discover_endpoint().await?;
+        let client = watchman_client::Connector::new()
+            .unix_domain_socket(&endpoint)
+            .connect()
+            .await?;
+        client.version().await?;
+        // Caching is only an optimization. A cache write failure must not make an
+        // otherwise valid Watchman connection unusable.
+        if let Some(path) = cache_path
+            && let Err(err) = write_cached_endpoint(&path, &endpoint)
+        {
+            tracing::debug!(?path, ?err, "failed to cache Watchman endpoint");
+        }
+        Ok(client)
+    }
 
     /// Represents an instance in time from the perspective of the filesystem
     /// monitor.
@@ -182,11 +312,7 @@ pub mod watchman {
             config: &super::WatchmanConfig,
         ) -> Result<Self, Error> {
             info!("Initializing Watchman filesystem monitor...");
-            let connector = watchman_client::Connector::new();
-            let client = connector
-                .connect()
-                .await
-                .map_err(Error::WatchmanConnectError)?;
+            let client = connect().await.map_err(Error::WatchmanConnectError)?;
             let working_copy_root = watchman_client::CanonicalPath::canonicalize(working_copy_path)
                 .map_err(Error::CanonicalizeRootError)?;
             let resolved_root = client


### PR DESCRIPTION
When no socket is provided watchman_client runs full Watchman CLI solely to discover it and running Watchman is slow-ish (to the point where it can dominate the cost of short jj commands), at least in the environment I tested (macOS 26.5.2, M1 Pro).

50 runs test (small repo to make the difference more obvious, the actual watchman get-sockname command to demonstrate the point):

    Command                   Mean ms   Min ms  Median ms   Max ms
    ========================  =======  =======  =========  =======
    watchman get-sockname     133.173  129.363    132.186  161.242
    jj status (0.44.0)        166.157  161.038    165.656  187.851
    jj status (this patch)    36.437   32.206     34.483   96.386

Remember the last endpoint in the platform cache directory and validate it with a cheap protocol request before use. Fall back to normal CLI discovery and refresh atomically when it is stale. Explicit nonempty WATCHMAN_SOCK values retain their existing behavior and do not affect the cache.

serde_bser is not actually a new dependency, watchman_client already pulls it in.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
