### PR TITLE
cli: unblock "git init" in non-main Git worktree directory

### DIFF
--- a/cli/src/commands/git/init.rs
+++ b/cli/src/commands/git/init.rs
@@ -207,15 +207,6 @@ async fn do_init(
         GitInitMode::External(git_repo_path)
     } else if colocate {
         if colocated_git_repo_path.exists() {
-            // Refuse to colocate inside a Git worktree
-            if is_linked_git_worktree(workspace_root) {
-                return Err(
-                    user_error("Cannot create a colocated jj repo inside a Git worktree.").hinted(
-                        "Run `jj git init` in the main Git repository instead, or use `jj \
-                         workspace add` to create additional jj workspaces.",
-                    ),
-                );
-            }
             GitInitMode::External(colocated_git_repo_path)
         } else {
             GitInitMode::Colocate
@@ -250,13 +241,10 @@ async fn do_init(
             let repo =
                 init_git_refs(ui, repo, command.string_args(), &workspace, colocated).await?;
             let mut workspace_command = command.for_workable_repo(ui, workspace, repo)?;
+            let git_repo = git::get_git_repo(workspace_command.repo().store())?;
             maybe_add_gitignore(&workspace_command)?;
             workspace_command.maybe_snapshot(ui).await?;
-            maybe_set_repository_level_trunk_alias(
-                ui,
-                &git::get_git_repo(workspace_command.repo().store())?,
-                &config_env,
-            )?;
+            maybe_set_repository_level_trunk_alias(ui, &git_repo, &config_env)?;
             if !workspace_command.working_copy_shared_with_git() {
                 let mut tx = workspace_command.start_transaction();
                 if let Some(git_head_commit) = git::import_head_commit(tx.repo_mut()).await? {
@@ -267,6 +255,16 @@ async fn do_init(
                 }
             }
             print_trackable_remote_bookmarks(ui, workspace_command.repo().view())?;
+            if colocated && git_repo.kind() == gix::repository::Kind::LinkedWorkTree {
+                writeln!(
+                    ui.warning_default(),
+                    "Initialized a new colocated jj repo inside a Git worktree."
+                )?;
+                writeln!(
+                    ui.hint_default(),
+                    "To add a workspace to an existing repository, use `jj workspace add` instead."
+                )?;
+            }
         }
         GitInitMode::Internal => {
             Workspace::init_internal_git(&settings, workspace_root, object_hash).await?;
@@ -399,14 +397,4 @@ fn print_trackable_remote_bookmarks(ui: &Ui, view: &View) -> io::Result<()> {
         )?;
     }
     Ok(())
-}
-
-/// Returns `true` if the path is inside a linked Git worktree.
-fn is_linked_git_worktree(workspace_root: &Path) -> bool {
-    let Ok(repo) = gix::open(workspace_root) else {
-        return false;
-    };
-    // In linked worktrees, git_dir points to .git/worktrees/<name> while
-    // common_dir points to the main .git directory
-    repo.git_dir() != repo.common_dir()
 }

--- a/cli/tests/test_git_init.rs
+++ b/cli/tests/test_git_init.rs
@@ -1260,21 +1260,26 @@ fn test_git_init_colocate_in_git_worktree() {
     let worktree_path = test_env.env_root().join("worktree");
     git::add_worktree(&main_repo_path, &worktree_path, Some("HEAD"));
 
-    // Try to init colocated jj repo - should fail
+    // jj git init --colocate should emit a warning
     let output = test_env.run_jj_in(
         worktree_path.to_str().unwrap(),
         ["git", "init", "--colocate"],
     );
-    insta::assert_snapshot!(output, @"
+    insta::assert_snapshot!(output, @r#"
     ------- stderr -------
-    Error: Cannot create a colocated jj repo inside a Git worktree.
-    Hint: Run `jj git init` in the main Git repository instead, or use `jj workspace add` to create additional jj workspaces.
+    Done importing changes from the underlying Git repo.
+    Warning: Initialized a new colocated jj repo inside a Git worktree.
+    Hint: To add a workspace to an existing repository, use `jj workspace add` instead.
+    Initialized repo in "."
     [EOF]
-    [exit status: 1]
-    ");
+    "#);
 
-    // Verify no .jj directory was created
-    assert!(!worktree_path.join(".jj").exists());
+    let worktree_dir = test_env.work_dir("worktree");
+    insta::assert_snapshot!(get_colocation_status(&worktree_dir), @"
+    Workspace is currently colocated with Git.
+    Last imported/exported Git HEAD: e80a42cccd069007c7a2bb427ac7f1d10b408633
+    [EOF]
+    ");
 }
 
 #[test]
@@ -1299,7 +1304,7 @@ fn test_git_init_colocate_gitlink_not_worktree() -> TestResult {
     // Verify .git is a file (gitlink)
     assert!(work_dir.join(".git").is_file());
 
-    // jj git init --colocate should succeed (not be blocked as a worktree)
+    // jj git init --colocate should succeed
     let output = test_env.run_jj_in(work_dir.to_str().unwrap(), ["git", "init", "--colocate"]);
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------

--- a/cli/tests/test_git_init.rs
+++ b/cli/tests/test_git_init.rs
@@ -1258,21 +1258,7 @@ fn test_git_init_colocate_in_git_worktree() {
 
     // Create a Git worktree
     let worktree_path = test_env.env_root().join("worktree");
-    let status = std::process::Command::new("git")
-        .args([
-            "worktree",
-            "add",
-            worktree_path.to_str().unwrap(),
-            "-b",
-            "worktree-branch",
-        ])
-        .current_dir(&main_repo_path)
-        .status()
-        .expect("git worktree add failed to spawn");
-    assert!(status.success(), "git worktree add failed: {status}");
-
-    // Verify .git is a file (gitlink)
-    assert!(worktree_path.join(".git").is_file());
+    git::add_worktree(&main_repo_path, &worktree_path, Some("HEAD"));
 
     // Try to init colocated jj repo - should fail
     let output = test_env.run_jj_in(

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -21,7 +21,6 @@ use std::io::Write as _;
 use std::iter;
 use std::path::Path;
 use std::path::PathBuf;
-use std::process::Command;
 use std::slice;
 use std::sync::Arc;
 use std::sync::Barrier;
@@ -2581,13 +2580,11 @@ fn test_import_export_head_bare_and_worktree() -> TestResult {
 
     // Create a new colocated workspace
     let workspace_root = test_repo.env.root().join("wt");
-    let output = Command::new("git")
-        .args(["worktree", "add", "--detach"])
-        .arg(&workspace_root)
-        .arg(commit1_oid.to_string())
-        .current_dir(git_repo.path())
-        .output()?;
-    assert!(output.status.success(), "{output:?}");
+    testutils::git::add_worktree(
+        git_repo.path(),
+        &workspace_root,
+        Some(&commit1_oid.to_string()),
+    );
     let (workspace, repo) = Workspace::init_workspace_with_existing_repo(
         &workspace_root,
         test_repo.repo_path(),
@@ -2851,16 +2848,16 @@ fn test_export_refs_worktree_head_changed() -> TestResult {
 
     let worktree_dir = test_workspace.env.root().join("git-wt");
     let git_workdir = git_repo.workdir().expect("git repo must have workdir");
-    let output = std::process::Command::new("git")
-        .args(["worktree", "add", "-b", "wt-branch"])
-        .arg(&worktree_dir)
-        .current_dir(git_workdir)
-        .output()?;
-    assert!(
-        output.status.success(),
-        "Failed to create worktree: {}",
-        String::from_utf8_lossy(&output.stderr)
-    );
+    testutils::git::add_worktree(git_workdir, &worktree_dir, Some("HEAD"));
+    let git_repo_wt = testutils::git::open(&worktree_dir);
+    git_repo_wt.reference(
+        "refs/heads/wt-branch",
+        commit1,
+        gix::refs::transaction::PreviousValue::MustNotExist,
+        "",
+    )?;
+    testutils::git::set_symbolic_reference(&git_repo_wt, "HEAD", "refs/heads/wt-branch");
+    assert!(!git_repo_wt.head()?.is_detached());
 
     let mut tx = repo.start_transaction();
     let mut_repo = tx.repo_mut();
@@ -2879,7 +2876,6 @@ fn test_export_refs_worktree_head_changed() -> TestResult {
     assert!(stats.failed_bookmarks.is_empty());
     assert!(stats.failed_tags.is_empty());
 
-    let git_repo_wt = gix::open(&worktree_dir)?;
     assert!(git_repo_wt.head()?.is_detached());
     Ok(())
 }
@@ -2895,16 +2891,16 @@ fn test_export_refs_worktree_no_detach() -> TestResult {
 
     let worktree_dir = test_workspace.env.root().join("git-wt");
     let git_workdir = git_repo.workdir().expect("git repo must have workdir");
-    let output = std::process::Command::new("git")
-        .args(["worktree", "add", "-b", "wt-branch"])
-        .arg(&worktree_dir)
-        .current_dir(git_workdir)
-        .output()?;
-    assert!(
-        output.status.success(),
-        "Failed to create worktree: {}",
-        String::from_utf8_lossy(&output.stderr)
-    );
+    testutils::git::add_worktree(git_workdir, &worktree_dir, Some("HEAD"));
+    let git_repo_wt = testutils::git::open(&worktree_dir);
+    git_repo_wt.reference(
+        "refs/heads/wt-branch",
+        commit1,
+        gix::refs::transaction::PreviousValue::MustNotExist,
+        "",
+    )?;
+    testutils::git::set_symbolic_reference(&git_repo_wt, "HEAD", "refs/heads/wt-branch");
+    assert!(!git_repo_wt.head()?.is_detached());
 
     let mut tx = repo.start_transaction();
     let mut_repo = tx.repo_mut();
@@ -2923,7 +2919,6 @@ fn test_export_refs_worktree_no_detach() -> TestResult {
     assert!(stats.failed_bookmarks.is_empty());
     assert!(stats.failed_tags.is_empty());
 
-    let git_repo_wt = gix::open(&worktree_dir)?;
     assert!(!git_repo_wt.head()?.is_detached());
     assert_eq!(
         git_repo_wt.head_name()?.unwrap().as_bstr(),

--- a/lib/testutils/src/git.rs
+++ b/lib/testutils/src/git.rs
@@ -12,15 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::ffi::OsStr;
 use std::path::Path;
 use std::path::PathBuf;
+use std::process::Command;
 
+use bstr::BString;
 use gix::date::parse::TimeBuf;
 
 pub const GIT_USER: &str = "Someone";
 pub const GIT_EMAIL: &str = "someone@example.org";
 
-fn git_config() -> Vec<bstr::BString> {
+fn git_config() -> Vec<BString> {
     vec![
         format!("user.name = {GIT_USER}").into(),
         format!("user.email = {GIT_EMAIL}").into(),
@@ -67,7 +70,7 @@ pub fn clone(dest_path: &Path, repo_url: &str, remote_name: Option<&str>) -> gix
     //
     // This, plus the fact that the code to clone a repo in gitoxide is non-trivial,
     // makes it appealing to just spawn a git subprocess
-    let output = std::process::Command::new("git")
+    let output = Command::new("git")
         .args(["clone", repo_url, "--origin", remote_name])
         .arg(dest_path)
         .output()
@@ -76,8 +79,8 @@ pub fn clone(dest_path: &Path, repo_url: &str, remote_name: Option<&str>) -> gix
         output.status.success(),
         "git cloning failed with {}:\n{}\n----- stderr -----\n{}",
         output.status,
-        bstr::BString::from(output.stdout),
-        bstr::BString::from(output.stderr),
+        BString::from(output.stdout),
+        BString::from(output.stderr),
     );
 
     open(dest_path)
@@ -213,8 +216,8 @@ pub fn checkout_tree_index(repo: &gix::Repository, tree_id: gix::ObjectId) {
 
 fn signature() -> gix::actor::Signature {
     gix::actor::Signature {
-        name: bstr::BString::from(GIT_USER),
-        email: bstr::BString::from(GIT_EMAIL),
+        name: BString::from(GIT_USER),
+        email: BString::from(GIT_EMAIL),
         time: gix::date::Time::new(0, 0),
     }
 }
@@ -355,7 +358,7 @@ impl<'a> IndexManager<'a> {
 }
 
 pub fn add_remote(repo_dir: impl AsRef<Path>, remote_name: &str, url: &str) {
-    let output = std::process::Command::new("git")
+    let output = Command::new("git")
         .current_dir(repo_dir)
         .args(["remote", "add", remote_name, url])
         .output()
@@ -364,13 +367,13 @@ pub fn add_remote(repo_dir: impl AsRef<Path>, remote_name: &str, url: &str) {
         output.status.success(),
         "git remote add {remote_name} {url} failed with {}:\n{}\n----- stderr -----\n{}",
         output.status,
-        bstr::BString::from(output.stdout),
-        bstr::BString::from(output.stderr),
+        BString::from(output.stdout),
+        BString::from(output.stderr),
     );
 }
 
 pub fn rename_remote(repo_dir: impl AsRef<Path>, original: &str, new: &str) {
-    let output = std::process::Command::new("git")
+    let output = Command::new("git")
         .current_dir(repo_dir)
         .args(["remote", "rename", original, new])
         .output()
@@ -379,13 +382,13 @@ pub fn rename_remote(repo_dir: impl AsRef<Path>, original: &str, new: &str) {
         output.status.success(),
         "git remote rename failed with {}:\n{}\n----- stderr -----\n{}",
         output.status,
-        bstr::BString::from(output.stdout),
-        bstr::BString::from(output.stderr),
+        BString::from(output.stdout),
+        BString::from(output.stderr),
     );
 }
 
 pub fn fetch(repo_dir: impl AsRef<Path>, remote: &str) {
-    let output = std::process::Command::new("git")
+    let output = Command::new("git")
         .current_dir(repo_dir)
         .args(["fetch", remote])
         .output()
@@ -394,7 +397,31 @@ pub fn fetch(repo_dir: impl AsRef<Path>, remote: &str) {
         output.status.success(),
         "git fetch {remote} failed with {}:\n{}\n----- stderr -----\n{}",
         output.status,
-        bstr::BString::from(output.stdout),
-        bstr::BString::from(output.stderr),
+        BString::from(output.stdout),
+        BString::from(output.stderr),
+    );
+}
+
+pub fn add_worktree(
+    repo_dir: impl AsRef<Path>,
+    worktree_dir: impl AsRef<OsStr>,
+    revision: Option<&str>,
+) {
+    let mut command = Command::new("git");
+    command.current_dir(repo_dir).args(["worktree", "add"]);
+    match revision {
+        Some(_) => command.arg("--detach"),
+        None => command.arg("--orphan"),
+    };
+    command.arg("--");
+    command.arg(worktree_dir);
+    command.args(revision);
+    let output = command.output().unwrap();
+    assert!(
+        output.status.success(),
+        "{command:?} failed with {}:\n{}\n----- stderr -----\n{}",
+        output.status,
+        BString::from(output.stdout),
+        BString::from(output.stderr),
     );
 }


### PR DESCRIPTION
# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [ ] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
