### PR TITLE
temp: validate codespell tasks on Windows CI

### DIFF
--- a/.config/mise.toml
+++ b/.config/mise.toml
@@ -11,10 +11,6 @@ rust_version = "1.89"
 uv_version = "0.8.13"
 node_version = "24"
 
-[settings]
-# the default cmd doesn't support shell expansion, use PowerShell instead
-windows_default_inline_shell_args = "pwsh -Command"
-
 [tools]
 # We need cargo-binstall so that Mise would download "cargo:" tools instead of building them.
 "cargo-binstall" = "latest"
@@ -79,6 +75,8 @@ run = "cargo clippy --workspace --all-targets"
 description = "Check code for common misspellings"
 tools.uv = "{{vars.uv_version}}"
 run = "uv run codespell $(jj file list)"
+# Windows commands run through cmd, which cannot expand $(...); pwsh can.
+run_windows = 'pwsh -NoProfile -Command "uv run codespell $(jj file list)"'
 
 [tasks."check:format"]
 description = "Check the code format"
@@ -110,6 +108,7 @@ run = "cargo clippy --fix"
 description = "Fix common code misspellings"
 tools.uv = "{{vars.uv_version}}"
 run = "uv run codespell -w $(jj file list)"
+run_windows = 'pwsh -NoProfile -Command "uv run codespell -w $(jj file list)"'
 
 [tasks."fix:format"]
 description = "Format the code"

--- a/.config/mise.toml
+++ b/.config/mise.toml
@@ -14,6 +14,8 @@ node_version = "24"
 [tools]
 # We need cargo-binstall so that Mise would download "cargo:" tools instead of building them.
 "cargo-binstall" = "latest"
+# temporary, for CI validation only
+jj = "latest"
 
 [tasks."review:cli-reference"]
 description = "Build and review the changes to the command line reference (cli/tests/cli-reference@.md.snap)"

--- a/.github/workflows/codespell-windows-test.yml
+++ b/.github/workflows/codespell-windows-test.yml
@@ -1,0 +1,48 @@
+# Temporary validation of the mise codespell tasks on Windows (run_windows + pwsh).
+# Remove this workflow and its revision once it has run.
+name: codespell-windows-test
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  codespell:
+    runs-on: windows-2022
+    steps:
+      - uses: actions/checkout@v4
+      - uses: jdx/mise-action@v2
+
+      - name: Configure jj identity
+        shell: pwsh
+        run: |
+          jj config set --user user.name "codespell-ci"
+          jj config set --user user.email "codespell-ci@example.com"
+
+      - name: check:codespell passes on clean repo
+        shell: pwsh
+        run: |
+          jj git init --colocate
+          mise run check:codespell
+          if ($LASTEXITCODE -ne 0) { exit 1 }
+
+      - name: check:codespell fails on planted misspelling
+        shell: pwsh
+        run: |
+          # misspelling assembled at runtime so this file stays clean for codespell
+          Set-Content -Path codespell-test.txt -Value ('This is cal' + 'ulated on Wind' + 'ows.')
+          mise run check:codespell
+          if ($LASTEXITCODE -eq 0) { exit 1 }
+
+      - name: fix:codespell fixes it
+        shell: pwsh
+        run: |
+          mise run fix:codespell
+          if ($LASTEXITCODE -ne 0) { exit 1 }
+
+      - name: check:codespell passes again
+        shell: pwsh
+        run: |
+          mise run check:codespell
+          if ($LASTEXITCODE -ne 0) { exit 1 }

--- a/.github/workflows/codespell-windows-test.yml
+++ b/.github/workflows/codespell-windows-test.yml
@@ -33,7 +33,10 @@ jobs:
           # misspelling assembled at runtime so this file stays clean for codespell
           Set-Content -Path codespell-test.txt -Value ('This is cal' + 'ulated on Wind' + 'ows.')
           mise run check:codespell
-          if ($LASTEXITCODE -eq 0) { exit 1 }
+          $rc = $LASTEXITCODE
+          # reset exit code: GHA appends `exit $LASTEXITCODE` to pwsh steps
+          $LASTEXITCODE = 0
+          if ($rc -eq 0) { exit 1 }
 
       - name: fix:codespell fixes it
         shell: pwsh


### PR DESCRIPTION
Temporary: runs the mise codespell tasks on windows-2022 to validate the run_windows + pwsh fix. Will be closed and abandoned after.