### PR TITLE
mise: fix codespell tasks on Windows by running them through pwsh

### DIFF
--- a/.config/mise.toml
+++ b/.config/mise.toml
@@ -11,10 +11,6 @@ rust_version = "1.89"
 uv_version = "0.8.13"
 node_version = "24"
 
-[settings]
-# the default cmd doesn't support shell expansion, use PowerShell instead
-windows_default_inline_shell_args = "pwsh -Command"
-
 [tools]
 # We need cargo-binstall so that Mise would download "cargo:" tools instead of building them.
 "cargo-binstall" = "latest"

--- a/.config/mise.toml
+++ b/.config/mise.toml
@@ -75,6 +75,8 @@ run = "cargo clippy --workspace --all-targets"
 description = "Check code for common misspellings"
 tools.uv = "{{vars.uv_version}}"
 run = "uv run codespell $(jj file list)"
+# Windows commands run through cmd, which cannot expand $(...), so use pwsh
+run_windows = 'pwsh -NoProfile -Command "uv run codespell $(jj file list)"'
 
 [tasks."check:format"]
 description = "Check the code format"
@@ -106,6 +108,8 @@ run = "cargo clippy --fix"
 description = "Fix common code misspellings"
 tools.uv = "{{vars.uv_version}}"
 run = "uv run codespell -w $(jj file list)"
+# Windows commands run through cmd, which cannot expand $(...), so use pwsh
+run_windows = 'pwsh -NoProfile -Command "uv run codespell -w $(jj file list)"'
 
 [tasks."fix:format"]
 description = "Format the code"


### PR DESCRIPTION
mise 2026.9.0 stopped honoring windows_default_inline_shell_args in project configs (it is ignored for security reasons now), so the codespell tasks fail on Windows: cmd cannot expand $(jj file list). Replace the [settings] block with explicit run_windows commands using pwsh, which supports $(...) subexpressions. This also removes the warning that mise now emits on Linux for that setting in non-global configs.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
