### PR TITLE
rewrite: don't lose content that both sides of a merge contain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,15 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   [#9711](https://github.com/jj-vcs/jj/issues/9711)
   [#8884](https://github.com/jj-vcs/jj/issues/8884)
 
+* Merging no longer silently drops content that both sides of the merge
+  contain. A recursive merge base is now reduced to a single virtual merge
+  base tree -- resolving what can be resolved and taking one side of whatever
+  remains, as Git's "resolve" strategy does when picking among several merge
+  bases -- instead of being flattened into the conflict unresolved, where the
+  content it carried canceled out the parents' copies of it. This affects
+  criss-cross histories, and merges whose base is itself conflicted.
+  [#6369](https://github.com/jj-vcs/jj/issues/6369)
+
 ## [0.44.0] - 2026-08-05
 
 ### Release highlights

--- a/cli/tests/test_new_command.rs
+++ b/cli/tests/test_new_command.rs
@@ -263,6 +263,52 @@ fn test_new_merge_conflicts() {
 }
 
 #[test]
+fn test_new_merge_same_change_of_same_change_merges() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    // https://github.com/jj-vcs/jj/issues/6369: "a" and "b" make the same
+    // change, "c" and "d" are two separate merges of them, and merging those
+    // used to resolve cleanly to "original" -- content that neither side has.
+    create_commit_with_files(&work_dir, "base", &[], &[("file", "original\n")]);
+    create_commit_with_files(&work_dir, "a", &["base"], &[("file", "modified\n")]);
+    create_commit_with_files(&work_dir, "b", &["base"], &[("file", "modified\n")]);
+    create_commit_with_files(&work_dir, "c", &["a", "b"], &[]);
+    create_commit_with_files(&work_dir, "d", &["a", "b"], &[]);
+
+    work_dir.run_jj(["new", "c|d"]).success();
+    assert_eq!(work_dir.read_file("file"), "modified\n");
+
+    // With "keep", the merge base of "c" and "d" is the *conflicted* merge of
+    // "a" and "b", so this also covers collapsing a base that cannot be
+    // resolved.
+    work_dir.run_jj(["new", "root()"]).success();
+    work_dir
+        .run_jj(["new", "c|d", "--config=merge.same-change=keep"])
+        .success();
+    assert_eq!(work_dir.read_file("file"), "modified\n");
+
+    // Whatever the merge produced has to survive a working-copy snapshot.
+    // Reducing an unresolvable base by materializing its conflict would leave
+    // conflict markers in the merged file, and those do not always parse back:
+    // the next snapshot would store them as ordinary content, silently turning
+    // a conflict into text that merely looks like one.
+    let commit_id = |work_dir: &TestWorkDir| {
+        work_dir
+            .run_jj(["log", "-r", "@", "--no-graph", "-T", "commit_id"])
+            .success()
+            .stdout
+            .raw()
+            .to_owned()
+    };
+    let before = commit_id(&work_dir);
+    work_dir.run_jj(["status"]).success(); // snapshots the working copy
+    assert_eq!(commit_id(&work_dir), before);
+    assert_eq!(work_dir.read_file("file"), "modified\n");
+}
+
+#[test]
 fn test_new_merge_same_change() {
     let test_env = TestEnvironment::default();
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();

--- a/lib/src/merged_tree.rs
+++ b/lib/src/merged_tree.rs
@@ -52,6 +52,7 @@ use crate::matchers::Matcher;
 use crate::merge::Diff;
 use crate::merge::Merge;
 use crate::merge::MergeBuilder;
+use crate::merged_tree_builder::MergedTreeBuilder;
 use crate::repo_path::RepoPath;
 use crate::repo_path::RepoPathBuf;
 use crate::repo_path::RepoPathComponent;
@@ -190,6 +191,30 @@ impl MergedTree {
             tree_ids: simplified,
             labels: simplified_labels,
         })
+    }
+
+    /// Collapses any remaining conflicts into a single resolved tree, keeping
+    /// the first side of each conflict that cannot be automatically resolved.
+    ///
+    /// This is lossy and order-dependent: the losing sides are discarded. It
+    /// is intended for constructing the virtual merge base of a recursive
+    /// merge, which must be a single tree; adding a conflicted base to the
+    /// outer merge terms instead would lose content that both sides of the
+    /// merge contain. Keeping the first side is comparable to git's "resolve"
+    /// strategy picking one of several merge bases. The choice of side only
+    /// affects which diffs the outer merge sees, not which content it can
+    /// keep: each side of the outer merge is still present as an add.
+    pub async fn collapse_conflicts(self) -> BackendResult<Self> {
+        let tree = self.resolve().await?;
+        if tree.tree_ids.is_resolved() {
+            return Ok(tree);
+        }
+        let conflicts: Vec<_> = tree.conflicts().collect();
+        let mut builder = MergedTreeBuilder::new(tree);
+        for (path, values) in conflicts {
+            builder.set_or_remove(path, Merge::resolved(values?.first().clone()));
+        }
+        builder.write_tree().await
     }
 
     /// An iterator over the conflicts in this tree, including subtrees.

--- a/lib/src/rewrite.rs
+++ b/lib/src/rewrite.rs
@@ -92,14 +92,91 @@ pub async fn merge_commit_trees_no_resolve_without_repo(
         .iter()
         .map(|commit| commit.id().clone())
         .collect_vec();
-    let commit_id_merge = find_recursive_merge_commits(store, index, commit_ids).await?;
-    let tree_merge: Merge<(MergedTree, String)> = commit_id_merge
-        .try_map_async(async |commit_id| {
-            let commit = store.get_commit_async(commit_id).await?;
-            Ok::<_, BackendError>((commit.tree(), commit.conflict_label()))
-        })
+    Box::pin(merge_commit_ids_no_resolve(store, index, &commit_ids)).await
+}
+
+/// Merges the trees of `commit_ids` against their merge bases, without
+/// attempting to resolve the resulting file conflicts.
+///
+/// When two commits have several best common ancestors (a criss-cross
+/// history), those ancestors are merged recursively and the result is
+/// collapsed into a single virtual merge base (see
+/// [`MergedTree::collapse_conflicts`]).
+///
+/// Reducing the base to a single tree is what keeps the merge from losing
+/// content. Flattening an unresolved base merge into the outer term list puts
+/// every side of it on the *remove* side, where the content it carries cancels
+/// against the same content in the parents.
+///
+/// The shape that triggers this is two bugfixes that independently add the
+/// same line, merged together twice:
+///
+/// ```text
+///        base          a file WITHOUT some line
+///        /  \
+///       A    B         two fixes, each independently ADDING that line
+///       |\  /|
+///       | \/ |
+///       | /\ |
+///  AB_for_X  AB_for_Y  two *separate* merges of A and B; both have the line
+///        \    /
+///          XY          merging them loses the line, with no conflict
+/// ```
+///
+/// `AB_for_X` and `AB_for_Y` have two best common ancestors, `A` and `B`, and
+/// both of those carry the line. Merging them recursively and flattening the
+/// result gives:
+///
+/// ```text
+/// adds    [AB_for_X(line), base(no line), AB_for_Y(line)]
+/// removes [A(line), B(line)]
+///
+/// line:    +2 -2 = 0   cancels, and vanishes without a trace
+/// no line: +1          wins, so XY gets base's version of the file
+/// ```
+///
+/// Exactly one value nets +1, which is the "resolved cleanly" case, so no
+/// conflict is recorded. Note that this needs only two parents; the line must
+/// be added *independently* on both sides (if it came from a single ancestor
+/// it would be in the base too, and could only collect +1 votes).
+async fn merge_commit_ids_no_resolve(
+    store: &Arc<Store>,
+    index: &dyn Index,
+    commit_ids: &[CommitId],
+) -> BackendResult<MergedTree> {
+    let commit_tree = async |commit_id: &CommitId| {
+        let commit = store.get_commit_async(commit_id).await?;
+        Ok::<_, BackendError>((commit.tree(), commit.conflict_label()))
+    };
+    let [first_id, other_ids @ ..] = commit_ids else {
+        let (tree, _label) = commit_tree(store.root_commit_id()).await?;
+        return Ok(tree);
+    };
+    let first_term = commit_tree(first_id).await?;
+    if other_ids.is_empty() {
+        return Ok(first_term.0);
+    }
+
+    let mut terms = vec![first_term];
+    for (pos, commit_id) in commit_ids.iter().enumerate().skip(1) {
+        let ancestor_ids = index
+            .common_ancestors(&commit_ids[..pos], slice::from_ref(commit_id))
+            .await
+            // TODO: indexing error shouldn't be a "BackendError"
+            .map_err(|err| BackendError::Other(err.into()))?;
+        let base_tree = Box::pin(merge_commit_ids_no_resolve(store, index, &ancestor_ids)).await?;
+        let base_tree = base_tree.collapse_conflicts().await?;
+        let base_commits: Vec<Commit> = try_join_all(
+            ancestor_ids
+                .iter()
+                .map(|id| store.get_commit_async(id))
+                .collect_vec(),
+        )
         .await?;
-    Ok(MergedTree::merge_no_resolve(tree_merge))
+        terms.push((base_tree, conflict_label_for_commits(&base_commits)));
+        terms.push(commit_tree(commit_id).await?);
+    }
+    Ok(MergedTree::merge_no_resolve(Merge::from_vec(terms)))
 }
 
 /// Find the commits to use as input to the recursive merge algorithm.

--- a/lib/tests/test_merge_trees.rs
+++ b/lib/tests/test_merge_trees.rs
@@ -18,6 +18,7 @@ use jj_lib::config::ConfigSource;
 use jj_lib::merge::Merge;
 use jj_lib::merge::SameChange;
 use jj_lib::repo::Repo as _;
+use jj_lib::rewrite::merge_commit_trees;
 use jj_lib::rewrite::rebase_commit;
 use jj_lib::settings::UserSettings;
 use pollster::FutureExt as _;
@@ -243,6 +244,223 @@ fn test_rebase_on_lossy_merge(same_change: SameChange) -> TestResult {
             assert_eq!(*commit_d2.tree_ids(), expected_tree_id);
         }
     }
+    Ok(())
+}
+
+/// A merge must not silently drop content that both sides carry.
+///
+/// Two bugfixes independently add the same dependency line, and are merged
+/// together twice -- once to base feature X on, once to base feature Y on:
+///
+/// ```text
+///        base          "packages" WITHOUT "bun"
+///        /  \
+///       A    B         both independently ADD "bun", plus one change of their own
+///       |\  /|
+///       | \/ |
+///       | /\ |
+///  AB_for_X  AB_for_Y  two *separate* clean merges of A and B; both keep "bun"
+///        \    /
+///          XY          merging them must not lose "bun"
+/// ```
+///
+/// `AB_for_X` and `AB_for_Y` have two best common ancestors, `A` and `B`, and
+/// both of those carry "bun". Merging the bases but flattening the result into
+/// the term list unresolved gives
+/// `adds [AB_for_X(bun), base(no bun), AB_for_Y(bun)],
+/// removes [A(bun), B(bun)]`, so "bun" cancels to net 0 while the no-bun
+/// version wins with +1: the line is resolved away with no conflict marker,
+/// and -- because a merge commit's diff is taken against its auto-merged
+/// parents -- with no diff either. Reducing the bases to a single virtual
+/// merge base first keeps it.
+#[test]
+fn test_merge_does_not_drop_content_carried_by_both_sides() -> TestResult {
+    let test_repo = TestRepo::init();
+    let repo = &test_repo.repo;
+    let path = repo_path("devbox.json");
+
+    // Two well-separated regions, so that "packages" and "scripts" fall in
+    // different diff hunks.
+    let file = |bun: bool, env: &str, script: &str| {
+        format!(
+            "packages:\n  php\n{}  nginx\n\nenv:\n  PORT=8081\n{}\nscripts:\n  lint\n{}",
+            if bun { "  bun\n" } else { "" },
+            env,
+            script,
+        )
+    };
+
+    let mut tx = repo.start_transaction();
+    let tree_base = create_tree(repo, &[(path, &file(false, "", ""))]);
+    let commit_base = tx
+        .repo_mut()
+        .new_commit(vec![repo.store().root_commit_id().clone()], tree_base)
+        .write_unwrap();
+    let tree_a = create_tree(repo, &[(path, &file(true, "  LOOKAROUND=1\n", ""))]);
+    let commit_a = tx
+        .repo_mut()
+        .new_commit(vec![commit_base.id().clone()], tree_a)
+        .write_unwrap();
+    let tree_b = create_tree(repo, &[(path, &file(true, "", "  less\n"))]);
+    let commit_b = tx
+        .repo_mut()
+        .new_commit(vec![commit_base.id().clone()], tree_b)
+        .write_unwrap();
+
+    // AB_for_X and AB_for_Y are two independent, cleanly-resolved merges of A
+    // and B. Both keep "bun": A and B made the same change to that region.
+    let parents = vec![commit_a.id().clone(), commit_b.id().clone()];
+    let merged_tree =
+        merge_commit_trees(tx.repo(), &[commit_a.clone(), commit_b.clone()]).block_on()?;
+    assert!(
+        merged_tree.path_value(path).block_on()?.is_resolved(),
+        "the test setup requires the two merges to be conflict-free"
+    );
+    let commit_ab_for_x = tx
+        .repo_mut()
+        .new_commit(parents.clone(), merged_tree.clone())
+        .write_unwrap();
+    let commit_ab_for_y = tx
+        .repo_mut()
+        .new_commit(parents, merged_tree)
+        .write_unwrap();
+    let repo = tx.commit("test").block_on()?;
+
+    let tree = merge_commit_trees(repo.as_ref(), &[commit_ab_for_x, commit_ab_for_y]).block_on()?;
+    let value = tree.path_value(path).block_on()?;
+    let Ok(Some(TreeValue::File { id, .. })) = value.clone().into_resolved() else {
+        panic!("expected a cleanly resolved file, got: {value:#?}");
+    };
+    let content = String::from_utf8(testutils::read_file(repo.store(), path, &id)).unwrap();
+    assert_eq!(content, file(true, "  LOOKAROUND=1\n", "  less\n"));
+
+    Ok(())
+}
+
+/// The reproduction from jj-vcs/jj#6369: `a` and `b` make the *same* change,
+/// so `c` and `d` resolve cleanly to it under `SameChange::Accept`, yet the
+/// merge of `c` and `d` used to go back to the base's content.
+#[test]
+fn test_merge_of_merges_with_same_change_keeps_the_change() -> TestResult {
+    let test_repo = TestRepo::init();
+    let repo = &test_repo.repo;
+    let path = repo_path("file.txt");
+
+    let mut tx = repo.start_transaction();
+    let tree_base = create_tree(repo, &[(path, "original\n")]);
+    let commit_base = tx
+        .repo_mut()
+        .new_commit(vec![repo.store().root_commit_id().clone()], tree_base)
+        .write_unwrap();
+    let tree_modified = create_tree(repo, &[(path, "modified\n")]);
+    let commit_a = tx
+        .repo_mut()
+        .new_commit(vec![commit_base.id().clone()], tree_modified.clone())
+        .write_unwrap();
+    let commit_b = tx
+        .repo_mut()
+        .new_commit(vec![commit_base.id().clone()], tree_modified)
+        .write_unwrap();
+
+    let parents = vec![commit_a.id().clone(), commit_b.id().clone()];
+    let merged_tree = merge_commit_trees(tx.repo(), &[commit_a, commit_b]).block_on()?;
+    let commit_c = tx
+        .repo_mut()
+        .new_commit(parents.clone(), merged_tree.clone())
+        .write_unwrap();
+    let commit_d = tx
+        .repo_mut()
+        .new_commit(parents, merged_tree)
+        .write_unwrap();
+    let repo = tx.commit("test").block_on()?;
+
+    let tree = merge_commit_trees(repo.as_ref(), &[commit_c, commit_d]).block_on()?;
+    let value = tree.path_value(path).block_on()?;
+    let Ok(Some(TreeValue::File { id, .. })) = value.clone().into_resolved() else {
+        panic!("expected a cleanly resolved file, got: {value:#?}");
+    };
+    assert_eq!(testutils::read_file(repo.store(), path, &id), b"modified\n");
+
+    Ok(())
+}
+
+/// A conflicted merge base must not let content revert to the base's own
+/// version.
+///
+/// ```text
+///    base        "original"
+///     / \
+///    a   b       "A" and "B" -- a genuine conflict
+///     \ /
+///      m         conflicted merge of a and b
+///     / \
+///   r1   r2      two *different* manual resolutions of m
+/// ```
+///
+/// `r1` and `r2` have a single merge base, `m`, whose tree is conflicted.
+/// Flattening that conflict into the term list puts `a` and `b` on the remove
+/// side, where they cancel `r1` and `r2`, leaving "original" -- a version
+/// *neither side chose* -- to win, with no conflict at all.
+///
+/// Collapsing the base to a single tree stops that. Ideally this merge would
+/// report a conflict, since `r1` and `r2` resolved the same conflict
+/// differently; it does not, because collapsing picks one side of the base and
+/// the other parent's resolution then wins outright. That is still a strict
+/// improvement: the result is a version somebody deliberately chose, rather
+/// than a reversion to content that predates both resolutions.
+#[test]
+fn test_merge_of_two_resolutions_does_not_revert_to_the_base() -> TestResult {
+    let test_repo = TestRepo::init();
+    let repo = &test_repo.repo;
+    let path = repo_path("file");
+
+    let mut tx = repo.start_transaction();
+    let tree_base = create_tree(repo, &[(path, "original\n")]);
+    let commit_base = tx
+        .repo_mut()
+        .new_commit(vec![repo.store().root_commit_id().clone()], tree_base)
+        .write_unwrap();
+    let tree_a = create_tree(repo, &[(path, "A\n")]);
+    let commit_a = tx
+        .repo_mut()
+        .new_commit(vec![commit_base.id().clone()], tree_a.clone())
+        .write_unwrap();
+    let tree_b = create_tree(repo, &[(path, "B\n")]);
+    let commit_b = tx
+        .repo_mut()
+        .new_commit(vec![commit_base.id().clone()], tree_b.clone())
+        .write_unwrap();
+
+    let tree_m = merge_commit_trees(tx.repo(), &[commit_a.clone(), commit_b.clone()]).block_on()?;
+    assert!(
+        !tree_m.path_value(path).block_on()?.is_resolved(),
+        "the test setup requires m to be conflicted"
+    );
+    let commit_m = tx
+        .repo_mut()
+        .new_commit(vec![commit_a.id().clone(), commit_b.id().clone()], tree_m)
+        .write_unwrap();
+    // Two different manual resolutions of the same conflict.
+    let commit_r1 = tx
+        .repo_mut()
+        .new_commit(vec![commit_m.id().clone()], tree_a)
+        .write_unwrap();
+    let commit_r2 = tx
+        .repo_mut()
+        .new_commit(vec![commit_m.id().clone()], tree_b)
+        .write_unwrap();
+    let repo = tx.commit("test").block_on()?;
+
+    let tree = merge_commit_trees(repo.as_ref(), &[commit_r1, commit_r2]).block_on()?;
+    let value = tree.path_value(path).block_on()?;
+    if let Ok(Some(TreeValue::File { id, .. })) = value.clone().into_resolved() {
+        let content = String::from_utf8(testutils::read_file(repo.store(), path, &id)).unwrap();
+        assert_ne!(
+            content, "original\n",
+            "the merge reverted to the base's content, which neither side chose"
+        );
+    }
+
     Ok(())
 }
 

--- a/lib/tests/test_merged_tree.rs
+++ b/lib/tests/test_merged_tree.rs
@@ -3124,3 +3124,43 @@ fn test_copy_diffstream_double_rename() -> TestResult {
     );
     Ok(())
 }
+
+#[test]
+fn test_collapse_conflicts() -> TestResult {
+    let test_repo = TestRepo::init();
+    let repo = &test_repo.repo;
+
+    // The "auto" path is trivially resolvable because the first side is
+    // unchanged from the base, so the second side wins even though it isn't
+    // first. The "conflicted" path cannot be resolved automatically and keeps
+    // the first side.
+    let auto_path = repo_path("auto");
+    let conflicted_path = repo_path("conflicted");
+    let base_tree = create_single_tree(repo, &[(auto_path, "base"), (conflicted_path, "base")]);
+    let side1 = create_single_tree(repo, &[(auto_path, "base"), (conflicted_path, "side1")]);
+    let side2 = create_single_tree(repo, &[(auto_path, "side2"), (conflicted_path, "side2")]);
+    let merged_tree = MergedTree::new(
+        repo.store().clone(),
+        Merge::from_removes_adds(
+            vec![base_tree.id().clone()],
+            vec![side1.id().clone(), side2.id().clone()],
+        ),
+        ConflictLabels::from_vec(vec!["side 1".into(), "base".into(), "side 2".into()]),
+    );
+    assert!(merged_tree.has_conflict());
+
+    let collapsed = merged_tree.collapse_conflicts().block_on()?;
+    assert!(!collapsed.has_conflict());
+    // Automatically resolved: the side that differs from the base wins, even
+    // though it is not the first side.
+    assert_eq!(
+        collapsed.path_value(auto_path).block_on()?,
+        Merge::resolved(side2.path_value(auto_path).block_on()?),
+    );
+    // Not automatically resolvable: the first side of the merge survives.
+    assert_eq!(
+        collapsed.path_value(conflicted_path).block_on()?,
+        Merge::resolved(side1.path_value(conflicted_path).block_on()?),
+    );
+    Ok(())
+}

--- a/lib/tests/test_rewrite.rs
+++ b/lib/tests/test_rewrite.rs
@@ -18,6 +18,7 @@ use assert_matches::assert_matches;
 use itertools::Itertools as _;
 use jj_lib::backend::ChangeId;
 use jj_lib::commit::Commit;
+use jj_lib::commit::conflict_label_for_commits;
 use jj_lib::matchers::EverythingMatcher;
 use jj_lib::matchers::FilesMatcher;
 use jj_lib::merge::Merge;
@@ -117,11 +118,27 @@ fn test_merge_criss_cross() -> TestResult {
         merge_commit_trees(tx.repo_mut(), &[commit_d.clone(), commit_e.clone()]).block_on()?;
     assert_tree_eq!(merged, tree_expected);
 
+    // D and E have two best common ancestors, B and C. They are merged and
+    // resolved into a single virtual merge base, so the unresolved merge has
+    // three sides rather than the five it would have if the base merge were
+    // flattened in unresolved.
+    let ancestor_ids = tx
+        .repo()
+        .index()
+        .common_ancestors(
+            slice::from_ref(commit_d.id()),
+            slice::from_ref(commit_e.id()),
+        )
+        .block_on()?;
+    let ancestor_commits: Vec<Commit> = ancestor_ids
+        .iter()
+        .map(|id| tx.repo().store().get_commit(id))
+        .try_collect()?;
+    assert_eq!(ancestor_commits.len(), 2, "expected a criss-cross history");
+    let tree_base = create_tree(repo, &[(path, "1\n2\n3C\n4\n5\n6\n7\n8B\n9\n")]);
     let tree_unresolved_expected = MergedTree::merge_no_resolve(Merge::from_vec(vec![
         (tree_d, commit_d.conflict_label()),
-        (tree_b, commit_b.conflict_label()),
-        (tree_a, commit_a.conflict_label()),
-        (tree_c, commit_c.conflict_label()),
+        (tree_base, conflict_label_for_commits(&ancestor_commits)),
         (tree_e, commit_e.conflict_label()),
     ]));
     let unresolved_merged =


### PR DESCRIPTION
A merge can silently delete content that both of its sides contain. No
conflict marker is produced, and because a merge commit's diff is taken
against its auto-merged parents, there is no diff either -- nothing records
that the content was ever there. git does not behave this way on the same
history. Reported as #6369.

It takes two fixes that each add the same line, merged together twice, and
those two merges later merged. Only two parents are needed at the end, so
this is not an octopus-merge problem:

```
       base          a file WITHOUT some line
       /  \
      A    B         two fixes, each independently ADDING that line
      |\  /|
      | \/ |
      | /\ |
 AB_for_X  AB_for_Y  two *separate* merges of A and B; both have the line
       \    /
         XY          the line disappears here, with no conflict
```

The same-change rule resolves AB_for_X and AB_for_Y to the line being
present, so they and their merge bases A and B all carry it. The base is
then never collapsed to a single tree:
merge_commit_trees_no_resolve_without_repo() asks
find_recursive_merge_commits() for a Merge<CommitId> and flattens it, which
moves each of the base merge's adds onto the remove side:

```
    adds    [AB_for_X(line), base(no line), AB_for_Y(line)]
    removes [A(line), B(line)]
```

trivial_merge() counts values as a signed multiset, +1 per add and -1 per
remove. The line nets 0, the version without it nets +1, and exactly one
value at +1 is the "resolved cleanly" case. A value that cancels to zero
disappears silently: the counting cannot tell "someone deleted this" from
"the base assignment put it on the wrong side".

Collapse the base instead, as martinvonz suggested in #6369: recurse over
trees rather than commit ids, and reduce each recursive base to exactly one
tree. The new merge_commit_ids_no_resolve() builds the outer terms
directly, and each recursive base is collapsed by
MergedTree::collapse_conflicts(), a new method next to MergedTree::resolve():
it applies the automatic resolutions resolve() would apply, then keeps the
first side of whatever remains. The merge becomes the ordinary three-way
`adds [AB_for_X, AB_for_Y], removes [virtual_base]`, where the line nets +1
and survives. Merge base selection is unchanged.

Keeping the first side is what git's "resolve" strategy effectively does
when it picks one of several merge bases. The choice of side only affects
which diffs the outer merge sees and which borderline merges auto-resolve
versus conflict, never which content the outer merge can keep: every
parent's own value is still an add. Materializing the leftover conflicts
into markers, as git's "recursive"/"ort" strategies do, is not an option:
git never parses a conflict back, but jj round-trips conflicts through the
working copy, and a base carrying markers can produce an outer conflict
whose materialization no longer parses, leaving the next snapshot to store
the marker text as ordinary content. A resolve() variant that also resolves
down to hunk level would shrink the set of paths needing the first-side
fallback; that belongs with #4152.

Merges with a single, already-resolved merge base are unaffected.
Criss-cross merges get smaller unresolved term lists --
test_merge_criss_cross's goes from five sides to three -- while their
resolved results are unchanged. find_recursive_merge_commits() is no longer
used by the tree merge, but is left in place and still tested since it is
public API.

The merge future is boxed at the merge_commit_trees_no_resolve_without_repo()
boundary so the deeper future type doesn't reach consumers. The
custom-command example already overflowed rustc's default recursion limit
under rustc 1.98.

Fixes #6369.
Part of #7640.

Assisted-by: Opus 5 via Claude Code

# Checklist

If applicable:

- [X] I have updated `CHANGELOG.md`
- [X] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [X] I have added/updated tests to cover my changes
- [ ] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
