### PR TITLE
revset: parse nested parentheses in linear time

### DIFF
--- a/lib/src/revset.pest
+++ b/lib/src/revset.pest
@@ -111,10 +111,11 @@ primary = {
 neighbors_expression = _{ primary ~ (parents_op | children_op | compat_parents_op)* }
 
 range_expression = _{
-  neighbors_expression ~ range_ops ~ neighbors_expression
-  | neighbors_expression ~ range_post_ops
+  // The alternatives starting with neighbors_expression are factored so that it
+  // is parsed once. Spelling them out separately made a failed match re-parse
+  // the whole operand, which is exponential in the nesting depth.
+  neighbors_expression ~ (range_ops ~ neighbors_expression | range_post_ops)?
   | range_pre_ops ~ neighbors_expression
-  | neighbors_expression
   | range_all_ops
 }
 

--- a/lib/src/revset_parser.rs
+++ b/lib/src/revset_parser.rs
@@ -1554,6 +1554,17 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_deeply_nested_parentheses() {
+        // Each `range_expression` alternative used to start with
+        // `neighbors_expression`, so a failed match re-parsed the whole operand
+        // and parsing cost 3^depth. At this depth that never finishes; the
+        // factored rule parses the operand once.
+        let depth = 32;
+        let text = format!("{}root(){}", "(".repeat(depth), ")".repeat(depth));
+        assert_eq!(parse_normalized(&text), parse_normalized("root()"));
+    }
+
+    #[test]
     fn test_parse_revset_operator_combinations() {
         // Parse repeated "parents" operator
         assert_eq!(parse_normalized("foo---"), parse_normalized("((foo-)-)-"));


### PR DESCRIPTION
# Checklist

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`) — no user-facing behaviour changes, only how long parsing takes
- [ ] I have updated the config schema (`cli/src/config-schema.json`) — n/a
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does, how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with an eye towards deleting anything that is irrelevant, clarifying anything that is confusing, and adding details that are relevant.

---

A revset with about a dozen nested parentheses hangs. On a debug build of `main`:

```console
$ jj debug revset --no-resolve --no-optimize "$(python3 -c "print('('*12 + 'root()' + ')'*12)")"
# 13.2s

$ jj debug revset --no-resolve --no-optimize "$(python3 -c "print('('*14 + 'root()' + ')'*14)")"
# still running after 30s
```

`--no-resolve --no-optimize` hangs too, so this is parsing alone, not evaluation or optimization.

Four of the five `range_expression` alternatives started with `neighbors_expression`. PEG alternatives are ordered, so on an operand with no trailing range operator the parser parsed the operand in full, failed to find `::`, backtracked, parsed it again for the second alternative, failed again, then parsed it a third time for the fourth. Each nesting level cost three times the level below it — 3^depth, which matches the measured ~2.8x per level.

Factoring the common prefix so the operand is parsed once:

| depth | before | after |
|---|---|---|
| 10 | 1.5s | 0.02s |
| 12 | 13.2s | 0.02s |
| 14 | >30s | 0.02s |
| 1000 | — | 0.02s |

I found this while looking at #10071, but it is a different problem and this does not fix that one. #10071 is unbounded recursion, and it is still there: after this change a depth around 5000 still overflows the stack. This change is only about the time spent parsing.

`cargo test -p jj-lib` passes (1038 tests). The added test uses depth 32, which the old grammar does not finish — I checked that by reverting only the `.pest` change and running it, where it was still going after 180s.

One thing I could not verify locally: `cargo +nightly fmt --all -- --check`, because downloading the nightly toolchain times out here. I checked the added lines against `rustfmt.toml` by hand — the longest is 80 columns, against a `max_width` of 100 — but CI is the real check on that.
