### PR TITLE
cargo: exclude all test code from coverage instrumentation

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,21 @@
+[alias]
+# Measure code coverage with cargo-llvm-cov and nextest. Requires a nightly
+# toolchain.
+#
+# The default test-exclusion heuristics aren't quite enough for us, so we get
+# rid of a few extra things below.
+cov = [
+    "llvm-cov",
+    "--branch",
+    "nextest",
+    "--exclude-from-report",
+    "testutils",
+    "--exclude-from-report",
+    "gen-protos",
+    "--ignore-filename-regex",
+    "(cli/testing/|lib/src/(secret_backend|test_signing_backend)\\.rs|cli/build\\.rs)",
+]
+
 [target.'cfg(all(target_family = "windows", target_env = "msvc"))']
 linker = "rust-lld.exe"
 rustflags = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -182,6 +182,10 @@ while_let_loop = "warn"
 [workspace.lints.rust]
 let_underscore_drop = "warn"
 redundant_imports = "warn"
+# set by cargo-llvm-cov, see .cargo/config.toml
+unexpected_cfgs = { level = "warn", check-cfg = [
+    'cfg(coverage, coverage_nightly)',
+] }
 
 [profile.dev.package."*"]
 # Compile all dependencies with opt-level=3 to help speed up tests and

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -4820,6 +4820,7 @@ pub fn shell_quote(s: &str) -> Cow<'_, str> {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use clap::CommandFactory as _;
 

--- a/cli/src/commands/arrange.rs
+++ b/cli/src/commands/arrange.rs
@@ -669,6 +669,7 @@ fn render(
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use indoc::indoc;
     use maplit::hashset;

--- a/cli/src/commands/fix.rs
+++ b/cli/src/commands/fix.rs
@@ -591,6 +591,7 @@ fn get_tools_config(
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
 

--- a/cli/src/commands/gerrit/upload.rs
+++ b/cli/src/commands/gerrit/upload.rs
@@ -730,6 +730,7 @@ pub async fn cmd_gerrit_upload(
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
 

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -233,6 +233,7 @@ pub async fn run_command(ui: &mut Ui, command_helper: &CommandHelper) -> Result<
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
 

--- a/cli/src/commands/status.rs
+++ b/cli/src/commands/status.rs
@@ -352,6 +352,7 @@ async fn visit_collapsed_untracked_files(
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod test {
     use pollster::FutureExt as _;
     use testutils::TestRepo;

--- a/cli/src/commit_ref_list.rs
+++ b/cli/src/commit_ref_list.rs
@@ -298,6 +298,7 @@ fn sort_inner(
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use jj_lib::backend::ChangeId;
     use jj_lib::backend::MillisSinceEpoch;

--- a/cli/src/commit_templater.rs
+++ b/cli/src/commit_templater.rs
@@ -3040,6 +3040,7 @@ fn builtin_trailer_list_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use std::path::Component;
 

--- a/cli/src/complete.rs
+++ b/cli/src/complete.rs
@@ -1407,6 +1407,7 @@ mod parse {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
 

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1175,6 +1175,7 @@ impl TryFrom<Vec<String>> for NonEmptyCommandArgsVec {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use std::env::join_paths;
     use std::fmt::Write as _;

--- a/cli/src/description_util.rs
+++ b/cli/src/description_util.rs
@@ -457,6 +457,7 @@ pub fn description_template(
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use indexmap::indexmap;
     use indoc::indoc;

--- a/cli/src/formatter.rs
+++ b/cli/src/formatter.rs
@@ -798,6 +798,7 @@ fn write_sanitized(output: &mut impl Write, buf: &[u8]) -> Result<(), Error> {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use std::error::Error as _;
 

--- a/cli/src/git_util.rs
+++ b/cli/src/git_util.rs
@@ -561,6 +561,7 @@ pub fn print_push_stats(ui: &Ui, stats: &GitPushStats) -> io::Result<()> {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use std::path::MAIN_SEPARATOR;
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -12,6 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Lets items opt out of coverage instrumentation via
+// `#[cfg_attr(coverage_nightly, coverage(off))]`, which we put on every
+// `#[cfg(test)]` module so that reported numbers describe the code we ship
+// rather than the tests exercising it. `coverage_nightly` is set only by
+// cargo-llvm-cov on nightly (see `cargo cov` in .cargo/config.toml), so stable
+// builds never see the unstable feature.
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 #![deny(unused_must_use)]
 
 pub mod cleanup_guard;

--- a/cli/src/merge_tools/builtin.rs
+++ b/cli/src/merge_tools/builtin.rs
@@ -763,6 +763,7 @@ async fn apply_merge_builtin(
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use std::collections::BTreeSet;
 

--- a/cli/src/merge_tools/external.rs
+++ b/cli/src/merge_tools/external.rs
@@ -527,6 +527,7 @@ pub fn invoke_external_diff(
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
 

--- a/cli/src/merge_tools/mod.rs
+++ b/cli/src/merge_tools/mod.rs
@@ -494,6 +494,7 @@ async fn pick_conflict_side(
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use jj_lib::config::ConfigLayer;
     use jj_lib::config::ConfigSource;

--- a/cli/src/template_builder.rs
+++ b/cli/src/template_builder.rs
@@ -3097,6 +3097,7 @@ fn expect_expression_of_type<'a, L: TemplateLanguage<'a> + ?Sized, T>(
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use std::path::Component;
 

--- a/cli/src/template_parser.rs
+++ b/cli/src/template_parser.rs
@@ -828,6 +828,7 @@ pub fn lookup_method<'a, V>(
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use assert_matches::assert_matches;
     use jj_lib::dsl_util::KeywordArgument;

--- a/cli/src/text_util.rs
+++ b/cli/src/text_util.rs
@@ -602,6 +602,7 @@ pub fn parse_author(author: &str) -> Result<(String, String), &'static str> {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use std::io::Write as _;
 

--- a/core/src/conflict_labels.rs
+++ b/core/src/conflict_labels.rs
@@ -133,6 +133,7 @@ impl fmt::Debug for ConflictLabels {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
 

--- a/core/src/content_hash.rs
+++ b/core/src/content_hash.rs
@@ -171,6 +171,7 @@ where
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use std::collections::BTreeMap;
     use std::collections::HashMap;

--- a/core/src/dag_walk.rs
+++ b/core/src/dag_walk.rs
@@ -249,6 +249,7 @@ fn to_infallible_iter<T>(
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use assert_matches::assert_matches;
     use maplit::hashmap;

--- a/core/src/dag_walk_async.rs
+++ b/core/src/dag_walk_async.rs
@@ -601,6 +601,7 @@ where
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use std::pin::pin;
 

--- a/core/src/diff.rs
+++ b/core/src/diff.rs
@@ -1023,6 +1023,7 @@ pub fn diff<'a, T: AsRef<[u8]> + ?Sized + 'a>(
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
 

--- a/core/src/file_util.rs
+++ b/core/src/file_util.rs
@@ -481,6 +481,7 @@ mod fallback {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use futures::io::Cursor;
     use itertools::Itertools as _;

--- a/core/src/graph.rs
+++ b/core/src/graph.rs
@@ -346,6 +346,7 @@ where
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use std::cell::RefCell;
     use std::convert::Infallible;

--- a/core/src/hex_util.rs
+++ b/core/src/hex_util.rs
@@ -113,6 +113,7 @@ pub fn common_hex_len(bytes_a: &[u8], bytes_b: &[u8]) -> usize {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -44,6 +44,7 @@ pub mod str_util;
 pub mod symbol_util;
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use tempfile::TempDir;
 

--- a/core/src/matchers.rs
+++ b/core/src/matchers.rs
@@ -596,6 +596,7 @@ impl<M1: Matcher, M2: Matcher> Matcher for IntersectionMatcher<M1, M2> {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use maplit::hashset;
 

--- a/core/src/merge.rs
+++ b/core/src/merge.rs
@@ -711,6 +711,7 @@ impl<T> Merge<Merge<T>> {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use test_case::test_case;
 

--- a/core/src/object_id.rs
+++ b/core/src/object_id.rs
@@ -303,6 +303,7 @@ impl<T: Clone> PrefixResolution<T> {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
 

--- a/core/src/ref_name.rs
+++ b/core/src/ref_name.rs
@@ -441,6 +441,7 @@ fn is_safe_identifier(symbol: &str) -> bool {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
 

--- a/core/src/repo_path.rs
+++ b/core/src/repo_path.rs
@@ -720,6 +720,7 @@ impl<V: Debug> Debug for RepoPathTree<V> {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use std::panic;
 

--- a/core/src/str_util.rs
+++ b/core/src/str_util.rs
@@ -586,6 +586,7 @@ impl Debug for StringMatcher {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use assert_matches::assert_matches;
     use itertools::Itertools as _;

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -258,6 +258,31 @@ These are listed roughly in order of decreasing importance.
    On Linux, you may be able to speed up `nextest` even further by using
    the `mold` linker, as explained below.
 
+### Measuring code coverage
+
+Install [`cargo-llvm-cov`](https://github.com/taiki-e/cargo-llvm-cov) and
+`cargo-nextest` (see above), then run:
+
+```shell
+cargo +nightly cov          # add --html to get a browsable report
+```
+
+`cov` is an alias defined in `.cargo/config.toml` which enables a consistent
+set of options for all contributors. The nightly Rust toolchain is required (the
+compiler instrumentation feature itself is nightly only).
+
+When you are writing new test modules, make sure to turn coverage off for
+that module so it doesn't skew the resultant accounting; this can be done by
+copy/pasting the following `#[cfg_attr]` after your `#[cfg(test)]` stanza:
+
+```rust
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    // ...
+}
+```
+
 ### Configuring `jj fix` to run `rustfmt`
 
 Run this in the jj repo:

--- a/lib/src/absorb.rs
+++ b/lib/src/absorb.rs
@@ -387,6 +387,7 @@ fn to_file_value(value: MaterializedTreeValue) -> Result<Option<MaterializedFile
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use maplit::hashmap;
 

--- a/lib/src/annotate.rs
+++ b/lib/src/annotate.rs
@@ -478,6 +478,7 @@ async fn get_file_contents(
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
 

--- a/lib/src/backend.rs
+++ b/lib/src/backend.rs
@@ -890,6 +890,7 @@ impl dyn Backend {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
 

--- a/lib/src/config.rs
+++ b/lib/src/config.rs
@@ -913,6 +913,7 @@ static DEFAULT_CONFIG_LAYERS: LazyLock<[Arc<ConfigLayer>; 1]> = LazyLock::new(||
 });
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use assert_matches::assert_matches;
     use indoc::indoc;

--- a/lib/src/config_resolver.rs
+++ b/lib/src/config_resolver.rs
@@ -455,6 +455,7 @@ fn migrate_layer(
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use assert_matches::assert_matches;
     use indoc::indoc;

--- a/lib/src/conflicts.rs
+++ b/lib/src/conflicts.rs
@@ -1133,6 +1133,7 @@ pub async fn update_from_content(
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     #![expect(clippy::too_many_arguments)]
 

--- a/lib/src/default_index/bit_set.rs
+++ b/lib/src/default_index/bit_set.rs
@@ -200,6 +200,7 @@ impl AncestorsBitSet {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::super::composite::AsCompositeIndex as _;
     use super::super::mutable::DefaultMutableIndex;

--- a/lib/src/default_index/changed_path.rs
+++ b/lib/src/default_index/changed_path.rs
@@ -246,6 +246,7 @@ impl ReadonlyChangedPathIndexSegment {
     }
 
     #[cfg(test)]
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn paths(&self) -> impl ExactSizeIterator<Item = &RepoPath> {
         (0..self.num_paths).map(|pos| self.path(PathPosition(pos)))
     }
@@ -592,6 +593,7 @@ pub(super) async fn collect_changed_paths(
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use test_case::test_case;
 

--- a/lib/src/default_index/mod.rs
+++ b/lib/src/default_index/mod.rs
@@ -44,6 +44,7 @@ pub use self::store::DefaultIndexStoreError;
 pub use self::store::DefaultIndexStoreInitError;
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 #[rustversion::attr(
     since(1.89),
     expect(clippy::cloned_ref_to_slice_refs, reason = "makes tests more readable")

--- a/lib/src/default_index/rev_walk.rs
+++ b/lib/src/default_index/rev_walk.rs
@@ -682,6 +682,7 @@ pub(super) fn filter_slice_by_range<'a, T: Copy>(slice: &'a [T], range: &Range<u
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 #[rustversion::attr(
     since(1.89),
     expect(clippy::cloned_ref_to_slice_refs, reason = "makes tests more readable")

--- a/lib/src/default_index/rev_walk_queue.rs
+++ b/lib/src/default_index/rev_walk_queue.rs
@@ -110,6 +110,7 @@ impl<P: Ord, T: Ord> RevWalkQueue<P, T> {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use assert_matches::assert_matches;
 

--- a/lib/src/default_index/revset_engine.rs
+++ b/lib/src/default_index/revset_engine.rs
@@ -257,6 +257,7 @@ impl<'a, I: AsCompositeIndex> PositionsAccumulator<'a, I> {
     }
 
     #[cfg(test)]
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn consumed_len(&self) -> usize {
         self.inner.borrow().consumed_positions.len()
     }
@@ -1571,6 +1572,7 @@ async fn to_file_content(
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 #[rustversion::attr(
     since(1.89),
     expect(clippy::cloned_ref_to_slice_refs, reason = "makes tests more readable")

--- a/lib/src/dsl_util.rs
+++ b/lib/src/dsl_util.rs
@@ -947,6 +947,7 @@ where
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
 

--- a/lib/src/eol.rs
+++ b/lib/src/eol.rs
@@ -188,6 +188,7 @@ async fn convert_eol<'a>(
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use std::error::Error;
     use std::pin::Pin;

--- a/lib/src/extensions_map.rs
+++ b/lib/src/extensions_map.rs
@@ -53,6 +53,7 @@ impl ExtensionsMap {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
 

--- a/lib/src/files.rs
+++ b/lib/src/files.rs
@@ -488,6 +488,7 @@ fn resolve_diff_hunks<'input>(
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use indoc::indoc;
 

--- a/lib/src/fileset.rs
+++ b/lib/src/fileset.rs
@@ -634,6 +634,7 @@ pub fn parse_maybe_bare(
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use std::path::PathBuf;
 

--- a/lib/src/fileset_parser.rs
+++ b/lib/src/fileset_parser.rs
@@ -575,6 +575,7 @@ fn attach_aliases_err(
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use assert_matches::assert_matches;
 

--- a/lib/src/fix.rs
+++ b/lib/src/fix.rs
@@ -505,6 +505,7 @@ pub async fn get_base_commit_map(
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
 

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -3516,6 +3516,7 @@ fn to_remote_tag_ref_update(
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use assert_matches::assert_matches;
 

--- a/lib/src/git_backend.rs
+++ b/lib/src/git_backend.rs
@@ -1657,6 +1657,7 @@ recover.
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use assert_matches::assert_matches;
     use gix::date::parse::TimeBuf;

--- a/lib/src/git_subprocess.rs
+++ b/lib/src/git_subprocess.rs
@@ -914,6 +914,7 @@ fn trim_sideband_line(line: &[u8]) -> (&[u8], Option<GitSidebandLineTerminator>)
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod test {
     use std::process::ExitStatus;
 

--- a/lib/src/gitignore.rs
+++ b/lib/src/gitignore.rs
@@ -142,6 +142,7 @@ impl GitIgnoreFile {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
 
     use super::*;

--- a/lib/src/gpg_signing.rs
+++ b/lib/src/gpg_signing.rs
@@ -319,6 +319,7 @@ impl SigningBackend for GpgsmBackend {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use assert_matches::assert_matches;
 

--- a/lib/src/graph_dominators.rs
+++ b/lib/src/graph_dominators.rs
@@ -643,6 +643,7 @@ where
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use maplit::hashmap;
     use pollster::FutureExt as _;

--- a/lib/src/id_prefix.rs
+++ b/lib/src/id_prefix.rs
@@ -563,6 +563,7 @@ fn unwrap_as_short_key<const N: usize>(key_bytes: &[u8]) -> &[u8; N] {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
 

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -14,6 +14,13 @@
 
 //! Jujutsu version control system.
 
+// Lets items opt out of coverage instrumentation via
+// `#[cfg_attr(coverage_nightly, coverage(off))]`, which we put on every
+// `#[cfg(test)]` module so that reported numbers describe the code we ship
+// rather than the tests exercising it. `coverage_nightly` is set only by
+// cargo-llvm-cov on nightly (see `cargo cov` in .cargo/config.toml), so stable
+// builds never see the unstable feature.
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 #![warn(missing_docs)]
 #![deny(unused_must_use)]
 #![forbid(unsafe_code)]
@@ -116,6 +123,7 @@ pub mod workspace;
 pub mod workspace_store;
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use tempfile::TempDir;
 

--- a/lib/src/local_working_copy.rs
+++ b/lib/src/local_working_copy.rs
@@ -2958,6 +2958,7 @@ impl LockedLocalWorkingCopy {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use std::time::Duration;
 

--- a/lib/src/lock/mod.rs
+++ b/lib/src/lock/mod.rs
@@ -40,6 +40,7 @@ pub struct FileLockError {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use std::cmp::max;
     use std::fs;

--- a/lib/src/op_store.rs
+++ b/lib/src/op_store.rs
@@ -497,6 +497,7 @@ impl dyn OpStore {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use maplit::btreemap;
 

--- a/lib/src/refs.rs
+++ b/lib/src/refs.rs
@@ -233,6 +233,7 @@ pub fn classify_ref_push_action(targets: LocalAndRemoteRef) -> RefPushAction {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
     use crate::op_store::RemoteRefState;

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -3621,6 +3621,7 @@ pub fn format_remote_symbol(name: &str, remote: &str) -> String {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 #[rustversion::attr(
     since(1.89),
     expect(clippy::cloned_ref_to_slice_refs, reason = "makes tests more readable")

--- a/lib/src/revset_parser.rs
+++ b/lib/src/revset_parser.rs
@@ -824,6 +824,7 @@ fn attach_aliases_err(
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use std::collections::HashMap;
 

--- a/lib/src/secure_config.rs
+++ b/lib/src/secure_config.rs
@@ -422,6 +422,7 @@ impl SecureConfig {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use std::ffi::OsStr;
 

--- a/lib/src/settings.rs
+++ b/lib/src/settings.rs
@@ -384,6 +384,7 @@ fn parse_human_byte_size(v: &str) -> Result<u64, &'static str> {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use assert_matches::assert_matches;
 

--- a/lib/src/simple_backend.rs
+++ b/lib/src/simple_backend.rs
@@ -504,6 +504,7 @@ fn signature_from_proto(proto: crate::protos::simple_store::commit::Signature) -
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use assert_matches::assert_matches;
 

--- a/lib/src/simple_op_heads_store.rs
+++ b/lib/src/simple_op_heads_store.rs
@@ -169,6 +169,7 @@ impl OpHeadsStore for SimpleOpHeadsStore {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
 
     use std::slice;

--- a/lib/src/simple_op_store.rs
+++ b/lib/src/simple_op_store.rs
@@ -888,6 +888,7 @@ fn ref_target_to_proto(value: &RefTarget) -> Option<crate::protos::simple_op_sto
 
 #[expect(deprecated)]
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 fn ref_target_to_proto_legacy(
     value: &RefTarget,
 ) -> Option<crate::protos::simple_op_store::RefTarget> {
@@ -970,6 +971,7 @@ fn remote_ref_state_from_proto(proto_value: i32) -> Result<RemoteRefState, PostD
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use insta::assert_snapshot;
     use maplit::btreemap;

--- a/lib/src/ssh_signing.rs
+++ b/lib/src/ssh_signing.rs
@@ -312,6 +312,7 @@ impl SigningBackend for SshBackend {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use std::fs::File;
     use std::io::Read as _;

--- a/lib/src/stacked_table.rs
+++ b/lib/src/stacked_table.rs
@@ -630,6 +630,7 @@ impl TableStore {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use test_case::test_case;
 

--- a/lib/src/time_util.rs
+++ b/lib/src/time_util.rs
@@ -133,6 +133,7 @@ pub fn parse_datetime(s: &str) -> chrono::ParseResult<Timestamp> {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use assert_matches::assert_matches;
 

--- a/lib/src/trailer.rs
+++ b/lib/src/trailer.rs
@@ -137,6 +137,7 @@ fn parse_trailers_impl(body: &str) -> (Vec<Trailer>, bool, bool, Option<String>)
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use indoc::indoc;
     use pretty_assertions::assert_eq;

--- a/lib/src/ui_path.rs
+++ b/lib/src/ui_path.rs
@@ -169,6 +169,7 @@ pub fn parse_fs_path(
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use assert_matches::assert_matches;
 

--- a/lib/src/union_find.rs
+++ b/lib/src/union_find.rs
@@ -98,6 +98,7 @@ where
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use itertools::Itertools as _;
 

--- a/lib/src/view.rs
+++ b/lib/src/view.rs
@@ -680,6 +680,7 @@ pub enum RenameWorkspaceError {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
     use crate::op_store::RemoteRefState;


### PR DESCRIPTION
I have a branch where I was investigating adding many Hegel proptests across the codebase. My goal was to find bugs and see how coverage increased, but I realized in the midst of that, that we still included far too much test code itself in the coverage report generated by `cargo llvm-cov` with the default settings (and so adding more hegel tests would skew things). Fix those settings with a default we can all rely on, exclude test modules throughout the codebase from participating in coverage reports, and add some notes on how to run coverage for users (I always forget this).

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
