### PR TITLE
ci: Use '$/...' instead of './...' for github actions ci yaml file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
         persist-credentials: false
     - name: Set up Windows Builders
       if: startswith(matrix.build, 'windows-x86_64') # FIXME: aarch64 doesn't have D:\ yet
-      uses: ./.github/actions/setup-windows
+      uses: $/.github/actions/setup-windows
     - name: Install Rust
       uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
       with:


### PR DESCRIPTION
I think this is also what https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#example-using-an-action-in-the-same-repository-as-the-workflow-at-the-running-commit-recommended suggests.

This fix is auto generated by `zizmor --fix=all`. It also prints the following output:
```
help[self-repository]: use GitHub's dedicated self-repository syntax
  --> ./.github/workflows/ci.yml:80:13
   |
78 |     - name: Set up Windows Builders
   |       ----------------------------- this step
79 |       if: startswith(matrix.build, 'windows-x86_64') # FIXME: aarch64 doesn't have D:\ yet
80 |       uses: ./.github/actions/setup-windows
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ use '$/...' instead of './...'
   |
   = note: audit confidence → High
   = note: this finding has an auto-fix
```

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
