### PR TITLE
docs: add a missing comma to Zed configuration example

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -379,7 +379,7 @@ We recommend at least these settings:
   "languages": {
     // We don't use a formatter for Markdown files, so format_on_save would just
     // mess with others' docs
-    "Markdown": { "format_on_save": "off" }
+    "Markdown": { "format_on_save": "off" },
     "Rust": {
       "format_on_save": "on",
       // Avoid removing trailing spaces within multi-line string literals

--- a/web/docs/src/content/docs/contributing.mdx
+++ b/web/docs/src/content/docs/contributing.mdx
@@ -326,7 +326,7 @@ We recommend at least these settings:
   "languages": {
     // We don't use a formatter for Markdown files, so format_on_save would just
     // mess with others' docs
-    "Markdown": { "format_on_save": "off" }
+    "Markdown": { "format_on_save": "off" },
     "Rust": {
       "format_on_save": "on",
       // Avoid removing trailing spaces within multi-line string literals


### PR DESCRIPTION
Contribution guide contains recommended configuration for the Zed editor. The configuration example is missing a comma which leads to a JSON parsing failure.

Add the missing comma to the configuration example.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [ ] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
