### PR TITLE
backend: remove abstract gc() method

### DIFF
--- a/cli/examples/custom-backend/main.rs
+++ b/cli/examples/custom-backend/main.rs
@@ -14,7 +14,6 @@
 
 use std::path::Path;
 use std::pin::Pin;
-use std::time::SystemTime;
 
 use async_trait::async_trait;
 use futures::AsyncRead;
@@ -40,7 +39,6 @@ use jj_lib::backend::SymlinkId;
 use jj_lib::backend::Tree;
 use jj_lib::backend::TreeId;
 use jj_lib::git_backend::GitBackend;
-use jj_lib::index::Index;
 use jj_lib::repo::StoreFactories;
 use jj_lib::repo_path::RepoPath;
 use jj_lib::repo_path::RepoPathBuf;
@@ -207,9 +205,5 @@ impl Backend for JitBackend {
         head: &CommitId,
     ) -> BackendResult<BoxStream<'_, BackendResult<CopyRecord>>> {
         self.inner.get_copy_records(paths, root, head)
-    }
-
-    fn gc(&self, index: &dyn Index, keep_newer: SystemTime) -> BackendResult<()> {
-        self.inner.gc(index, keep_newer)
     }
 }

--- a/cli/src/commands/util/gc.rs
+++ b/cli/src/commands/util/gc.rs
@@ -62,6 +62,9 @@ pub async fn cmd_util_gc(
     repo.op_store()
         .gc(slice::from_ref(repo.op_id()), keep_newer)
         .await?;
-    repo.store().gc(repo.index(), keep_newer)?;
+    #[cfg(feature = "git")]
+    if let Ok(git_backend) = jj_lib::git::get_git_backend(repo.store()) {
+        git_backend.gc(repo.index(), keep_newer)?;
+    }
     Ok(())
 }

--- a/lib/src/backend.rs
+++ b/lib/src/backend.rs
@@ -22,7 +22,6 @@ use std::fmt::Write as _;
 use std::iter::zip;
 use std::pin::Pin;
 use std::slice;
-use std::time::SystemTime;
 
 use async_trait::async_trait;
 use chrono::TimeZone as _;
@@ -34,7 +33,6 @@ use thiserror::Error;
 use crate::conflict_labels::ConflictLabels;
 use crate::content_hash::ContentHash;
 use crate::hex_util;
-use crate::index::Index;
 use crate::merge::Merge;
 use crate::object_id::ObjectId as _;
 use crate::object_id::id_type;
@@ -873,13 +871,6 @@ pub trait Backend: Any + Send + Sync + Debug {
         root: &CommitId,
         head: &CommitId,
     ) -> BackendResult<BoxStream<'_, BackendResult<CopyRecord>>>;
-
-    /// Perform garbage collection.
-    ///
-    /// All commits found in the `index` won't be removed. In addition to that,
-    /// objects created after `keep_newer` will be preserved. This mitigates a
-    /// risk of deleting new commits created concurrently by another process.
-    fn gc(&self, index: &dyn Index, keep_newer: SystemTime) -> BackendResult<()>;
 }
 
 impl dyn Backend {

--- a/lib/src/git_backend.rs
+++ b/lib/src/git_backend.rs
@@ -1553,9 +1553,16 @@ impl Backend for GitBackend {
             .map_err(|err| BackendError::Other(err.into()))?;
         Ok(futures::stream::iter(records).boxed())
     }
+}
 
+impl GitBackend {
+    /// Perform garbage collection.
+    ///
+    /// All commits found in the `index` won't be removed. In addition to that,
+    /// objects created after `keep_newer` will be preserved. This mitigates a
+    /// risk of deleting new commits created concurrently by another process.
     #[tracing::instrument(skip(self, index))]
-    fn gc(&self, index: &dyn Index, keep_newer: SystemTime) -> BackendResult<()> {
+    pub fn gc(&self, index: &dyn Index, keep_newer: SystemTime) -> BackendResult<()> {
         let git_repo = self.lock_git_repo();
         let new_heads = index
             .all_heads_for_gc()

--- a/lib/src/secret_backend.rs
+++ b/lib/src/secret_backend.rs
@@ -16,7 +16,6 @@
 
 use std::path::Path;
 use std::pin::Pin;
-use std::time::SystemTime;
 
 use async_trait::async_trait;
 use futures::AsyncRead;
@@ -39,7 +38,6 @@ use crate::backend::SymlinkId;
 use crate::backend::Tree;
 use crate::backend::TreeId;
 use crate::git_backend::GitBackend;
-use crate::index::Index;
 use crate::object_id::ObjectId as _;
 use crate::repo_path::RepoPath;
 use crate::repo_path::RepoPathBuf;
@@ -202,9 +200,5 @@ impl Backend for SecretBackend {
         head: &CommitId,
     ) -> BackendResult<BoxStream<'_, BackendResult<CopyRecord>>> {
         self.inner.get_copy_records(paths, root, head)
-    }
-
-    fn gc(&self, index: &dyn Index, keep_newer: SystemTime) -> BackendResult<()> {
-        self.inner.gc(index, keep_newer)
     }
 }

--- a/lib/src/simple_backend.rs
+++ b/lib/src/simple_backend.rs
@@ -22,7 +22,6 @@ use std::io::Write as _;
 use std::path::Path;
 use std::path::PathBuf;
 use std::pin::Pin;
-use std::time::SystemTime;
 
 use async_trait::async_trait;
 use blake2::Blake2b512;
@@ -61,7 +60,6 @@ use crate::backend::make_root_commit;
 use crate::conflict_labels::ConflictLabels;
 use crate::content_hash::blake2b_hash;
 use crate::file_util::persist_content_addressed_temp_file;
-use crate::index::Index;
 use crate::merge::MergeBuilder;
 use crate::object_id::ObjectId;
 use crate::repo_path::RepoPath;
@@ -345,10 +343,6 @@ impl Backend for SimpleBackend {
         _head: &CommitId,
     ) -> BackendResult<BoxStream<'_, BackendResult<CopyRecord>>> {
         Ok(stream::empty().boxed())
-    }
-
-    fn gc(&self, _index: &dyn Index, _keep_newer: SystemTime) -> BackendResult<()> {
-        Ok(())
     }
 }
 

--- a/lib/src/store.rs
+++ b/lib/src/store.rs
@@ -20,7 +20,6 @@ use std::num::NonZeroUsize;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::Mutex;
-use std::time::SystemTime;
 
 use clru::CLruCache;
 use futures::AsyncRead;
@@ -38,7 +37,6 @@ use crate::backend::SigningFn;
 use crate::backend::SymlinkId;
 use crate::backend::TreeId;
 use crate::commit::Commit;
-use crate::index::Index;
 use crate::merge::Merge;
 use crate::merged_tree::MergedTree;
 use crate::repo_path::RepoPath;
@@ -250,10 +248,6 @@ impl Store {
 
     pub async fn write_symlink(&self, path: &RepoPath, contents: &str) -> BackendResult<SymlinkId> {
         self.backend.write_symlink(path, contents).await
-    }
-
-    pub fn gc(&self, index: &dyn Index, keep_newer: SystemTime) -> BackendResult<()> {
-        self.backend.gc(index, keep_newer)
     }
 
     /// Clear cached objects. Mainly intended for testing.

--- a/lib/tests/test_git_backend.rs
+++ b/lib/tests/test_git_backend.rs
@@ -170,8 +170,7 @@ fn test_gc() -> TestResult {
 
     // Empty index, but all kept by file modification time
     // (Beware that this invokes "git gc" and refs will be packed.)
-    repo.store()
-        .gc(base_index.as_index(), SystemTime::UNIX_EPOCH)?;
+    get_git_backend(&repo).gc(base_index.as_index(), SystemTime::UNIX_EPOCH)?;
     assert_eq!(
         collect_no_gc_refs(git_repo_path),
         hashset! {
@@ -191,7 +190,7 @@ fn test_gc() -> TestResult {
     let now = || SystemTime::now() + Duration::from_secs(1);
 
     // All reachable: redundant no-gc refs will be removed
-    repo.store().gc(repo.index(), now())?;
+    get_git_backend(&repo).gc(repo.index(), now())?;
     assert_eq!(
         collect_no_gc_refs(git_repo_path),
         hashset! {
@@ -210,7 +209,7 @@ fn test_gc() -> TestResult {
     mut_index.add_commit(&commit_e).block_on()?;
     mut_index.add_commit(&commit_f).block_on()?;
     mut_index.add_commit(&commit_h).block_on()?;
-    repo.store().gc(mut_index.as_index(), now())?;
+    get_git_backend(&repo).gc(mut_index.as_index(), now())?;
     assert_eq!(
         collect_no_gc_refs(git_repo_path),
         hashset! {
@@ -226,7 +225,7 @@ fn test_gc() -> TestResult {
     mut_index.add_commit(&commit_b).block_on()?;
     mut_index.add_commit(&commit_c).block_on()?;
     mut_index.add_commit(&commit_f).block_on()?;
-    repo.store().gc(mut_index.as_index(), now())?;
+    get_git_backend(&repo).gc(mut_index.as_index(), now())?;
     assert_eq!(
         collect_no_gc_refs(git_repo_path),
         hashset! {
@@ -238,7 +237,7 @@ fn test_gc() -> TestResult {
     // B|C|F are no longer reachable
     let mut mut_index = base_index.start_modification();
     mut_index.add_commit(&commit_a).block_on()?;
-    repo.store().gc(mut_index.as_index(), now())?;
+    get_git_backend(&repo).gc(mut_index.as_index(), now())?;
     assert_eq!(
         collect_no_gc_refs(git_repo_path),
         hashset! {
@@ -247,7 +246,7 @@ fn test_gc() -> TestResult {
     );
 
     // All unreachable
-    repo.store().gc(base_index.as_index(), now())?;
+    get_git_backend(&repo).gc(base_index.as_index(), now())?;
     assert_eq!(collect_no_gc_refs(git_repo_path), hashset! {});
     Ok(())
 }
@@ -300,13 +299,13 @@ fn test_gc_extra_table() -> TestResult {
     let index = repo.readonly_index().as_index();
 
     // All segments should be kept by modification time
-    repo.store().gc(index, SystemTime::UNIX_EPOCH)?;
+    get_git_backend(&repo).gc(index, SystemTime::UNIX_EPOCH)?;
     assert_eq!(collect_extra_segment_num_entries(), [3, 1]);
     assert_eq!(list_dir(&extra_path).len(), 5 + 1);
 
     // All unreachable segments should be removed
     let now = SystemTime::now() + Duration::from_secs(1);
-    repo.store().gc(index, now)?;
+    get_git_backend(&repo).gc(index, now)?;
     assert_eq!(collect_extra_segment_num_entries(), [3, 1]);
     assert_eq!(list_dir(&extra_path).len(), 2 + 1);
 

--- a/lib/testutils/src/test_backend.rs
+++ b/lib/testutils/src/test_backend.rs
@@ -22,7 +22,6 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::MutexGuard;
-use std::time::SystemTime;
 
 use async_trait::async_trait;
 use futures::AsyncRead;
@@ -50,7 +49,6 @@ use jj_lib::backend::Tree;
 use jj_lib::backend::TreeId;
 use jj_lib::backend::make_root_commit;
 use jj_lib::dag_walk::topo_order_reverse;
-use jj_lib::index::Index;
 use jj_lib::object_id::ObjectId as _;
 use jj_lib::repo_path::RepoPath;
 use jj_lib::repo_path::RepoPathBuf;
@@ -426,10 +424,6 @@ impl Backend for TestBackend {
         _head: &CommitId,
     ) -> BackendResult<BoxStream<'_, BackendResult<CopyRecord>>> {
         Ok(stream::empty().boxed())
-    }
-
-    fn gc(&self, _index: &dyn Index, _keep_newer: SystemTime) -> BackendResult<()> {
-        Ok(())
     }
 }
 


### PR DESCRIPTION
This removes the Index dependency from the backend module, which will likely help with jj-core extraction.

Garbage collection is often implementation-dependent, and the current abstraction is leaky since &dyn Index is only required by GitBackend. We might need an abstracted entry point eventually, but we can address that later.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [ ] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
