### PR TITLE
workspace forget: update the workspace store after the operation commits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed bugs
 
+* `jj workspace forget` no longer leaves a workspace without a recorded path
+  when the operation fails to commit (or the process is killed while
+  committing). Such a workspace stayed in `jj workspace list` but
+  `jj workspace root --name` failed with "Workspace has no recorded path".
+
 ## [0.45.1] - 2026-09-03
 
 This release fixes an error that prevented the new jj-core crate from being

--- a/cli/src/commands/workspace/forget.rs
+++ b/cli/src/commands/workspace/forget.rs
@@ -100,8 +100,6 @@ pub async fn cmd_workspace_forget(
         tx.repo_mut().remove_workspace(ws).await?;
     }
 
-    workspace_store.forget(&forget_ws.iter().map(|x| x.as_ref()).collect::<Vec<_>>())?;
-
     let description = if let [ws] = forget_ws.as_slice() {
         format!("forget workspace {}", ws.as_symbol())
     } else {
@@ -121,6 +119,10 @@ pub async fn cmd_workspace_forget(
             unlink_git_worktree(ui, store, subprocess_options.clone(), path)?;
         }
     }
+
+    // The store isn't part of the operation, so update it only after the
+    // operation has been committed.
+    workspace_store.forget(&forget_ws.iter().map(|x| x.as_ref()).collect::<Vec<_>>())?;
 
     Ok(())
 }

--- a/cli/tests/test_workspaces.rs
+++ b/cli/tests/test_workspaces.rs
@@ -1625,6 +1625,46 @@ fn test_workspaces_forget_multi_transaction() {
     ");
 }
 
+/// Test that a failed `workspace forget` leaves the workspace's path intact
+#[cfg(unix)]
+#[test]
+fn test_workspaces_forget_failed_operation_keeps_path() {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "main"]).success();
+    let main_dir = test_env.work_dir("main");
+    main_dir.run_jj(["workspace", "add", "../second"]).success();
+
+    // Make the operation fail to commit
+    let operations_dir = main_dir.root().join(".jj/repo/op_store/operations");
+    let original = std::fs::metadata(&operations_dir).unwrap().permissions();
+    std::fs::set_permissions(&operations_dir, std::fs::Permissions::from_mode(0o500)).unwrap();
+    let output = main_dir.run_jj(["workspace", "forget", "second"]);
+    std::fs::set_permissions(&operations_dir, original).unwrap();
+    assert!(!output.status.success(), "{output}");
+
+    // The workspace is still there and its path still resolves
+    let output = main_dir.run_jj(["workspace", "list"]);
+    insta::assert_snapshot!(output.normalize_backslash(), @"
+    default: . qpvuntsm e8849ae1 (empty) (no description set)
+    second: ../second uuqppmxq 94f41578 (empty) (no description set)
+    [EOF]
+    ");
+    let output = main_dir.run_jj(["workspace", "root", "--name", "second"]);
+    assert!(output.status.success(), "{output}");
+
+    // A forget that commits removes it
+    main_dir.run_jj(["workspace", "forget", "second"]).success();
+    let output = main_dir.run_jj(["workspace", "root", "--name", "second"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    Error: No such workspace: second
+    [EOF]
+    [exit status: 1]
+    ");
+}
+
 #[test]
 fn test_workspaces_forget_abandon_commits() {
     let test_env = TestEnvironment::default();


### PR DESCRIPTION
Found while many agents shared one colocated repository: a `jj workspace forget` killed by its caller's timeout while committing the operation left the workspace listed with no path, and only a hand edit of `.jj/repo/workspace_store/index` recovers it. Details in the commit message.

# Checklist
If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
