### PR TITLE
cli: make the Git import/export lock per-workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed bugs
 
+* In a repository with several colocated workspaces, a `jj` command in one
+  workspace no longer waits for a snapshot or checkout in progress in another
+  workspace. The lock that serializes Git HEAD import/export is now
+  per-workspace, matching the state it guards.
+
 ## [0.45.1] - 2026-09-03
 
 This release fixes an error that prevented the new jj-core crate from being

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -1013,12 +1013,20 @@ impl WorkspaceCommandEnvironment {
 
     /// Acquires a lock for Git import/export operations if the workspace is
     /// supposed to be colocated.
+    ///
+    /// The lock guards the Git HEAD (and index) of this workspace's worktree,
+    /// which is per-workspace state, so it lives in the workspace's `.jj`
+    /// directory rather than in the shared repo directory. Other Git refs are
+    /// updated concurrently by design.
     fn lock_git_import_export(
         &self,
         workspace: &Workspace,
     ) -> Result<GitImportExportLock, CommandError> {
         let lock = if self.working_copy_shared_with_git {
-            let lock_path = workspace.repo_path().join("git_import_export.lock");
+            let lock_path = workspace
+                .workspace_root()
+                .join(".jj")
+                .join("git_import_export.lock");
             Some(FileLock::lock(lock_path).map_err(|err| {
                 user_error_with_message("Failed to take lock for Git import/export", err)
             })?)

--- a/cli/tests/test_workspaces.rs
+++ b/cli/tests/test_workspaces.rs
@@ -2358,6 +2358,85 @@ fn test_workspaces_add_colocated_unborn_head() {
     assert!(!test_env.env_root().join("tertiary/file").exists());
 }
 
+/// The Git import/export lock guards a workspace's own Git HEAD, so a command
+/// holding it in one colocated workspace must not block commands in another.
+#[cfg(unix)]
+#[test]
+fn test_workspaces_colocated_git_lock_is_per_workspace() {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let mut test_env = TestEnvironment::default();
+    test_env.add_config("git.colocate = true");
+
+    // A stand-in `watchman` that blocks until released. The snapshot queries it
+    // while holding the import/export lock, so the lock stays held until then.
+    // Exiting non-zero makes jj fall back to a full scan, so the command still
+    // succeeds. Only the command that opts into `fsmonitor.backend=watchman`
+    // runs it.
+    let started = test_env.env_root().join("watchman-started");
+    let release = test_env.env_root().join("watchman-release");
+    let bin_dir = test_env.env_root().join("bin");
+    std::fs::create_dir(&bin_dir).unwrap();
+    let fake_watchman = bin_dir.join("watchman");
+    std::fs::write(
+        &fake_watchman,
+        format!(
+            "#!/bin/sh\ntouch {started}\nwhile [ ! -e {release} ]; do sleep 0.1; done\nexit 1\n",
+            started = started.display(),
+            release = release.display(),
+        ),
+    )
+    .unwrap();
+    std::fs::set_permissions(&fake_watchman, std::fs::Permissions::from_mode(0o755)).unwrap();
+    let path = std::env::join_paths(
+        std::iter::once(bin_dir).chain(std::env::split_paths(&std::env::var_os("PATH").unwrap())),
+    )
+    .unwrap();
+    test_env.add_env_var("PATH", path);
+
+    test_env
+        .run_jj_in(".", ["git", "init", "--colocate", "main"])
+        .success();
+    let main_dir = test_env.work_dir("main");
+    main_dir.write_file("file", "contents\n");
+    main_dir.run_jj(["commit", "-m", "one"]).success();
+    main_dir
+        .run_jj(["workspace", "add", "../secondary"])
+        .success();
+    let secondary_dir = test_env.work_dir("secondary");
+
+    let mut stalled = test_env.new_jj_cmd();
+    stalled
+        .current_dir(main_dir.root())
+        .args(["status", "--config=fsmonitor.backend=watchman"]);
+    let stalled = std::thread::spawn(move || stalled.output().unwrap());
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+    while !started.exists() {
+        assert!(
+            std::time::Instant::now() < deadline,
+            "the main workspace never queried watchman"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+
+    // The main workspace now holds its lock. A command in the secondary
+    // workspace must not wait for it.
+    secondary_dir
+        .run_jj_with(|cmd| {
+            cmd.timeout(std::time::Duration::from_secs(10))
+                .args(["status"])
+        })
+        .success();
+
+    std::fs::write(&release, "").unwrap();
+    let output = stalled.join().unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
 /// Returns the repo's Git HEAD: the ref name if HEAD points at a ref, or the
 /// commit id if HEAD is detached.
 fn git_head(repo: &gix::Repository) -> String {


### PR DESCRIPTION
In a repository with several colocated workspaces, a `jj` command in one workspace waited for any snapshot or checkout in progress in another. Details in the commit message.

Observed on a 125k-file repository with ~70 colocated workspaces: a `jj workspace add` held the lock for the length of its checkout (~30 s of file writes; longer with filters), and a stalled fsmonitor query in one workspace held it for the fsmonitor timeout. In both cases every `jj status` in every other workspace queued behind it.

The new test stands in a blocking `watchman` on `PATH` so the main workspace provably holds its lock, then runs `jj status` in a second workspace with a timeout. Before this change it times out; after, it returns immediately.

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does, how it works, why it is organized the way it is), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with an eye towards deleting anything that is irrelevant, clarifying anything that is confusing, and adding details that are relevant. This includes, for example, commit descriptions, PR descriptions, and code comments.
