### PR TITLE
working_copy: re-examine placeholder file states under an fsmonitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed bugs
 
+* With `fsmonitor.backend = "watchman"`, local modifications were no longer
+  detected after Git HEAD moved without the working copy being rewritten
+  (for example after `git reset --soft` or `git update-ref HEAD` in a
+  colocated repository). Snapshots now re-examine every file whose recorded
+  state was reset, whether or not the monitor reports it as changed.
+
 ## [0.45.1] - 2026-09-03
 
 This release fixes an error that prevented the new jj-core crate from being

--- a/lib/src/local_working_copy.rs
+++ b/lib/src/local_working_copy.rs
@@ -324,6 +324,13 @@ impl FileState {
         }
     }
 
+    /// Whether this state was recorded without inspecting the file on disk
+    /// (see [`FileState::placeholder`] and [`TreeState::reset`]), so the file
+    /// must be re-stat'ed on the next snapshot.
+    fn is_placeholder(&self) -> bool {
+        self.mtime == MillisSinceEpoch(0) && self.size == 0
+    }
+
     fn for_file(
         exec_bit: ExecBit,
         size: u64,
@@ -1313,9 +1320,21 @@ impl TreeState {
         } = self
             .make_fsmonitor_matcher(&self.fsmonitor_settings)
             .await?;
-        let fsmonitor_matcher = match fsmonitor_matcher.as_ref() {
-            None => &EverythingMatcher,
-            Some(fsmonitor_matcher) => fsmonitor_matcher.as_ref(),
+        // A file state recorded as a placeholder was written without looking
+        // at the file (after a reset, or when a checkout skipped the file), so
+        // it must be re-stat'ed even if the monitor has not seen the file
+        // change since its clock.
+        let fsmonitor_matcher: Box<dyn Matcher> = match fsmonitor_matcher {
+            None => Box::new(EverythingMatcher),
+            Some(fsmonitor_matcher) => {
+                let placeholder_matcher = FilesMatcher::new(
+                    self.file_states()
+                        .iter()
+                        .filter(|(_, state)| state.is_placeholder())
+                        .map(|(path, _)| path),
+                );
+                Box::new(UnionMatcher::new(fsmonitor_matcher, placeholder_matcher))
+            }
         };
 
         let matcher = IntersectionMatcher::new(

--- a/lib/tests/test_local_working_copy.rs
+++ b/lib/tests/test_local_working_copy.rs
@@ -2804,6 +2804,73 @@ fn test_fsmonitor() -> TestResult {
     Ok(())
 }
 
+/// A file state left as a placeholder by `reset()` (as importing a moved Git
+/// HEAD does, without touching the working copy) must be re-examined by the
+/// next snapshot even when the filesystem monitor reports no change for it.
+#[test]
+fn test_fsmonitor_reexamines_reset_file_states() -> TestResult {
+    let test_repo = TestRepo::init();
+    let repo = &test_repo.repo;
+    let workspace_root = test_repo.env.root().join("workspace");
+    let state_path = test_repo.env.root().join("state");
+    std::fs::create_dir(&workspace_root)?;
+    std::fs::create_dir(&state_path)?;
+    let tree_state_settings = TreeStateSettings::try_from_user_settings(repo.settings())?;
+    TreeState::init(
+        repo.store().clone(),
+        workspace_root.clone(),
+        state_path.clone(),
+        &tree_state_settings,
+    )?;
+
+    let file_path = repo_path("file");
+    testutils::write_working_copy_file(&workspace_root, file_path, "modified\n");
+
+    let snapshot = |paths: &[&RepoPath]| {
+        let changed_files = paths
+            .iter()
+            .map(|p| p.to_fs_path_unchecked(Path::new("")))
+            .collect();
+        let settings = TreeStateSettings {
+            fsmonitor_settings: FsmonitorSettings::Test { changed_files },
+            ..tree_state_settings.clone()
+        };
+        let mut tree_state = TreeState::load(
+            repo.store().clone(),
+            workspace_root.clone(),
+            state_path.clone(),
+            &settings,
+        )
+        .unwrap();
+        let (is_dirty, _) = tree_state
+            .snapshot(&empty_snapshot_options())
+            .block_on()
+            .unwrap();
+        (is_dirty, tree_state)
+    };
+
+    // The monitor reports the file, so the snapshot records its contents.
+    let (_, mut tree_state) = snapshot(&[file_path]);
+    let tree_with_modification = tree_state.current_tree().clone();
+    assert_tree_eq!(
+        tree_with_modification,
+        create_tree(repo, &[(file_path, "modified\n")])
+    );
+
+    // Reset to a tree with other contents for the file without touching the
+    // working copy, leaving a placeholder file state behind.
+    let committed_tree = create_tree(repo, &[(file_path, "committed\n")]);
+    tree_state.reset(&committed_tree).block_on()?;
+    tree_state.save()?;
+
+    // The monitor has seen no change since its clock, but the reset file
+    // must be stat'ed again, which finds the modification.
+    let (is_dirty, tree_state) = snapshot(&[]);
+    assert!(is_dirty);
+    assert_tree_eq!(*tree_state.current_tree(), tree_with_modification);
+    Ok(())
+}
+
 #[test]
 fn track_ignored_with_flag_and_fsmonitor() -> TestResult {
     let test_repo = TestRepo::init();


### PR DESCRIPTION
With `fsmonitor.backend = "watchman"`, local modifications stopped being detected after Git HEAD was moved without the working copy being rewritten. Details in the commit message.

Minimal reproduction on a colocated repository (`A` and `B` are commits that differ in `f`):

```
jj new A
echo b > f
jj status                    # M f
git update-ref HEAD B        # tree untouched
jj status                    # "Reset the working copy parent to the new Git HEAD."
                             # "The working copy has no changes."   <- f still holds b on disk
jj --config fsmonitor.backend=none status   # M f
```

Reproduced on 0.44.0 and on main. Observed in practice on a 125k-file repository where a `git reset` in a worktree hid ~90 modified files from `jj` for nine hours, across every snapshot in between, until a full scan ran.

The new lib test drives the same sequence through `TreeState::reset()` with the `Test` monitor reporting no changes; it fails on main at the `is_dirty` assertion.

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does, how it works, why it is organized the way it is), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with an eye towards deleting anything that is irrelevant, clarifying anything that is confusing, and adding details that are relevant. This includes, for example, commit descriptions, PR descriptions, and code comments.
