### PR TITLE
Add bookmarks.move-backwards={allow,deny,warn} config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   removes it, allowing colocation to be toggled after workspace
   creation.
 
+* Added config option `bookmarks.move-backwards = never/warn/always`, to control
+  the behavior of `jj bookmark move` & `jj bookmark set` on moving bookmarks
+  backwards.
+
 ### Fixed bugs
 
 ## [0.45.1] - 2026-09-03

--- a/cli/src/commands/bookmark/mod.rs
+++ b/cli/src/commands/bookmark/mod.rs
@@ -95,6 +95,14 @@ pub enum BookmarkCommand {
     Untrack(BookmarkUntrackArgs),
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum MoveBackwards {
+    Never,
+    Warn,
+    Always,
+}
+
 pub async fn cmd_bookmark(
     ui: &mut Ui,
     command: &CommandHelper,

--- a/cli/src/commands/bookmark/move.rs
+++ b/cli/src/commands/bookmark/move.rs
@@ -21,6 +21,7 @@ use jj_lib::object_id::ObjectId as _;
 use jj_lib::op_store::RefTarget;
 use jj_lib::str_util::StringExpression;
 
+use super::MoveBackwards;
 use super::is_fast_forward;
 use super::warn_unmatched_local_bookmarks;
 use crate::cli_util::CommandHelper;
@@ -121,21 +122,37 @@ pub async fn cmd_bookmark_move(
         return Ok(());
     }
 
-    if !args.allow_backwards
-        && let Some((name, _)) = fallible_find(
-            matched_bookmarks.iter(),
-            async |(_, old_target)| -> Result<_, CommandError> {
-                let is_ff = is_fast_forward(repo.as_ref(), old_target, target_commit.id()).await?;
-                Ok(!is_ff)
-            },
-        )
-        .await?
+    if let Some((name, _)) = fallible_find(
+        matched_bookmarks.iter(),
+        async |(_, old_target)| -> Result<_, CommandError> {
+            let is_ff = is_fast_forward(repo.as_ref(), old_target, target_commit.id()).await?;
+            Ok(!is_ff)
+        },
+    )
+    .await?
     {
-        return Err(user_error(format!(
-            "Refusing to move bookmark backwards or sideways: {name}",
-            name = name.as_symbol()
-        ))
-        .hinted("Use --allow-backwards to allow it."));
+        let move_backwards = if args.allow_backwards {
+            MoveBackwards::Always
+        } else {
+            workspace_command
+                .settings()
+                .get("bookmarks.move-backwards")?
+        };
+        match move_backwards {
+            MoveBackwards::Never => {
+                return Err(user_error(format!(
+                    "Refusing to move bookmark backwards or sideways: {name}",
+                    name = name.as_symbol()
+                ))
+                .hinted("Use --allow-backwards to allow it."));
+            }
+            MoveBackwards::Warn => writeln!(
+                ui.warning_default(),
+                "Moving bookmark backwards or sideways: {name}",
+                name = name.as_symbol()
+            )?,
+            MoveBackwards::Always => {}
+        }
     }
     if target_commit.is_discardable(repo.as_ref()).await? {
         writeln!(ui.warning_default(), "Target revision is empty.")?;

--- a/cli/src/commands/bookmark/set.rs
+++ b/cli/src/commands/bookmark/set.rs
@@ -21,6 +21,7 @@ use jj_lib::object_id::ObjectId as _;
 use jj_lib::op_store::RefTarget;
 use jj_lib::ref_name::RefNameBuf;
 
+use super::MoveBackwards;
 use super::is_fast_forward;
 use crate::cli_util::CommandHelper;
 use crate::cli_util::RevisionArg;
@@ -80,12 +81,29 @@ pub async fn cmd_bookmark_set(
         } else if old_target.as_normal() != Some(target_commit.id()) {
             moved_bookmark_count += 1;
         }
-        if !args.allow_backwards && !is_fast_forward(repo, old_target, target_commit.id()).await? {
-            return Err(user_error(format!(
-                "Refusing to move bookmark backwards or sideways: {name}",
-                name = name.as_symbol()
-            ))
-            .hinted("Use --allow-backwards to allow it."));
+        if !is_fast_forward(repo, old_target, target_commit.id()).await? {
+            let move_backwards = if args.allow_backwards {
+                MoveBackwards::Always
+            } else {
+                workspace_command
+                    .settings()
+                    .get("bookmarks.move-backwards")?
+            };
+            match move_backwards {
+                MoveBackwards::Never => {
+                    return Err(user_error(format!(
+                        "Refusing to move bookmark backwards or sideways: {name}",
+                        name = name.as_symbol()
+                    ))
+                    .hinted("Use --allow-backwards to allow it."));
+                }
+                MoveBackwards::Warn => writeln!(
+                    ui.warning_default(),
+                    "Moving bookmark backwards or sideways: {name}",
+                    name = name.as_symbol()
+                )?,
+                MoveBackwards::Always => {}
+            }
         }
     }
     if target_commit.is_discardable(repo).await? {

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -1266,6 +1266,22 @@
                 "$comment": "https://json-schema.org/understanding-json-schema/structuring#recursion",
                 "$ref": "#"
             }
+        },
+        "bookmarks": {
+            "type": "object",
+            "description": "Settings related to bookmarks",
+            "properties": {
+                "move-backwards": {
+                    "type": "string",
+                    "description": "Whether to allow moving bookmarks backwards or sideways by default",
+                    "enum": [
+                        "never",
+                        "warn",
+                        "always"
+                    ],
+                    "default": "never"
+                }
+            }
         }
     }
 }

--- a/cli/src/config/misc.toml
+++ b/cli/src/config/misc.toml
@@ -8,6 +8,9 @@ ci = ["commit"]
 desc = ["describe"]
 st = ["status"]
 
+[bookmarks]
+move-backwards = "deny"
+
 [diff.color-words]
 conflict = "materialize"
 max-inline-alternation = 3

--- a/cli/tests/test_bookmark_command.rs
+++ b/cli/tests/test_bookmark_command.rs
@@ -593,6 +593,92 @@ fn test_bookmark_move_conflicting() {
 }
 
 #[test]
+fn test_bookmark_set_backwards() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    work_dir.run_jj(["new"]).success();
+    work_dir
+        .run_jj(["bookmark", "set", "--revision", "@", "foo"])
+        .success();
+
+    let output = work_dir.run_jj(["bookmark", "set", "-r@-", "foo"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    Error: Refusing to move bookmark backwards or sideways: foo
+    Hint: Use --allow-backwards to allow it.
+    [EOF]
+    [exit status: 1]
+    ");
+
+    test_env.add_config("bookmarks.move-backwards = 'always'");
+    let output = work_dir.run_jj(["bookmark", "set", "-r@-", "foo"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    Warning: Target revision is empty.
+    Moved 1 bookmarks to qpvuntsm e8849ae1 foo | (empty) (no description set)
+    [EOF]
+    ");
+
+    work_dir
+        .run_jj(["bookmark", "set", "--revision", "@", "foo"])
+        .success();
+    test_env.add_config("bookmarks.move-backwards = 'warn'");
+    let output = work_dir.run_jj(["bookmark", "set", "-r@-", "foo"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    Warning: Moving bookmark backwards or sideways: foo
+    Warning: Target revision is empty.
+    Moved 1 bookmarks to qpvuntsm e8849ae1 foo | (empty) (no description set)
+    [EOF]
+    ");
+}
+
+#[test]
+fn test_bookmark_move_backwards() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    work_dir.run_jj(["new"]).success();
+    work_dir
+        .run_jj(["bookmark", "set", "--revision", "@", "foo"])
+        .success();
+
+    let output = work_dir.run_jj(["bookmark", "move", "-t@-", "foo"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    Error: Refusing to move bookmark backwards or sideways: foo
+    Hint: Use --allow-backwards to allow it.
+    [EOF]
+    [exit status: 1]
+    ");
+
+    test_env.add_config("bookmarks.move-backwards = 'always'");
+    let output = work_dir.run_jj(["bookmark", "move", "-t@-", "foo"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    Warning: Target revision is empty.
+    Moved 1 bookmarks to qpvuntsm e8849ae1 foo | (empty) (no description set)
+    [EOF]
+    ");
+
+    work_dir
+        .run_jj(["bookmark", "move", "--to", "@", "foo"])
+        .success();
+    test_env.add_config("bookmarks.move-backwards = 'warn'");
+    let output = work_dir.run_jj(["bookmark", "move", "-t@-", "foo"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    Warning: Moving bookmark backwards or sideways: foo
+    Warning: Target revision is empty.
+    Moved 1 bookmarks to qpvuntsm e8849ae1 foo | (empty) (no description set)
+    [EOF]
+    ");
+}
+
+#[test]
 fn test_bookmark_rename() {
     let test_env = TestEnvironment::default();
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();

--- a/docs/bookmarks.md
+++ b/docs/bookmarks.md
@@ -162,6 +162,13 @@ met:
 You could describe the updates as following along the change-id of the
 current bookmark commit, even if it isn't entirely accurate.
 
+### Manually moving bookmarks
+
+Bookmarks can be moved using `jj bookmark move foo --to xyz`.
+Moving backwards or sideways is prevented by default - you can either specify
+`jj bookmark move foo --to xyz --allow-backwards` for a one-off command, or set the config
+option `bookmarks.move-backwards` to one of `never`, `warn`, or `always`.
+
 ## Pushing bookmarks: Safety checks
 
 Before `jj git push` actually moves, creates, or deletes a remote bookmark, it

--- a/docs/config.md
+++ b/docs/config.md
@@ -1074,6 +1074,23 @@ echo "args: $@"
 > Note: Shebangs (e.g. `#!/usr/bin/env`) aren't necessary since you're already
 > explicitly passing your script into the right shell.
 
+## Bookmarks
+
+Bookmarks can be moved using `jj bookmark set` or `jj bookmark move`.
+The default behavior when moving bookmarks sideways or backwards is controlled
+via `bookmarks.move-backwards`. It defaults to `never`.
+
+```toml
+[bookmarks]
+# Prevent moving backwards or sideways.
+# Can be overridden with `--allow-backwards`.
+move-backwards = "never"
+# Allow moving backwards or sideways, but warn on stderr.
+move-backwards = "warn"
+# Allow moving backwards or sideways.
+move-backwards = "always"
+```
+
 ## Editor
 
 The default editor is set via `ui.editor`, though there are several places to


### PR DESCRIPTION
See https://github.com/jj-vcs/jj/issues/8808

Just a draft at the moment, I wanted to confirm this is something we want first.

Stuff to fix before merge

- [ ] If you set `bookmarks.move-backwards=warn` and use `jj bookmark move` to move multiple bookmarks backwards, it only warns about the first one but moves all of them
- [ ] don't know if we should reduce some of the duplication between move.rs & set.rs ?
- [ ] Is `bookmarks.move-backwards` the appropriate place?  We don't currently have a `bookmarks` namespace.
- [ ] Previously, if `--allow-backwards` was set, it wouldn't bother scanning the history to check if a move was a fast-forward or not. Now it always scans, just because the code was slightly simpler that way. Is that a potentially expensive operation I should try & avoid?
- [ ] Sanity check my code. First time writing rust, be gentle 🙂


# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [x] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
