### PR TITLE
git-lfs: make `gitattributes` module gated on `git` feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -331,7 +331,7 @@ jobs:
           fi
         env:
           # This limit *can* be raised, we just want to be aware if we exceed it
-          TOTAL_DEP_LIMIT: 555
+          TOTAL_DEP_LIMIT: 550
 
   # Block the merge if required checks fail, but only in the merge
   # queue. See also `required-checks-hack.yml`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1387,7 +1387,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb3790fd8981cba7949f1ba924ef865d902df731627bc5998d14164063892fce"
 dependencies = [
  "gix-actor",
- "gix-attributes 0.34.0",
+ "gix-attributes",
  "gix-command",
  "gix-commitgraph",
  "gix-config",
@@ -1396,10 +1396,10 @@ dependencies = [
  "gix-dir",
  "gix-discover",
  "gix-error",
- "gix-features 0.49.0",
+ "gix-features",
  "gix-filter",
  "gix-fs",
- "gix-glob 0.27.0",
+ "gix-glob",
  "gix-hash",
  "gix-hashtable",
  "gix-ignore",
@@ -1447,30 +1447,13 @@ dependencies = [
 
 [[package]]
 name = "gix-attributes"
-version = "0.33.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39b40888d0ed415c0744a6cdc61eebf0304c9d26ab726725b718443c322e5ba4"
-dependencies = [
- "bstr",
- "gix-glob 0.26.1",
- "gix-path",
- "gix-quote",
- "gix-trace",
- "kstring",
- "smallvec",
- "thiserror 2.0.20",
- "unicode-bom",
-]
-
-[[package]]
-name = "gix-attributes"
 version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c31c593692ebdc1e38858d9a2b56f6a594c501e24a38971fe6685571f5a07be0"
 dependencies = [
  "bstr",
- "gix-features 0.49.0",
- "gix-glob 0.27.0",
+ "gix-features",
+ "gix-glob",
  "gix-path",
  "gix-quote",
  "gix-trace",
@@ -1532,8 +1515,8 @@ checksum = "103d11bef95c467577ecfa8b7b86a22e65af3507b2c9bfa3809a4afbae7df301"
 dependencies = [
  "bstr",
  "gix-config-value",
- "gix-features 0.49.0",
- "gix-glob 0.27.0",
+ "gix-features",
+ "gix-glob",
  "gix-path",
  "gix-ref",
  "gix-sec",
@@ -1575,7 +1558,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fee7d89a3c507491cdfc57a1d1e0e300214720b4f7709ebc253e422f99822bfc"
 dependencies = [
  "bstr",
- "gix-attributes 0.34.0",
+ "gix-attributes",
  "gix-command",
  "gix-filter",
  "gix-fs",
@@ -1638,16 +1621,6 @@ dependencies = [
 
 [[package]]
 name = "gix-features"
-version = "0.48.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1849ae154d38bc403185be14fa871e38e3c93ee606875d94e207fdb9fba52dbc"
-dependencies = [
- "gix-trace",
- "libc",
-]
-
-[[package]]
-name = "gix-features"
 version = "0.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20aa09e83a48dc02c5f5f08578aa79d3ab1bab4618b8c362f88684645a02bdcc"
@@ -1673,7 +1646,7 @@ checksum = "5e7b5dbf524d97e839f642930c76d7f011c0791e7d11d8148989ac5af7c76aa8"
 dependencies = [
  "bstr",
  "encoding_rs",
- "gix-attributes 0.34.0",
+ "gix-attributes",
  "gix-command",
  "gix-hash",
  "gix-object",
@@ -1693,22 +1666,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "865cf13fcaf5455220546cb9607c416bd1be9a6caafd143655a362fdeab64e80"
 dependencies = [
  "bstr",
- "gix-features 0.49.0",
+ "gix-features",
  "gix-path",
  "gix-utils",
  "thiserror 2.0.20",
-]
-
-[[package]]
-name = "gix-glob"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1fcb8ef5b16bcf874abe9b68d8abb3c0493c876d367ab824151f30a0f3f3756"
-dependencies = [
- "bitflags 2.13.1",
- "bstr",
- "gix-features 0.48.1",
- "gix-path",
 ]
 
 [[package]]
@@ -1719,7 +1680,7 @@ checksum = "421e92a711554fa5827d1b0599d3389acdd0f6729e97a8c5a57d79af1e50bf36"
 dependencies = [
  "bitflags 2.13.1",
  "bstr",
- "gix-features 0.49.0",
+ "gix-features",
  "gix-path",
 ]
 
@@ -1730,7 +1691,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13adaa73415fd6c902310923f68d0b98e8cecf14b33ea58c02cc387cee56f54e"
 dependencies = [
  "faster-hex",
- "gix-features 0.49.0",
+ "gix-features",
  "sha1-checked",
  "sha2 0.11.0",
  "thiserror 2.0.20",
@@ -1754,7 +1715,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12cff8e8aa125e39377456073e63df3334d9e5741372ddcc226198015076dda2"
 dependencies = [
  "bstr",
- "gix-glob 0.27.0",
+ "gix-glob",
  "gix-path",
  "gix-trace",
  "unicode-bom",
@@ -1781,7 +1742,7 @@ dependencies = [
  "filetime",
  "fnv",
  "gix-bitmap",
- "gix-features 0.49.0",
+ "gix-features",
  "gix-fs",
  "gix-hash",
  "gix-lock",
@@ -1818,7 +1779,7 @@ dependencies = [
  "bstr",
  "gix-actor",
  "gix-date",
- "gix-features 0.49.0",
+ "gix-features",
  "gix-hash",
  "gix-hashtable",
  "gix-utils",
@@ -1835,7 +1796,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8dd494ffb5037e62b8220109e894d2861ff2150a2cacbfccdba57ae1ebab2b96"
 dependencies = [
  "arc-swap",
- "gix-features 0.49.0",
+ "gix-features",
  "gix-fs",
  "gix-hash",
  "gix-hashtable",
@@ -1859,7 +1820,7 @@ dependencies = [
  "clru",
  "gix-chunk",
  "gix-error",
- "gix-features 0.49.0",
+ "gix-features",
  "gix-hash",
  "gix-hashtable",
  "gix-object",
@@ -1903,9 +1864,9 @@ checksum = "49f6fa5f8007f008187c3f60b4373209ca83d1cc947f35ede03e16cd15a4d137"
 dependencies = [
  "bitflags 2.13.1",
  "bstr",
- "gix-attributes 0.34.0",
+ "gix-attributes",
  "gix-config-value",
- "gix-glob 0.27.0",
+ "gix-glob",
  "gix-path",
  "thiserror 2.0.20",
 ]
@@ -1919,7 +1880,7 @@ dependencies = [
  "bisync",
  "bstr",
  "gix-date",
- "gix-features 0.49.0",
+ "gix-features",
  "gix-hash",
  "gix-ref",
  "gix-shallow",
@@ -1947,7 +1908,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eeb0c90a8f6202ceaaa22996cbf837c943ccb2d8af9ff3490f0758305e6b7883"
 dependencies = [
  "gix-actor",
- "gix-features 0.49.0",
+ "gix-features",
  "gix-fs",
  "gix-hash",
  "gix-lock",
@@ -1968,7 +1929,7 @@ checksum = "7406282cc0259b51f6aee299ca3d31279a020530363152a2e6c96e8a7f7bbc83"
 dependencies = [
  "bstr",
  "gix-error",
- "gix-glob 0.27.0",
+ "gix-glob",
  "gix-hash",
  "gix-revision",
  "gix-validate",
@@ -2043,7 +2004,7 @@ dependencies = [
  "filetime",
  "gix-diff",
  "gix-dir",
- "gix-features 0.49.0",
+ "gix-features",
  "gix-filter",
  "gix-fs",
  "gix-hash",
@@ -2100,7 +2061,7 @@ checksum = "3f36d045b840f8aeee1a527e677eab1fbebfbbe94bf2e708fa81d0b4b742d5fc"
 dependencies = [
  "bstr",
  "gix-command",
- "gix-features 0.49.0",
+ "gix-features",
  "gix-packetline",
  "gix-path",
  "gix-quote",
@@ -2167,10 +2128,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31eb8e675122e83585e461fe28f68ff8c5ed55b49017b697e7e76423ff973424"
 dependencies = [
  "bstr",
- "gix-attributes 0.34.0",
- "gix-features 0.49.0",
+ "gix-attributes",
+ "gix-features",
  "gix-fs",
- "gix-glob 0.27.0",
+ "gix-glob",
  "gix-hash",
  "gix-ignore",
  "gix-index",
@@ -2186,7 +2147,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc47372fc12b9fbea51b257bcc8d4970326cf5c7e42135bbfb5d72871bb30bd4"
 dependencies = [
  "bstr",
- "gix-features 0.49.0",
+ "gix-features",
  "gix-filter",
  "gix-fs",
  "gix-index",
@@ -2203,9 +2164,9 @@ version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b088c8724e7be120c4798dd86925cf05332c9d356a463542578600c50c7a549"
 dependencies = [
- "gix-attributes 0.34.0",
+ "gix-attributes",
  "gix-error",
- "gix-features 0.49.0",
+ "gix-features",
  "gix-filter",
  "gix-fs",
  "gix-hash",
@@ -2731,7 +2692,6 @@ dependencies = [
  "eyre",
  "futures 0.3.34",
  "gix",
- "gix-attributes 0.33.2",
  "gix-ignore",
  "globset",
  "hashbrown 0.17.1",
@@ -2856,15 +2816,6 @@ dependencies = [
  "hashbrown 0.16.1",
  "portable-atomic",
  "thiserror 2.0.20",
-]
-
-[[package]]
-name = "kstring"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "558bf9508a558512042d3095138b1f7b8fe90c5467d94f9f1da28b3731c5dbd1"
-dependencies = [
- "static_assertions",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,6 @@ gix = { version = "0.86.0", default-features = false, features = [
     "sha1",
     "sha256",
 ] }
-gix-attributes = "0.33.1"
 gix-ignore = { version = "0.22.0" }
 globset = "0.4.18"
 hashbrown = { version = "0.17.1", default-features = false, features = ["inline-more"] }

--- a/cli/src/command_error.rs
+++ b/cli/src/command_error.rs
@@ -34,6 +34,7 @@ use jj_lib::fileset::FilePatternParseError;
 use jj_lib::fileset::FilesetParseError;
 use jj_lib::fileset::FilesetParseErrorKind;
 use jj_lib::fix::FixError;
+#[cfg(feature = "git")]
 use jj_lib::gitattributes::GitAttributesError;
 use jj_lib::gitignore::GitIgnoreError;
 use jj_lib::index::IndexError;
@@ -714,6 +715,7 @@ impl From<GitIgnoreError> for CommandError {
     }
 }
 
+#[cfg(feature = "git")]
 impl From<GitAttributesError> for CommandError {
     fn from(err: GitAttributesError) -> Self {
         user_error_with_message("Failed to process .gitattributes.", err)

--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -100,12 +100,15 @@ impl From<RunError> for CommandError {
     }
 }
 
-fn default_tree_state_settings(ignore_filters: &HashSet<String>) -> TreeStateSettings {
+fn default_tree_state_settings(
+    #[cfg(feature = "git")] ignore_filters: &HashSet<String>,
+) -> TreeStateSettings {
     TreeStateSettings {
         conflict_marker_style: ConflictMarkerStyle::Snapshot,
         eol_conversion_mode: EolConversionMode::None,
         exec_change_setting: ExecChangeSetting::Auto,
         fsmonitor_settings: FsmonitorSettings::None,
+        #[cfg(feature = "git")]
         ignore_filters: ignore_filters.clone(),
     }
 }
@@ -168,6 +171,7 @@ struct WorkspacePool {
     /// When true, wipe each slot's working copy on acquisition so every commit
     /// starts from a freshly checked-out tree (no artifact reuse).
     clean: bool,
+    #[cfg(feature = "git")]
     ignore_filters: HashSet<String>,
 }
 
@@ -177,7 +181,7 @@ impl WorkspacePool {
         size: NonZeroUsize,
         auto_tracking_matcher: Box<dyn Matcher>,
         clean: bool,
-        ignore_filters: HashSet<String>,
+        #[cfg(feature = "git")] ignore_filters: HashSet<String>,
     ) -> Result<Self, RunError> {
         // The parent() call is needed to not write under `.jj/repo/`.
         let base_path = repo_path.parent().unwrap().join("run").join("default");
@@ -187,6 +191,7 @@ impl WorkspacePool {
             size,
             auto_tracking_matcher,
             clean,
+            #[cfg(feature = "git")]
             ignore_filters,
         })
     }
@@ -214,7 +219,10 @@ impl WorkspacePool {
         let tree_state_path = state_dir.join("tree_state");
 
         let is_reused_workspace = tree_state_path.exists();
-        let settings = default_tree_state_settings(&self.ignore_filters);
+        let settings = default_tree_state_settings(
+            #[cfg(feature = "git")]
+            &self.ignore_filters,
+        );
         let mut tree_state = if !self.clean && is_reused_workspace {
             // Load the persisted tree state so `check_out` below can diff
             // against it, only touching files that changed and removing files
@@ -761,19 +769,13 @@ pub async fn cmd_run(
 
     let store = workspace_command.repo().store().clone();
     let auto_tracking_matcher = workspace_command.auto_tracking_matcher(ui)?;
+    #[cfg(feature = "git")]
     let ignore_filters = {
-        #[cfg(feature = "git")]
-        {
-            use jj_lib::git::GitSettings;
-            GitSettings::from_settings(workspace_command.settings())?
-                .ignore_filters
-                .into_iter()
-                .collect()
-        }
-        #[cfg(not(feature = "git"))]
-        {
-            HashSet::new()
-        }
+        use jj_lib::git::GitSettings;
+        GitSettings::from_settings(workspace_command.settings())?
+            .ignore_filters
+            .into_iter()
+            .collect()
     };
     let mut tx = workspace_command.start_transaction();
 
@@ -791,6 +793,7 @@ pub async fn cmd_run(
         jobs,
         auto_tracking_matcher,
         args.clean,
+        #[cfg(feature = "git")]
         ignore_filters,
     )?);
 

--- a/cli/src/merge_tools/diff_working_copies.rs
+++ b/cli/src/merge_tools/diff_working_copies.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+#[cfg(feature = "git")]
 use std::collections::HashSet;
 use std::fs::File;
 use std::io;
@@ -157,7 +158,7 @@ pub(crate) async fn check_out_trees(
     matcher: &dyn Matcher,
     diff_type: DiffType,
     conflict_marker_style: ConflictMarkerStyle,
-    ignore_filters: HashSet<String>,
+    #[cfg(feature = "git")] ignore_filters: HashSet<String>,
 ) -> Result<DiffWorkingCopies, DiffCheckoutError> {
     let store = trees.before.store();
     let changed_files: Vec<_> = trees
@@ -181,6 +182,7 @@ pub(crate) async fn check_out_trees(
             eol_conversion_mode: EolConversionMode::None,
             exec_change_setting: ExecChangeSetting::Auto,
             fsmonitor_settings: FsmonitorSettings::None,
+            #[cfg(feature = "git")]
             ignore_filters: ignore_filters.clone(),
         };
         let mut state = TreeState::init(store.clone(), wc_path, state_dir, &tree_state_settings)?;
@@ -217,13 +219,14 @@ impl DiffEditWorkingCopies {
         diff_type: DiffType,
         instructions: Option<&str>,
         conflict_marker_style: ConflictMarkerStyle,
-        ignore_filters: HashSet<String>,
+        #[cfg(feature = "git")] ignore_filters: HashSet<String>,
     ) -> Result<Self, DiffEditError> {
         let working_copies = check_out_trees(
             trees,
             matcher,
             diff_type,
             conflict_marker_style,
+            #[cfg(feature = "git")]
             ignore_filters,
         )
         .await?;

--- a/cli/src/merge_tools/external.rs
+++ b/cli/src/merge_tools/external.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+#[cfg(feature = "git")]
 use std::collections::HashSet;
 use std::io;
 use std::io::Write;
@@ -388,7 +389,7 @@ pub async fn edit_diff_external(
     instructions: Option<&str>,
     base_ignores: Arc<GitIgnoreFile>,
     default_conflict_marker_style: ConflictMarkerStyle,
-    ignore_filters: HashSet<String>,
+    #[cfg(feature = "git")] ignore_filters: HashSet<String>,
 ) -> Result<MergedTree, DiffEditError> {
     let conflict_marker_style = editor
         .conflict_marker_style
@@ -406,6 +407,7 @@ pub async fn edit_diff_external(
         diff_type,
         instructions,
         conflict_marker_style,
+        #[cfg(feature = "git")]
         ignore_filters,
     )
     .await?;

--- a/cli/src/merge_tools/mod.rs
+++ b/cli/src/merge_tools/mod.rs
@@ -16,6 +16,7 @@ mod builtin;
 mod diff_working_copies;
 mod external;
 
+#[cfg(feature = "git")]
 use std::collections::HashSet;
 use std::sync::Arc;
 
@@ -235,6 +236,7 @@ pub fn get_external_tool_config(
 pub struct DiffEditor {
     tool: DiffEditTool,
     base_ignores: Arc<GitIgnoreFile>,
+    #[cfg(feature = "git")]
     ignore_filters: HashSet<String>,
     use_instructions: bool,
     conflict_marker_style: ConflictMarkerStyle,
@@ -285,23 +287,18 @@ impl DiffEditor {
                 tool_name: name.to_string(),
             });
         }
+        #[cfg(feature = "git")]
         let ignore_filters = {
-            #[cfg(feature = "git")]
-            {
-                use jj_lib::git::GitSettings;
-                GitSettings::from_settings(settings)?
-                    .ignore_filters
-                    .into_iter()
-                    .collect()
-            }
-            #[cfg(not(feature = "git"))]
-            {
-                HashSet::new()
-            }
+            use jj_lib::git::GitSettings;
+            GitSettings::from_settings(settings)?
+                .ignore_filters
+                .into_iter()
+                .collect()
         };
         Ok(Self {
             tool,
             base_ignores,
+            #[cfg(feature = "git")]
             ignore_filters,
             use_instructions: settings.get_bool("ui.diff-instructions")?,
             conflict_marker_style,
@@ -332,6 +329,7 @@ impl DiffEditor {
                     instructions.as_deref(),
                     self.base_ignores.clone(),
                     self.conflict_marker_style,
+                    #[cfg(feature = "git")]
                     self.ignore_filters.clone(),
                 )
                 .await

--- a/cli/tests/test_diffedit_command.rs
+++ b/cli/tests/test_diffedit_command.rs
@@ -18,6 +18,7 @@ use testutils::TestResult;
 
 use crate::common::TestEnvironment;
 
+#[cfg(feature = "git")]
 #[test]
 fn test_diffedit_gitattributes_filter_in_temp_snapshot() -> TestResult {
     let mut test_env = TestEnvironment::default();

--- a/cli/tests/test_run_command.rs
+++ b/cli/tests/test_run_command.rs
@@ -66,6 +66,7 @@ fn test_run_simple() {
     insta::assert_snapshot!(stdout, @"xxxx[EOF]");
 }
 
+#[cfg(feature = "git")]
 #[test]
 fn test_run_gitattributes_filter_in_temp_snapshot() {
     let test_env = TestEnvironment::default();

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -42,7 +42,6 @@ etcetera = { workspace = true }
 futures = { workspace = true }
 gix = { workspace = true, optional = true }
 gix-ignore = { workspace = true }
-gix-attributes = { workspace = true }
 globset = { workspace = true }
 hashbrown = { workspace = true }
 indexmap = { workspace = true }

--- a/lib/src/gitattributes.rs
+++ b/lib/src/gitattributes.rs
@@ -51,11 +51,11 @@ use std::sync::Mutex;
 use futures::AsyncRead;
 use futures::AsyncReadExt as _;
 use futures::io::AllowStdIo;
-use gix_attributes::Search;
-use gix_attributes::State;
-use gix_attributes::glob::pattern::Case;
-use gix_attributes::search::MetadataCollection;
-use gix_attributes::search::Outcome;
+use gix::attrs::Search;
+use gix::attrs::State;
+use gix::attrs::glob::pattern::Case;
+use gix::attrs::search::MetadataCollection;
+use gix::attrs::search::Outcome;
 
 use crate::backend::TreeValue;
 use crate::merge::SameChange;
@@ -463,7 +463,7 @@ pub struct GitAttributesError {
 mod tests {
 
     use futures::io::Cursor;
-    use gix_attributes::state::Value;
+    use gix::attrs::state::Value;
     use indoc::indoc;
     use pollster::FutureExt as _;
 

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -64,6 +64,7 @@ pub mod git;
 pub mod git_backend;
 #[cfg(feature = "git")]
 mod git_subprocess;
+#[cfg(feature = "git")]
 pub mod gitattributes;
 pub mod gitignore;
 pub mod gpg_signing;

--- a/lib/src/local_working_copy.rs
+++ b/lib/src/local_working_copy.rs
@@ -94,9 +94,13 @@ use crate::fsmonitor::WatchmanConfig;
 use crate::fsmonitor::watchman;
 #[cfg(feature = "git")]
 use crate::git::GitSettings;
+#[cfg(feature = "git")]
 use crate::gitattributes::DiskFileLoader;
+#[cfg(feature = "git")]
 use crate::gitattributes::GitAttributes;
+#[cfg(feature = "git")]
 use crate::gitattributes::SearchPriority;
+#[cfg(feature = "git")]
 use crate::gitattributes::TreeFileLoader;
 use crate::gitignore::GitIgnoreFile;
 use crate::lock::FileLock;
@@ -983,6 +987,7 @@ pub struct TreeStateSettings {
 
     /// Names of .gitattributes filters whose matching files should be ignored
     /// in the working copy.
+    #[cfg(feature = "git")]
     pub ignore_filters: HashSet<String>,
 }
 
@@ -994,19 +999,11 @@ impl TreeStateSettings {
             eol_conversion_mode: EolConversionMode::try_from_settings(user_settings)?,
             exec_change_setting: user_settings.get("working-copy.exec-bit-change")?,
             fsmonitor_settings: FsmonitorSettings::from_settings(user_settings)?,
-            ignore_filters: {
-                #[cfg(feature = "git")]
-                {
-                    GitSettings::from_settings(user_settings)?
-                        .ignore_filters
-                        .into_iter()
-                        .collect()
-                }
-                #[cfg(not(feature = "git"))]
-                {
-                    HashSet::new()
-                }
-            },
+            #[cfg(feature = "git")]
+            ignore_filters: GitSettings::from_settings(user_settings)?
+                .ignore_filters
+                .into_iter()
+                .collect(),
         })
     }
 }
@@ -1032,6 +1029,7 @@ pub struct TreeState {
     fsmonitor_settings: FsmonitorSettings,
     target_eol_strategy: TargetEolStrategy,
 
+    #[cfg(feature = "git")]
     ignore_filters: HashSet<String>,
 }
 
@@ -1106,14 +1104,16 @@ impl TreeState {
             eol_conversion_mode,
             exec_change_setting,
             fsmonitor_settings,
-            ignore_filters: settings_ignore_filters,
+            #[cfg(feature = "git")]
+            ignore_filters,
         }: &TreeStateSettings,
     ) -> Self {
         let exec_policy = ExecChangePolicy::new(*exec_change_setting, &state_path);
 
-        // Only enable ignore filters when using Git.
+        // Only enable ignore filters when using Git in the current repo with the Git feature on
+        #[cfg(feature = "git")]
         let ignore_filters = if store.backend().name() == "git" {
-            settings_ignore_filters.clone()
+            ignore_filters.clone()
         } else {
             HashSet::new()
         };
@@ -1132,6 +1132,7 @@ impl TreeState {
             exec_policy,
             fsmonitor_settings: fsmonitor_settings.clone(),
             target_eol_strategy: TargetEolStrategy::new(*eol_conversion_mode),
+            #[cfg(feature = "git")]
             ignore_filters,
         }
     }
@@ -1366,6 +1367,7 @@ impl TreeState {
         let (untracked_paths_tx, untracked_paths_rx) = channel();
         let (invalid_utf8_paths_tx, invalid_utf8_paths_rx) = channel();
         let (deleted_files_tx, deleted_files_rx) = channel();
+        #[cfg(feature = "git")]
         let git_attributes = Arc::new(GitAttributes::new(
             TreeFileLoader::new(self.tree.clone()),
             DiskFileLoader::new(self.working_copy_path.clone()),
@@ -1387,7 +1389,9 @@ impl TreeState {
                 error: OnceLock::new(),
                 progress: *progress,
                 max_new_file_size: *max_new_file_size,
+                #[cfg(feature = "git")]
                 git_attributes,
+                #[cfg(feature = "git")]
                 ignore_filters: self.ignore_filters.clone(),
             };
             let directory_to_visit = DirectoryToVisit {
@@ -1565,7 +1569,9 @@ struct FileSnapshotter<'a> {
     progress: Option<&'a SnapshotProgress<'a>>,
     max_new_file_size: u64,
 
+    #[cfg(feature = "git")]
     git_attributes: Arc<GitAttributes>,
+    #[cfg(feature = "git")]
     ignore_filters: HashSet<String>,
 }
 
@@ -1714,6 +1720,7 @@ impl FileSnapshotter<'_> {
             if let Some(progress) = self.progress {
                 progress(&path);
             }
+            #[cfg(feature = "git")]
             if self
                 .git_attributes
                 .filter_matches(&path, &self.ignore_filters, SearchPriority::Disk)
@@ -1722,8 +1729,9 @@ impl FileSnapshotter<'_> {
                 // Skip gitattributes files that we want to ignore - this
                 // would result in them showing up as deleted, but we also
                 // omit them in `emit_deleted_files` to avoid that.
-                Ok(None)
-            } else if maybe_current_file_state.is_none()
+                return Ok(None);
+            }
+            if maybe_current_file_state.is_none()
                 && (git_ignore.matches_file(path.as_ref())
                     && !self.force_tracking_matcher.matches(&path))
             {
@@ -1784,6 +1792,7 @@ impl FileSnapshotter<'_> {
             if !self.matcher.matches(tracked_path) {
                 continue;
             }
+            #[cfg(feature = "git")]
             if self
                 .git_attributes
                 .filter_matches(tracked_path, &self.ignore_filters, SearchPriority::Disk)
@@ -1877,6 +1886,7 @@ impl FileSnapshotter<'_> {
                 if state.file_type == FileType::GitSubmodule {
                     continue;
                 }
+                #[cfg(feature = "git")]
                 if self
                     .git_attributes
                     .filter_matches(path, &self.ignore_filters, SearchPriority::Disk)

--- a/lib/tests/test_local_working_copy.rs
+++ b/lib/tests/test_local_working_copy.rs
@@ -3174,6 +3174,7 @@ fn test_always_store_empty_tree() -> TestResult {
     Ok(())
 }
 
+#[cfg(feature = "git")]
 #[test_case(TestRepoBackend::Simple ; "simple backend")]
 #[test_case(TestRepoBackend::Git ; "git backend")]
 fn test_gitattributes_ignore_only_on_git_backend(backend: TestRepoBackend) -> TestResult {


### PR DESCRIPTION
Intended to be merged into #9635 before it is merged into main, not to live out on its own
