### PR TITLE
template: add methods to retrieve bookmarks pointing to any commit of a change ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   removes it, allowing colocation to be toggled after workspace
   creation.
 
+* The `ChangeId` type in templates now has a `.remote_bookmarks()` method available
+  for listing remote bookmarks pointing any of the change ID's commits.
+
 ### Fixed bugs
 
 ## [0.45.1] - 2026-09-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,8 +32,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   removes it, allowing colocation to be toggled after workspace
   creation.
 
-* The `ChangeId` type in templates now has a `.remote_bookmarks()` method available
-  for listing remote bookmarks pointing any of the change ID's commits.
+* The `ChangeId` type in templates now has `.local_bookmarks()` and `.remote_bookmarks()` 
+  methods available for listing local and remote bookmarks pointing to any of the change 
+  ID's commits.
 
 ### Fixed bugs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,9 +32,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   removes it, allowing colocation to be toggled after workspace
   creation.
 
-* The `ChangeId` type in templates now has `.local_bookmarks()` and `.remote_bookmarks()` 
-  methods available for listing local and remote bookmarks pointing to any of the change 
-  ID's commits.
+* The `ChangeId` type in templates now has `.bookmarks()`, `.local_bookmarks()` and 
+  `.remote_bookmarks()` methods available for listing bookmarks pointing to any of the
+  change ID's commits.
 
 ### Fixed bugs
 

--- a/cli/src/commit_templater.rs
+++ b/cli/src/commit_templater.rs
@@ -2131,6 +2131,30 @@ fn builtin_change_id_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, C
             Ok(out_property.into_dyn_wrapped())
         },
     );
+    map.insert(
+        "remote_bookmarks",
+        |language, _diagnostics, _build_ctx, self_property, function| {
+            function.expect_no_arguments()?;
+            let repo = language.repo;
+            let index = language
+                .keyword_cache
+                .bookmarks_index(language.repo)
+                .clone();
+            let out_property = self_property.and_then(move |change_id| {
+                let maybe_targets = repo.resolve_change_id(&change_id).block_on()?;
+                Ok(maybe_targets
+                    .iter()
+                    .flat_map(|targets| targets.targets.iter())
+                    .flat_map(|(commit_id, _state)| collect_remote_refs(index.get(commit_id)))
+                    // Since we are iterating through commits here, a confliciting remote bookmark
+                    // could point two different commits for the same change ID. Check here for
+                    // uniqueness so we don't return the same bookmark twice.
+                    .unique_by(Rc::as_ptr)
+                    .collect_vec())
+            });
+            Ok(out_property.into_dyn_wrapped())
+        },
+    );
     map
 }
 

--- a/cli/src/commit_templater.rs
+++ b/cli/src/commit_templater.rs
@@ -2132,6 +2132,26 @@ fn builtin_change_id_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, C
         },
     );
     map.insert(
+        "bookmarks",
+        |language, _diagnostics, _build_ctx, self_property, function| {
+            function.expect_no_arguments()?;
+            let repo = language.repo;
+            let index = language
+                .keyword_cache
+                .bookmarks_index(language.repo)
+                .clone();
+            let out_property = self_property.and_then(move |change_id| {
+                let maybe_targets = repo.resolve_change_id(&change_id).block_on()?;
+                Ok(maybe_targets
+                    .iter()
+                    .flat_map(|targets| targets.targets.iter())
+                    .flat_map(|(commit_id, _state)| collect_distinct_refs(index.get(commit_id)))
+                    .collect_vec())
+            });
+            Ok(out_property.into_dyn_wrapped())
+        },
+    );
+    map.insert(
         "local_bookmarks",
         |language, _diagnostics, _build_ctx, self_property, function| {
             function.expect_no_arguments()?;

--- a/cli/src/commit_templater.rs
+++ b/cli/src/commit_templater.rs
@@ -2132,6 +2132,26 @@ fn builtin_change_id_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, C
         },
     );
     map.insert(
+        "local_bookmarks",
+        |language, _diagnostics, _build_ctx, self_property, function| {
+            function.expect_no_arguments()?;
+            let repo = language.repo;
+            let index = language
+                .keyword_cache
+                .bookmarks_index(language.repo)
+                .clone();
+            let out_property = self_property.and_then(move |change_id| {
+                let maybe_targets = repo.resolve_change_id(&change_id).block_on()?;
+                Ok(maybe_targets
+                    .iter()
+                    .flat_map(|targets| targets.targets.iter())
+                    .flat_map(|(commit_id, _state)| collect_local_refs(index.get(commit_id)))
+                    .collect_vec())
+            });
+            Ok(out_property.into_dyn_wrapped())
+        },
+    );
+    map.insert(
         "remote_bookmarks",
         |language, _diagnostics, _build_ctx, self_property, function| {
             function.expect_no_arguments()?;

--- a/cli/tests/test_commit_template.rs
+++ b/cli/tests/test_commit_template.rs
@@ -798,25 +798,27 @@ fn test_log_bookmarks() {
             " ",
             commit_id.short(),
             change_id.shortest(),
+            "L:",
+            if(change_id.local_bookmarks(), change_id.local_bookmarks(), '(no bookmarks)'),
             "R:",
             if(change_id.remote_bookmarks(), change_id.remote_bookmarks(), '(no bookmarks)')
         )
     "#;
     let output = work_dir.run_jj(["log", "-T", template]);
     insta::assert_snapshot!(output, @"
-    @  3cbd8e4b6166 x R: (no bookmarks)
-    ○  38a204733702 zs R: bookmark2@origin unchanged@origin
-    │ ○  8906307e46e3 r R: bookmark3@origin
+    @  3cbd8e4b6166 x L: bookmark2* new-bookmark R: (no bookmarks)
+    ○  38a204733702 zs L: unchanged R: bookmark2@origin unchanged@origin
+    │ ○  8906307e46e3 r L: bookmark3?? bookmark3?? R: bookmark3@origin
     ├─╯
-    │ ○  ac650536ccab r R: bookmark3@origin
+    │ ○  ac650536ccab r L: bookmark3?? bookmark3?? R: bookmark3@origin
     ├─╯
-    │ ○  326821eda8e4 q R: bookmark1@origin
+    │ ○  326821eda8e4 q L: bookmark1* R: bookmark1@origin
     ├─╯
-    │ ○  dfab68f8f3c2 v R: divergent-0-bookmark@origin divergent-1-bookmark@origin divergent-2-bookmark@origin
+    │ ○  dfab68f8f3c2 v L: divergent-0-bookmark divergent-1-bookmark R: divergent-0-bookmark@origin divergent-1-bookmark@origin divergent-2-bookmark@origin
     ├─╯
-    │ ○  1df228500f25 v R: divergent-0-bookmark@origin divergent-1-bookmark@origin divergent-2-bookmark@origin
+    │ ○  1df228500f25 v L: divergent-0-bookmark divergent-1-bookmark R: divergent-0-bookmark@origin divergent-1-bookmark@origin divergent-2-bookmark@origin
     ├─╯
-    ◆  000000000000 zz R: (no bookmarks)
+    ◆  000000000000 zz L: (no bookmarks) R: (no bookmarks)
     [EOF]
     ");
 }
@@ -900,6 +902,8 @@ fn test_change_id_remote_bookmarks_conflict_dedup() {
             " ",
             commit_id.short(),
             change_id.shortest(),
+            "L:",
+            if(change_id.local_bookmarks(), change_id.local_bookmarks(), '(no bookmarks)'),
             "R:",
             change_id.remote_bookmarks(),
             "\n",
@@ -913,8 +917,8 @@ fn test_change_id_remote_bookmarks_conflict_dedup() {
         template,
     ]);
     insta::assert_snapshot!(output, @"
-    b3df2ad60e03 r R: conflicting-bookmark@origin?? 
-    33a2f5ef1cd2 r R: conflicting-bookmark@origin?? 
+    b3df2ad60e03 r L: (no bookmarks) R: conflicting-bookmark@origin?? 
+    33a2f5ef1cd2 r L: (no bookmarks) R: conflicting-bookmark@origin?? 
     [EOF]
     ------- stderr -------
     Concurrent modification detected, resolving automatically.

--- a/cli/tests/test_commit_template.rs
+++ b/cli/tests/test_commit_template.rs
@@ -798,6 +798,32 @@ fn test_log_bookmarks() {
             " ",
             commit_id.short(),
             change_id.shortest(),
+            if(change_id.bookmarks(), change_id.bookmarks(), '(no bookmarks)'),
+        )
+    "#;
+    let output = work_dir.run_jj(["log", "-T", template]);
+    insta::assert_snapshot!(output, @"
+    @  3cbd8e4b6166 x bookmark2* new-bookmark
+    ○  38a204733702 zs bookmark2@origin unchanged
+    │ ○  8906307e46e3 r bookmark3?? bookmark3@origin bookmark3??
+    ├─╯
+    │ ○  ac650536ccab r bookmark3?? bookmark3@origin bookmark3??
+    ├─╯
+    │ ○  326821eda8e4 q bookmark1* bookmark1@origin
+    ├─╯
+    │ ○  dfab68f8f3c2 v divergent-0-bookmark divergent-1-bookmark divergent-2-bookmark@origin
+    ├─╯
+    │ ○  1df228500f25 v divergent-0-bookmark divergent-1-bookmark divergent-2-bookmark@origin
+    ├─╯
+    ◆  000000000000 zz (no bookmarks)
+    [EOF]
+    ");
+
+    let template = r#"
+        separate(
+            " ",
+            commit_id.short(),
+            change_id.shortest(),
             "L:",
             if(change_id.local_bookmarks(), change_id.local_bookmarks(), '(no bookmarks)'),
             "R:",

--- a/cli/tests/test_commit_template.rs
+++ b/cli/tests/test_commit_template.rs
@@ -641,6 +641,34 @@ fn test_log_bookmarks() {
     origin_dir
         .run_jj(["bookmark", "create", "-r@", "bookmark3"])
         .success();
+
+    // Create a divergent change so we have two visible and one hidden
+    // commit for the same change ID to test change ID bookmarks.
+    origin_dir
+        .run_jj(["new", "root()", "-m=divergent-2"])
+        .success();
+    origin_dir.run_jj(["describe", "-m=divergent-1"]).success();
+    origin_dir.run_jj(["describe", "-m=divergent-0"]).success();
+
+    let divergent_change_id = origin_dir
+        .run_jj(["log", "--no-graph", "-r=@", "-T=change_id"])
+        .success()
+        .stdout
+        .raw()
+        .trim()
+        .to_owned();
+
+    for revision in 0..3 {
+        origin_dir
+            .run_jj([
+                "bookmark",
+                "create",
+                &format!("-r={divergent_change_id}/{revision}"),
+                &format!("divergent-{revision}-bookmark"),
+            ])
+            .success();
+    }
+
     origin_dir.run_jj(["git", "export"]).success();
     test_env
         .run_jj_in(
@@ -677,16 +705,26 @@ fn test_log_bookmarks() {
     origin_dir.run_jj(["git", "export"]).success();
     work_dir.run_jj(["git", "fetch"]).success();
 
+    // Abandon divergent-2-bookmark so we can assert bookmarks
+    // pointing to hidden commits are shown.
+    work_dir
+        .run_jj(["abandon", "-r=divergent-2-bookmark"])
+        .success();
+
     let template = r#"commit_id.short() ++ " " ++ if(bookmarks, bookmarks, "(no bookmarks)")"#;
     let output = work_dir.run_jj(["log", "-T", template]);
     insta::assert_snapshot!(output, @"
-    @  4bc3723efff8 bookmark2* new-bookmark
+    @  3cbd8e4b6166 bookmark2* new-bookmark
     ○  38a204733702 bookmark2@origin unchanged
-    │ ○  1c14797dac42 bookmark3?? bookmark3@origin
+    │ ○  8906307e46e3 bookmark3?? bookmark3@origin
     ├─╯
-    │ ○  8223b15ac1f1 bookmark3??
+    │ ○  ac650536ccab bookmark3??
     ├─╯
-    │ ○  a156ef717a61 bookmark1*
+    │ ○  326821eda8e4 bookmark1*
+    ├─╯
+    │ ○  dfab68f8f3c2 divergent-0-bookmark
+    ├─╯
+    │ ○  1df228500f25 divergent-1-bookmark
     ├─╯
     ◆  000000000000 (no bookmarks)
     [EOF]
@@ -703,6 +741,10 @@ fn test_log_bookmarks() {
     ├─╯
     │ ○  bookmark1
     ├─╯
+    │ ○  divergent-0-bookmark
+    ├─╯
+    │ ○  divergent-1-bookmark
+    ├─╯
     ◆
     [EOF]
     ");
@@ -717,6 +759,10 @@ fn test_log_bookmarks() {
     │ ○  L: bookmark3?? R:
     ├─╯
     │ ○  L: bookmark1* R:
+    ├─╯
+    │ ○  L: divergent-0-bookmark R: divergent-0-bookmark@origin
+    ├─╯
+    │ ○  L: divergent-1-bookmark R: divergent-1-bookmark@origin
     ├─╯
     ◆  L: R:
     [EOF]
@@ -733,11 +779,145 @@ fn test_log_bookmarks() {
     let output = work_dir.run_jj(["log", "-r::remote_bookmarks()", "-T", template]);
     insta::assert_snapshot!(output, @"
     ○  bookmark3@origin(+0/-1)
+    │ ○  divergent-0-bookmark@origin(+0/-0)
+    ├─╯
+    │ ○  divergent-1-bookmark@origin(+0/-0)
+    ├─╯
+    │ ○  divergent-2-bookmark@origin(+2/-0)
+    ├─╯
     │ ○  bookmark2@origin(+0/-1) unchanged@origin(+0/-0)
     ├─╯
     │ ○  bookmark1@origin(+1/-1)
     ├─╯
     ◆
+    [EOF]
+    ");
+
+    let template = r#"
+        separate(
+            " ",
+            commit_id.short(),
+            change_id.shortest(),
+            "R:",
+            if(change_id.remote_bookmarks(), change_id.remote_bookmarks(), '(no bookmarks)')
+        )
+    "#;
+    let output = work_dir.run_jj(["log", "-T", template]);
+    insta::assert_snapshot!(output, @"
+    @  3cbd8e4b6166 x R: (no bookmarks)
+    ○  38a204733702 zs R: bookmark2@origin unchanged@origin
+    │ ○  8906307e46e3 r R: bookmark3@origin
+    ├─╯
+    │ ○  ac650536ccab r R: bookmark3@origin
+    ├─╯
+    │ ○  326821eda8e4 q R: bookmark1@origin
+    ├─╯
+    │ ○  dfab68f8f3c2 v R: divergent-0-bookmark@origin divergent-1-bookmark@origin divergent-2-bookmark@origin
+    ├─╯
+    │ ○  1df228500f25 v R: divergent-0-bookmark@origin divergent-1-bookmark@origin divergent-2-bookmark@origin
+    ├─╯
+    ◆  000000000000 zz R: (no bookmarks)
+    [EOF]
+    ");
+}
+
+#[test]
+fn test_change_id_remote_bookmarks_conflict_dedup() {
+    let test_env = TestEnvironment::default();
+    test_env.add_config(r#"revset-aliases."immutable_heads()" = "none()""#);
+
+    test_env.run_jj_in(".", ["git", "init", "origin"]).success();
+    let origin_dir = test_env.work_dir("origin");
+    let origin_git_repo_path = origin_dir
+        .root()
+        .join(".jj")
+        .join("repo")
+        .join("store")
+        .join("git");
+
+    origin_dir.run_jj(["new", "-m=divergent-1"]).success();
+
+    origin_dir.run_jj(["describe", "-m=divergent-0"]).success();
+
+    let change_id = origin_dir
+        .run_jj(["log", "--no-graph", "-r=@", "-T=change_id"])
+        .success()
+        .stdout
+        .raw()
+        .trim()
+        .to_owned();
+
+    origin_dir
+        .run_jj([
+            "bookmark",
+            "create",
+            &format!("-r={change_id}/0"),
+            "conflicting-bookmark",
+        ])
+        .success();
+
+    origin_dir.run_jj(["git", "export"]).success();
+
+    test_env
+        .run_jj_in(
+            ".",
+            [
+                "git",
+                "clone",
+                origin_git_repo_path.to_str().unwrap(),
+                "local",
+            ],
+        )
+        .success();
+
+    let work_dir = test_env.work_dir("local");
+
+    // The local repository now sees `conflict-bookmark` at {change_id}/0. Move it
+    // backwards on the remote to create a conflict, and fetch at an earlier position
+    // in the operation log to simulate a second fetch happening concurrently with the
+    // first. The concurrent fetches to create a conflict on the remote bookmark that
+    // is introduced newly in the fetch. First fetch saw it pointing to /0, and the
+    // second fetch sees it pointing to /1. We're interested in asserting that we don't
+    // see the bookmark twice on the either commit when retrieving the remote bookmarks
+    // through the change ID.
+    work_dir.run_jj(["git", "fetch"]).success();
+    origin_dir
+        .run_jj([
+            "bookmark",
+            "set",
+            "--allow-backwards",
+            &format!("-r={change_id}/1"),
+            "conflicting-bookmark",
+        ])
+        .success();
+    origin_dir.run_jj(["git", "export"]).success();
+    work_dir.run_jj(["git", "fetch", "--at-op=@-"]).success();
+
+    // change_id.remote_bookmarks() should report the conflicted bookmark
+    // once, not once per divergent commit it targets.
+    let template = r#"
+        separate(
+            " ",
+            commit_id.short(),
+            change_id.shortest(),
+            "R:",
+            change_id.remote_bookmarks(),
+            "\n",
+        ) 
+    "#;
+    let output = work_dir.run_jj([
+        "log",
+        "--no-graph",
+        &format!("-r={change_id}/0 | {change_id}/1"),
+        "-T",
+        template,
+    ]);
+    insta::assert_snapshot!(output, @"
+    b3df2ad60e03 r R: conflicting-bookmark@origin?? 
+    33a2f5ef1cd2 r R: conflicting-bookmark@origin?? 
+    [EOF]
+    ------- stderr -------
+    Concurrent modification detected, resolving automatically.
     [EOF]
     ");
 }

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -240,6 +240,7 @@ The following methods are defined.
   canonical "reversed" (z-k) representation.
 * `.short([len: Integer]) -> String`
 * `.shortest([min_len: Integer]) -> ShortestIdPrefix`: Shortest unique prefix.
+* `.local_bookmarks() -> List<CommitRef>`:  All local bookmarks pointing to the change ID.
 * `.remote_bookmarks() -> List<CommitRef>`: All remote bookmarks pointing to the change ID.
 
 ### `Commit` type

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -240,8 +240,11 @@ The following methods are defined.
   canonical "reversed" (z-k) representation.
 * `.short([len: Integer]) -> String`
 * `.shortest([min_len: Integer]) -> ShortestIdPrefix`: Shortest unique prefix.
-* `.local_bookmarks() -> List<CommitRef>`:  All local bookmarks pointing to the change ID.
-* `.remote_bookmarks() -> List<CommitRef>`: All remote bookmarks pointing to the change ID.
+* `.bookmarks() -> List<CommitRef>`: Local and remote tags pointing to the change ID.
+  A tracked remote bookmark will be included only if its target is different from the
+  local one.
+ * `.local_bookmarks() -> List<CommitRef>`: Returns all local bookmarks pointing to the change ID.
+ * `.remote_bookmarks() -> List<CommitRef>`: Returns all remote bookmarks pointing to the change ID.
 
 ### `Commit` type
 

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -240,6 +240,7 @@ The following methods are defined.
   canonical "reversed" (z-k) representation.
 * `.short([len: Integer]) -> String`
 * `.shortest([min_len: Integer]) -> ShortestIdPrefix`: Shortest unique prefix.
+* `.remote_bookmarks() -> List<CommitRef>`: All remote bookmarks pointing to the change ID.
 
 ### `Commit` type
 


### PR DESCRIPTION
Currently there's no easy way to retrieve bookmarks pointing to a given change ID when templating. This can be useful as bookmarks are sometimes used to communicate metadata about a commit. If we're templating the commit that is directly pointed to by the bookmark, we can already access it through the bookmark methods of the commit. However, if we're working on a commit that has the same change ID but is a different revision, we don't have a great way to access the bookmarks. This could be the case for example if the bookmark points to a commit that was since rebased for example before merging the commit to the `main` branch. 

Add methods to retrieve bookmarks pointing to any commits of a change ID. This provides a way to link the metadata of a given change ID even if the commit the bookmark points to is different.

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
