### PR TITLE
templater: make List getter functions return Option type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `jj workspace add` uses `git worktree add --orphan`, which was added in
   2.42.0.
 
+* The `List.get()`, `.first()`, and `.last()` template functions now return
+  `Option<T>` instead of throwing an error on out-of-bounds access.
+
 ### Deprecations
 
 ### New features

--- a/cli/src/commit_templater.rs
+++ b/cli/src/commit_templater.rs
@@ -336,6 +336,10 @@ impl<'repo> TemplateLanguage<'repo> for CommitTemplateLanguage<'repo> {
                 let build = template_parser::lookup_method(type_name, table, function)?;
                 build(self, diagnostics, build_ctx, property, function)
             }
+            CommitTemplatePropertyKind::TreeDiffEntryOpt(property) => {
+                let inner_property = property.try_unwrap(type_name).into_dyn_wrapped();
+                self.build_method(diagnostics, build_ctx, inner_property, function)
+            }
             CommitTemplatePropertyKind::TreeDiffEntryList(property) => {
                 let table = &self.build_fn_table.tree_diff_entry_list_methods;
                 let build = template_parser::lookup_method(type_name, table, function)?;
@@ -345,6 +349,10 @@ impl<'repo> TemplateLanguage<'repo> for CommitTemplateLanguage<'repo> {
                 let table = &self.build_fn_table.tree_entry_methods;
                 let build = template_parser::lookup_method(type_name, table, function)?;
                 build(self, diagnostics, build_ctx, property, function)
+            }
+            CommitTemplatePropertyKind::TreeEntryOpt(property) => {
+                let inner_property = property.try_unwrap(type_name).into_dyn_wrapped();
+                self.build_method(diagnostics, build_ctx, inner_property, function)
             }
             CommitTemplatePropertyKind::TreeEntryList(property) => {
                 let table = &self.build_fn_table.tree_entry_list_methods;
@@ -363,6 +371,10 @@ impl<'repo> TemplateLanguage<'repo> for CommitTemplateLanguage<'repo> {
                 let table = &self.build_fn_table.diff_stat_entry_methods;
                 let build = template_parser::lookup_method(type_name, table, function)?;
                 build(self, diagnostics, build_ctx, property, function)
+            }
+            CommitTemplatePropertyKind::DiffStatEntryOpt(property) => {
+                let inner_property = property.try_unwrap(type_name).into_dyn_wrapped();
+                self.build_method(diagnostics, build_ctx, inner_property, function)
             }
             CommitTemplatePropertyKind::DiffStatEntryList(property) => {
                 let table = &self.build_fn_table.diff_stat_entry_list_methods;
@@ -387,6 +399,10 @@ impl<'repo> TemplateLanguage<'repo> for CommitTemplateLanguage<'repo> {
                 let table = &self.build_fn_table.trailer_methods;
                 let build = template_parser::lookup_method(type_name, table, function)?;
                 build(self, diagnostics, build_ctx, property, function)
+            }
+            CommitTemplatePropertyKind::TrailerOpt(property) => {
+                let inner_property = property.try_unwrap(type_name).into_dyn_wrapped();
+                self.build_method(diagnostics, build_ctx, inner_property, function)
             }
             CommitTemplatePropertyKind::TrailerList(property) => {
                 let table = &self.build_fn_table.trailer_list_methods;
@@ -450,16 +466,20 @@ pub enum CommitTemplatePropertyKind<'repo> {
     ShortestIdPrefix(BoxedTemplateProperty<'repo, ShortestIdPrefix>),
     TreeDiff(BoxedTemplateProperty<'repo, TreeDiff>),
     TreeDiffEntry(BoxedTemplateProperty<'repo, TreeDiffEntry>),
+    TreeDiffEntryOpt(BoxedTemplateProperty<'repo, Option<TreeDiffEntry>>),
     TreeDiffEntryList(BoxedTemplateProperty<'repo, Vec<TreeDiffEntry>>),
     TreeEntry(BoxedTemplateProperty<'repo, TreeEntry>),
+    TreeEntryOpt(BoxedTemplateProperty<'repo, Option<TreeEntry>>),
     TreeEntryList(BoxedTemplateProperty<'repo, Vec<TreeEntry>>),
     DiffStats(BoxedTemplateProperty<'repo, DiffStatsFormatted<'repo>>),
     DiffStatEntry(BoxedTemplateProperty<'repo, DiffStatEntry>),
+    DiffStatEntryOpt(BoxedTemplateProperty<'repo, Option<DiffStatEntry>>),
     DiffStatEntryList(BoxedTemplateProperty<'repo, Vec<DiffStatEntry>>),
     CryptographicSignature(BoxedTemplateProperty<'repo, CryptographicSignature>),
     CryptographicSignatureOpt(BoxedTemplateProperty<'repo, Option<CryptographicSignature>>),
     AnnotationLine(BoxedTemplateProperty<'repo, AnnotationLine>),
     Trailer(BoxedTemplateProperty<'repo, Trailer>),
+    TrailerOpt(BoxedTemplateProperty<'repo, Option<Trailer>>),
     TrailerList(BoxedTemplateProperty<'repo, Vec<Trailer>>),
 }
 
@@ -485,16 +505,20 @@ template_builder::impl_property_wrappers!(<'repo> CommitTemplatePropertyKind<'re
     ShortestIdPrefix(ShortestIdPrefix),
     TreeDiff(TreeDiff),
     TreeDiffEntry(TreeDiffEntry),
+    TreeDiffEntryOpt(Option<TreeDiffEntry>),
     TreeDiffEntryList(Vec<TreeDiffEntry>),
     TreeEntry(TreeEntry),
+    TreeEntryOpt(Option<TreeEntry>),
     TreeEntryList(Vec<TreeEntry>),
     DiffStats(DiffStatsFormatted<'repo>),
     DiffStatEntry(DiffStatEntry),
+    DiffStatEntryOpt(Option<DiffStatEntry>),
     DiffStatEntryList(Vec<DiffStatEntry>),
     CryptographicSignature(CryptographicSignature),
     CryptographicSignatureOpt(Option<CryptographicSignature>),
     AnnotationLine(AnnotationLine),
     Trailer(Trailer),
+    TrailerOpt(Option<Trailer>),
     TrailerList(Vec<Trailer>),
 });
 
@@ -534,16 +558,20 @@ impl<'repo> CoreTemplatePropertyVar<'repo> for CommitTemplatePropertyKind<'repo>
             Self::ShortestIdPrefix(_) => "ShortestIdPrefix",
             Self::TreeDiff(_) => "TreeDiff",
             Self::TreeDiffEntry(_) => "TreeDiffEntry",
+            Self::TreeDiffEntryOpt(_) => "Option<TreeDiffEntry>",
             Self::TreeDiffEntryList(_) => "List<TreeDiffEntry>",
             Self::TreeEntry(_) => "TreeEntry",
+            Self::TreeEntryOpt(_) => "Option<TreeEntry>",
             Self::TreeEntryList(_) => "List<TreeEntry>",
             Self::DiffStats(_) => "DiffStats",
             Self::DiffStatEntry(_) => "DiffStatEntry",
+            Self::DiffStatEntryOpt(_) => "Option<DiffStatEntry>",
             Self::DiffStatEntryList(_) => "List<DiffStatEntry>",
             Self::CryptographicSignature(_) => "CryptographicSignature",
             Self::CryptographicSignatureOpt(_) => "Option<CryptographicSignature>",
             Self::AnnotationLine(_) => "AnnotationLine",
             Self::Trailer(_) => "Trailer",
+            Self::TrailerOpt(_) => "Option<Trailer>",
             Self::TrailerList(_) => "List<Trailer>",
         }
     }
@@ -593,16 +621,20 @@ impl<'repo> CoreTemplatePropertyVar<'repo> for CommitTemplatePropertyKind<'repo>
             // diff.empty() method might be better.
             Self::TreeDiff(_) => Err(self),
             Self::TreeDiffEntry(_) => Err(self),
+            Self::TreeDiffEntryOpt(property) => Ok(option_to_boolean(property)),
             Self::TreeDiffEntryList(property) => Ok(list_to_boolean(property)),
             Self::TreeEntry(_) => Err(self),
+            Self::TreeEntryOpt(property) => Ok(option_to_boolean(property)),
             Self::TreeEntryList(property) => Ok(list_to_boolean(property)),
             Self::DiffStats(_) => Err(self),
             Self::DiffStatEntry(_) => Err(self),
+            Self::DiffStatEntryOpt(property) => Ok(option_to_boolean(property)),
             Self::DiffStatEntryList(property) => Ok(list_to_boolean(property)),
             Self::CryptographicSignature(_) => Err(self),
             Self::CryptographicSignatureOpt(property) => Ok(option_to_boolean(property)),
             Self::AnnotationLine(_) => Err(self),
             Self::Trailer(_) => Err(self),
+            Self::TrailerOpt(property) => Ok(option_to_boolean(property)),
             Self::TrailerList(property) => Ok(list_to_boolean(property)),
         }
     }
@@ -646,16 +678,20 @@ impl<'repo> CoreTemplatePropertyVar<'repo> for CommitTemplatePropertyKind<'repo>
             Self::ShortestIdPrefix(property) => Some(property.into_serialize()),
             Self::TreeDiff(_) => None,
             Self::TreeDiffEntry(_) => None,
+            Self::TreeDiffEntryOpt(_) => None,
             Self::TreeDiffEntryList(_) => None,
             Self::TreeEntry(_) => None,
+            Self::TreeEntryOpt(_) => None,
             Self::TreeEntryList(_) => None,
             Self::DiffStats(_) => None,
             Self::DiffStatEntry(_) => None,
+            Self::DiffStatEntryOpt(_) => None,
             Self::DiffStatEntryList(_) => None,
             Self::CryptographicSignature(_) => None,
             Self::CryptographicSignatureOpt(_) => None,
             Self::AnnotationLine(_) => None,
             Self::Trailer(_) => None,
+            Self::TrailerOpt(_) => None,
             Self::TrailerList(_) => None,
         }
     }
@@ -683,16 +719,20 @@ impl<'repo> CoreTemplatePropertyVar<'repo> for CommitTemplatePropertyKind<'repo>
             Self::ShortestIdPrefix(property) => Some(property.into_template()),
             Self::TreeDiff(_) => None,
             Self::TreeDiffEntry(_) => None,
+            Self::TreeDiffEntryOpt(_) => None,
             Self::TreeDiffEntryList(_) => None,
             Self::TreeEntry(_) => None,
+            Self::TreeEntryOpt(_) => None,
             Self::TreeEntryList(_) => None,
             Self::DiffStats(property) => Some(property.into_template()),
             Self::DiffStatEntry(_) => None,
+            Self::DiffStatEntryOpt(_) => None,
             Self::DiffStatEntryList(_) => None,
             Self::CryptographicSignature(_) => None,
             Self::CryptographicSignatureOpt(_) => None,
             Self::AnnotationLine(_) => None,
             Self::Trailer(property) => Some(property.into_template()),
+            Self::TrailerOpt(property) => Some(property.into_template()),
             Self::TrailerList(property) => Some(property.into_template()),
         }
     }
@@ -753,16 +793,20 @@ impl<'repo> CoreTemplatePropertyVar<'repo> for CommitTemplatePropertyKind<'repo>
             (Self::ShortestIdPrefix(_), _) => None,
             (Self::TreeDiff(_), _) => None,
             (Self::TreeDiffEntry(_), _) => None,
+            (Self::TreeDiffEntryOpt(_), _) => None,
             (Self::TreeDiffEntryList(_), _) => None,
             (Self::TreeEntry(_), _) => None,
+            (Self::TreeEntryOpt(_), _) => None,
             (Self::TreeEntryList(_), _) => None,
             (Self::DiffStats(_), _) => None,
             (Self::DiffStatEntry(_), _) => None,
+            (Self::DiffStatEntryOpt(_), _) => None,
             (Self::DiffStatEntryList(_), _) => None,
             (Self::CryptographicSignature(_), _) => None,
             (Self::CryptographicSignatureOpt(_), _) => None,
             (Self::AnnotationLine(_), _) => None,
             (Self::Trailer(_), _) => None,
+            (Self::TrailerOpt(_), _) => None,
             (Self::TrailerList(_), _) => None,
         }
     }
@@ -796,16 +840,20 @@ impl<'repo> CoreTemplatePropertyVar<'repo> for CommitTemplatePropertyKind<'repo>
             (Self::ShortestIdPrefix(_), _) => None,
             (Self::TreeDiff(_), _) => None,
             (Self::TreeDiffEntry(_), _) => None,
+            (Self::TreeDiffEntryOpt(_), _) => None,
             (Self::TreeDiffEntryList(_), _) => None,
             (Self::TreeEntry(_), _) => None,
+            (Self::TreeEntryOpt(_), _) => None,
             (Self::TreeEntryList(_), _) => None,
             (Self::DiffStats(_), _) => None,
             (Self::DiffStatEntry(_), _) => None,
+            (Self::DiffStatEntryOpt(_), _) => None,
             (Self::DiffStatEntryList(_), _) => None,
             (Self::CryptographicSignature(_), _) => None,
             (Self::CryptographicSignatureOpt(_), _) => None,
             (Self::AnnotationLine(_), _) => None,
             (Self::Trailer(_), _) => None,
+            (Self::TrailerOpt(_), _) => None,
             (Self::TrailerList(_), _) => None,
         }
     }

--- a/cli/src/commit_templater.rs
+++ b/cli/src/commit_templater.rs
@@ -124,6 +124,7 @@ use crate::templater::BoxedAnyProperty;
 use crate::templater::BoxedSerializeProperty;
 use crate::templater::BoxedTemplateProperty;
 use crate::templater::Literal;
+use crate::templater::NoTemplateBooleanCast;
 use crate::templater::SizeHint;
 use crate::templater::Template;
 use crate::templater::TemplateFormatter;
@@ -443,6 +444,24 @@ impl OperationTemplateEnvironment for CommitTemplateLanguage<'_> {
         Some(self.repo.base_repo().op_id())
     }
 }
+
+impl NoTemplateBooleanCast for Commit {}
+impl NoTemplateBooleanCast for CommitEvolutionEntry {}
+impl NoTemplateBooleanCast for Rc<CommitRef> {}
+impl NoTemplateBooleanCast for WorkspaceRef {}
+impl NoTemplateBooleanCast for RefSymbolBuf {}
+impl NoTemplateBooleanCast for RepoPathBuf {}
+impl NoTemplateBooleanCast for ChangeId {}
+impl NoTemplateBooleanCast for CommitId {}
+impl NoTemplateBooleanCast for ShortestIdPrefix {}
+impl NoTemplateBooleanCast for TreeDiff {}
+impl NoTemplateBooleanCast for TreeDiffEntry {}
+impl NoTemplateBooleanCast for TreeEntry {}
+impl NoTemplateBooleanCast for DiffStatsFormatted<'_> {}
+impl NoTemplateBooleanCast for DiffStatEntry {}
+impl NoTemplateBooleanCast for CryptographicSignature {}
+impl NoTemplateBooleanCast for AnnotationLine {}
+impl NoTemplateBooleanCast for Trailer {}
 
 pub enum CommitTemplatePropertyKind<'repo> {
     Core(CoreTemplatePropertyKind<'repo>),

--- a/cli/src/operation_templater.rs
+++ b/cli/src/operation_templater.rs
@@ -48,6 +48,7 @@ use crate::template_parser::TemplateParseResult;
 use crate::templater::BoxedAnyProperty;
 use crate::templater::BoxedSerializeProperty;
 use crate::templater::BoxedTemplateProperty;
+use crate::templater::NoTemplateBooleanCast;
 use crate::templater::Template;
 use crate::templater::TemplateFormatter;
 use crate::templater::TemplatePropertyExt as _;
@@ -172,6 +173,9 @@ where
     Self: WrapTemplateProperty<'a, OperationId>,
 {
 }
+
+impl NoTemplateBooleanCast for Operation {}
+impl NoTemplateBooleanCast for OperationId {}
 
 /// Tagged union of the operation template property types.
 pub enum OperationTemplatePropertyKind<'a> {

--- a/cli/src/template_builder.rs
+++ b/cli/src/template_builder.rs
@@ -66,6 +66,8 @@ use crate::templater::LabelTemplate;
 use crate::templater::ListMapProperty;
 use crate::templater::ListPropertyTemplate;
 use crate::templater::Literal;
+use crate::templater::NoTemplateBooleanCast;
+use crate::templater::OptionalTemplateValue;
 use crate::templater::PlainTextFormattedProperty;
 use crate::templater::PropertyPlaceholder;
 use crate::templater::RawEscapeSequenceTemplate;
@@ -221,6 +223,15 @@ where
     /// Transforms into a property that will evaluate to an [`Ordering`].
     fn try_into_cmp(self, other: Self) -> Option<BoxedTemplateProperty<'a, Ordering>>;
 }
+
+impl NoTemplateBooleanCast for i64 {}
+impl NoTemplateBooleanCast for ConfigValue {}
+impl NoTemplateBooleanCast for PathBuf {}
+impl NoTemplateBooleanCast for Signature {}
+impl NoTemplateBooleanCast for SizeHint {}
+impl NoTemplateBooleanCast for RegexCaptures {}
+impl NoTemplateBooleanCast for Timestamp {}
+impl NoTemplateBooleanCast for TimestampRange {}
 
 pub enum CoreTemplatePropertyKind<'a> {
     ByteString(BoxedTemplateProperty<'a, BString>),
@@ -2053,8 +2064,10 @@ fn builtin_any_list_methods<'a, L: TemplateLanguage<'a> + ?Sized>() -> BuildAnyM
 pub fn builtin_formattable_list_methods<'a, L, O>() -> TemplateBuildMethodFnMap<'a, L, Vec<O>>
 where
     L: TemplateLanguage<'a> + ?Sized,
-    L::Property: WrapTemplateProperty<'a, O> + WrapTemplateProperty<'a, Vec<O>>,
-    O: Template + Clone + 'a,
+    L::Property: WrapTemplateProperty<'a, O>,
+    L::Property: WrapTemplateProperty<'a, Vec<O>>,
+    L::Property: WrapTemplateProperty<'a, O::Optional>,
+    O: OptionalTemplateValue + Template + Clone + 'a,
 {
     let mut map = builtin_unformattable_list_methods::<L, O>();
     map.insert(
@@ -2077,8 +2090,10 @@ where
 pub fn builtin_unformattable_list_methods<'a, L, O>() -> TemplateBuildMethodFnMap<'a, L, Vec<O>>
 where
     L: TemplateLanguage<'a> + ?Sized,
-    L::Property: WrapTemplateProperty<'a, O> + WrapTemplateProperty<'a, Vec<O>>,
-    O: Clone + 'a,
+    L::Property: WrapTemplateProperty<'a, O>,
+    L::Property: WrapTemplateProperty<'a, Vec<O>>,
+    L::Property: WrapTemplateProperty<'a, O::Optional>,
+    O: OptionalTemplateValue + Clone + 'a,
 {
     // Not using maplit::hashmap!{} or custom declarative macro here because
     // code completion inside macro is quite restricted.
@@ -2127,13 +2142,7 @@ where
         "first",
         |_language, _diagnostics, _build_ctx, self_property, function| {
             function.expect_no_arguments()?;
-            // TODO: Return `Option<T>` instead of erroring out.
-            let out_property = self_property.and_then(|items| {
-                items
-                    .into_iter()
-                    .next()
-                    .ok_or_else(|| TemplatePropertyError("List is empty".into()))
-            });
+            let out_property = self_property.map(|items| O::from_option(items.into_iter().next()));
             Ok(L::Property::wrap_property(out_property.into_dyn()))
         },
     );
@@ -2141,12 +2150,7 @@ where
         "last",
         |_language, _diagnostics, _build_ctx, self_property, function| {
             function.expect_no_arguments()?;
-            // TODO: Return `Option<T>` instead of erroring out.
-            let out_property = self_property.and_then(|mut items| {
-                items
-                    .pop()
-                    .ok_or_else(|| TemplatePropertyError("List is empty".into()))
-            });
+            let out_property = self_property.map(|mut items| O::from_option(items.pop()));
             Ok(L::Property::wrap_property(out_property.into_dyn()))
         },
     );
@@ -2155,15 +2159,8 @@ where
         |language, diagnostics, build_ctx, self_property, function| {
             let [index_node] = function.expect_exact_arguments()?;
             let index = expect_usize_expression(language, diagnostics, build_ctx, index_node)?;
-            // TODO: Return `Option<T>` instead of erroring out.
-            let out_property = (self_property, index).and_then(|(mut items, index)| {
-                if index < items.len() {
-                    Ok(items.remove(index))
-                } else {
-                    Err(TemplatePropertyError(
-                        format!("Index {index} out of bounds").into(),
-                    ))
-                }
+            let out_property = (self_property, index).map(|(mut items, index)| {
+                O::from_option((index < items.len()).then(|| items.remove(index)))
             });
             Ok(L::Property::wrap_property(out_property.into_dyn()))
         },
@@ -4282,18 +4279,18 @@ mod tests {
 
         // List.first()
         insta::assert_snapshot!(env.render_ok(r#""a\nb\nc".lines().first()"#), @"a");
-        insta::assert_snapshot!(env.render_ok(r#""".lines().first()"#), @"<Error: List is empty>");
+        insta::assert_snapshot!(env.render_ok(r#""".lines().first()"#), @"");
 
         // List.last()
         insta::assert_snapshot!(env.render_ok(r#""a\nb\nc".lines().last()"#), @"c");
-        insta::assert_snapshot!(env.render_ok(r#""".lines().last()"#), @"<Error: List is empty>");
+        insta::assert_snapshot!(env.render_ok(r#""".lines().last()"#), @"");
 
         // List.get(index)
         insta::assert_snapshot!(env.render_ok(r#""a\nb\nc".lines().get(0)"#), @"a");
         insta::assert_snapshot!(env.render_ok(r#""a\nb\nc".lines().get(1)"#), @"b");
         insta::assert_snapshot!(env.render_ok(r#""a\nb\nc".lines().get(2)"#), @"c");
-        insta::assert_snapshot!(env.render_ok(r#""a\nb\nc".lines().get(3)"#), @"<Error: Index 3 out of bounds>");
-        insta::assert_snapshot!(env.render_ok(r#""".lines().get(0)"#), @"<Error: Index 0 out of bounds>");
+        insta::assert_snapshot!(env.render_ok(r#""a\nb\nc".lines().get(3)"#), @"");
+        insta::assert_snapshot!(env.render_ok(r#""".lines().get(0)"#), @"");
 
         // List.reverse()
         insta::assert_snapshot!(env.render_ok(r#""a\nb\nc".lines().reverse().join("|")"#), @"c|b|a");

--- a/cli/src/templater.rs
+++ b/cli/src/templater.rs
@@ -436,6 +436,54 @@ where
     }
 }
 
+/// Marker for types that don't support implicit boolean cast.
+pub trait NoTemplateBooleanCast {}
+
+/// Converts a value of the `Option<Self>` type to a template property value.
+///
+/// Types that support implicit boolean conversion should map `Option<T>` to
+/// `T`. Other types should return `Option<T>` transparently.
+#[diagnostic::on_unimplemented(
+    message = "`NoTemplateBooleanCast` not implemented for the template value type `{Self}`"
+)]
+pub trait OptionalTemplateValue: Sized {
+    type Optional;
+
+    fn from_option(value: Option<Self>) -> Self::Optional;
+}
+
+impl<T: NoTemplateBooleanCast> OptionalTemplateValue for T {
+    type Optional = Option<Self>;
+
+    fn from_option(value: Option<Self>) -> Self::Optional {
+        value
+    }
+}
+
+impl OptionalTemplateValue for BString {
+    type Optional = Self;
+
+    fn from_option(value: Option<Self>) -> Self::Optional {
+        value.unwrap_or_default()
+    }
+}
+
+impl OptionalTemplateValue for String {
+    type Optional = Self;
+
+    fn from_option(value: Option<Self>) -> Self::Optional {
+        value.unwrap_or_default()
+    }
+}
+
+impl<T> OptionalTemplateValue for Vec<T> {
+    type Optional = Self;
+
+    fn from_option(value: Option<Self>) -> Self::Optional {
+        value.unwrap_or_default()
+    }
+}
+
 /// Wrapper around an error occurred during template evaluation.
 #[derive(Debug)]
 pub struct TemplatePropertyError(pub Box<dyn error::Error + Send + Sync>);

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -469,10 +469,9 @@ defined.
   the predicate `expression`. Example: `parents.any(|c| c.description().contains("fix"))`
 * `.all(|item| expression) -> Boolean`: Returns true if all elements satisfy
   the predicate `expression`. Example: `parents.all(|c| c.mine())`
-* `.first() -> T`: Returns the first element. Errors if the list is empty.
-* `.last() -> T`: Returns the last element. Errors if the list is empty.
-* `.get(index: Integer) -> T`: Returns the element at `index` (0-based). Errors
-  if the index is out of bounds.
+* `.first() -> Option<T>`: Returns the first element.
+* `.last() -> Option<T>`: Returns the last element.
+* `.get(index: Integer) -> Option<T>`: Returns the element at `index` (0-based).
 * `.reverse() -> List`: Returns the list in reverse order.
 * `.skip(count: Integer) -> List`: Skips the first `count` elements and
   returns the rest.
@@ -522,6 +521,11 @@ invoked. If not set, an error will be reported inline on method call.
 
 On comparison between two optional values or optional and non-optional values,
 unset value is not an error. Unset value is considered less than any set values.
+
+Types convertible to `Boolean` (e.g. `String` and `List`) lack support for
+`Option` because the truthy conversion of an unset value would conflict with
+it. Instead, unset values of these types are converted to their empty
+equivalents.
 
 ### `RefSymbol` type
 
@@ -633,7 +637,7 @@ following methods are defined.
   of a UTF-8 codepoint, the codepoint is fully part of the result. If the `end`
   index is in the middle of a UTF-8 codepoint, the codepoint is not part of the
   result. If `end` is not given, returns from `start` to the end of the string.
-* `.first_line() -> String`
+* `.first_line() -> String`: Equivalent to `.lines().first()`.
 * `.lines() -> List<String>`: Split into lines excluding newline characters.
 * `.split(separator: StringPattern, [limit: Integer]) -> List<String>`: Split
   into substrings by the given `separator` pattern. If `limit` is specified, it


### PR DESCRIPTION
Note that this is a breaking change because we can suppress runtime errors by `try()`.

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [ ] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
