### PR TITLE
template: Emit warning when `json` is used with `ui.log-word-wrap`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   Use the `--sparse-patterns` option to control this behavior (evaluated
   per each `jj run` invocation).
 
+* Using the `json` template with `ui.log-word-wrap` set to `true` now emits
+  a warning that the output may be broken due to wrapping, regardless of the
+  template content. Users should set the config option to `false` to avoid
+  receiving invalid JSON objects on small terminals.
+
 ### Fixed bugs
 
 ## [0.45.1] - 2026-09-03

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -194,6 +194,7 @@ use crate::revset_util::RevsetExpressionEvaluator;
 use crate::revset_util::parse_union_name_patterns;
 use crate::template_builder;
 use crate::template_builder::TemplateLanguage;
+use crate::template_parser::ExpressionKind;
 use crate::template_parser::TemplateAliasesMap;
 use crate::template_parser::TemplateDiagnostics;
 use crate::templater::TemplateRenderer;
@@ -1199,6 +1200,33 @@ impl WorkspaceCommandEnvironment {
         Ok(template)
     }
 
+    /// Parses template of the given language into evaluation tree and walks
+    /// the AST using `walker`.
+    pub fn parse_and_walk_template<'a, 'i, C, L, F>(
+        &'i self,
+        ui: &Ui,
+        language: &L,
+        template_text: &'i str,
+        walker: F,
+    ) -> Result<TemplateRenderer<'a, C>, CommandError>
+    where
+        C: Clone + 'a,
+        L: TemplateLanguage<'a> + ?Sized,
+        L::Property: WrapTemplateProperty<'a, C>,
+        F: FnMut(&mut TemplateDiagnostics, &ExpressionKind<'i>, pest::Span<'i>),
+    {
+        let mut diagnostics = TemplateDiagnostics::new();
+        let template = template_builder::parse_and_walk(
+            language,
+            &mut diagnostics,
+            template_text,
+            &self.template_aliases_map,
+            walker,
+        )?;
+        print_parse_diagnostics(ui, "In template expression", &diagnostics)?;
+        Ok(template)
+    }
+
     /// Creates commit template language environment for this workspace and the
     /// given `repo`.
     pub fn commit_template_language<'a>(
@@ -1930,6 +1958,25 @@ to the current parents may contain changes from multiple commits.
         L::Property: WrapTemplateProperty<'a, C>,
     {
         self.env.parse_template(ui, language, template_text)
+    }
+
+    /// Parses template of the given language into evaluation tree and walks
+    /// the AST using `walker`.
+    pub fn parse_and_walk_template<'a, 'i, C, L, F>(
+        &'i self,
+        ui: &Ui,
+        language: &L,
+        template_text: &'i str,
+        walker: F,
+    ) -> Result<TemplateRenderer<'a, C>, CommandError>
+    where
+        C: Clone + 'a,
+        L: TemplateLanguage<'a> + ?Sized,
+        L::Property: WrapTemplateProperty<'a, C>,
+        F: FnMut(&mut TemplateDiagnostics, &ExpressionKind<'i>, pest::Span<'i>),
+    {
+        self.env
+            .parse_and_walk_template(ui, language, template_text, walker)
     }
 
     /// Parses template that is validated by `Self::new()`.

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -3570,6 +3570,11 @@ impl LogContentFormat {
         self.width
     }
 
+    /// Whether word wrapping is enabled.
+    pub fn word_wrap(&self) -> bool {
+        self.word_wrap
+    }
+
     /// Writes content which will optionally be wrapped at the current width.
     pub async fn write<E: From<io::Error>>(
         &self,

--- a/cli/src/commands/evolog.rs
+++ b/cli/src/commands/evolog.rs
@@ -38,6 +38,7 @@ use crate::complete;
 use crate::diff_util::DiffFormatArgs;
 use crate::graphlog::GraphStyle;
 use crate::graphlog::get_graphlog;
+use crate::template_parser;
 use crate::templater::TemplateRenderer;
 use crate::ui::Ui;
 
@@ -128,9 +129,17 @@ pub(crate) async fn cmd_evolog(
             Some(value) => value.clone(),
             None => workspace_command.settings().get("templates.evolog")?,
         };
-        template = workspace_command
-            .parse_template(ui, &language, &template_string)?
-            .labeled(["evolog"]); // TODO: add label for the context type?
+        template = if with_content_format.word_wrap() {
+            workspace_command.parse_and_walk_template(
+                ui,
+                &language,
+                &template_string,
+                template_parser::walk_json_wrapping_warning,
+            )?
+        } else {
+            workspace_command.parse_template(ui, &language, &template_string)?
+        }
+        .labeled(["evolog"]); // TODO: add label for the context type?
         node_template = workspace_command
             .parse_template(
                 ui,

--- a/cli/src/commands/log.rs
+++ b/cli/src/commands/log.rs
@@ -44,6 +44,7 @@ use crate::diff_util::DiffFormatArgs;
 use crate::formatter::FormatterExt as _;
 use crate::graphlog::GraphStyle;
 use crate::graphlog::get_graphlog;
+use crate::template_parser;
 use crate::templater::TemplateRenderer;
 use crate::ui::Ui;
 
@@ -212,9 +213,17 @@ pub(crate) async fn cmd_log(
             Some(value) => value.clone(),
             None => settings.get_string("templates.log")?,
         };
-        template = workspace_command
-            .parse_template(ui, &language, &template_string)?
-            .labeled(["log", "commit"]);
+        template = if with_content_format.word_wrap() {
+            workspace_command.parse_and_walk_template(
+                ui,
+                &language,
+                &template_string,
+                template_parser::walk_json_wrapping_warning,
+            )?
+        } else {
+            workspace_command.parse_template(ui, &language, &template_string)?
+        }
+        .labeled(["log", "commit"]);
         node_template = workspace_command
             .parse_template(ui, &language, &settings.get_string("templates.log_node")?)?
             .labeled(["log", "commit", "node"]);

--- a/cli/src/commands/operation/log.rs
+++ b/cli/src/commands/operation/log.rs
@@ -41,6 +41,7 @@ use crate::formatter::Formatter;
 use crate::graphlog::GraphStyle;
 use crate::graphlog::get_graphlog;
 use crate::operation_templater::OperationTemplateLanguage;
+use crate::template_parser;
 use crate::templater::TemplateRenderer;
 use crate::ui::Ui;
 
@@ -151,9 +152,17 @@ async fn do_op_log(
             Some(value) => value.to_owned(),
             None => settings.get_string("templates.op_log")?,
         };
-        template = workspace_env
-            .parse_template(ui, &language, &text)?
-            .labeled(["op_log", "operation"]);
+        template = if with_content_format.word_wrap() {
+            workspace_env.parse_and_walk_template(
+                ui,
+                &language,
+                &text,
+                template_parser::walk_json_wrapping_warning,
+            )?
+        } else {
+            workspace_env.parse_template(ui, &language, &text)?
+        }
+        .labeled(["op_log", "operation"]);
         op_node_template = workspace_env
             .parse_template(
                 ui,

--- a/cli/src/template_builder.rs
+++ b/cli/src/template_builder.rs
@@ -28,6 +28,7 @@ use jj_lib::config::ConfigGetResultExt as _;
 use jj_lib::config::ConfigNamePathBuf;
 use jj_lib::config::ConfigValue;
 use jj_lib::content_hash::blake2b_hash;
+use jj_lib::dsl_util::WalkableExpression;
 use jj_lib::file_util;
 use jj_lib::hex_util;
 use jj_lib::op_store::TimestampRange;
@@ -2909,6 +2910,27 @@ where
     L::Property: WrapTemplateProperty<'a, C>,
 {
     let node = template_parser::parse(template_text, aliases_map)?;
+    build(language, diagnostics, &node).map_err(|err| err.extend_alias_candidates(aliases_map))
+}
+
+/// Same as `parse`, but walks the parsed AST with `walker` before building the
+/// template renderer from it.
+pub fn parse_and_walk<'a, 'i, C, L, F>(
+    language: &L,
+    diagnostics: &mut TemplateDiagnostics,
+    template_text: &'i str,
+    aliases_map: &'i TemplateAliasesMap,
+    mut walker: F,
+) -> TemplateParseResult<TemplateRenderer<'a, C>>
+where
+    C: Clone + 'a,
+    L: TemplateLanguage<'a> + ?Sized,
+    L::Property: WrapTemplateProperty<'a, C>,
+    F: FnMut(&mut TemplateDiagnostics, &ExpressionKind<'i>, pest::Span<'i>),
+{
+    let node = template_parser::parse(template_text, aliases_map)?;
+    node.kind
+        .walk(&mut |kind, span| walker(diagnostics, kind, span), node.span);
     build(language, diagnostics, &node).map_err(|err| err.extend_alias_candidates(aliases_map))
 }
 

--- a/cli/src/template_parser.rs
+++ b/cli/src/template_parser.rs
@@ -32,6 +32,7 @@ use jj_lib::dsl_util::FoldableExpression;
 use jj_lib::dsl_util::FunctionCallParser;
 use jj_lib::dsl_util::InvalidArguments;
 use jj_lib::dsl_util::StringLiteralParser;
+use jj_lib::dsl_util::WalkableExpression;
 use jj_lib::dsl_util::collect_similar;
 use jj_lib::str_util::StringPattern;
 use pest::Parser as _;
@@ -302,6 +303,44 @@ pub enum ExpressionKind<'i> {
     Lambda(Box<LambdaNode<'i>>),
     /// Identity node to preserve the span in the source template text.
     AliasExpanded(AliasId<'i>, Box<ExpressionNode<'i>>),
+}
+
+impl<'i> WalkableExpression<'i> for ExpressionKind<'i> {
+    fn walk<F>(&self, walker: &mut F, span: pest::Span<'i>)
+    where
+        F: FnMut(&Self, pest::Span<'i>),
+    {
+        walker(self, span);
+        match self {
+            Self::Identifier(_)
+            | Self::Boolean(_)
+            | Self::Integer(_)
+            | Self::String(_)
+            | Self::Pattern(_) => {}
+            Self::Unary(_, arg) => arg.kind.walk(walker, arg.span),
+            Self::Binary(_, lhs, rhs) => {
+                lhs.kind.walk(walker, lhs.span);
+                rhs.kind.walk(walker, rhs.span);
+            }
+            Self::Concat(nodes) => nodes
+                .iter()
+                .for_each(|node| node.kind.walk(walker, node.span)),
+            Self::FunctionCall(function) => function
+                .args
+                .iter()
+                .for_each(|arg| arg.kind.walk(walker, arg.span)),
+            Self::MethodCall(method) => {
+                method.object.kind.walk(walker, method.object.span);
+                method
+                    .function
+                    .args
+                    .iter()
+                    .for_each(|arg| arg.kind.walk(walker, arg.span));
+            }
+            Self::Lambda(lambda) => lambda.body.kind.walk(walker, lambda.body.span),
+            Self::AliasExpanded(_, subst) => subst.kind.walk(walker, subst.span),
+        }
+    }
 }
 
 impl<'i> FoldableExpression<'i> for ExpressionKind<'i> {

--- a/cli/src/template_parser.rs
+++ b/cli/src/template_parser.rs
@@ -343,6 +343,25 @@ impl<'i> WalkableExpression<'i> for ExpressionKind<'i> {
     }
 }
 
+/// A walker for the `parse_and_walk_template` function family which emits a
+/// warning about `json` being used with `ui.log-word-wrap`.
+pub fn walk_json_wrapping_warning<'i>(
+    diagnostics: &mut TemplateDiagnostics,
+    kind: &ExpressionKind<'i>,
+    _span: pest::Span<'i>,
+) {
+    let ExpressionKind::FunctionCall(function) = kind else {
+        return;
+    };
+    if function.name != "json" {
+        return;
+    }
+    diagnostics.add_warning(TemplateParseError::expression(
+        "Using `json` with ui.log-word-wrap=true may wrap its output, which might not be desired",
+        function.name_span,
+    ));
+}
+
 impl<'i> FoldableExpression<'i> for ExpressionKind<'i> {
     fn fold<F>(self, folder: &mut F, span: pest::Span<'i>) -> Result<Self, F::Error>
     where

--- a/cli/tests/test_commit_template.rs
+++ b/cli/tests/test_commit_template.rs
@@ -1855,3 +1855,124 @@ fn test_log_git_web_url() {
     ]);
     insta::assert_snapshot!(output, @"https://github.com/owner/repo https://github.com/upstream/repo [EOF]");
 }
+
+#[test]
+fn test_log_json_word_wrap_warning() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    work_dir.run_jj(["describe", "-m", "first"]).success();
+    work_dir.run_jj(["new", "-m", "second"]).success();
+
+    // No warning when word wrap is disabled.
+    let output = work_dir.run_jj_with(|cmd| {
+        cmd.args([
+            "log",
+            r#"-Tjson(self) ++ "\n""#,
+            "--config=ui.log-word-wrap=false",
+        ])
+    });
+    insta::assert_snapshot!(output, @r#"
+    @  {"commit_id":"b1cb6b2f9141e6ffee18532a8bf9a2075ca02606","parents":["68a505386f936fff6d718f55005e77ea72589bc1"],"change_id":"kkmpptxzrspxrzommnulwmwkkqwworpl","description":"second\n","author":{"name":"Test User","email":"test.user@example.com","timestamp":"2001-02-03T04:05:09+07:00"},"committer":{"name":"Test User","email":"test.user@example.com","timestamp":"2001-02-03T04:05:09+07:00"}}
+    ○  {"commit_id":"68a505386f936fff6d718f55005e77ea72589bc1","parents":["0000000000000000000000000000000000000000"],"change_id":"qpvuntsmwlqtpsluzzsnyyzlmlwvmlnu","description":"first\n","author":{"name":"Test User","email":"test.user@example.com","timestamp":"2001-02-03T04:05:08+07:00"},"committer":{"name":"Test User","email":"test.user@example.com","timestamp":"2001-02-03T04:05:08+07:00"}}
+    ◆  {"commit_id":"0000000000000000000000000000000000000000","parents":[],"change_id":"zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz","description":"","author":{"name":"","email":"","timestamp":"1970-01-01T00:00:00Z"},"committer":{"name":"","email":"","timestamp":"1970-01-01T00:00:00Z"}}
+    [EOF]
+    "#);
+
+    // Warning when word wrap is enabled.
+    let output = work_dir.run_jj_with(|cmd| {
+        cmd.args([
+            "log",
+            r#"-Tjson(self) ++ "\n""#,
+            "--config=ui.log-word-wrap=true",
+        ])
+    });
+    insta::assert_snapshot!(output, @r#"
+    @  {"commit_id":"b1cb6b2f9141e6ffee18532a8bf9a2075ca02606","parents":["68a505386f936fff6d718f55005e77ea72589bc1"],"change_id":"kkmpptxzrspxrzommnulwmwkkqwworpl","description":"second\n","author":{"name":"Test
+    │  User","email":"test.user@example.com","timestamp":"2001-02-03T04:05:09+07:00"},"committer":{"name":"Test
+    │  User","email":"test.user@example.com","timestamp":"2001-02-03T04:05:09+07:00"}}
+    ○  {"commit_id":"68a505386f936fff6d718f55005e77ea72589bc1","parents":["0000000000000000000000000000000000000000"],"change_id":"qpvuntsmwlqtpsluzzsnyyzlmlwvmlnu","description":"first\n","author":{"name":"Test
+    │  User","email":"test.user@example.com","timestamp":"2001-02-03T04:05:08+07:00"},"committer":{"name":"Test
+    │  User","email":"test.user@example.com","timestamp":"2001-02-03T04:05:08+07:00"}}
+    ◆  {"commit_id":"0000000000000000000000000000000000000000","parents":[],"change_id":"zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz","description":"","author":{"name":"","email":"","timestamp":"1970-01-01T00:00:00Z"},"committer":{"name":"","email":"","timestamp":"1970-01-01T00:00:00Z"}}
+    [EOF]
+    ------- stderr -------
+    Warning: In template expression
+     --> 1:1
+      |
+    1 | json(self) ++ "\n"
+      | ^--^
+      |
+      = Using `json` with ui.log-word-wrap=true may wrap its output, which might not be desired
+    [EOF]
+    "#);
+}
+
+#[test]
+fn test_log_json_word_wrap_narrow_terminal() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    work_dir.run_jj(["describe", "-m", "first"]).success();
+    work_dir.run_jj(["new", "-m", "second"]).success();
+
+    let output = work_dir.run_jj_with(|cmd| {
+        cmd.args([
+            "log",
+            "-r@",
+            r#"-Tjson(self) ++ "\n""#,
+            "--config=ui.log-word-wrap=true",
+        ])
+        .env("COLUMNS", "40")
+    });
+    insta::assert_snapshot!(output, @r#"
+    @  {"commit_id":"b1cb6b2f9141e6ffee18532a8bf9a2075ca02606","parents":["68a505386f936fff6d718f55005e77ea72589bc1"],"change_id":"kkmpptxzrspxrzommnulwmwkkqwworpl","description":"second\n","author":{"name":"Test
+    │  User","email":"test.user@example.com","timestamp":"2001-02-03T04:05:09+07:00"},"committer":{"name":"Test
+    ~  User","email":"test.user@example.com","timestamp":"2001-02-03T04:05:09+07:00"}}
+    [EOF]
+    ------- stderr -------
+    Warning: In template expression
+     --> 1:1
+      |
+    1 | json(self) ++ "\n"
+      | ^--^
+      |
+      = Using `json` with ui.log-word-wrap=true may wrap its output, which might not be desired
+    [EOF]
+    "#);
+}
+
+#[test]
+fn test_show_json_no_warning() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    // `jj show` does not respect `ui.log-word-wrap`, so the warning is not
+    // emitted either way.
+    let output = work_dir.run_jj_with(|cmd| {
+        cmd.args([
+            "show",
+            r#"-Tjson(self) ++ "\n""#,
+            "--config=ui.log-word-wrap=false",
+        ])
+    });
+    insta::assert_snapshot!(output, @r#"
+    {"commit_id":"e8849ae12c709f2321908879bc724fdb2ab8a781","parents":["0000000000000000000000000000000000000000"],"change_id":"qpvuntsmwlqtpsluzzsnyyzlmlwvmlnu","description":"","author":{"name":"Test User","email":"test.user@example.com","timestamp":"2001-02-03T04:05:07+07:00"},"committer":{"name":"Test User","email":"test.user@example.com","timestamp":"2001-02-03T04:05:07+07:00"}}
+    [EOF]
+    "#);
+
+    let output = work_dir.run_jj_with(|cmd| {
+        cmd.args([
+            "show",
+            r#"-Tjson(self) ++ "\n""#,
+            "--config=ui.log-word-wrap=true",
+        ])
+    });
+    insta::assert_snapshot!(output, @r#"
+    {"commit_id":"e8849ae12c709f2321908879bc724fdb2ab8a781","parents":["0000000000000000000000000000000000000000"],"change_id":"qpvuntsmwlqtpsluzzsnyyzlmlwvmlnu","description":"","author":{"name":"Test User","email":"test.user@example.com","timestamp":"2001-02-03T04:05:07+07:00"},"committer":{"name":"Test User","email":"test.user@example.com","timestamp":"2001-02-03T04:05:07+07:00"}}
+    [EOF]
+    "#);
+}

--- a/lib/src/dsl_util.rs
+++ b/lib/src/dsl_util.rs
@@ -332,6 +332,14 @@ pub struct InvalidArguments<'i> {
     pub span: pest::Span<'i>,
 }
 
+/// Expression item that can be walked recursively and visited by `walker: F`.
+pub trait WalkableExpression<'i>: Sized {
+    /// Walks `self` and calls `walker` on the inner items.
+    fn walk<F>(&self, walker: &mut F, span: pest::Span<'i>)
+    where
+        F: FnMut(&Self, pest::Span<'i>);
+}
+
 /// Expression item that can be transformed recursively by using `folder: F`.
 pub trait FoldableExpression<'i>: Sized {
     /// Transforms `self` by applying the `folder` to inner items.


### PR DESCRIPTION
I wasn't sure if I should treat an error in the config lookup as a hard error there.

Regarding the tests, I had `--no-graph` tests at first, but the graph actually made the tests easier to read, especially the one that showed the breaking behavior.

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
