### PR TITLE
git: delete many refs in the same transaction for perf

### DIFF
--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -1434,18 +1434,9 @@ fn export_refs_to_git(
     refs: RefsToExport,
 ) -> Vec<(RemoteRefSymbolBuf, FailedRefExportReason)> {
     let mut failed = refs.failed;
-    for (symbol, old_oid) in refs.to_delete {
-        let Some(git_ref_name) = to_git_ref_name(kind, symbol.as_ref()) else {
-            failed.push((symbol, FailedRefExportReason::InvalidGitName));
-            continue;
-        };
-        if let Err(reason) = delete_git_ref(git_repo, &git_ref_name, &old_oid) {
-            failed.push((symbol, reason));
-        } else {
-            let new_target = RefTarget::absent();
-            mut_repo.set_git_ref_target(&git_ref_name, new_target);
-        }
-    }
+
+    failed.extend(delete_git_refs(mut_repo, git_repo, kind, refs.to_delete));
+
     for (symbol, (old_commit_oid, new_commit_oid)) in refs.to_update {
         let Some(git_ref_name) = to_git_ref_name(kind, symbol.as_ref()) else {
             failed.push((symbol, FailedRefExportReason::InvalidGitName));
@@ -1675,27 +1666,66 @@ fn find_git_tag_oid_to_copy(
         .find_map(|git_ref| git_ref.inner.target.try_into_id().ok())
 }
 
-fn delete_git_ref(
+/// Deletes multiple Git refs, falling back to deleting one by one on failure.
+fn delete_git_refs(
+    mut_repo: &mut MutableRepo,
     git_repo: &gix::Repository,
-    git_ref_name: &GitRefName,
-    old_oid: &gix::oid,
-) -> Result<(), FailedRefExportReason> {
-    let Some(git_ref) = git_repo
-        .try_find_reference(git_ref_name.as_str())
-        .map_err(|err| FailedRefExportReason::FailedToDelete(err.into()))?
-    else {
-        // The ref is already deleted
-        return Ok(());
-    };
-    if resolve_git_ref_to_commit_id(&git_ref, Some(old_oid)).as_deref() == Some(old_oid) {
-        // The ref has not been updated by git, so go ahead and delete it
-        git_ref
-            .delete()
-            .map_err(|err| FailedRefExportReason::FailedToDelete(err.into()))
-    } else {
-        // The ref was updated by git
-        Err(FailedRefExportReason::DeletedInJjModifiedInGit)
+    kind: GitRefKind,
+    refs: Vec<(RemoteRefSymbolBuf, gix::ObjectId)>,
+) -> Vec<(RemoteRefSymbolBuf, FailedRefExportReason)> {
+    let mut failed = vec![];
+
+    let mut to_apply = vec![];
+
+    for (symbol, old_oid) in refs {
+        let Some(git_ref_name) = to_git_ref_name(kind, symbol.as_ref()) else {
+            failed.push((symbol, FailedRefExportReason::InvalidGitName));
+            continue;
+        };
+        let git_ref = match git_repo.try_find_reference(git_ref_name.as_str()) {
+            Err(err) => {
+                failed.push((symbol, FailedRefExportReason::FailedToDelete(err.into())));
+                continue;
+            }
+            Ok(None) => {
+                // The ref is already deleted in git
+                to_apply.push((symbol, git_ref_name.clone(), None));
+                continue;
+            }
+            Ok(Some(git_ref)) => git_ref,
+        };
+        if resolve_git_ref_to_commit_id(&git_ref, Some(&old_oid)).as_deref() == Some(&old_oid) {
+            // The ref has not been updated by git, so go ahead and delete it
+            let edit = remove_ref(git_ref.clone());
+            to_apply.push((symbol, git_ref_name.clone(), Some(edit)));
+        } else {
+            // The ref was updated by git
+            failed.push((symbol, FailedRefExportReason::DeletedInJjModifiedInGit));
+        }
     }
+
+    let edits = to_apply.iter().filter_map(|(.., edit)| edit.clone());
+    if git_repo.edit_references(edits).is_ok() {
+        for (_, git_ref_name, _) in &to_apply {
+            mut_repo.set_git_ref_target(git_ref_name, RefTarget::absent());
+        }
+    } else {
+        // Fall back to deleting one by one
+        for (symbol, git_ref_name, edit) in &to_apply {
+            if let Some(edit) = edit
+                && let Err(reason) = git_repo.edit_reference(edit.clone())
+            {
+                failed.push((
+                    symbol.clone(),
+                    FailedRefExportReason::FailedToDelete(reason.into()),
+                ));
+            } else {
+                mut_repo.set_git_ref_target(git_ref_name, RefTarget::absent());
+            }
+        }
+    }
+
+    failed
 }
 
 /// Creates new ref pointing to `new_ref_oid` or (peeled) `new_commit_oid`.


### PR DESCRIPTION
I mistakenly fetched ~40k tags, so I run `jj tag delete "tag-glob"`. It
wasn't completing in a reasonable amount of time and profiling I noticed
we spent most of the time rewriting packed-refs. Doing the whole
deletion in 1 gix transaction finished in a couple of seconds.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [x] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
