### PR TITLE
template: add revset() method for evaluating revsets in templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * `Commit.contained_in()` now accepts a `Stringify` instead of a `StringLiteral`.
   This enables dynamic query building during templating. 
 
+* Templates now have a top-level `revset(revset: Stringify) -> List<Commit>`
+  function for evaluating revsets during templating.
+
 ### Fixed bugs
 
 ## [0.45.1] - 2026-09-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   where you need to pass multiple arguments to the tool, such as separate args
   for the range start and range end.
 
+* `Commit.contained_in()` now accepts a `Stringify` instead of a `StringLiteral`.
+  This enables dynamic query building during templating. 
+
 ### Fixed bugs
 
 ## [0.45.1] - 2026-09-03

--- a/cli/src/commit_templater.rs
+++ b/cli/src/commit_templater.rs
@@ -74,6 +74,7 @@ use jj_lib::revset::RevsetContainingFn;
 use jj_lib::revset::RevsetDiagnostics;
 use jj_lib::revset::RevsetParseContext;
 use jj_lib::revset::RevsetParseError;
+use jj_lib::revset::RevsetStreamExt as _;
 use jj_lib::revset::UserRevsetExpression;
 use jj_lib::rewrite::rebase_to_dest_parent;
 use jj_lib::settings::UserSettings;
@@ -1099,6 +1100,24 @@ fn evaluate_user_revset_query<'repo>(
     Ok(revset)
 }
 
+fn resolve_user_revset_query_commits<'repo>(
+    repo: &'repo dyn Repo,
+    revset_parse_context: &RevsetParseContext<'repo>,
+    id_prefix_context: &'repo IdPrefixContext,
+    query: &str,
+) -> Result<(Vec<Commit>, RevsetDiagnostics), UserRevsetQueryError> {
+    let (expression, diagnostics) = parse_user_revset_expression(revset_parse_context, query)?;
+    let revset =
+        evaluate_user_revset_query(repo, revset_parse_context, id_prefix_context, &expression)?;
+    let commits: Vec<Commit> = revset
+        .stream()
+        .commits(repo.store())
+        .try_collect()
+        .block_on()
+        .map_err(UserRevsetEvaluationError::Evaluation)?;
+    Ok((commits, diagnostics))
+}
+
 fn resolve_user_revset_query_containing_fn<'repo>(
     repo: &'repo dyn Repo,
     revset_parse_context: &RevsetParseContext<'repo>,
@@ -1115,6 +1134,36 @@ fn resolve_user_revset_query_containing_fn<'repo>(
 fn builtin_commit_template_functions<'repo>()
 -> TemplateBuildFunctionFnMap<'repo, CommitTemplateLanguage<'repo>> {
     let mut map = TemplateBuildFunctionFnMap::<CommitTemplateLanguage>::new();
+    map.insert("revset", |language, diagnostics, build_ctx, function| {
+        let [revset_node] = function.expect_exact_arguments()?;
+        let revset_property =
+            expect_stringify_expression(language, diagnostics, build_ctx, revset_node)?;
+        if let Ok(query) = revset_property.extract() {
+            let (commits, inner_diagnostics) = resolve_user_revset_query_commits(
+                language.repo,
+                &language.revset_parse_context,
+                language.id_prefix_context,
+                &query,
+            )
+            .map_err(|err| user_revset_template_query_error(err, revset_node.span))?;
+            extend_user_revset_diagnostics(diagnostics, revset_node.span, inner_diagnostics);
+            Ok(Literal(commits).into_dyn_wrapped())
+        } else {
+            let repo = language.repo;
+            let revset_parse_context = language.revset_parse_context.clone();
+            let id_prefix_context = language.id_prefix_context;
+            let out_property = revset_property.and_then(move |query| {
+                let (commits, _) = resolve_user_revset_query_commits(
+                    repo,
+                    &revset_parse_context,
+                    id_prefix_context,
+                    &query,
+                )?;
+                Ok(commits)
+            });
+            Ok(out_property.into_dyn_wrapped())
+        }
+    });
     map.insert(
         "git_web_url",
         |language, diagnostics, build_ctx, function| {

--- a/cli/src/commit_templater.rs
+++ b/cli/src/commit_templater.rs
@@ -73,6 +73,7 @@ use jj_lib::revset::Revset;
 use jj_lib::revset::RevsetContainingFn;
 use jj_lib::revset::RevsetDiagnostics;
 use jj_lib::revset::RevsetParseContext;
+use jj_lib::revset::RevsetParseError;
 use jj_lib::revset::UserRevsetExpression;
 use jj_lib::rewrite::rebase_to_dest_parent;
 use jj_lib::settings::UserSettings;
@@ -103,6 +104,7 @@ use crate::operation_templater::OperationTemplateEnvironment;
 use crate::operation_templater::OperationTemplatePropertyKind;
 use crate::operation_templater::OperationTemplatePropertyVar;
 use crate::revset_util;
+use crate::revset_util::UserRevsetEvaluationError;
 use crate::template_builder;
 use crate::template_builder::BuildContext;
 use crate::template_builder::CoreTemplateBuildFnTable;
@@ -1027,6 +1029,88 @@ impl<'repo> CommitKeywordCache<'repo> {
     }
 }
 
+fn user_revset_template_parse_error(
+    err: RevsetParseError,
+    span: pest::Span<'_>,
+) -> TemplateParseError {
+    TemplateParseError::expression("In revset expression", span).with_source(err)
+}
+
+fn user_revset_template_evaluation_error(
+    err: UserRevsetEvaluationError,
+    span: pest::Span<'_>,
+) -> TemplateParseError {
+    TemplateParseError::expression("Failed to evaluate revset", span).with_source(err)
+}
+
+#[derive(Debug, thiserror::Error)]
+enum UserRevsetQueryError {
+    #[error(transparent)]
+    Parse(#[from] RevsetParseError),
+    #[error(transparent)]
+    Evaluation(#[from] UserRevsetEvaluationError),
+}
+
+fn user_revset_template_query_error(
+    err: UserRevsetQueryError,
+    span: pest::Span<'_>,
+) -> TemplateParseError {
+    match err {
+        UserRevsetQueryError::Parse(err) => user_revset_template_parse_error(err, span),
+        UserRevsetQueryError::Evaluation(err) => user_revset_template_evaluation_error(err, span),
+    }
+}
+
+fn extend_user_revset_diagnostics(
+    diagnostics: &mut TemplateDiagnostics,
+    span: pest::Span<'_>,
+    inner_diagnostics: RevsetDiagnostics,
+) {
+    diagnostics.extend_with(inner_diagnostics, |diag| {
+        TemplateParseError::expression("In revset expression", span).with_source(diag)
+    });
+}
+
+fn parse_user_revset_expression(
+    revset_parse_context: &RevsetParseContext<'_>,
+    revset_str: &str,
+) -> Result<(Arc<UserRevsetExpression>, RevsetDiagnostics), RevsetParseError> {
+    let mut diagnostics = RevsetDiagnostics::new();
+    let expression = revset::parse(&mut diagnostics, revset_str, revset_parse_context)?;
+    Ok((expression, diagnostics))
+}
+
+fn evaluate_user_revset_query<'repo>(
+    repo: &'repo dyn Repo,
+    revset_parse_context: &RevsetParseContext<'repo>,
+    id_prefix_context: &'repo IdPrefixContext,
+    expression: &UserRevsetExpression,
+) -> Result<Box<dyn Revset + 'repo>, UserRevsetEvaluationError> {
+    let symbol_resolver = revset_util::default_symbol_resolver(
+        repo,
+        revset_parse_context.extensions.symbol_resolvers(),
+        id_prefix_context,
+    );
+    let revset = expression
+        .resolve_user_expression(repo, &symbol_resolver)
+        .map_err(UserRevsetEvaluationError::Resolution)?
+        .evaluate(repo)
+        .map_err(UserRevsetEvaluationError::Evaluation)?;
+    Ok(revset)
+}
+
+fn resolve_user_revset_query_containing_fn<'repo>(
+    repo: &'repo dyn Repo,
+    revset_parse_context: &RevsetParseContext<'repo>,
+    id_prefix_context: &'repo IdPrefixContext,
+    query: &str,
+) -> Result<(Box<RevsetContainingFn<'repo>>, RevsetDiagnostics), UserRevsetQueryError> {
+    let (expression, diagnostics) = parse_user_revset_expression(revset_parse_context, query)?;
+    let revset =
+        evaluate_user_revset_query(repo, revset_parse_context, id_prefix_context, &expression)?;
+    Ok((revset.containing_fn(), diagnostics))
+}
+
 /// Builtin functions for the commit template language.
 fn builtin_commit_template_functions<'repo>()
 -> TemplateBuildFunctionFnMap<'repo, CommitTemplateLanguage<'repo>> {
@@ -1284,19 +1368,43 @@ fn builtin_commit_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, Comm
     );
     map.insert(
         "contained_in",
-        |language, diagnostics, _build_ctx, self_property, function| {
+        |language, diagnostics, build_ctx, self_property, function| {
             let [revset_node] = function.expect_exact_arguments()?;
-
-            let is_contained =
-                template_parser::catch_aliases(diagnostics, revset_node, |diagnostics, node| {
-                    let text = template_parser::expect_string_literal(node)?;
-                    let revset = evaluate_user_revset(language, diagnostics, node.span, text)?;
-                    Ok(revset.containing_fn())
-                })?;
-
-            let out_property =
-                self_property.and_then(move |commit| Ok(is_contained(commit.id()).block_on()?));
-            Ok(out_property.into_dyn_wrapped())
+            let revset_property =
+                expect_stringify_expression(language, diagnostics, build_ctx, revset_node)?;
+            if let Ok(query) = revset_property.extract() {
+                let (is_contained, inner_diagnostics) = resolve_user_revset_query_containing_fn(
+                    language.repo,
+                    &language.revset_parse_context,
+                    language.id_prefix_context,
+                    &query,
+                )
+                .map_err(|err| user_revset_template_query_error(err, revset_node.span))?;
+                extend_user_revset_diagnostics(diagnostics, revset_node.span, inner_diagnostics);
+                let out_property = self_property.and_then(move |commit| {
+                    Ok(is_contained(commit.id())
+                        .block_on()
+                        .map_err(UserRevsetEvaluationError::Evaluation)?)
+                });
+                Ok(out_property.into_dyn_wrapped())
+            } else {
+                let repo = language.repo;
+                let revset_parse_context = language.revset_parse_context.clone();
+                let id_prefix_context = language.id_prefix_context;
+                let out_property =
+                    (self_property, revset_property).and_then(move |(commit, query)| {
+                        let (is_contained, _) = resolve_user_revset_query_containing_fn(
+                            repo,
+                            &revset_parse_context,
+                            id_prefix_context,
+                            &query,
+                        )?;
+                        Ok(is_contained(commit.id())
+                            .block_on()
+                            .map_err(UserRevsetEvaluationError::Evaluation)?)
+                    });
+                Ok(out_property.into_dyn_wrapped())
+            }
         },
     );
     map.insert(
@@ -1437,25 +1545,6 @@ fn evaluate_revset_expression<'repo>(
         .evaluate(repo)
         .map_err(|err| make_error().with_source(err))?;
     Ok(revset)
-}
-
-fn evaluate_user_revset<'repo>(
-    language: &CommitTemplateLanguage<'repo>,
-    diagnostics: &mut TemplateDiagnostics,
-    span: pest::Span<'_>,
-    revset: &str,
-) -> Result<Box<dyn Revset + 'repo>, TemplateParseError> {
-    let mut inner_diagnostics = RevsetDiagnostics::new();
-    let expression = revset::parse(
-        &mut inner_diagnostics,
-        revset,
-        &language.revset_parse_context,
-    )
-    .map_err(|err| TemplateParseError::expression("In revset expression", span).with_source(err))?;
-    diagnostics.extend_with(inner_diagnostics, |diag| {
-        TemplateParseError::expression("In revset expression", span).with_source(diag)
-    });
-    evaluate_revset_expression(language, span, &expression)
 }
 
 fn builtin_commit_evolution_entry_methods<'repo>()

--- a/cli/tests/test_commit_template.rs
+++ b/cli/tests/test_commit_template.rs
@@ -1857,6 +1857,116 @@ fn test_log_format_trailers() {
 }
 
 #[test]
+fn test_log_revset() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    work_dir.run_jj(["desc", "-m=first commit"]).success();
+    work_dir.run_jj(["desc", "-m=second commit"]).success();
+    work_dir.run_jj(["desc", "-m=third commit"]).success();
+    let change_id = work_dir
+        .run_jj(["log", "--no-graph", "-r=@", "-T=change_id"])
+        .success()
+        .stdout
+        .raw()
+        .trim()
+        .to_owned();
+
+    for revision in 0..3 {
+        work_dir
+            .run_jj([
+                "bookmark",
+                "create",
+                &format!("-r={change_id}/{revision}"),
+                &format!("bookmark-{revision}"),
+            ])
+            .success();
+    }
+
+    work_dir
+        .run_jj(["abandon", &format!("{change_id}/2")])
+        .success();
+
+    let output = work_dir.run_jj([
+        "log",
+        "-T",
+        r#"
+            separate(
+                " ",
+                commit_id.short(),
+                change_id.short(),
+                "Build-time evaluation: " ++ revset("000000000000").first().change_id().short()
+            ) ++ "\n"
+        "#,
+    ]);
+    insta::assert_snapshot!(output, @"
+    @  776560591705 qpvuntsmwlqt Build-time evaluation: zzzzzzzzzzzz
+    │ ○  6c3346980c51 qpvuntsmwlqt Build-time evaluation: zzzzzzzzzzzz
+    ├─╯
+    ◆  000000000000 zzzzzzzzzzzz Build-time evaluation: zzzzzzzzzzzz
+    [EOF]
+    ");
+
+    let output = work_dir.run_jj([
+        "log",
+        "-T",
+        r#"
+            separate(
+                " ",
+                commit_id.short(),
+                change_id.short(),
+                "Own: " ++ bookmarks,
+                "Others: " ++ revset("change_id(" ++ change_id ++ ")").map(|c| c.bookmarks().map(|b| b.name())).join(", ")
+            ) ++ "\n"
+        "#,
+    ]);
+    insta::assert_snapshot!(output, @"
+    @  776560591705 qpvuntsmwlqt Own: bookmark-0 Others: bookmark-0, bookmark-1
+    │ ○  6c3346980c51 qpvuntsmwlqt Own: bookmark-1 Others: bookmark-0, bookmark-1
+    ├─╯
+    ◆  000000000000 zzzzzzzzzzzz Own:  Others:
+    [EOF]
+    ");
+
+    let output = work_dir.run_jj(["log", "-T=revset()"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    Error: Failed to parse template: Function `revset`: Expected 1 arguments
+    Caused by:  --> 1:8
+      |
+    1 | revset()
+      |        ^
+      |
+      = Function `revset`: Expected 1 arguments
+    [EOF]
+    [exit status: 1]
+    ");
+
+    let output = work_dir.run_jj(["log", r#"-T=revset("non-existent()")"#]);
+    insta::assert_snapshot!(output, @r#"
+    ------- stderr -------
+    Error: Failed to parse template: In revset expression
+    Caused by:
+    1:  --> 1:8
+      |
+    1 | revset("non-existent()")
+      |        ^--------------^
+      |
+      = In revset expression
+    2:  --> 1:13
+      |
+    1 | non-existent()
+      |             ^---
+      |
+      = expected <EOI>, `@`, `:`, `-`, `+`, `::`, `..`, `|`, `&`, or `~`
+    Hint: See https://docs.jj-vcs.dev/latest/revsets/ or use `jj help -k revsets` for revsets syntax and how to quote symbols.
+    [EOF]
+    [exit status: 1]
+    "#);
+}
+
+#[test]
 fn test_log_git_web_url() {
     let test_env = TestEnvironment::default();
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();

--- a/cli/tests/test_commit_template.rs
+++ b/cli/tests/test_commit_template.rs
@@ -935,6 +935,23 @@ fn test_log_contained_in() {
     [EOF]
     ");
 
+    let output = work_dir.run_jj([
+        "log",
+        "-r::",
+        "-T",
+        // Build the revset query dynamically from the current commit.
+        &template_for_revset(r#""++ commit_id ++""#),
+    ]);
+    insta::assert_snapshot!(output, @"
+    @  D [contained_in]
+    │ ○  C [contained_in]
+    │ ○  B main [contained_in]
+    │ ○  A [contained_in]
+    ├─╯
+    ◆  [contained_in]
+    [EOF]
+    ");
+
     // Suppress error that could be detected earlier
     let output = work_dir.run_jj(["log", "-r::", "-T", &template_for_revset("unknown_fn()")]);
     insta::assert_snapshot!(output, @r#"
@@ -993,6 +1010,26 @@ fn test_log_contained_in() {
       = Failed to evaluate revset
     2: Revision `maine` doesn't exist
     Hint: Did you mean `main`?
+    [EOF]
+    [exit status: 1]
+    "#);
+
+    let output = work_dir.run_jj([
+        "log",
+        "-r::",
+        "-T",
+        // Test dynamic query parsing failure
+        &template_for_revset(r#""++ non_existent() ++""#),
+    ]);
+    insta::assert_snapshot!(output, @r#"
+    ------- stderr -------
+    Error: Failed to parse template: Function `non_existent` doesn't exist
+    Caused by:  --> 5:33
+      |
+    5 |       if(self.contained_in(""++ non_existent() ++""), "[contained_in]"),
+      |                                 ^----------^
+      |
+      = Function `non_existent` doesn't exist
     [EOF]
     [exit status: 1]
     "#);

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -79,6 +79,11 @@ The following functions are defined.
   content by adding both leading and trailing fill characters. If an odd number
   of fill characters are needed, the trailing fill will be one longer than the
   leading fill. The `content` shouldn't have newline characters.
+* `revset(revset: Stringify) -> List<Commit>`: Evaluates [a revset](revsets.md).
+
+  The revset is evaluated once during template parsing if its value evaluates to
+  a constant string. Queries built from values that aren't yet known during
+  parsing, for example `self.change_id()`, are evaluated per call at runtime.
 * `truncate_start(width: Integer, content: Template, [ellipsis: Template])`:
   Truncate `content` by removing leading characters. The `content` shouldn't
   have newline character. If `ellipsis` is provided and `content` was truncated,

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -285,7 +285,7 @@ This type cannot be printed. The following methods are defined.
   of this commit. May not be available for some commits.
 * `.immutable() -> Boolean`: True if the commit is included in [the set of
   immutable commits](config.md#set-of-immutable-commits).
-* `.contained_in(revset: StringLiteral) -> Boolean`: True if the commit is included in
+* `.contained_in(revset: Stringify) -> Boolean`: True if the commit is included in
   [the provided revset](revsets.md).
 * `.conflict() -> Boolean`: True if the commit contains merge conflicts.
 * `.empty() -> Boolean`: True if the commit modifies no files.
@@ -687,8 +687,7 @@ A single-quoted string literal has no escape syntax. `'` can't be expressed
 inside a single-quoted string literal.
 
 String literals have their own type so that the value can be validated at parse
-time. For example, `contained_in(revset)` requires a literal so the revset can
-be parsed and checked before the template is evaluated.
+time.
 
 ### `StringPattern` type
 


### PR DESCRIPTION
Sometimes it would be useful to have access to arbitrary revisions during
templating to render additional information that might be useful in the
current context.

Revsets already provide a flexible way to query a set of commits but
they are not currently available in templates. Expose a `revset()` function
that allows for evaluating revsets in the templating context to access
arbitrary revisions.

Closes https://github.com/jj-vcs/jj/issues/7422

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
