### PR TITLE
revset: optionally return hidden commits with `change_id`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   where you need to pass multiple arguments to the tool, such as separate args
   for the range start and range end.
 
+* `change_id()` now accepts an optional `include_hidden` parameter. Hidden commits
+  are included in the output if true.
+
 ### Fixed bugs
 
 ## [0.45.1] - 2026-09-03

--- a/docs/revsets.md
+++ b/docs/revsets.md
@@ -280,9 +280,12 @@ revsets (expressions) as arguments.
 * `none()`: No commits. This function is rarely useful; it is provided for
   completeness.
 
-* `change_id(prefix)`: Commits with the given change ID prefix. If the specified
-  change is divergent, this resolves to multiple commits. It is an error to use a
-  non-unique prefix. Unmatched prefix isn't an error.
+* `change_id(prefix, [include_hidden])`: Commits with the given change ID prefix.
+  If the specified change is divergent, this resolves to multiple commits. It is
+  an error to use a non-unique prefix. Unmatched prefix isn't an error.
+
+  By default, only visible commits are returned. If `include_hidden` is `true`,
+  then hidden commits are included.
 
 * `commit_id(prefix)`: Commits with the given commit ID prefix. It is an error
   to use a non-unique prefix. Unmatched prefix isn't an error.

--- a/lib/src/index.rs
+++ b/lib/src/index.rs
@@ -276,6 +276,14 @@ impl ResolvedChangeTargets {
             .position(|(target, _state)| target == commit_id)
     }
 
+    /// Extracts both hidden and visible commits for this change ID.
+    pub fn all(self) -> Vec<CommitId> {
+        self.targets
+            .into_iter()
+            .map(|(target, _state)| target)
+            .collect_vec()
+    }
+
     /// Extracts the visible commits for this change ID. Returns `None` if there
     /// are no visible commits with this change ID.
     pub fn into_visible(self) -> Option<Vec<CommitId>> {

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -149,7 +149,7 @@ pub enum RevsetCommitRef {
     WorkingCopies,
     Symbol(String),
     RemoteSymbol(RemoteRefSymbolBuf),
-    ChangeId(HexPrefix),
+    ChangeId(HexPrefix, bool),
     CommitId(HexPrefix),
     Bookmarks(StringExpression),
     RemoteBookmarks {
@@ -428,8 +428,8 @@ impl<St: ExpressionState<CommitRef = RevsetCommitRef>> RevsetExpression<St> {
         Arc::new(Self::CommitRef(commit_ref))
     }
 
-    pub fn change_id_prefix(prefix: HexPrefix) -> Arc<Self> {
-        let commit_ref = RevsetCommitRef::ChangeId(prefix);
+    pub fn change_id_prefix(prefix: HexPrefix, include_hidden: bool) -> Arc<Self> {
+        let commit_ref = RevsetCommitRef::ChangeId(prefix, include_hidden);
         Arc::new(Self::CommitRef(commit_ref))
     }
 
@@ -929,13 +929,19 @@ static BUILTIN_FUNCTION_MAP: LazyLock<HashMap<&str, RevsetFunction>> = LazyLock:
         Ok(RevsetExpression::root())
     });
     map.insert("change_id", |diagnostics, function, _context| {
-        let [arg] = function.expect_exact_arguments()?;
+        let ([arg], [include_hidden_arg]) =
+            function.expect_named_arguments(&["", "include_hidden"])?;
         let prefix = revset_parser::catch_aliases(diagnostics, arg, |_diagnostics, arg| {
             let value = revset_parser::expect_string_literal("change ID prefix", arg)?;
             HexPrefix::try_from_reverse_hex(value)
                 .ok_or_else(|| RevsetParseError::expression("Invalid change ID prefix", arg.span))
         })?;
-        Ok(RevsetExpression::change_id_prefix(prefix))
+        Ok(RevsetExpression::change_id_prefix(
+            prefix,
+            include_hidden_arg.map_or(Ok(false), |arg| {
+                revset_parser::expect_literal("boolean", arg)
+            })?,
+        ))
     });
     map.insert("commit_id", |diagnostics, function, _context| {
         let [arg] = function.expect_exact_arguments()?;
@@ -2968,12 +2974,15 @@ fn resolve_commit_ref(
             let wc_commits = repo.view().wc_commit_ids().values().cloned().collect_vec();
             Ok(wc_commits)
         }
-        RevsetCommitRef::ChangeId(prefix) => {
+        RevsetCommitRef::ChangeId(prefix, include_hidden) => {
             let resolver = &symbol_resolver.change_id_resolver;
-            Ok(resolver
-                .try_resolve(repo, prefix)?
-                .and_then(ResolvedChangeTargets::into_visible)
-                .unwrap_or_else(Vec::new))
+            let targets = resolver.try_resolve(repo, prefix)?;
+            Ok(if *include_hidden {
+                targets.map(ResolvedChangeTargets::all)
+            } else {
+                targets.and_then(ResolvedChangeTargets::into_visible)
+            }
+            .unwrap_or_else(Vec::new))
         }
         RevsetCommitRef::CommitId(prefix) => {
             let resolver = &symbol_resolver.commit_id_resolver;
@@ -4322,10 +4331,64 @@ mod tests {
 
         insta::assert_debug_snapshot!(
             parse("change_id(z)")?,
-            @r#"CommitRef(ChangeId(HexPrefix("0")))"#);
+            @r#"
+            CommitRef(
+                ChangeId(
+                    HexPrefix("0"),
+                    false,
+                ),
+            )
+        "#);
         insta::assert_debug_snapshot!(
             parse("change_id('zk')")?,
-            @r#"CommitRef(ChangeId(HexPrefix("0f")))"#);
+            @r#"
+            CommitRef(
+                ChangeId(
+                    HexPrefix("0f"),
+                    false,
+                ),
+            )
+        "#);
+        insta::assert_debug_snapshot!(
+            parse("change_id('zk', include_hidden=true)")?,
+            @r#"
+            CommitRef(
+                ChangeId(
+                    HexPrefix("0f"),
+                    true,
+                ),
+            )
+        "#);
+        insta::assert_debug_snapshot!(
+            parse("change_id('zk', include_hidden=false)")?,
+            @r#"
+            CommitRef(
+                ChangeId(
+                    HexPrefix("0f"),
+                    false,
+                ),
+            )
+        "#);
+        insta::assert_debug_snapshot!(
+            parse("change_id('zk', true)")?,
+            @r#"
+            CommitRef(
+                ChangeId(
+                    HexPrefix("0f"),
+                    true,
+                ),
+            )
+        "#);
+        insta::assert_debug_snapshot!(
+            parse("change_id('zk', false)")?,
+            @r#"
+            CommitRef(
+                ChangeId(
+                    HexPrefix("0f"),
+                    false,
+                ),
+            )
+        "#);
         insta::assert_debug_snapshot!(
             parse("change_id(01234)").unwrap_err().kind(),
             @r#"Expression("Invalid change ID prefix")"#);

--- a/lib/tests/test_revset.rs
+++ b/lib/tests/test_revset.rs
@@ -486,6 +486,29 @@ fn test_resolve_symbol_hidden_change_id() -> TestResult {
         vec![commit2.id().clone()]
     );
 
+    assert_eq!(
+        resolve_symbol(
+            repo.as_ref(),
+            &format!("change_id({change_id}, include_hidden=true)")
+        )?,
+        vec![commit2.id().clone(), commit1.id().clone()]
+    );
+    assert_eq!(
+        resolve_symbol(
+            repo.as_ref(),
+            &format!("change_id({change_id}, include_hidden=false)")
+        )?,
+        vec![commit2.id().clone()]
+    );
+    assert_eq!(
+        resolve_symbol(repo.as_ref(), &format!("change_id({change_id}, true)"))?,
+        vec![commit2.id().clone(), commit1.id().clone()]
+    );
+    assert_eq!(
+        resolve_symbol(repo.as_ref(), &format!("change_id({change_id}, false)"))?,
+        vec![commit2.id().clone()]
+    );
+
     // Abandon the new commit as well so that there are only hidden commits.
     let mut tx = repo.start_transaction();
     tx.repo_mut().record_abandoned_commit(&commit2);


### PR DESCRIPTION
`change_id` currently returns only visible commits. It can be useful to have access to hidden commits of a change ID as well.

Add an optional `include_hidden` parameter on `change_id`. Hidden commits are included in the output if `include_hidden` is set.

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
