### PR TITLE
changelog: move two misplaced new features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,15 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   where you need to pass multiple arguments to the tool, such as separate args
   for the range start and range end.
 
+* `jj git push` now supports pushing to multiple remotes at the same time.
+  This can be configured via `git.push` set to a string pattern
+  or array of string patterns, or with the repeatable `--remote` flag,
+  which also accepts string patterns.
+
+* `jj run` now uses the sparse patterns from the workspace it's run from.
+  Use the `--sparse-patterns` option to control this behavior (evaluated
+  per each `jj run` invocation).
+
 ### Fixed bugs
 
 ## [0.45.1] - 2026-09-03
@@ -95,15 +104,6 @@ None
   target a specific configuration file (such as files inside a `conf.d/`
   directory or loaded via `--config-file`). This allows precise file targeting
   and avoids interactive prompts when multiple config files exist.
-
-* `jj git push` now supports pushing to multiple remotes at the same time.
-  This can be configured via `git.push` set to a string pattern
-  or array of string patterns, or with the repeatable `--remote` flag,
-  which also accepts string patterns.
-
-* `jj run` now uses the sparse patterns from the workspace it's run from.
-  Use the `--sparse-patterns` option to control this behavior (evaluated
-  per each `jj run` invocation).
 
 ### Fixed bugs
 


### PR DESCRIPTION
Two items on the changelog were previously misplaced, this PR moves them to the right spot:

https://github.com/jj-vcs/jj/blame/b17839a4deea92/CHANGELOG.md#L99-L107

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [ ] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
