### PR TITLE
git: write HEAD after the index reset in reset_head

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,13 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed bugs
 
+* In a colocated repository, Git HEAD is no longer moved when resetting the
+  Git index fails (for example because another process holds
+  `.git/index.lock`). Previously the next command could import the moved HEAD
+  and replace the workspace's working-copy commit with a fresh one, leaving the
+  previous commit's description and bookmarks behind on the previous commit.
+  [#7530](https://github.com/jj-vcs/jj/issues/7530)
+
 ## [0.45.1] - 2026-09-03
 
 This release fixes an error that prevented the new jj-core crate from being

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -1997,6 +1997,16 @@ impl GitResetHeadError {
 
 /// Sets Git HEAD to the parent of the given working-copy commit and resets
 /// the Git index.
+///
+/// The HEAD ref is written last, after the fallible index reset. Writing the
+/// ref is an immediate on-disk side effect that the caller's transaction
+/// cannot roll back, whereas `mut_repo` is only updated in memory. If the
+/// index reset failed after HEAD had moved, the command would abort with the
+/// view still naming the old HEAD, and the next command in that workspace
+/// would import the new HEAD and replace the working-copy commit with a fresh
+/// one. Writing HEAD only after the reset succeeds prevents that unrecorded
+/// move; it does not make the Git side effects atomic with the caller's
+/// transaction.
 pub async fn reset_head(
     mut_repo: &mut MutableRepo,
     workspace_name: &WorkspaceName,
@@ -2014,10 +2024,13 @@ pub async fn reset_head(
     } else {
         RefTarget::absent()
     };
-
-    // If the first parent of the working copy has changed, reset the Git HEAD.
     let old_head_target = mut_repo.git_head(workspace_name);
-    if *old_head_target != new_head_target {
+    // Resolved here, while the old target is still borrowed from the view, and
+    // applied after the index reset. The Git import/export lock is held across
+    // the whole function, so no other jj process moves HEAD in between.
+    let head_move = if *old_head_target == new_head_target {
+        None
+    } else {
         let expected_ref = if let Some(id) = old_head_target.as_normal() {
             // We have to check the actual HEAD state because we don't record a
             // symbolic ref as such.
@@ -2035,10 +2048,8 @@ pub async fn reset_head(
             gix::refs::transaction::PreviousValue::MustExist
         };
         let new_oid = new_head_target.as_normal().map(owned_oid_from_commit_id);
-        update_git_head(&git_repo, expected_ref, new_oid)
-            .map_err(|err| GitResetHeadError::UpdateHeadRef(err.into()))?;
-        mut_repo.set_git_head_target(workspace_name, new_head_target);
-    }
+        Some((expected_ref, new_oid))
+    };
 
     // If there is an ongoing operation (merge, rebase, etc.), we need to clean it
     // up.
@@ -2046,7 +2057,14 @@ pub async fn reset_head(
         clear_operation_state(&git_repo)?;
     }
 
-    reset_index(mut_repo, &git_repo, wc_commit).await
+    reset_index(mut_repo, &git_repo, wc_commit).await?;
+
+    if let Some((expected_ref, new_oid)) = head_move {
+        update_git_head(&git_repo, expected_ref, new_oid)
+            .map_err(|err| GitResetHeadError::UpdateHeadRef(err.into()))?;
+        mut_repo.set_git_head_target(workspace_name, new_head_target);
+    }
+    Ok(())
 }
 
 // TODO: Polish and upstream this to `gix`.

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -3781,6 +3781,63 @@ fn test_reset_head_detached_out_of_sync() -> TestResult {
     Ok(())
 }
 
+#[test]
+fn test_reset_head_does_not_move_head_when_index_reset_fails() -> TestResult {
+    let test_workspace = TestWorkspace::init_colocated_git();
+    let repo = &test_workspace.repo;
+    let git_repo = get_git_repo(repo);
+    let workspace_root = test_workspace.workspace.workspace_root().to_owned();
+
+    let mut tx = repo.start_transaction();
+    let commit1 = write_random_commit(tx.repo_mut());
+    let commit2 = write_random_commit_with_parents(tx.repo_mut(), &[&commit1]);
+    let commit3 = write_random_commit_with_parents(tx.repo_mut(), &[&commit2]);
+
+    // unborn -> commit1 (= commit2's parent)
+    reset_head(tx.repo_mut(), &test_workspace.workspace, &commit2)?;
+    assert_eq!(
+        tx.repo().git_head(WorkspaceName::DEFAULT),
+        &RefTarget::normal(commit1.id().clone())
+    );
+    assert_eq!(git_repo.head_id()?, git_id(&commit1));
+
+    // Another process holds the index lock, so writing the index fails. The
+    // caller's transaction is discarded on error, taking the view update with
+    // it, so HEAD must not have been written either: a moved HEAD with an
+    // unmoved view makes the next command import the new HEAD and replace the
+    // working-copy commit with a fresh one.
+    let index_lock = git_repo.path().join("index.lock");
+    std::fs::write(&index_lock, b"").unwrap();
+
+    assert_matches!(
+        reset_head(tx.repo_mut(), &test_workspace.workspace, &commit3),
+        Err(GitResetHeadError::Git(_))
+    );
+    assert_eq!(
+        tx.repo().git_head(WorkspaceName::DEFAULT),
+        &RefTarget::normal(commit1.id().clone()),
+        "view shouldn't be updated when the index reset fails"
+    );
+    assert_eq!(
+        gix::open(&workspace_root).unwrap().head_id()?,
+        git_id(&commit1),
+        "on-disk HEAD shouldn't move when the index reset fails"
+    );
+
+    // Once the lock is gone the move goes through as usual.
+    std::fs::remove_file(&index_lock).unwrap();
+    reset_head(tx.repo_mut(), &test_workspace.workspace, &commit3)?;
+    assert_eq!(
+        tx.repo().git_head(WorkspaceName::DEFAULT),
+        &RefTarget::normal(commit2.id().clone())
+    );
+    assert_eq!(
+        gix::open(&workspace_root).unwrap().head_id()?,
+        git_id(&commit2)
+    );
+    Ok(())
+}
+
 fn get_index_state(workspace_root: &Path) -> String {
     let git_repo = gix::open(workspace_root).unwrap();
     let index = git_repo.index().unwrap();


### PR DESCRIPTION
In a colocated repository, `reset_head()` wrote the on-disk Git HEAD before the fallible index reset. When the index reset failed — another process holding `.git/index.lock` is enough — the command aborted with HEAD moved but the view unchanged, and the next command imported that HEAD and replaced the working-copy commit with a fresh one. Details and the observed sequence are in the commit message.

The new test holds `index.lock`, asks `reset_head()` for a different HEAD, and checks that both the recorded target and the on-disk HEAD are unchanged after the failure and that a retry after releasing the lock succeeds. On main it fails on the recorded-target assertion; with this change it passes.

Related: #7530. The immediate index-lock failure itself is addressed separately in #10160..

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.