### PR TITLE
git: wait for the index lock instead of failing on the first attempt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,12 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed bugs
 
+* In a colocated repository, `jj` no longer fails with `Could not acquire lock
+  for index file` when another process (such as `git status` run by an editor
+  or a prompt) briefly holds `.git/index.lock`. It now waits up to one second
+  for the lock; a lock that is never released still fails.
+  [#7530](https://github.com/jj-vcs/jj/issues/7530)
+
 ## [0.45.1] - 2026-09-03
 
 This release fixes an error that prevented the new jj-core crate from being

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -2131,9 +2131,39 @@ async fn reset_index(
 
     debug_assert!(index.verify_entries().is_ok());
 
+    write_index(&index)
+}
+
+/// How long a Git index write waits for `.git/index.lock` before failing.
+///
+/// A concurrent Git process may hold the lock briefly (a `git status` run by an
+/// editor or a prompt persists the stat cache it just refreshed, for example).
+/// gix's `File::write()` gives up on the first attempt, which turned each such
+/// moment into a failed `jj` command. A lock nobody releases (left by a killed
+/// process) still fails, after this long.
+const INDEX_LOCK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(1);
+
+/// Writes `index` to its path, waiting up to [`INDEX_LOCK_TIMEOUT`] for the
+/// index lock. Same on-disk result and error types as `File::write()`, whose
+/// lock mode isn't configurable.
+fn write_index(index: &gix::index::File) -> Result<(), GitResetHeadError> {
+    use gix::index::file::write::Error;
+    let lock = gix::lock::File::acquire_to_update_resource(
+        index.path(),
+        gix::lock::acquire::Fail::AfterDurationWithBackoff(INDEX_LOCK_TIMEOUT),
+        None,
+    )
+    .map_err(|err| GitResetHeadError::from_git(Error::AcquireLock(err)))?;
+    let mut out = std::io::BufWriter::with_capacity(64 * 1024, lock);
     index
-        .write(gix::index::write::Options::default())
-        .map_err(GitResetHeadError::from_git)
+        .write_to(&mut out, gix::index::write::Options::default())
+        .map_err(|err| GitResetHeadError::from_git(Error::Io(err)))?;
+    let lock = out
+        .into_inner()
+        .map_err(|err| GitResetHeadError::from_git(Error::Io(err.into_error().into())))?;
+    lock.commit()
+        .map_err(|err| GitResetHeadError::from_git(Error::CommitLock(err)))?;
+    Ok(())
 }
 
 fn build_index_from_merged_tree(
@@ -2272,9 +2302,7 @@ pub async fn update_intent_to_add(
     let mut_index = Arc::make_mut(&mut index);
     update_intent_to_add_impl(&git_repo, mut_index, old_tree, new_tree).await?;
     debug_assert!(mut_index.verify_entries().is_ok());
-    mut_index
-        .write(gix::index::write::Options::default())
-        .map_err(GitResetHeadError::from_git)?;
+    write_index(mut_index)?;
 
     Ok(())
 }

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -3836,6 +3836,78 @@ fn test_reset_head_with_index() -> TestResult {
 }
 
 #[test]
+fn test_reset_head_waits_for_transient_index_lock() -> TestResult {
+    let test_workspace = TestWorkspace::init_colocated_git();
+    let repo = &test_workspace.repo;
+    let git_repo = get_git_repo(repo);
+    let workspace_root = test_workspace.workspace.workspace_root();
+
+    let mut tx = repo.start_transaction();
+    let commit1 = write_random_commit(tx.repo_mut());
+    let commit2 = write_random_commit_with_parents(tx.repo_mut(), &[&commit1]);
+
+    // Another process holds the index lock briefly. Resetting the index must
+    // wait for its release rather than fail on the first attempt (#7530).
+    let index_lock = git_repo.path().join("index.lock");
+    fs::write(&index_lock, b"")?;
+    let releaser = std::thread::spawn({
+        let index_lock = index_lock.clone();
+        move || {
+            std::thread::sleep(std::time::Duration::from_millis(200));
+            fs::remove_file(&index_lock).unwrap();
+        }
+    });
+    reset_head(tx.repo_mut(), &test_workspace.workspace, &commit2)?;
+    releaser.join().unwrap();
+    assert_eq!(
+        tx.repo().git_head(WorkspaceName::DEFAULT),
+        &RefTarget::normal(commit1.id().clone())
+    );
+    assert_eq!(git_repo.head_id()?, git_id(&commit1));
+    assert!(!index_lock.exists(), "the lock is released after the write");
+    // The index was written: commit1's tree (the new HEAD's tree) plus an
+    // intent-to-add entry for each file commit2 adds on top of it.
+    let index = gix::open(workspace_root)?.open_index()?;
+    let indexed: Vec<_> = index
+        .entries()
+        .iter()
+        .map(|entry| {
+            (
+                entry.path(&index).to_string(),
+                entry
+                    .flags
+                    .contains(gix::index::entry::Flags::INTENT_TO_ADD),
+            )
+        })
+        .collect();
+    let tree_paths = |commit: &Commit| -> HashSet<String> {
+        commit
+            .tree()
+            .entries()
+            .map(|(path, _)| path.as_internal_file_string().to_owned())
+            .collect()
+    };
+    let head_paths = tree_paths(&commit1);
+    let mut expected: Vec<_> = tree_paths(&commit2)
+        .union(&head_paths)
+        .map(|path| (path.clone(), !head_paths.contains(path)))
+        .collect();
+    expected.sort();
+    assert_eq!(indexed, expected);
+
+    // A lock nobody releases is still an error: a stale lock left by a
+    // killed process must surface, not hang the command.
+    fs::write(&index_lock, b"")?;
+    let started = std::time::Instant::now();
+    assert_matches!(
+        reset_head(tx.repo_mut(), &test_workspace.workspace, &commit2),
+        Err(GitResetHeadError::Git(_))
+    );
+    assert!(started.elapsed() < std::time::Duration::from_secs(30));
+    Ok(())
+}
+
+#[test]
 fn test_reset_head_with_index_no_conflict() -> TestResult {
     let test_workspace = TestWorkspace::init_colocated_git();
     let repo = &test_workspace.repo;


### PR DESCRIPTION
In a colocated repository, any `jj` command that resets the Git index fails the instant another process holds `.git/index.lock`, because `gix::index::File::write()` acquires the lock with `Fail::Immediately`. A `git status` run by an editor or a prompt holds it for a moment while it persists the refreshed stat cache, which is the `Could not acquire lock for index file ... after 1 attempt(s)` error in #7530. Details in the commit message.

The change acquires the lock with gix's own quadratic backoff and a one-second budget, then writes through it exactly as `File::write()` does. A lock that is never released still fails after the budget, so a stale lock left by a killed process surfaces instead of hanging.

The new test holds `index.lock` for 200ms and checks that `reset_head()` succeeds and writes the expected index once the lock is released, then that an unreleased lock is still an error. On main it fails immediately with the error above; with this change it passes.

Related: #7530. The other half of that report — HEAD already moved when the index reset failed — is #10159.

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
