### PR TITLE
docs: bookmarks on an abandoned commit move to its parent unless `jj abandon`

### DIFF
--- a/docs/bookmarks.md
+++ b/docs/bookmarks.md
@@ -157,7 +157,11 @@ met:
 
  * When a commit has been rewritten (e.g, when you rebase) bookmarks and the
    working-copy will move along with it.
- * When a commit has been abandoned, all associated bookmarks will be deleted.
+ * When a commit is abandoned as part of a rewrite (e.g. when `jj squash`
+   empties it, or `jj rebase --skip-emptied` drops it), its bookmarks move to
+   the abandoned commit's parent.
+ * When a commit is abandoned with `jj abandon`, its bookmarks are deleted
+   instead. Pass `--retain-bookmarks` to move them to the parent.
 
 You could describe the updates as following along the change-id of the
 current bookmark commit, even if it isn't entirely accurate.


### PR DESCRIPTION
`docs/bookmarks.md` says abandoning a commit deletes its bookmarks. That is only what `jj abandon` does; when a commit is abandoned as part of another rewrite (`jj squash` emptying its source, `jj rebase --skip-emptied`), the bookmarks move to the parent. Verified each case against 0.45.1 in the commit message.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
