### PR TITLE
cli: do not check out on Git HEAD import when nothing moved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,12 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed bugs
 
+* In a colocated repository, a `jj` command no longer replaces the working-copy
+  commit when the view's recorded Git HEAD was lost but on-disk HEAD still
+  points at the working-copy commit's parent (as happens when an operation was
+  written by a tool embedding a jj-lib too old to know per-workspace Git
+  HEADs). The target is re-recorded without a checkout.
+
 ## [0.45.1] - 2026-09-03
 
 This release fixes an error that prevented the new jj-core crate from being

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -1398,7 +1398,23 @@ impl WorkspaceCommandHelper {
 
         let mut tx = tx.into_inner();
         let old_git_head = self.repo().view().git_head(&workspace_name).clone();
-        let new_git_head = tx.repo().view().git_head(&workspace_name);
+        let new_git_head = tx.repo().view().git_head(&workspace_name).clone();
+        // No recorded target, but on-disk HEAD is exactly where our own export
+        // leaves it: at the working-copy commit's parent. The recorded target
+        // was lost (e.g. the view was rewritten by a client too old to know
+        // per-workspace Git HEADs) rather than HEAD having moved. Re-record it
+        // without replacing the working-copy commit.
+        if old_git_head.is_absent()
+            && let Some(new_git_head_id) = new_git_head.as_normal()
+            && let Some(wc_commit_id) = tx.repo().view().get_wc_commit_id(&workspace_name)
+        {
+            let wc_commit = tx.repo().store().get_commit_async(wc_commit_id).await?;
+            if wc_commit.parent_ids().first() == Some(new_git_head_id) {
+                self.finish_transaction(ui, tx, "import git head", git_import_export_lock)
+                    .await?;
+                return Ok(());
+            }
+        }
         if let Some(new_git_head_id) = new_git_head.as_normal() {
             let new_git_head_commit = tx.repo().store().get_commit_async(new_git_head_id).await?;
             let wc_commit = tx

--- a/cli/tests/test_git_colocated.rs
+++ b/cli/tests/test_git_colocated.rs
@@ -1115,6 +1115,56 @@ fn test_git_colocated_external_checkout() -> TestResult {
 }
 
 #[test]
+fn test_git_colocated_import_after_recorded_head_lost() -> TestResult {
+    let test_env = TestEnvironment::default();
+    test_env
+        .run_jj_in(".", ["git", "init", "--colocate", "repo"])
+        .success();
+    let work_dir = test_env.work_dir("repo");
+    work_dir.write_file("file", "contents");
+    work_dir.run_jj(["commit", "-m=A"]).success();
+    work_dir.write_file("file2", "more");
+    work_dir
+        .run_jj(["describe", "-m=work in progress"])
+        .success();
+    let before = work_dir
+        .run_jj(["log", "-r@", "--no-graph", "-T", "change_id"])
+        .success();
+
+    // The state left behind when the recorded target is lost while the
+    // workspace and its working-copy commit survive: an operation written by a
+    // client too old to know per-workspace Git HEADs drops every workspace's
+    // entry but the default one, whose target survives through the deprecated
+    // single `git_head` field. On-disk HEAD stays where our own export left
+    // it: at the working-copy commit's parent.
+    testutils::strip_git_heads_from_head_view(&work_dir.root().join(".jj/repo"));
+
+    // Nothing moved, so the import must re-record the target without replacing
+    // the working-copy commit (and without the "Reset the working copy parent"
+    // message a real external checkout prints).
+    let output = work_dir.run_jj(["status"]);
+    insta::assert_snapshot!(output, @"
+    Working copy changes:
+    A file2
+    Working copy  (@) : rlvkpnrz a8691208 work in progress
+    Parent commit (@-): qpvuntsm ff26c357 A
+    [EOF]
+    ");
+    let after = work_dir
+        .run_jj(["log", "-r@", "--no-graph", "-T", "change_id"])
+        .success();
+    assert_eq!(after.stdout.raw(), before.stdout.raw());
+
+    // The recorded target is restored: the next command has nothing to import.
+    let output = work_dir.run_jj(["log", "-r@", "--no-graph", "-T", "description"]);
+    insta::assert_snapshot!(output, @"
+    work in progress
+    [EOF]
+    ");
+    Ok(())
+}
+
+#[test]
 #[cfg_attr(windows, ignore = "uses POSIX sh")]
 fn test_git_colocated_concurrent_checkout() -> TestResult {
     let test_env = TestEnvironment::default();

--- a/lib/testutils/src/lib.rs
+++ b/lib/testutils/src/lib.rs
@@ -53,6 +53,7 @@ use jj_lib::matchers::NothingMatcher;
 use jj_lib::merge::Merge;
 use jj_lib::merged_tree::MergedTree;
 use jj_lib::object_id::ObjectId as _;
+use jj_lib::op_store::RefTarget;
 use jj_lib::repo::MutableRepo;
 use jj_lib::repo::ReadonlyRepo;
 use jj_lib::repo::Repo;
@@ -411,6 +412,29 @@ impl TestWorkspace {
         let (tree, _stats) = self.snapshot_with_options(&empty_snapshot_options())?;
         Ok(tree)
     }
+}
+
+/// Commits an operation whose view has no per-workspace Git HEADs, modeling
+/// the loss a jj-lib too old to know the view's `git_heads` field inflicts:
+/// every workspace it cannot round-trip through the deprecated single
+/// `git_head` field (i.e. every workspace but the default one) loses its
+/// recorded target, while `wc_commit_ids` survives.
+///
+/// `repo_path` is the workspace's `.jj/repo` directory.
+pub fn strip_git_heads_from_head_view(repo_path: &Path) {
+    let settings = user_settings();
+    let loader =
+        RepoLoader::init_from_file_system(&settings, repo_path, &default_backend_factories())
+            .unwrap();
+    let repo = loader.load_at_head().block_on().unwrap();
+    let workspaces: Vec<_> = repo.view().wc_commit_ids().keys().cloned().collect();
+    let mut tx = repo.start_transaction();
+    for name in &workspaces {
+        tx.repo_mut().set_git_head_target(name, RefTarget::absent());
+    }
+    tx.commit("strip git heads (simulated old client)")
+        .block_on()
+        .unwrap();
 }
 
 pub fn commit_transactions(txs: Vec<Transaction>) -> Arc<ReadonlyRepo> {


### PR DESCRIPTION
`import_git_head()` treats any difference between the view's recorded Git HEAD and the on-disk HEAD as an external checkout and replaces the working-copy commit. The recorded target can also simply be missing: a view rewritten by a tool embedding a jj-lib older than 0.45.0 keeps only the default workspace's target (through the deprecated single `git_head` field) and drops every other workspace's entry, while `wc_commit_ids` survives. Nothing on disk has moved in that state — HEAD is still at the working-copy commit's parent, where our own export left it — yet the next command in each affected workspace "imported" that HEAD and silently replaced `@`, orphaning its description and bookmarks. On a machine with ~100 colocated workspaces this happened 1183 times in one 6000-operation window; details in the commit message.

With this change, an absent recorded target plus a HEAD equal to the working-copy commit's first parent re-records the target and finishes the transaction without checking out. A HEAD anywhere else still checks out as before.

The test rewrites the head view without `git_heads` via a new `testutils` helper and asserts the next command keeps `@`'s change id and description. On main it fails with `@` replaced by a fresh undescribed commit.


#10164 addresses the same lost-entry state one layer down, in `merge_view()`; the two are independent.

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
