### PR TITLE
repo: do not treat a lost git_heads entry as a deletion when merging views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed bugs
 
+* Reconciling concurrent operations no longer deletes a workspace's recorded
+  Git HEAD when one operation's view merely lacks the entry (as when written by
+  a tool embedding a jj-lib too old to know per-workspace Git HEADs) while the
+  workspace itself survives. A genuine `jj workspace forget` still removes it.
+
 ## [0.45.1] - 2026-09-03
 
 This release fixes an error that prevented the new jj-core crate from being

--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -2032,12 +2032,48 @@ impl MutableRepo {
             self.merge_remote_tag(symbol, base_ref, other_ref).await?;
         }
 
+        // A view written by a client too old to know per-workspace Git HEADs
+        // (the field predates jj-lib 0.45.0) drops every `git_heads` entry it
+        // cannot round-trip while its workspaces survive. Treat such an
+        // absence as no information rather than as a deletion: a genuine
+        // workspace removal also removes the workspace's working-copy commit
+        // (`View::remove_workspace`). The cost is that a concurrent
+        // legitimate removal in a surviving workspace -- `git::reset_head()`
+        // records an absent target both for an unborn HEAD and for a
+        // working-copy commit parented on the root commit -- is not
+        // propagated; the next command in that workspace re-records it.
+        fn lost_git_head(view: &View, workspace: &WorkspaceName) -> bool {
+            view.git_head(workspace).is_absent() && view.get_wc_commit_id(workspace).is_some()
+        }
         let changed_git_heads = diff_named_ref_targets(base.all_git_heads(), other.all_git_heads());
         for (workspace, (base_target, other_target)) in changed_git_heads {
+            if base_target.is_present() && lost_git_head(other, workspace) {
+                // `other` lost the entry, not the workspace: it contributes no
+                // change. If `self` lost it the same way, the base still knows
+                // the target.
+                if lost_git_head(self.view(), workspace) {
+                    self.set_git_head_target(workspace, base_target.clone());
+                }
+                continue;
+            }
             let self_target = self.view().git_head(workspace);
             let new_target =
                 merge_ref_targets(self.index(), self_target, base_target, other_target).await?;
             self.set_git_head_target(workspace, new_target);
+        }
+        // The mirrored ordering: `self` is the view that lost its entries, and
+        // for a workspace where `base` and `other` agree the loop above never
+        // runs.
+        let restored: Vec<_> = other
+            .all_git_heads()
+            .iter()
+            .filter(|&(workspace, other_target)| {
+                base.git_head(workspace) == other_target && lost_git_head(self.view(), workspace)
+            })
+            .map(|(workspace, target)| (workspace.clone(), target.clone()))
+            .collect();
+        for (workspace, target) in restored {
+            self.set_git_head_target(&workspace, target);
         }
 
         Ok(())

--- a/lib/tests/test_view.rs
+++ b/lib/tests/test_view.rs
@@ -553,6 +553,90 @@ fn test_merge_views_git_heads() -> TestResult {
 }
 
 #[test]
+fn test_merge_views_git_heads_lost_by_old_client() -> TestResult {
+    // A view written by a client too old to know per-workspace Git HEADs
+    // drops every `git_heads` entry while `wc_commit_ids` survives. Merging
+    // such a view must not delete the surviving side's recorded target,
+    // whichever side the reconcile loads first.
+    for wipe_first in [false, true] {
+        let test_repo = TestRepo::init();
+        let repo = &test_repo.repo;
+
+        let mut tx0 = repo.start_transaction();
+        let head = write_random_commit(tx0.repo_mut());
+        let wc_commit = write_random_commit(tx0.repo_mut());
+        tx0.repo_mut()
+            .set_wc_commit(WorkspaceName::DEFAULT.to_owned(), wc_commit.id().clone())?;
+        tx0.repo_mut()
+            .set_git_head_target(WorkspaceName::DEFAULT, RefTarget::normal(head.id().clone()));
+        let repo = tx0.commit("test").block_on()?;
+
+        // An unrelated concurrent operation.
+        let mut tx1 = repo.start_transaction();
+        write_random_commit(tx1.repo_mut());
+
+        // The old client's operation: git_heads gone, workspace kept.
+        let mut tx2 = repo.start_transaction();
+        write_random_commit(tx2.repo_mut());
+        tx2.repo_mut()
+            .set_git_head_target(WorkspaceName::DEFAULT, RefTarget::absent());
+
+        let txs = if wipe_first {
+            vec![tx2, tx1]
+        } else {
+            vec![tx1, tx2]
+        };
+        let repo = commit_transactions(txs);
+        assert_eq!(
+            repo.view().git_head(WorkspaceName::DEFAULT),
+            &RefTarget::normal(head.id().clone()),
+            "recorded Git HEAD must survive the merge (wipe_first={wipe_first})"
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn test_merge_views_git_heads_workspace_removed() -> TestResult {
+    // A genuine workspace removal deletes both the working-copy commit and
+    // the recorded Git HEAD; the merge must not resurrect the target.
+    for removal_first in [false, true] {
+        let test_repo = TestRepo::init();
+        let repo = &test_repo.repo;
+
+        let ws_name = WorkspaceNameBuf::from("second");
+        let mut tx0 = repo.start_transaction();
+        let head = write_random_commit(tx0.repo_mut());
+        let wc_commit = write_random_commit(tx0.repo_mut());
+        tx0.repo_mut()
+            .set_wc_commit(ws_name.clone(), wc_commit.id().clone())?;
+        tx0.repo_mut()
+            .set_git_head_target(&ws_name, RefTarget::normal(head.id().clone()));
+        let repo = tx0.commit("test").block_on()?;
+
+        let mut tx1 = repo.start_transaction();
+        write_random_commit(tx1.repo_mut());
+
+        let mut tx2 = repo.start_transaction();
+        write_random_commit(tx2.repo_mut());
+        tx2.repo_mut().remove_workspace(&ws_name).block_on()?;
+
+        let txs = if removal_first {
+            vec![tx2, tx1]
+        } else {
+            vec![tx1, tx2]
+        };
+        let repo = commit_transactions(txs);
+        assert!(
+            repo.view().git_head(&ws_name).is_absent(),
+            "a removed workspace's Git HEAD must stay deleted (removal_first={removal_first})"
+        );
+        assert_eq!(repo.view().get_wc_commit_id(&ws_name), None);
+    }
+    Ok(())
+}
+
+#[test]
 fn test_merge_views_divergent() -> TestResult {
     // We start with just commit A. Operation 1 rewrites it as A2. Operation 2
     // rewrites it as A3.


### PR DESCRIPTION
`merge_view()` resolves each workspace's Git HEAD with a three-way ref merge, so a view carrying no entry for a workspace deletes the other side's recorded target — and when the entry-less view is the side the reconcile loaded first, `base` and `other` agree and the loop never visits the workspace, so the loss is kept silently. Views missing entries are written in practice by tools embedding a jj-lib older than 0.45.0: the round trip keeps only the default workspace's target and drops every other workspace's entry while `wc_commit_ids` survives. On a machine with ~100 colocated workspaces, 39 of 341 reconciles in one 6000-operation window deleted a surviving workspace's target this way (385 deletions, none a genuine workspace removal); details in the commit message.

The change distinguishes that loss from a genuine deletion by the workspace itself: `View::remove_workspace` removes the working-copy commit together with the recorded target, so a side that lacks the entry but still has the workspace contributes no change (and the base's target is restored if both sides lost it). A side that removed the workspace still merges as a deletion. The cost — a concurrent legitimate move to an absent target in a surviving workspace is not propagated until that workspace's next command re-records it — and the one shape left unfixed are stated in the commit message.

Tests cover both reconcile orderings of a lost entry (fail on main with the target deleted) and both orderings of a genuine workspace-forget (still deleted).


#10163 stops the damage at the CLI layer for the same state; the two are independent.

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
