### PR TITLE
jj workspace add: resolve --revision before creating the workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed bugs
 
+* `jj workspace add --revision <rev>` no longer creates the workspace when the
+  revision does not resolve. It used to leave a registered workspace whose
+  working-copy commit was parented at the root, along with the new directory
+  and, in a colocated repository, a Git worktree.
+
 ## [0.45.1] - 2026-09-03
 
 This release fixes an error that prevented the new jj-core crate from being

--- a/cli/src/commands/workspace/add.rs
+++ b/cli/src/commands/workspace/add.rs
@@ -15,8 +15,7 @@
 use std::fs;
 
 use futures::future::try_join_all;
-use itertools::Itertools as _;
-use jj_lib::commit::CommitIteratorExt as _;
+use jj_lib::backend::CommitId;
 use jj_lib::file_util;
 use jj_lib::file_util::IoResultExt as _;
 #[cfg(feature = "git")]
@@ -136,6 +135,34 @@ pub async fn cmd_workspace_add(
             name = workspace_name.as_symbol()
         )));
     }
+    // Resolve the new working copy's parents before creating anything: the
+    // directory, the Git worktree and the workspace registration below are
+    // all committed to disk, and an unresolvable revision must not leave a
+    // half-created workspace behind.
+    //
+    // If no parent revisions are specified, use the parents of the current
+    // workspace's working-copy commit, or the root if there is no working-copy
+    // commit in the current workspace.
+    let parent_ids: Vec<CommitId> = if args.revisions.is_empty() {
+        if let Some(old_wc_commit_id) = repo
+            .view()
+            .get_wc_commit_id(old_workspace_command.workspace_name())
+        {
+            repo.store()
+                .get_commit_async(old_wc_commit_id)
+                .await?
+                .parent_ids()
+                .to_vec()
+        } else {
+            vec![repo.store().root_commit_id().clone()]
+        }
+    } else {
+        old_workspace_command
+            .resolve_some_revsets(ui, &args.revisions)
+            .await?
+            .into_iter()
+            .collect()
+    };
     if !destination_path.exists() {
         fs::create_dir(&destination_path).context(&destination_path)?;
     } else if !file_util::is_empty_dir(&destination_path)? {
@@ -221,38 +248,13 @@ pub async fn cmd_workspace_add(
 
     let mut tx = new_workspace_command.start_transaction();
 
-    // If no parent revisions are specified, create a working-copy commit based
-    // on the parent of the current working-copy commit.
-    let parents = if args.revisions.is_empty() {
-        // Check out parents of the current workspace's working-copy commit, or the
-        // root if there is no working-copy commit in the current workspace.
-        if let Some(old_wc_commit_id) = tx
-            .base_repo()
-            .view()
-            .get_wc_commit_id(old_workspace_command.workspace_name())
-        {
-            tx.repo()
-                .store()
-                .get_commit_async(old_wc_commit_id)
-                .await?
-                .parents()
-                .await?
-        } else {
-            vec![tx.repo().store().root_commit()]
-        }
-    } else {
-        try_join_all(
-            old_workspace_command
-                .resolve_some_revsets(ui, &args.revisions)
-                .await?
-                .iter()
-                .map(|id| tx.repo().store().get_commit_async(id)),
-        )
-        .await?
-    };
-
+    let parents: Vec<_> = try_join_all(
+        parent_ids
+            .iter()
+            .map(|id| tx.repo().store().get_commit_async(id)),
+    )
+    .await?;
     let tree = merge_commit_trees(tx.repo(), &parents).await?;
-    let parent_ids = parents.iter().ids().cloned().collect_vec();
     let mut commit_builder = tx.repo_mut().new_commit(parent_ids, tree).detach();
     let mut description = join_message_paragraphs(&args.message_paragraphs);
     if !description.is_empty() {

--- a/cli/tests/test_workspaces.rs
+++ b/cli/tests/test_workspaces.rs
@@ -458,6 +458,46 @@ fn test_workspaces_add_workspace_at_revision() {
     "#);
 }
 
+/// A revision that fails to resolve must leave nothing behind: no directory,
+/// no registered workspace, no operation.
+#[test]
+fn test_workspaces_add_workspace_at_unresolvable_revision() {
+    let test_env = TestEnvironment::default();
+    test_env
+        .run_jj_in(".", ["git", "init", "--colocate", "main"])
+        .success();
+    let main_dir = test_env.work_dir("main");
+    main_dir.write_file("file-1", "contents");
+    main_dir.run_jj(["commit", "-m", "first"]).success();
+    let ops_before = main_dir.run_jj(["op", "log", "--no-graph", "-T", "id"]);
+
+    let output = main_dir.run_jj(["workspace", "add", "-r", "nonexistent", "../secondary"]);
+    insta::assert_snapshot!(output.normalize_backslash(), @"
+    ------- stderr -------
+    Error: Revision `nonexistent` doesn't exist
+    [EOF]
+    [exit status: 1]
+    ");
+
+    assert!(
+        !test_env.env_root().join("secondary").exists(),
+        "no workspace directory should be created for an unresolvable revision"
+    );
+    let output = main_dir.run_jj(["workspace", "list"]);
+    insta::assert_snapshot!(output, @"
+    default: . rlvkpnrz 274ba245 (empty) (no description set)
+    [EOF]
+    ");
+    let ops_after = main_dir.run_jj(["op", "log", "--no-graph", "-T", "id"]);
+    assert_eq!(ops_after.stdout.raw(), ops_before.stdout.raw());
+    let git_repo = git::open(main_dir.root());
+    assert_eq!(
+        git_repo.worktrees().unwrap().len(),
+        0,
+        "no Git worktree should be created for an unresolvable revision"
+    );
+}
+
 /// Test multiple `-r` flags to `workspace add` to create a workspace
 /// working-copy commit with multiple parents.
 #[test]


### PR DESCRIPTION
`jj workspace add --revision <rev>` created the destination directory, the Git worktree (in a colocated repository) and the workspace itself — including the `add workspace` operation `Workspace::init_workspace_with_existing_repo()` commits — before resolving `--revision`. A revision that does not resolve therefore failed after the fact, with a registered workspace whose working-copy commit is parented at the root and, in a colocated repository, a Git worktree already linked. Reproducible on v0.45.1 with `jj workspace add --revision doesnotexist ../w2`: the error is printed after `Created workspace in "../w2"`, and `jj workspace list` / `git worktree list` both show the leftover.

This resolves the parents first; the default-parent computation only needs the current repository view and `--revision` only needs the current workspace, so nothing is created until both have succeeded. The commit message spells out why moving the default-parent lookup ahead of `init_workspace_with_existing_repo()` resolves against the same view.

The test asks for a nonexistent revision in a colocated repository and checks that no directory, workspace, operation or Git worktree was created. On main it fails with `Created workspace in "../secondary"` printed ahead of the error.

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
