### PR TITLE
workspace forget: disconnect only its own Git worktree, and fail when it cannot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,13 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed bugs
 
+* `jj workspace forget` and `jj git colocation disable` now fail when a
+  workspace's Git worktree could not be disconnected (for example because its
+  directory is read-only), instead of printing a warning and continuing with
+  the worktree still registered in Git. For `jj workspace forget` the workspace
+  itself is still forgotten; the error explains how to disconnect the leftover
+  worktree without deleting the workspace's files.
+
 * `jj workspace forget` no longer runs `git worktree prune` on the whole
   repository, which could unregister another workspace's Git worktree if its
   directory was unreadable at that moment. Only the forgotten workspace's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed bugs
 
+* `jj workspace forget` no longer runs `git worktree prune` on the whole
+  repository, which could unregister another workspace's Git worktree if its
+  directory was unreadable at that moment. Only the forgotten workspace's
+  worktree is removed.
+
 ## [0.45.1] - 2026-09-03
 
 This release fixes an error that prevented the new jj-core crate from being

--- a/cli/src/commands/git/colocation.rs
+++ b/cli/src/commands/git/colocation.rs
@@ -242,13 +242,7 @@ async fn cmd_git_colocation_disable(
     let workspace_root = workspace_command.workspace_root();
 
     if is_child_workspace(&workspace_command) {
-        let subprocess_options = GitSubprocessOptions::from_settings(workspace_command.settings())?;
-        unlink_git_worktree(
-            ui,
-            workspace_command.repo().store(),
-            subprocess_options,
-            workspace_root,
-        )?;
+        unlink_git_worktree(ui, workspace_command.repo().store(), workspace_root)?;
     } else {
         let git_store_path = workspace_command.repo_path().join("store").join("git");
         let git_target_path = workspace_command

--- a/cli/src/commands/workspace/forget.rs
+++ b/cli/src/commands/workspace/forget.rs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[cfg(feature = "git")]
+use std::error::Error as _;
+
 use clap_complete::ArgValueCandidates;
 use itertools::Itertools as _;
 use jj_lib::ref_name::WorkspaceNameBuf;
@@ -23,6 +26,8 @@ use tracing::instrument;
 
 use crate::cli_util::CommandHelper;
 use crate::command_error::CommandError;
+#[cfg(feature = "git")]
+use crate::command_error::print_error_sources;
 use crate::complete;
 #[cfg(feature = "git")]
 use crate::git_util::unlink_git_worktree;
@@ -113,9 +118,23 @@ pub async fn cmd_workspace_forget(
 
     #[cfg(feature = "git")]
     {
+        // Disconnect every worktree before failing on any of them, so one
+        // unreadable directory does not leave the others linked as well. Every
+        // failure is reported; the first one is returned.
         let store = workspace_command.repo().store();
+        let mut first_error = None;
         for path in &workspace_paths {
-            unlink_git_worktree(ui, store, path)?;
+            if let Err(err) = unlink_git_worktree(ui, store, path) {
+                if first_error.is_some() {
+                    writeln!(ui.warning_default(), "{}", err.error)?;
+                    print_error_sources(ui, err.error.source())?;
+                } else {
+                    first_error = Some(err);
+                }
+            }
+        }
+        if let Some(err) = first_error {
+            return Err(err);
         }
     }
 

--- a/cli/src/commands/workspace/forget.rs
+++ b/cli/src/commands/workspace/forget.rs
@@ -14,8 +14,6 @@
 
 use clap_complete::ArgValueCandidates;
 use itertools::Itertools as _;
-#[cfg(feature = "git")]
-use jj_lib::git::GitSubprocessOptions;
 use jj_lib::ref_name::WorkspaceNameBuf;
 #[cfg(feature = "git")]
 use jj_lib::repo::Repo as _;
@@ -115,10 +113,9 @@ pub async fn cmd_workspace_forget(
 
     #[cfg(feature = "git")]
     {
-        let subprocess_options = GitSubprocessOptions::from_settings(workspace_command.settings())?;
         let store = workspace_command.repo().store();
         for path in &workspace_paths {
-            unlink_git_worktree(ui, store, subprocess_options.clone(), path)?;
+            unlink_git_worktree(ui, store, path)?;
         }
     }
 

--- a/cli/src/git_util.rs
+++ b/cli/src/git_util.rs
@@ -55,8 +55,8 @@ use crate::cli_util::WorkspaceCommandTransaction;
 use crate::cli_util::print_updated_commits;
 use crate::command_error::CommandError;
 use crate::command_error::cli_error;
-use crate::command_error::print_error_sources;
 use crate::command_error::user_error;
+use crate::command_error::user_error_with_message;
 use crate::formatter::Formatter;
 use crate::formatter::FormatterExt as _;
 use crate::revset_util::parse_remote_auto_track_bookmarks_map;
@@ -565,31 +565,55 @@ pub fn print_push_stats(ui: &Ui, stats: &GitPushStats) -> io::Result<()> {
 
 /// Disconnects the Git worktree backing a jj workspace, if there is one.
 ///
-/// The workspace has already been forgotten by the time this runs, and a
-/// leftover gitlink or stale worktree metadata isn't worth failing the command
-/// over, so errors are reported as warnings.
+/// A worktree that could not be disconnected is an error: Git keeps it
+/// registered, and the caller must not report a clean disconnect. The hint
+/// explains how to finish disconnecting it without deleting the workspace's
+/// files, which `git worktree remove` would do.
 pub fn unlink_git_worktree(
     ui: &Ui,
     store: &Arc<Store>,
     worktree_path: &Path,
 ) -> Result<(), CommandError> {
     match git::unlink_worktree(store, worktree_path) {
-        Ok(false) => {}
-        Ok(true) => writeln!(
-            ui.status(),
-            r#"Removed Git worktree for "{}"."#,
-            worktree_path.display()
-        )?,
-        Err(err) => {
+        Ok(false) => Ok(()),
+        Ok(true) => {
             writeln!(
-                ui.warning_default(),
-                r#"Failed to remove Git worktree for "{}"."#,
+                ui.status(),
+                r#"Removed Git worktree for "{}"."#,
                 worktree_path.display()
             )?;
-            print_error_sources(ui, Some(&err))?;
+            Ok(())
+        }
+        Err(err) => {
+            let hint = match &err {
+                git::GitUnlinkWorktreeError::ReadGitLink(_)
+                | git::GitUnlinkWorktreeError::RemoveGitLink(_)
+                | git::GitUnlinkWorktreeError::Git(_) => Some(format!(
+                    "Git still has this worktree registered. Delete \"{}\" and run `git worktree \
+                     prune` to disconnect it.",
+                    worktree_path.join(".git").display()
+                )),
+                git::GitUnlinkWorktreeError::RemoveMetadata(_) => Some(
+                    "The gitlink has been removed. Run `git worktree prune` to drop the stale \
+                     worktree metadata."
+                        .to_owned(),
+                ),
+                git::GitUnlinkWorktreeError::NotALinkedWorktree(_)
+                | git::GitUnlinkWorktreeError::UnexpectedBackend(_) => None,
+            };
+            let err = user_error_with_message(
+                format!(
+                    r#"Failed to remove Git worktree for "{}""#,
+                    worktree_path.display()
+                ),
+                err,
+            );
+            Err(match hint {
+                Some(hint) => err.hinted(hint),
+                None => err,
+            })
         }
     }
-    Ok(())
 }
 
 #[cfg(test)]

--- a/cli/src/git_util.rs
+++ b/cli/src/git_util.rs
@@ -41,7 +41,6 @@ use jj_lib::git::GitRefKind;
 use jj_lib::git::GitSettings;
 use jj_lib::git::GitSidebandLineTerminator;
 use jj_lib::git::GitSubprocessCallback;
-use jj_lib::git::GitSubprocessOptions;
 use jj_lib::git_backend::GitRepoAtWorkdirError;
 use jj_lib::op_store::RemoteRefState;
 use jj_lib::repo::ReadonlyRepo;
@@ -572,10 +571,9 @@ pub fn print_push_stats(ui: &Ui, stats: &GitPushStats) -> io::Result<()> {
 pub fn unlink_git_worktree(
     ui: &Ui,
     store: &Arc<Store>,
-    subprocess_options: GitSubprocessOptions,
     worktree_path: &Path,
 ) -> Result<(), CommandError> {
-    match git::unlink_worktree(store, subprocess_options, worktree_path) {
+    match git::unlink_worktree(store, worktree_path) {
         Ok(false) => {}
         Ok(true) => writeln!(
             ui.status(),

--- a/cli/tests/test_git_colocation.rs
+++ b/cli/tests/test_git_colocation.rs
@@ -526,6 +526,57 @@ fn test_git_colocation_enable_disable_child_workspace() {
     ");
 }
 
+/// When a child workspace's Git worktree cannot be disconnected,
+/// `git colocation disable` must fail before it touches anything else,
+/// instead of warning and then reporting a successful conversion.
+#[test]
+#[cfg(unix)]
+fn test_git_colocation_disable_child_workspace_fails_when_worktree_stays_linked() {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let test_env = TestEnvironment::default();
+    test_env.add_config("git.colocate = true");
+    test_env
+        .run_jj_in(".", ["git", "init", "--colocate", "main"])
+        .success();
+    let main_dir = test_env.work_dir("main");
+    main_dir.write_file("file", "contents");
+    main_dir.run_jj(["commit", "-m", "initial"]).success();
+    main_dir
+        .run_jj(["workspace", "add", "../secondary"])
+        .success();
+    let secondary_dir = test_env.work_dir("secondary");
+    let secondary = test_env.env_root().join("secondary");
+    assert!(secondary.join(".jj/.gitignore").is_file());
+
+    // The gitlink cannot be removed: its directory is read-only.
+    let writable = std::fs::metadata(&secondary).unwrap().permissions();
+    std::fs::set_permissions(&secondary, std::fs::Permissions::from_mode(0o555)).unwrap();
+    let output = secondary_dir.run_jj(["git", "colocation", "disable"]);
+    std::fs::set_permissions(&secondary, writable).unwrap();
+    insta::assert_snapshot!(output.normalize_backslash(), @r#"
+    ------- stderr -------
+    Error: Failed to remove Git worktree for "$TEST_ENV/secondary"
+    Caused by:
+    1: Failed to remove .git gitlink file
+    2: Cannot access $TEST_ENV/secondary/.git
+    3: Permission denied (os error 13)
+    Hint: Git still has this worktree registered. Delete "$TEST_ENV/secondary/.git" and run `git worktree prune` to disconnect it.
+    [EOF]
+    [exit status: 1]
+    "#);
+
+    // Nothing was half-converted: the workspace is still fully colocated.
+    assert!(secondary.join(".git").is_file());
+    assert!(secondary.join(".jj/.gitignore").is_file());
+    let output = secondary_dir.run_jj(["git", "colocation", "status", "--quiet"]);
+    insta::assert_snapshot!(output, @"
+    Workspace 'secondary' is currently colocated with Git.
+    Last imported/exported Git HEAD: 7b22a8cbe888adcb4d5ff6dd46a38049e870c6ab
+    [EOF]
+    ");
+}
+
 #[test]
 fn test_git_colocation_enable_child_workspace_with_existing_git_dir() -> TestResult {
     let test_env = TestEnvironment::default();

--- a/cli/tests/test_workspaces.rs
+++ b/cli/tests/test_workspaces.rs
@@ -2285,6 +2285,122 @@ fn test_workspaces_forget_colocated_leaves_unreadable_sibling_registered() {
     );
 }
 
+/// When the Git worktree cannot be disconnected, `workspace forget` must fail
+/// (the workspace itself is still forgotten) instead of printing a warning and
+/// exiting 0 with the worktree left registered.
+#[test]
+#[cfg(unix)]
+fn test_workspaces_forget_colocated_fails_when_worktree_stays_linked() {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let test_env = TestEnvironment::default();
+    test_env.add_config("git.colocate = true");
+    test_env
+        .run_jj_in(".", ["git", "init", "--colocate", "main"])
+        .success();
+    let main_dir = test_env.work_dir("main");
+    let main_repo = git::open(main_dir.root());
+    main_dir.write_file("file", "contents");
+    main_dir.run_jj(["commit", "-m", "initial"]).success();
+    main_dir
+        .run_jj(["workspace", "add", "../secondary"])
+        .success();
+    assert_eq!(git_worktree_ids(&main_repo), ["secondary"]);
+
+    // The gitlink cannot be removed: its directory is read-only.
+    let secondary = test_env.env_root().join("secondary");
+    let writable = std::fs::metadata(&secondary).unwrap().permissions();
+    std::fs::set_permissions(&secondary, std::fs::Permissions::from_mode(0o555)).unwrap();
+    let output = main_dir.run_jj(["workspace", "forget", "secondary"]);
+    std::fs::set_permissions(&secondary, writable.clone()).unwrap();
+    insta::assert_snapshot!(output.normalize_backslash(), @r#"
+    ------- stderr -------
+    Error: Failed to remove Git worktree for "$TEST_ENV/secondary"
+    Caused by:
+    1: Failed to remove .git gitlink file
+    2: Cannot access $TEST_ENV/secondary/.git
+    3: Permission denied (os error 13)
+    Hint: Git still has this worktree registered. Delete "$TEST_ENV/secondary/.git" and run `git worktree prune` to disconnect it.
+    [EOF]
+    [exit status: 1]
+    "#);
+    // The workspace is gone from jj, the worktree is still registered in Git.
+    let output = main_dir.run_jj(["workspace", "list"]);
+    insta::assert_snapshot!(output, @"
+    default: . rlvkpnrz 504e3d8c (empty) (no description set)
+    [EOF]
+    ");
+    assert_eq!(git_worktree_ids(&main_repo), ["secondary"]);
+
+    // A worktree directory that cannot even be inspected is an error too, not
+    // a silent "nothing to do".
+    main_dir
+        .run_jj(["workspace", "add", "../tertiary"])
+        .success();
+    let tertiary = test_env.env_root().join("tertiary");
+    std::fs::set_permissions(&tertiary, std::fs::Permissions::from_mode(0o000)).unwrap();
+    let output = main_dir.run_jj(["workspace", "forget", "tertiary"]);
+    std::fs::set_permissions(&tertiary, writable.clone()).unwrap();
+    insta::assert_snapshot!(output.normalize_backslash(), @r#"
+    ------- stderr -------
+    Error: Failed to remove Git worktree for "$TEST_ENV/tertiary"
+    Caused by:
+    1: Failed to read .git gitlink file
+    2: Cannot access $TEST_ENV/tertiary/.git
+    3: Permission denied (os error 13)
+    Hint: Git still has this worktree registered. Delete "$TEST_ENV/tertiary/.git" and run `git worktree prune` to disconnect it.
+    [EOF]
+    [exit status: 1]
+    "#);
+    assert_eq!(git_worktree_ids(&main_repo), ["secondary", "tertiary"]);
+
+    // The hinted recipe disconnects the leftover worktree and keeps the
+    // workspace's files, unlike `git worktree remove`.
+    std::fs::remove_file(secondary.join(".git")).unwrap();
+    std::fs::remove_file(tertiary.join(".git")).unwrap();
+    let output = std::process::Command::new("git")
+        .args(["worktree", "prune"])
+        .current_dir(main_dir.root())
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "{output:?}");
+    assert!(git_worktree_ids(&main_repo).is_empty());
+    assert!(secondary.join("file").exists());
+    assert!(tertiary.join("file").exists());
+
+    // Forgetting several workspaces reports every worktree that could not be
+    // disconnected, not just the first.
+    for name in ["fourth", "fifth"] {
+        main_dir
+            .run_jj(["workspace", "add", &format!("../{name}")])
+            .success();
+        let dir = test_env.env_root().join(name);
+        std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o555)).unwrap();
+    }
+    let output = main_dir.run_jj(["workspace", "forget", "fourth", "fifth"]);
+    for name in ["fourth", "fifth"] {
+        let dir = test_env.env_root().join(name);
+        std::fs::set_permissions(&dir, writable.clone()).unwrap();
+    }
+    insta::assert_snapshot!(output.normalize_backslash(), @r#"
+    ------- stderr -------
+    Warning: Failed to remove Git worktree for "$TEST_ENV/fifth"
+    Caused by:
+    1: Failed to remove .git gitlink file
+    2: Cannot access $TEST_ENV/fifth/.git
+    3: Permission denied (os error 13)
+    Error: Failed to remove Git worktree for "$TEST_ENV/fourth"
+    Caused by:
+    1: Failed to remove .git gitlink file
+    2: Cannot access $TEST_ENV/fourth/.git
+    3: Permission denied (os error 13)
+    Hint: Git still has this worktree registered. Delete "$TEST_ENV/fourth/.git" and run `git worktree prune` to disconnect it.
+    [EOF]
+    [exit status: 1]
+    "#);
+    assert_eq!(git_worktree_ids(&main_repo), ["fifth", "fourth"]);
+}
+
 #[test]
 fn test_workspaces_add_colocated_at_revision() {
     let test_env = TestEnvironment::default();

--- a/cli/tests/test_workspaces.rs
+++ b/cli/tests/test_workspaces.rs
@@ -2236,6 +2236,55 @@ fn test_workspaces_add_forget_colocated() {
     assert_eq!(local_branches(&main_repo), [] as [String; 0]);
 }
 
+/// Forgetting one workspace must not disconnect another whose directory is
+/// momentarily unreadable. `git worktree prune` would: it drops the metadata
+/// of every worktree it cannot stat, and that worktree then silently loses
+/// its colocation while jj keeps using it.
+#[cfg(unix)]
+#[test]
+fn test_workspaces_forget_colocated_leaves_unreadable_sibling_registered() {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let test_env = TestEnvironment::default();
+    test_env.add_config("git.colocate = true");
+    test_env
+        .run_jj_in(".", ["git", "init", "--colocate", "main"])
+        .success();
+    let main_dir = test_env.work_dir("main");
+    main_dir.write_file("file", "contents");
+    main_dir.run_jj(["commit", "-m", "initial"]).success();
+
+    main_dir
+        .run_jj(["workspace", "add", "../secondary"])
+        .success();
+    std::fs::create_dir(test_env.env_root().join("blocked")).unwrap();
+    main_dir
+        .run_jj(["workspace", "add", "../blocked/sibling"])
+        .success();
+    let main_repo = git::open(test_env.env_root().join("main"));
+    assert_eq!(git_worktree_ids(&main_repo), ["secondary", "sibling"]);
+
+    // Git cannot stat `blocked/sibling` while `blocked` is unreadable, which
+    // is exactly when `git worktree prune` would discard it.
+    let blocked = test_env.env_root().join("blocked");
+    let readable = std::fs::metadata(&blocked).unwrap().permissions();
+    std::fs::set_permissions(&blocked, std::fs::Permissions::from_mode(0o000)).unwrap();
+    let output = main_dir.run_jj(["workspace", "forget", "secondary"]);
+    std::fs::set_permissions(&blocked, readable).unwrap();
+    insta::assert_snapshot!(output.normalize_backslash(), @r#"
+    ------- stderr -------
+    Removed Git worktree for "$TEST_ENV/secondary".
+    [EOF]
+    "#);
+
+    assert_eq!(git_worktree_ids(&main_repo), ["sibling"]);
+    let sibling_repo = git::open(test_env.env_root().join("blocked/sibling"));
+    assert!(
+        sibling_repo.head_id().is_ok(),
+        "sibling worktree still resolves HEAD"
+    );
+}
+
 #[test]
 fn test_workspaces_add_colocated_at_revision() {
     let test_env = TestEnvironment::default();

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -1934,6 +1934,8 @@ fn add_worktree_to_populated_dir(
 
 #[derive(Debug, Error)]
 pub enum GitUnlinkWorktreeError {
+    #[error("Failed to read .git gitlink file")]
+    ReadGitLink(#[source] PathError),
     #[error("Failed to remove .git gitlink file")]
     RemoveGitLink(#[source] PathError),
     #[error("Failed to remove Git worktree metadata")]
@@ -1963,15 +1965,27 @@ pub enum GitUnlinkWorktreeError {
 ///
 /// The gitlink is removed before the bookkeeping, so an error means either
 /// that nothing was done, or that the worktree is already disconnected and
-/// only stale metadata remains. Neither is worth failing a command over, so
-/// callers may treat all errors as non-fatal.
+/// only stale metadata remains. Git still has the worktree registered in both
+/// cases, so callers must surface the failure rather than report a clean
+/// disconnect.
 pub fn unlink_worktree(
     store: &Store,
     worktree_path: &Path,
 ) -> Result<bool, GitUnlinkWorktreeError> {
     let dot_git = worktree_path.join(".git");
-    if !dot_git.is_file() {
-        return Ok(false);
+    // A missing gitlink means there is no Git worktree to disconnect; any other
+    // failure to look at it (unreadable directory) must surface, not read as
+    // "nothing to do".
+    match std::fs::symlink_metadata(&dot_git) {
+        Ok(metadata) if metadata.is_file() => {}
+        Ok(_) => return Ok(false),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(source) => {
+            return Err(GitUnlinkWorktreeError::ReadGitLink(PathError {
+                path: dot_git,
+                source,
+            }));
+        }
     }
     let git_backend = get_git_backend(store)?;
     let worktree_repo = git_backend

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -1936,8 +1936,12 @@ fn add_worktree_to_populated_dir(
 pub enum GitUnlinkWorktreeError {
     #[error("Failed to remove .git gitlink file")]
     RemoveGitLink(#[source] PathError),
+    #[error("Failed to remove Git worktree metadata")]
+    RemoveMetadata(#[source] PathError),
+    #[error("{0} is not a linked worktree of this repository")]
+    NotALinkedWorktree(PathBuf),
     #[error(transparent)]
-    Subprocess(#[from] GitSubprocessError),
+    Git(Box<dyn std::error::Error + Send + Sync>),
     #[error(transparent)]
     UnexpectedBackend(#[from] UnexpectedGitBackendError),
 }
@@ -1947,16 +1951,22 @@ pub enum GitUnlinkWorktreeError {
 /// Returns `false` if there was no Git worktree to disconnect.
 ///
 /// The worktree directory and its contents are left in place: only the `.git`
-/// gitlink and Git's bookkeeping under `.git/worktrees/` are removed. This is
-/// the inverse of [`create_worktree()`], which likewise only sets those up.
+/// gitlink and Git's bookkeeping under `.git/worktrees/<name>` are removed.
+/// This is the inverse of [`create_worktree()`], which likewise only sets those
+/// up.
 ///
-/// The gitlink is removed before the bookkeeping is pruned, so an error means
-/// either that nothing was done, or that the worktree is already disconnected
-/// and only stale metadata remains. Neither is worth failing a command over,
-/// so callers may treat all errors as non-fatal.
+/// Only this worktree's bookkeeping is touched. `git worktree prune` would
+/// remove the metadata of every worktree whose directory happens to be
+/// unreadable at that moment — on a network mount, mid-`chmod`, or being
+/// moved — and those worktrees then silently lose their Git colocation while
+/// jj keeps using them.
+///
+/// The gitlink is removed before the bookkeeping, so an error means either
+/// that nothing was done, or that the worktree is already disconnected and
+/// only stale metadata remains. Neither is worth failing a command over, so
+/// callers may treat all errors as non-fatal.
 pub fn unlink_worktree(
     store: &Store,
-    subprocess_options: GitSubprocessOptions,
     worktree_path: &Path,
 ) -> Result<bool, GitUnlinkWorktreeError> {
     let dot_git = worktree_path.join(".git");
@@ -1964,16 +1974,37 @@ pub fn unlink_worktree(
         return Ok(false);
     }
     let git_backend = get_git_backend(store)?;
+    let worktree_repo = git_backend
+        .open_git_repo_at_workdir(worktree_path)
+        .map_err(|err| GitUnlinkWorktreeError::Git(err.into()))?;
+    // For a linked worktree, gix's `git_dir()` is the admin directory the
+    // gitlink names, `<common_dir>/worktrees/<name>`. Anything else — the main
+    // worktree, a submodule's gitlink — is not ours to disconnect. gix reports
+    // `common_dir()` relative to the admin dir (`worktrees/<name>/../..`), so
+    // both sides are canonicalized before comparing.
+    let metadata_dir = worktree_repo.git_dir().to_owned();
+    let worktrees_dir = worktree_repo.common_dir().join("worktrees");
+    drop(worktree_repo);
+    let is_linked = match (
+        metadata_dir.parent().map(dunce::canonicalize),
+        dunce::canonicalize(&worktrees_dir),
+    ) {
+        (Some(Ok(parent)), Ok(worktrees_dir)) => parent == worktrees_dir,
+        _ => false,
+    };
+    if !is_linked {
+        return Err(GitUnlinkWorktreeError::NotALinkedWorktree(
+            worktree_path.to_owned(),
+        ));
+    }
     // `git worktree remove` isn't used because it deletes the directory
     // contents, and forgetting a workspace should preserve its files.
     std::fs::remove_file(&dot_git)
         .context(&dot_git)
         .map_err(GitUnlinkWorktreeError::RemoveGitLink)?;
-    // TODO: `git worktree prune` removes metadata for all worktrees whose
-    // working directories are missing, not just the one we removed. Ideally
-    // we'd target only the specific worktree.
-    let git_ctx = GitSubprocessContext::from_git_backend(git_backend, subprocess_options);
-    git_ctx.spawn_worktree_prune()?;
+    std::fs::remove_dir_all(&metadata_dir)
+        .context(&metadata_dir)
+        .map_err(GitUnlinkWorktreeError::RemoveMetadata)?;
     Ok(true)
 }
 

--- a/lib/src/git_subprocess.rs
+++ b/lib/src/git_subprocess.rs
@@ -342,17 +342,6 @@ impl GitSubprocessContext {
 
         parse_git_worktree_output(output)
     }
-
-    /// Remove the bookkeeping of worktrees whose directories are gone.
-    pub(crate) fn spawn_worktree_prune(&self) -> Result<(), GitSubprocessError> {
-        let mut command = self.create_command();
-        command.stdout(Stdio::null());
-        command.args(["worktree", "prune"]);
-
-        let output = wait_with_output(self.spawn_cmd(command)?)?;
-
-        parse_git_worktree_output(output)
-    }
 }
 
 /// Generate a GitSubprocessError::ExternalGitError if the stderr output was not


### PR DESCRIPTION
Two commits about disconnecting a colocated workspace's Git worktree on `jj workspace forget`.

**git: unlink only the forgotten worktree's metadata, not every prunable one.** `unlink_worktree()` removed the gitlink and then ran a repo-wide `git worktree prune`, which drops the metadata of *any* worktree whose directory is momentarily unreadable — on a network mount, mid-`chmod`, or being moved. Such a sibling then silently loses its colocation (`is_colocated_git_workspace()` maps NotFound to `false`) while jj keeps using it. Now only the forgotten worktree's own admin directory under `<common_dir>/worktrees` is removed, after verifying that is where gix says it lives; `spawn_worktree_prune` is gone. The test makes a sibling's directory unreadable, forgets another workspace, and asserts the sibling is still registered and its HEAD still resolves; on main it fails with the sibling gone.

**workspace forget: fail when the Git worktree could not be disconnected.** Every failure to disconnect was reported as a warning and the command exited 0 with the worktree still registered in Git; one case was fully silent, because the gitlink check used `Path::is_file()`, which reads a permission error as "no such file". The failure to read the gitlink is now its own error, and both callers (`jj workspace forget`, `jj git colocation disable` for a child workspace) exit non-zero with a hint that disconnects the leftover without deleting the workspace's files. For `forget` the workspace itself is still forgotten, every worktree is attempted and every failure reported before the first is returned. Tests cover the read-only and the inaccessible directory for `forget`, the hinted recipe, forgetting two such workspaces at once, and the `colocation disable` case; on main they fail with `Warning:` and exit 0 (and, for `disable`, a "successfully converted" message over a half-converted workspace).

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
