### PR TITLE
docs: add jj-stack to community tools

### DIFF
--- a/docs/community_tools.md
+++ b/docs/community_tools.md
@@ -126,6 +126,13 @@ JJ View is an open-source Visual Studio Code extension that provides a rich, nat
 
 Find it [here][jj-view].
 
+## jj-stack
+
+`jj-stack` turns a linear series of local `jj` changes into a stack of GitHub pull requests.
+Rewrite, split, squash, or reorder your changes with `jj`, then run `jj-stack submit` to update
+GitHub. Existing PRs follow their change IDs, keeping comments and review history together.
+
+Find it [here][jj-stack].
 
 ## Finding other integrations
 
@@ -151,4 +158,5 @@ You can find other community contributed tools and integrations in our
 [visualjj]: https://www.visualjj.com
 [vjj]: https://github.com/noahmayr/vjj
 [jj-view]: https://github.com/brychanrobot/jj-view
+[jj-stack]: https://www.serpentine.com/software/jj-stack
 [Wiki]: https://github.com/jj-vcs/jj/wiki


### PR DESCRIPTION
Adds jj-stack to the community tools page with a short description of its stacked pull request workflow and a link to its website.

Validation: reviewed the Markdown structure and link reference. Tests not run; documentation-only change.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [ ] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
