### PR TITLE
workspaces: Make jj default to creating subvolumes on btrfs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   Use the `--sparse-patterns` option to control this behavior (evaluated
   per each `jj run` invocation).
 
+* When on `btrfs`, `jj clone` and `jj git init` create a subvolume that it can
+  efficiently snapshot to create copies of instantaneously. If the directory
+  already exists, It will print warnings that certain features will not be
+  available.
+
 ### Fixed bugs
 
 ## [0.45.1] - 2026-09-03

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2544,6 +2544,7 @@ dependencies = [
  "jj-cli",
  "jj-lib",
  "jsonschema",
+ "libbtrfs",
  "libc",
  "maplit",
  "mimalloc",
@@ -2560,6 +2561,7 @@ dependencies = [
  "ratatui",
  "regex",
  "rpassword",
+ "rustix",
  "sapling-renderdag",
  "sapling-streampager",
  "scm-record",
@@ -2767,6 +2769,18 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "libbtrfs"
+version = "0.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418277c83529d0119958f63c2478a51ed4b6019915e0cf6f7a6b49665fce4286"
+dependencies = [
+ "bitflags 2.13.1",
+ "either",
+ "libc",
+ "uuid",
+]
 
 [[package]]
 name = "libc"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -119,6 +119,10 @@ percent-encoding = { workspace = true }
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }
 nix = { workspace = true, features = [ "signal" ] }
+rustix = { workspace = true }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+libbtrfs = { version = "0.0.40", default-features = false }
 
 [dev-dependencies]
 anstream = { workspace = true }

--- a/cli/src/commands/git/clone.rs
+++ b/cli/src/commands/git/clone.rs
@@ -45,6 +45,7 @@ use crate::command_error::user_error;
 use crate::command_error::user_error_with_message;
 use crate::commands::git::maybe_add_gitignore;
 use crate::config::ConfigEnv;
+use crate::cow::create_cow_dir;
 use crate::git_util::GitSubprocessUi;
 use crate::git_util::absolute_git_url;
 use crate::git_util::load_git_import_options;
@@ -192,7 +193,12 @@ pub async fn cmd_git_clone(
     }
 
     // will create a tree dir in case if was deleted after last check
-    fs::create_dir_all(&wc_path)
+    if let Some(parent) = wc_path.parent() {
+        fs::create_dir_all(parent).map_err(|err| {
+            user_error_with_message(format!("Failed to create {}", parent.display()), err)
+        })?;
+    }
+    create_cow_dir(ui, &wc_path)
         .map_err(|err| user_error_with_message(format!("Failed to create {wc_path_str}"), err))?;
 
     let colocate = if command.settings().get_bool("git.colocate")? {

--- a/cli/src/commands/git/init.rs
+++ b/cli/src/commands/git/init.rs
@@ -44,6 +44,7 @@ use crate::command_error::user_error;
 use crate::command_error::user_error_with_message;
 use crate::commands::git::maybe_add_gitignore;
 use crate::config::ConfigEnv;
+use crate::cow::create_cow_dir;
 use crate::formatter::FormatterExt as _;
 use crate::git_util::is_colocated_git_workspace;
 use crate::git_util::load_git_import_options;
@@ -145,7 +146,7 @@ pub async fn cmd_git_init(
     }
     let cwd = command.cwd();
     let wc_path = cwd.join(&args.destination);
-    let wc_path = file_util::create_or_reuse_dir(&wc_path)
+    let wc_path = create_cow_dir(ui, &wc_path)
         .and_then(|_| dunce::canonicalize(wc_path))
         .map_err(|e| user_error_with_message("Failed to create workspace", e))?;
 

--- a/cli/src/cow.rs
+++ b/cli/src/cow.rs
@@ -1,0 +1,80 @@
+// Copyright 2024 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::io;
+use std::path::Path;
+
+use crate::ui::Ui;
+
+/// Supported filesystems for copy-on-write semantics
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum FilesystemType {
+    /// No Copy-on-write semantics supported.
+    /// We just use normal filesystem operations.
+    Generic,
+    /// Btrfs isn't available on other OSes
+    #[cfg(target_os = "linux")]
+    Btrfs,
+}
+
+/// Calculates the filesystem that a path exists on.
+pub fn filesystem_type(p: &Path) -> FilesystemType {
+    #[cfg(target_os = "linux")]
+    if libbtrfs::fs::is_btrfs(p).unwrap_or(false) {
+        return FilesystemType::Btrfs;
+    }
+    let _ = p;
+    FilesystemType::Generic
+}
+
+/// Creates a directory that can be CoW'd in the future.
+pub fn create_cow_dir(ui: &mut Ui, p: &Path) -> io::Result<()> {
+    let is_dir = p.is_dir();
+    let fs_type = if is_dir {
+        filesystem_type(p)
+    } else if let Some(parent) = p.parent() {
+        filesystem_type(parent)
+    } else {
+        FilesystemType::Generic
+    };
+    match fs_type {
+        FilesystemType::Generic => {}
+        #[cfg(target_os = "linux")]
+        FilesystemType::Btrfs => {
+            if is_dir {
+                if !libbtrfs::subvol::is_subvol(p).unwrap_or(false) {
+                    writeln!(
+                        ui.warning_default(),
+                        "Not a subvolume. Copy-on-write features will be disabled when using jj \
+                         workspaces"
+                    )?;
+                }
+                return Ok(());
+            } else {
+                match libbtrfs::subvol::create(p) {
+                    Ok(()) => return Ok(()),
+                    Err(err) => {
+                        writeln!(
+                            ui.warning_default(),
+                            "Failed to create Btrfs subvolume at {}: {err}. Falling back to \
+                             standard directory.",
+                            p.display()
+                        )?;
+                    }
+                }
+            }
+        }
+    };
+    jj_lib::file_util::create_or_reuse_dir(p)
+}

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -22,6 +22,7 @@ pub mod commit_ref_list;
 pub mod commit_templater;
 pub mod complete;
 pub mod config;
+pub mod cow;
 pub mod description_util;
 pub mod diff_util;
 pub mod formatter;


### PR DESCRIPTION
This allows repos to be efficiently copied, eg. for `jj run` and `jj workspace`.

Unfortunately, although I was able to test it locally to prove it was working, actually writing a test for it is impossible because it requires a btrfs filesystem to be available.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [x] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
