### PR TITLE
gpg: accept GnuPG 2.5.22 metadata in unknown-key tests

### DIFF
--- a/lib/src/gpg_signing.rs
+++ b/lib/src/gpg_signing.rs
@@ -406,6 +406,24 @@ mod tests {
     }
 
     #[test]
+    fn gpgsm_verify_unknown_signature_with_issuer() {
+        assert_eq!(
+            parse_gpg_verify_output(
+                b"[GNUPG:] NO_PUBKEY #7C6DDB3D1978999B/CN=JJ,O=X509+Signing+Test\n\
+                  [GNUPG:] ERROR verify.findkey 50331657\n",
+                true,
+            )
+            .unwrap()
+            .unwrap(),
+            Verification::new(
+                SigStatus::Unknown,
+                Some("#7C6DDB3D1978999B/CN=JJ,O=X509+Signing+Test".into()),
+                None,
+            ),
+        );
+    }
+
+    #[test]
     fn gpgsm_verify_invalid_signature_format() {
         assert_matches!(
             parse_gpg_verify_output(b"[GNUPG:] ERROR verify.leave 150995087", true),

--- a/lib/tests/test_gpg.rs
+++ b/lib/tests/test_gpg.rs
@@ -440,20 +440,16 @@ fn gpgsm_unknown_key() -> TestResult {
     xiNbRmGtEonl9d8JS/IAAAAAAAA=
     -----END SIGNED MESSAGE-----
     ";
-    assert_debug_snapshot!(backend.verify(b"hello world", signature)?, @r#"
-    Verification {
-        status: Unknown,
-        key: None,
-        display: None,
+    for data in ["hello world", "so bad"] {
+        let check = backend.verify(data.as_bytes(), signature)?;
+        assert_eq!(check.status, SigStatus::Unknown);
+        assert_eq!(check.display, None);
+        // GnuPG 2.5.22 added the missing certificate's serial number and issuer.
+        assert_matches!(
+            check.key.as_deref(),
+            None | Some("#7C6DDB3D1978999B/CN=JJ,O=X509+Signing+Test")
+        );
     }
-    "#);
-    assert_debug_snapshot!(backend.verify(b"so bad", signature)?, @r#"
-    Verification {
-        status: Unknown,
-        key: None,
-        display: None,
-    }
-    "#);
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

Fix the `gpgsm_unknown_key` test failure with GnuPG 2.5.22, which now reports the missing certificate's serial number and issuer. Accept the exact old and new results and add parser coverage for the new output. No runtime behavior changes.

Observed in [macOS ARM CI](https://github.com/jj-vcs/jj/actions/runs/34591887105/job/103238830257).

Without this fix the CI will always fail when building for MacOS.

## Testing

- Linux with GnuPG 2.4.8: all 9 GPG parser tests and all 8 GPG integration tests passed.
- Replayed the new status line through a temporary wrapper: the original integration test failed with the CI mismatch, and the updated test passed.
- Focused `jj-lib` Clippy and workspace formatting checks passed.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
