### PR TITLE
squash: show change IDs in combined description headings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### New features
 
+* `jj squash` includes change IDs in the source and destination description
+  headings shown in the editor when combining descriptions.
+
 * Git-format diff hunk headers now include nearby source symbols for many common
   programming and markup languages.
 

--- a/cli/src/description_util.rs
+++ b/cli/src/description_util.rs
@@ -24,6 +24,7 @@ use jj_lib::trailer::parse_trailers;
 use thiserror::Error;
 
 use crate::cli_util::WorkspaceCommandTransaction;
+use crate::cli_util::short_change_hash;
 use crate::cli_util::short_commit_hash;
 use crate::command_error::CommandError;
 use crate::command_error::user_error;
@@ -323,11 +324,21 @@ pub async fn combine_messages_for_editing(
 ) -> Result<String, CommandError> {
     let mut combined = String::new();
     if let Some(destination) = destination {
-        combined.push_str("JJ: Description from the destination commit:\n");
+        writeln!(
+            combined,
+            "JJ: Description from the destination commit ({}):",
+            short_change_hash(destination.change_id())
+        )
+        .unwrap();
         combined.push_str(destination.description());
     }
     for commit in sources {
-        combined.push_str("\nJJ: Description from source commit:\n");
+        writeln!(
+            combined,
+            "\nJJ: Description from source commit ({}):",
+            short_change_hash(commit.change_id())
+        )
+        .unwrap();
         combined.push_str(commit.description());
     }
 

--- a/cli/tests/test_squash_command.rs
+++ b/cli/tests/test_squash_command.rs
@@ -14,6 +14,8 @@
 
 use std::path::PathBuf;
 
+use indoc::formatdoc;
+use test_case::test_case;
 use testutils::TestResult;
 
 use crate::common::CommandOutput;
@@ -1379,10 +1381,10 @@ fn test_squash_description() -> TestResult {
     insta::assert_snapshot!(
         editor0, @r#"
     JJ: Enter a description for the combined commit.
-    JJ: Description from the destination commit:
+    JJ: Description from the destination commit (qpvuntsmwlqt):
     destination
 
-    JJ: Description from source commit:
+    JJ: Description from source commit (rlvkpnrzqnoo):
     source
 
     JJ: Change ID: qpvuntsm
@@ -1452,10 +1454,10 @@ fn test_squash_description() -> TestResult {
     insta::assert_snapshot!(
         editor0, @r#"
     JJ: Enter a description for the combined commit.
-    JJ: Description from the destination commit:
+    JJ: Description from the destination commit (qpvuntsmwlqt):
     destination
 
-    JJ: Description from source commit:
+    JJ: Description from source commit (rlvkpnrzqnoo):
     source
 
     foo: bar
@@ -1487,10 +1489,10 @@ fn test_squash_description() -> TestResult {
     insta::assert_snapshot!(
         std::fs::read_to_string(test_env.env_root().join("editor0")).unwrap(), @r#"
     JJ: Enter a description for the combined commit.
-    JJ: Description from the destination commit:
+    JJ: Description from the destination commit (qpvuntsmwlqt):
     destination
 
-    JJ: Description from source commit:
+    JJ: Description from source commit (rlvkpnrzqnoo):
     source
 
     foo: bar
@@ -2142,10 +2144,10 @@ fn test_squash_to_new_commit() -> TestResult {
         editor1, @r#"
     JJ: Enter a description for the combined commit.
 
-    JJ: Description from source commit:
+    JJ: Description from source commit (kkmpptxzrspx):
     file3
 
-    JJ: Description from source commit:
+    JJ: Description from source commit (zsuskulnrvyr):
     file4
 
     JJ: Change ID: pkstwlsy
@@ -2443,6 +2445,75 @@ fn test_squash_to_new_commit() -> TestResult {
     Ok(())
 }
 
+#[test_case(false; "default_template")]
+#[test_case(true; "with_diff")]
+fn test_squash_description_identifies_sources(with_diff: bool) -> TestResult {
+    let mut test_env = TestEnvironment::default();
+    let edit_script = test_env.set_up_fake_editor();
+    if with_diff {
+        test_env.add_config(
+            "templates.draft_commit_description = 'builtin_draft_commit_description_with_diff'",
+        );
+    }
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    work_dir.run_jj(["describe", "-m", "destination"]).success();
+    work_dir.write_file("destination", "contents\n");
+    for (file, description) in [("first", "same"), ("second", "same"), ("third", "")] {
+        work_dir.run_jj(["new", "-m", description]).success();
+        work_dir.write_file(file, "contents\n");
+    }
+    let ids = ["@---", "@--", "@-", "@"].map(|revision| {
+        work_dir
+            .run_jj([
+                "log",
+                "--no-graph",
+                "-r",
+                revision,
+                "-T",
+                "change_id.short(12)",
+            ])
+            .success()
+            .stdout
+            .into_raw()
+    });
+
+    // Identical and empty descriptions should still identify their source.
+    std::fs::write(&edit_script, "dump editor")?;
+    work_dir
+        .run_jj(["squash", "--from", "@--::@", "--into", "@---"])
+        .success();
+    let editor = std::fs::read_to_string(test_env.env_root().join("editor"))?;
+    let (sections, _) = editor.split_once("JJ: Change ID:").unwrap();
+    assert_eq!(
+        sections,
+        formatdoc! {"
+            JJ: Enter a description for the combined commit.
+            JJ: Description from the destination commit ({}):
+            destination
+
+            JJ: Description from source commit ({}):
+            same
+
+            JJ: Description from source commit ({}):
+            same
+
+            JJ: Description from source commit ({}):
+
+            ", ids[0], ids[1], ids[2], ids[3]
+        }
+    );
+    if with_diff {
+        assert!(editor.contains("\nJJ: ignore-rest\ndiff --git "));
+    }
+    assert_eq!(
+        get_description(&work_dir, "@-").success().stdout.raw(),
+        "destination\n\nsame\n\nsame\n"
+    );
+    Ok(())
+}
+
 #[test]
 fn test_squash_with_editor_combine_messages() -> TestResult {
     let mut test_env = TestEnvironment::default();
@@ -2468,10 +2539,10 @@ fn test_squash_with_editor_combine_messages() -> TestResult {
     insta::assert_snapshot!(
         editor, @r#"
     JJ: Enter a description for the combined commit.
-    JJ: Description from the destination commit:
+    JJ: Description from the destination commit (qpvuntsmwlqt):
     destination
 
-    JJ: Description from source commit:
+    JJ: Description from source commit (kkmpptxzrspx):
     source
 
     JJ: Change ID: qpvuntsm


### PR DESCRIPTION
When `jj squash` combines several descriptions, identical source headings make it difficult to tell which change each section came from, especially with similar or empty descriptions.

Add 12-character source and destination change IDs to those headings, e.g. `JJ: Description from source commit (kkmpptxzrspx):`. They remain `JJ:` comments and are stripped from the final description.

The formatting stays in `combine_messages_for_editing()`. Description ordering, empty-source handling, and trailer processing are unchanged. Squashing into a newly created commit still omits a destination-description heading.

The IDs use the existing fixed-length formatter rather than `format_short_change_id`, so they aren't customizable or guaranteed to be unique. Divergent revisions sharing a change ID receive the same label.

This implements the heading suggestion in #9164, leaving the issue open for its broader template proposal. I'd like to keep that work separate because exposing sources, destinations, and per-source diffs needs its own template interface design. Persistent split/squash provenance also needs decisions about storage and publishing transient IDs. This editor improvement adds no Git headers or trailers.
